### PR TITLE
Fix test failures in show and wizard packages

### DIFF
--- a/internal/commands/show/tree.go
+++ b/internal/commands/show/tree.go
@@ -328,7 +328,7 @@ func formatFraction(completed, total int) string {
 	return ui.Value(fmt.Sprintf("%d/%d", completed, total), ui.MetadataColor)
 }
 
-func truncateGoal(goal string, maxLen int) string {
+func truncateGoal(goal string, _ int) string {
 	// Don't truncate goals - let them display fully and wrap naturally
 	return goal
 }

--- a/internal/commands/show/tree_test.go
+++ b/internal/commands/show/tree_test.go
@@ -223,19 +223,21 @@ func TestFormatPercent(t *testing.T) {
 }
 
 func TestTruncateGoal(t *testing.T) {
+	// truncateGoal no longer truncates - it returns goals as-is to allow natural wrapping
 	tests := []struct {
+		name     string
 		goal     string
 		maxLen   int
 		expected string
 	}{
-		{"Short goal", 20, "Short goal"},
-		{"This is a very long goal that needs truncation", 20, "This is a very lo..."},
-		{"Exact length goal", 17, "Exact length goal"},
-		{"", 10, ""},
+		{"short goal", "Short goal", 20, "Short goal"},
+		{"long goal returned as-is", "This is a very long goal that needs truncation", 20, "This is a very long goal that needs truncation"},
+		{"exact length goal", "Exact length goal", 17, "Exact length goal"},
+		{"empty goal", "", 10, ""},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.expected, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			result := truncateGoal(tt.goal, tt.maxLen)
 			if result != tt.expected {
 				t.Errorf("truncateGoal(%q, %d) = %q, want %q", tt.goal, tt.maxLen, result, tt.expected)

--- a/internal/commands/wizard/fill_test.go
+++ b/internal/commands/wizard/fill_test.go
@@ -34,6 +34,19 @@ func TestGetEditor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Isolate from user's real config by pointing FEST_CONFIG_DIR to temp dir
+			// This ensures config.Load returns default config (empty editor)
+			tmpDir := t.TempDir()
+			origConfigDir := os.Getenv("FEST_CONFIG_DIR")
+			os.Setenv("FEST_CONFIG_DIR", tmpDir)
+			defer func() {
+				if origConfigDir == "" {
+					os.Unsetenv("FEST_CONFIG_DIR")
+				} else {
+					os.Setenv("FEST_CONFIG_DIR", origConfigDir)
+				}
+			}()
+
 			// Save and restore EDITOR
 			origEditor := os.Getenv("EDITOR")
 			defer func() {


### PR DESCRIPTION
- Update TestTruncateGoal to match current implementation that doesn't truncate goals (allows natural text wrapping)
- Fix unused parameter warning in truncateGoal by using _ for maxLen
- Fix TestGetEditor by isolating from user's config using FEST_CONFIG_DIR env var pointing to a temp directory