### PR TITLE
[OBEY-FE-AC0001] feat: add __manifest command and agent restriction a…

### DIFF
--- a/internal/commands/config/repo.go
+++ b/internal/commands/config/repo.go
@@ -18,6 +18,11 @@ func NewConfigCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Manage fest configuration repositories",
+		Annotations: map[string]string{
+			"agent_allowed": "false",
+			"agent_reason":  "Interactive TUI theme editor",
+			"interactive":   "true",
+		},
 		Long: `Manage fest configuration repositories.
 
 Config repos contain custom templates, policies, plugins, and extensions

--- a/internal/commands/config/shell.go
+++ b/internal/commands/config/shell.go
@@ -14,7 +14,9 @@ func NewShellInitCommand() *cobra.Command {
 		Use:   "shell-init <shell>",
 		Short: "Output shell integration code for festival helpers",
 		Annotations: map[string]string{
-			"scope": string(scope.Global),
+			"scope":         string(scope.Global),
+			"agent_allowed": "false",
+			"agent_reason":  "Shell config output, irrelevant to agents",
 		},
 		Long: `Output shell code that provides shell helper functions.
 

--- a/internal/commands/manifest/manifest.go
+++ b/internal/commands/manifest/manifest.go
@@ -1,0 +1,76 @@
+package manifest
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// Manifest represents the CLI command restriction manifest.
+type Manifest struct {
+	Version  int            `json:"version"`
+	CLI      string         `json:"cli"`
+	Commands []CommandEntry `json:"commands"`
+}
+
+// CommandEntry represents a single command's agent restriction metadata.
+type CommandEntry struct {
+	Path         string `json:"path"`
+	AgentAllowed bool   `json:"agent_allowed"`
+	Reason       string `json:"reason,omitempty"`
+	Interactive  bool   `json:"interactive,omitempty"`
+}
+
+// NewManifestCommand creates the hidden __manifest command.
+func NewManifestCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:    "__manifest",
+		Short:  "Output command manifest for daemon enforcement",
+		Hidden: true,
+		Annotations: map[string]string{
+			"scope": "global",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			m := Manifest{
+				Version:  1,
+				CLI:      "fest",
+				Commands: []CommandEntry{},
+			}
+			WalkCommands(cmd.Root(), "", &m.Commands)
+			data, err := json.MarshalIndent(m, "", "  ")
+			if err != nil {
+				return err
+			}
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), string(data))
+			return err
+		},
+	}
+}
+
+// WalkCommands recursively traverses the command tree and collects
+// commands that have agent restriction annotations.
+func WalkCommands(cmd *cobra.Command, prefix string, entries *[]CommandEntry) {
+	for _, child := range cmd.Commands() {
+		path := child.Name()
+		if prefix != "" {
+			path = prefix + " " + child.Name()
+		}
+
+		if val, ok := child.Annotations["agent_allowed"]; ok {
+			entry := CommandEntry{
+				Path:         path,
+				AgentAllowed: val == "true",
+			}
+			if reason, ok := child.Annotations["agent_reason"]; ok {
+				entry.Reason = reason
+			}
+			if interactive, ok := child.Annotations["interactive"]; ok {
+				entry.Interactive = interactive == "true"
+			}
+			*entries = append(*entries, entry)
+		}
+
+		WalkCommands(child, path, entries)
+	}
+}

--- a/internal/commands/manifest/manifest_test.go
+++ b/internal/commands/manifest/manifest_test.go
@@ -1,0 +1,198 @@
+package manifest
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// newMockCommandTree creates a command tree with both annotated and unannotated commands
+// for testing WalkCommands behavior.
+func newMockCommandTree() *cobra.Command {
+	root := &cobra.Command{Use: "fest"}
+
+	// A restricted command
+	restricted := &cobra.Command{
+		Use: "restricted-cmd",
+		Annotations: map[string]string{
+			"agent_allowed": "false",
+			"agent_reason":  "Test restriction reason",
+			"interactive":   "true",
+		},
+	}
+
+	// An allowed command (no annotations)
+	allowed := &cobra.Command{
+		Use: "allowed-cmd",
+	}
+
+	// A parent with a restricted child
+	parent := &cobra.Command{
+		Use: "parent",
+	}
+	restrictedChild := &cobra.Command{
+		Use: "restricted-child",
+		Annotations: map[string]string{
+			"agent_allowed": "false",
+			"agent_reason":  "Child restriction reason",
+		},
+	}
+	allowedChild := &cobra.Command{
+		Use: "allowed-child",
+	}
+	parent.AddCommand(restrictedChild)
+	parent.AddCommand(allowedChild)
+
+	root.AddCommand(restricted)
+	root.AddCommand(allowed)
+	root.AddCommand(parent)
+
+	return root
+}
+
+func TestWalkCommands_CollectsAnnotatedCommands(t *testing.T) {
+	root := newMockCommandTree()
+
+	var entries []CommandEntry
+	WalkCommands(root, "", &entries)
+
+	if len(entries) == 0 {
+		t.Fatal("WalkCommands returned no entries from annotated command tree")
+	}
+
+	// Should collect exactly 2: restricted-cmd and parent restricted-child
+	if len(entries) != 2 {
+		t.Errorf("expected 2 annotated commands, got %d", len(entries))
+	}
+}
+
+func TestWalkCommands_IgnoresUnannotatedCommands(t *testing.T) {
+	root := newMockCommandTree()
+
+	var entries []CommandEntry
+	WalkCommands(root, "", &entries)
+
+	for _, entry := range entries {
+		if entry.Path == "allowed-cmd" {
+			t.Error("unannotated command 'allowed-cmd' should not appear in manifest")
+		}
+		if entry.Path == "parent allowed-child" {
+			t.Error("unannotated command 'parent allowed-child' should not appear in manifest")
+		}
+	}
+}
+
+func TestWalkCommands_BuildsCorrectSubcommandPaths(t *testing.T) {
+	root := newMockCommandTree()
+
+	var entries []CommandEntry
+	WalkCommands(root, "", &entries)
+
+	pathMap := make(map[string]bool)
+	for _, entry := range entries {
+		pathMap[entry.Path] = true
+	}
+
+	if !pathMap["restricted-cmd"] {
+		t.Error("expected top-level path 'restricted-cmd' not found")
+	}
+	if !pathMap["parent restricted-child"] {
+		t.Error("expected subcommand path 'parent restricted-child' not found")
+	}
+}
+
+func TestWalkCommands_ExtractsAnnotationFields(t *testing.T) {
+	root := newMockCommandTree()
+
+	var entries []CommandEntry
+	WalkCommands(root, "", &entries)
+
+	// Find the restricted-cmd entry
+	var found bool
+	for _, entry := range entries {
+		if entry.Path == "restricted-cmd" {
+			found = true
+			if entry.AgentAllowed {
+				t.Error("expected agent_allowed=false")
+			}
+			if entry.Reason != "Test restriction reason" {
+				t.Errorf("expected reason 'Test restriction reason', got %q", entry.Reason)
+			}
+			if !entry.Interactive {
+				t.Error("expected interactive=true")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatal("restricted-cmd not found in entries")
+	}
+
+	// Find the child entry - should NOT have interactive set
+	for _, entry := range entries {
+		if entry.Path == "parent restricted-child" {
+			if entry.Interactive {
+				t.Error("child command should not have interactive=true")
+			}
+			if entry.Reason != "Child restriction reason" {
+				t.Errorf("expected reason 'Child restriction reason', got %q", entry.Reason)
+			}
+		}
+	}
+}
+
+func TestManifest_JSONMarshal(t *testing.T) {
+	m := Manifest{
+		Version: 1,
+		CLI:     "fest",
+		Commands: []CommandEntry{
+			{
+				Path:         "tui",
+				AgentAllowed: false,
+				Reason:       "Full interactive Charm TUI",
+				Interactive:  true,
+			},
+		},
+	}
+
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal manifest: %v", err)
+	}
+
+	var parsed Manifest
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("failed to parse marshaled manifest: %v", err)
+	}
+
+	if parsed.Version != 1 {
+		t.Errorf("expected version 1, got %d", parsed.Version)
+	}
+	if parsed.CLI != "fest" {
+		t.Errorf("expected cli 'fest', got %q", parsed.CLI)
+	}
+	if len(parsed.Commands) != 1 {
+		t.Errorf("expected 1 command, got %d", len(parsed.Commands))
+	}
+	if parsed.Commands[0].Path != "tui" {
+		t.Errorf("expected path 'tui', got %q", parsed.Commands[0].Path)
+	}
+}
+
+func TestExpectedRestrictedCommands(t *testing.T) {
+	expected := []string{
+		"tui",
+		"create",
+		"config",
+		"shell-init",
+		"wizard fill",
+		"system config",
+		"system sync",
+		"system update",
+	}
+
+	if len(expected) != 8 {
+		t.Errorf("expected 8 restricted commands, got %d", len(expected))
+	}
+}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/commands/gates"
 	introcmd "github.com/Obedience-Corp/fest/internal/commands/intro"
 	listcmd "github.com/Obedience-Corp/fest/internal/commands/list"
+	manifestcmd "github.com/Obedience-Corp/fest/internal/commands/manifest"
 	"github.com/Obedience-Corp/fest/internal/commands/markers"
 	"github.com/Obedience-Corp/fest/internal/commands/migrate"
 	"github.com/Obedience-Corp/fest/internal/commands/navigation"
@@ -150,7 +151,10 @@ func init() {
 		Short:   "Create festivals, phases, sequences, or tasks (TUI)",
 		GroupID: "creation",
 		Annotations: map[string]string{
-			"scope": string(scope.Festival),
+			"scope":         string(scope.Festival),
+			"agent_allowed": "false",
+			"agent_reason":  "Launches interactive TUI picker when run without subcommand",
+			"interactive":   "true",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return shared.StartCreateTUI(cmd.Context())
@@ -328,6 +332,10 @@ func init() {
 	typesCmd := typescmd.NewTypesCommand()
 	typesCmd.GroupID = "query"
 	rootCmd.AddCommand(typesCmd)
+
+	// Manifest command for daemon enforcement (hidden)
+	manifestCmd := manifestcmd.NewManifestCommand()
+	rootCmd.AddCommand(manifestCmd)
 }
 
 // styledLongDescription returns the styled long description for the root command.

--- a/internal/commands/system/config.go
+++ b/internal/commands/system/config.go
@@ -22,7 +22,10 @@ func NewConfigCommand() *cobra.Command {
 		Use:   "config",
 		Short: "Manage fest configuration settings",
 		Annotations: map[string]string{
-			"scope": string(scope.Global),
+			"scope":         string(scope.Global),
+			"agent_allowed": "false",
+			"agent_reason":  "Interactive configuration TUI",
+			"interactive":   "true",
 		},
 		Long: `Interactive TUI for managing fest configuration.
 

--- a/internal/commands/system/sync.go
+++ b/internal/commands/system/sync.go
@@ -31,6 +31,10 @@ func NewSyncCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sync",
 		Short: "System: Download latest fest templates from GitHub",
+		Annotations: map[string]string{
+			"agent_allowed": "false",
+			"agent_reason":  "Downloads from GitHub, requires network and human judgment",
+		},
 		Long: `Download the latest fest methodology templates from GitHub to ~/.config/obey/fest/
 
 This is a SYSTEM command that maintains fest itself, not your festival content.

--- a/internal/commands/system/update.go
+++ b/internal/commands/system/update.go
@@ -34,6 +34,10 @@ func NewUpdateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update [path]",
 		Short: "System: Update fest methodology files from templates",
+		Annotations: map[string]string{
+			"agent_allowed": "false",
+			"agent_reason":  "Updates methodology files, destructive operation",
+		},
 		Long: `Update the .festival/ methodology files from latest templates.
 
 This is a SYSTEM command that updates fest's methodology files (templates,

--- a/internal/commands/tui/charm.go
+++ b/internal/commands/tui/charm.go
@@ -30,6 +30,11 @@ func NewTUICommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tui",
 		Short: "Interactive UI (Charm) for festival creation and editing",
+		Annotations: map[string]string{
+			"agent_allowed": "false",
+			"agent_reason":  "Full interactive Charm TUI",
+			"interactive":   "true",
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCharmTUI(cmd.Context())
 		},

--- a/internal/commands/wizard/fill.go
+++ b/internal/commands/wizard/fill.go
@@ -107,6 +107,11 @@ EXAMPLES:
 
 The fill wizard transforms tedious manual editing into a guided experience,
 ensuring all template markers are properly completed.`,
+		Annotations: map[string]string{
+			"agent_allowed": "false",
+			"agent_reason":  "Interactive editor-based marker filling",
+			"interactive":   "true",
+		},
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Path = "."


### PR DESCRIPTION
…nnotations to fest CLI

Add hidden __manifest command that walks the Cobra command tree and emits JSON describing all 8 restricted commands with agent_allowed, reason, and interactive fields.

Annotated commands: tui, create, config, shell-init, wizard fill, system config, system sync, system update. Subcommands (create festival, create phase, etc.) are intentionally excluded from restrictions.

Includes unit tests for WalkCommands logic covering annotation collection, filtering, subcommand path building, and JSON round-trip.

Part of: 004_FEST_MANIFEST/01_manifest_command