### PR TITLE
Fix workspace detection regression in fest create

### DIFF
--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -152,7 +152,7 @@ func init() {
 		Short:   "Create festivals, phases, sequences, or tasks (TUI)",
 		GroupID: "creation",
 		Annotations: map[string]string{
-			"scope":         string(scope.Festival),
+			"scope":         string(scope.Workspace),
 			"agent_allowed": "false",
 			"agent_reason":  "Launches interactive TUI picker when run without subcommand",
 			"interactive":   "true",

--- a/internal/commands/tui/charm.go
+++ b/internal/commands/tui/charm.go
@@ -4,12 +4,11 @@ package tui
 
 import (
 	"context"
-	"os"
 	"strings"
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
 	"github.com/Obedience-Corp/fest/internal/errors"
-	tpl "github.com/Obedience-Corp/fest/internal/template"
+	"github.com/Obedience-Corp/fest/internal/scope"
 	uitheme "github.com/Obedience-Corp/fest/internal/ui/theme"
 	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
@@ -43,9 +42,8 @@ func NewTUICommand() *cobra.Command {
 }
 
 func runCharmTUI(ctx context.Context) error {
-	// Validate inside festivals workspace; if absent, offer to init
-	cwd, _ := os.Getwd()
-	if _, err := tpl.FindFestivalsRoot(cwd); err != nil {
+	// Validate workspace is resolved (scope middleware already did this)
+	if _, ok := scope.WorkspaceFrom(ctx); !ok {
 		var initNow bool
 		form := huh.NewForm(
 			huh.NewGroup(

--- a/internal/commands/tui/charm_festival.go
+++ b/internal/commands/tui/charm_festival.go
@@ -5,12 +5,10 @@ package tui
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
-	tpl "github.com/Obedience-Corp/fest/internal/template"
 	uitheme "github.com/Obedience-Corp/fest/internal/ui/theme"
 	"github.com/charmbracelet/huh"
 )
@@ -20,8 +18,7 @@ func charmCreateFestival(ctx context.Context) error {
 		return err
 	}
 
-	cwd, _ := os.Getwd()
-	tmplRoot, err := tpl.LocalTemplateRoot(cwd)
+	tmplRoot, err := templateRootFromCtx(ctx)
 	if err != nil {
 		return err
 	}
@@ -93,12 +90,11 @@ func charmPlanFestivalWizard(ctx context.Context) error {
 		return err
 	}
 
-	cwd, _ := os.Getwd()
-	festivalsRoot, err := tpl.FindFestivalsRoot(cwd)
+	festivalsRoot, err := festivalsRootFromCtx(ctx)
 	if err != nil {
 		return err
 	}
-	tmplRoot, err := tpl.LocalTemplateRoot(cwd)
+	tmplRoot, err := templateRootFromCtx(ctx)
 	if err != nil {
 		return err
 	}
@@ -209,8 +205,7 @@ func charmPlanFestivalWizard(ctx context.Context) error {
 }
 
 func charmGenerateFestivalGoal(ctx context.Context) error {
-	cwd, _ := os.Getwd()
-	if _, err := tpl.LocalTemplateRoot(cwd); err != nil {
+	if _, err := templateRootFromCtx(ctx); err != nil {
 		return err
 	}
 	var festDir, name, goal string

--- a/internal/commands/tui/charm_phase.go
+++ b/internal/commands/tui/charm_phase.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
-	tpl "github.com/Obedience-Corp/fest/internal/template"
 	uitheme "github.com/Obedience-Corp/fest/internal/ui/theme"
 	"github.com/charmbracelet/huh"
 )
@@ -21,7 +20,7 @@ func charmCreatePhase(ctx context.Context) error {
 	}
 
 	// Use hierarchical selector to select festival
-	selector, err := NewHierarchySelectorFromCwd(SelectToFestival(false))
+	selector, err := NewHierarchySelectorFromCwd(ctx, SelectToFestival(false))
 	if err != nil {
 		// Fallback to manual path entry
 		return charmCreatePhaseManual(ctx)
@@ -41,8 +40,7 @@ func charmCreatePhase(ctx context.Context) error {
 
 // createPhaseInFestival creates a phase in the specified festival.
 func createPhaseInFestival(ctx context.Context, festivalPath string) error {
-	cwd, _ := os.Getwd()
-	tmplRoot, err := tpl.LocalTemplateRoot(cwd)
+	tmplRoot, err := templateRootFromCtx(ctx)
 	if err != nil {
 		return err
 	}
@@ -151,7 +149,7 @@ func createPhaseInFestival(ctx context.Context, festivalPath string) error {
 // charmCreatePhaseManual is the fallback when hierarchical selector can't initialize.
 func charmCreatePhaseManual(ctx context.Context) error {
 	cwd, _ := os.Getwd()
-	tmplRoot, err := tpl.LocalTemplateRoot(cwd)
+	tmplRoot, err := templateRootFromCtx(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/tui/charm_sequence.go
+++ b/internal/commands/tui/charm_sequence.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
-	tpl "github.com/Obedience-Corp/fest/internal/template"
 	uitheme "github.com/Obedience-Corp/fest/internal/ui/theme"
 	"github.com/charmbracelet/huh"
 )
@@ -21,7 +20,7 @@ func charmCreateSequence(ctx context.Context) error {
 	}
 
 	// Use hierarchical selector to select festival and phase
-	selector, err := NewHierarchySelectorFromCwd(SelectToPhase(true))
+	selector, err := NewHierarchySelectorFromCwd(ctx, SelectToPhase(true))
 	if err != nil {
 		// Fallback to manual path entry
 		return charmCreateSequenceManual(ctx)
@@ -41,8 +40,7 @@ func charmCreateSequence(ctx context.Context) error {
 
 // createSequenceInPhase creates a sequence in the specified phase.
 func createSequenceInPhase(ctx context.Context, phasePath string) error {
-	cwd, _ := os.Getwd()
-	tmplRoot, err := tpl.LocalTemplateRoot(cwd)
+	tmplRoot, err := templateRootFromCtx(ctx)
 	if err != nil {
 		return err
 	}
@@ -140,7 +138,7 @@ func createSequenceInPhase(ctx context.Context, phasePath string) error {
 // charmCreateSequenceManual is the fallback when hierarchical selector can't initialize.
 func charmCreateSequenceManual(ctx context.Context) error {
 	cwd, _ := os.Getwd()
-	tmplRoot, err := tpl.LocalTemplateRoot(cwd)
+	tmplRoot, err := templateRootFromCtx(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/tui/charm_task.go
+++ b/internal/commands/tui/charm_task.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
-	tpl "github.com/Obedience-Corp/fest/internal/template"
 	uitheme "github.com/Obedience-Corp/fest/internal/ui/theme"
 	"github.com/charmbracelet/huh"
 )
@@ -21,7 +20,7 @@ func charmCreateTask(ctx context.Context) error {
 	}
 
 	// Use hierarchical selector to select festival, phase, and sequence
-	selector, err := NewHierarchySelectorFromCwd(SelectToSequence(true))
+	selector, err := NewHierarchySelectorFromCwd(ctx, SelectToSequence(true))
 	if err != nil {
 		// Fallback to manual path entry
 		return charmCreateTaskManual(ctx)
@@ -41,8 +40,7 @@ func charmCreateTask(ctx context.Context) error {
 
 // createTaskInSequence creates a task in the specified sequence.
 func createTaskInSequence(ctx context.Context, sequencePath string) error {
-	cwd, _ := os.Getwd()
-	tmplRoot, err := tpl.LocalTemplateRoot(cwd)
+	tmplRoot, err := templateRootFromCtx(ctx)
 	if err != nil {
 		return err
 	}
@@ -140,7 +138,7 @@ func createTaskInSequence(ctx context.Context, sequencePath string) error {
 // charmCreateTaskManual is the fallback when hierarchical selector can't initialize.
 func charmCreateTaskManual(ctx context.Context) error {
 	cwd, _ := os.Getwd()
-	tmplRoot, err := tpl.LocalTemplateRoot(cwd)
+	tmplRoot, err := templateRootFromCtx(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/tui/fallback.go
+++ b/internal/commands/tui/fallback.go
@@ -4,11 +4,10 @@ package tui
 
 import (
 	"context"
-	"os"
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
 	"github.com/Obedience-Corp/fest/internal/errors"
-	tpl "github.com/Obedience-Corp/fest/internal/template"
+	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -37,10 +36,9 @@ func NewTUICommand() *cobra.Command {
 
 func runTUI(ctx context.Context) error {
 	display := ui.New(shared.IsNoColor(), shared.IsVerbose())
-	cwd, _ := os.Getwd()
 
-	// Ensure we are inside a festivals workspace; if not, offer to init
-	if _, err := tpl.FindFestivalsRoot(cwd); err != nil {
+	// Ensure workspace is resolved (scope middleware already did this)
+	if _, ok := scope.WorkspaceFrom(ctx); !ok {
 		display.Warning("No festivals/ directory detected.")
 		if display.Confirm("Initialize a new festival workspace here?") {
 			if err := shared.RunInit(ctx, ".", &shared.InitOpts{}); err != nil {

--- a/internal/commands/tui/fallback_festival.go
+++ b/internal/commands/tui/fallback_festival.go
@@ -4,13 +4,12 @@ package tui
 
 import (
 	"context"
-	"os"
+	"fmt"
 	"path/filepath"
 	"strings"
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
 	"github.com/Obedience-Corp/fest/internal/errors"
-	tpl "github.com/Obedience-Corp/fest/internal/template"
 	"github.com/Obedience-Corp/fest/internal/ui"
 )
 
@@ -18,8 +17,7 @@ func tuiCreateFestival(ctx context.Context, display *ui.UI) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	cwd, _ := os.Getwd()
-	tmplRoot, err := tpl.LocalTemplateRoot(cwd)
+	tmplRoot, err := templateRootFromCtx(ctx)
 	if err != nil {
 		return err
 	}
@@ -89,13 +87,11 @@ func tuiPlanFestivalWizard(ctx context.Context, display *ui.UI) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	cwd, _ := os.Getwd()
-	festivalsRoot, err := tpl.FindFestivalsRoot(cwd)
+	festivalsRoot, err := festivalsRootFromCtx(ctx)
 	if err != nil {
 		return err
 	}
-	// First create festival (quick)
-	cwdTmpl, err := tpl.LocalTemplateRoot(cwd)
+	cwdTmpl, err := templateRootFromCtx(ctx)
 	if err != nil {
 		return err
 	}
@@ -173,8 +169,7 @@ func tuiPlanFestivalWizard(ctx context.Context, display *ui.UI) error {
 }
 
 func tuiGenerateFestivalGoal(ctx context.Context, display *ui.UI) error {
-	cwd, _ := os.Getwd()
-	if _, err := tpl.LocalTemplateRoot(cwd); err != nil {
+	if _, err := templateRootFromCtx(ctx); err != nil {
 		return err
 	}
 	festDir := strings.TrimSpace(display.PromptDefault("Festival directory (where to write FESTIVAL_GOAL.md)", "."))

--- a/internal/commands/tui/fallback_phase.go
+++ b/internal/commands/tui/fallback_phase.go
@@ -4,13 +4,13 @@ package tui
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
 	"github.com/Obedience-Corp/fest/internal/errors"
-	tpl "github.com/Obedience-Corp/fest/internal/template"
 	"github.com/Obedience-Corp/fest/internal/ui"
 )
 
@@ -19,7 +19,7 @@ func tuiCreatePhase(ctx context.Context, display *ui.UI) error {
 		return err
 	}
 	cwd, _ := os.Getwd()
-	tmplRoot, err := tpl.LocalTemplateRoot(cwd)
+	tmplRoot, err := templateRootFromCtx(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/tui/fallback_sequence.go
+++ b/internal/commands/tui/fallback_sequence.go
@@ -4,13 +4,13 @@ package tui
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
 	"github.com/Obedience-Corp/fest/internal/errors"
-	tpl "github.com/Obedience-Corp/fest/internal/template"
 	"github.com/Obedience-Corp/fest/internal/ui"
 )
 
@@ -19,7 +19,7 @@ func tuiCreateSequence(ctx context.Context, display *ui.UI) error {
 		return err
 	}
 	cwd, _ := os.Getwd()
-	tmplRoot, err := tpl.LocalTemplateRoot(cwd)
+	tmplRoot, err := templateRootFromCtx(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/tui/fallback_task.go
+++ b/internal/commands/tui/fallback_task.go
@@ -4,13 +4,13 @@ package tui
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
 	"github.com/Obedience-Corp/fest/internal/errors"
-	tpl "github.com/Obedience-Corp/fest/internal/template"
 	"github.com/Obedience-Corp/fest/internal/ui"
 )
 
@@ -19,7 +19,7 @@ func tuiCreateTask(ctx context.Context, display *ui.UI) error {
 		return err
 	}
 	cwd, _ := os.Getwd()
-	tmplRoot, err := tpl.LocalTemplateRoot(cwd)
+	tmplRoot, err := templateRootFromCtx(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/tui/helpers.go
+++ b/internal/commands/tui/helpers.go
@@ -12,8 +12,27 @@ import (
 
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/festival"
+	"github.com/Obedience-Corp/fest/internal/scope"
 	tpl "github.com/Obedience-Corp/fest/internal/template"
 )
+
+// templateRootFromCtx derives the template root from the workspace already resolved by scope middleware.
+func templateRootFromCtx(ctx context.Context) (string, error) {
+	ws, ok := scope.WorkspaceFrom(ctx)
+	if !ok {
+		return "", errors.NotFound("workspace not in context")
+	}
+	return filepath.Join(ws.FestivalsPath, ".festival", "templates"), nil
+}
+
+// festivalsRootFromCtx derives the festivals root from the workspace already resolved by scope middleware.
+func festivalsRootFromCtx(ctx context.Context) (string, error) {
+	ws, ok := scope.WorkspaceFrom(ctx)
+	if !ok {
+		return "", errors.NotFound("workspace not in context")
+	}
+	return ws.FestivalsPath, nil
+}
 
 func collectRequiredVars(ctx context.Context, templateRoot string, paths []string) []string {
 	loader := tpl.NewLoader()

--- a/internal/commands/tui/hierarchy.go
+++ b/internal/commands/tui/hierarchy.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/Obedience-Corp/fest/internal/errors"
-	tpl "github.com/Obedience-Corp/fest/internal/template"
 	uitheme "github.com/Obedience-Corp/fest/internal/ui/theme"
 	"github.com/charmbracelet/huh"
 )
@@ -70,16 +69,16 @@ func NewHierarchySelector(festivalsRoot string, config HierarchyConfig) *Hierarc
 }
 
 // NewHierarchySelectorFromCwd creates a selector initialized from current directory.
-func NewHierarchySelectorFromCwd(config HierarchyConfig) (*HierarchySelector, error) {
+func NewHierarchySelectorFromCwd(ctx context.Context, config HierarchyConfig) (*HierarchySelector, error) {
+	// Use workspace already resolved by scope middleware
+	festivalsRoot, err := festivalsRootFromCtx(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "finding festivals root")
+	}
+
 	cwd, err := os.Getwd()
 	if err != nil {
 		return nil, errors.IO("getting working directory", err)
-	}
-
-	// Find festivals root
-	festivalsRoot, err := tpl.FindFestivalsRoot(cwd)
-	if err != nil {
-		return nil, errors.Wrap(err, "finding festivals root")
 	}
 
 	h := &HierarchySelector{

--- a/internal/scope/resolve.go
+++ b/internal/scope/resolve.go
@@ -1,6 +1,7 @@
 package scope
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -78,7 +79,7 @@ func Resolve(cmd *cobra.Command) error {
 func resolveWorkspaceScope(cmd *cobra.Command) error {
 	ctx := cmd.Context()
 
-	ws, err := resolveWorkspace()
+	ws, err := resolveWorkspace(ctx)
 	if err != nil {
 		return workspaceScopeError()
 	}
@@ -88,24 +89,28 @@ func resolveWorkspaceScope(cmd *cobra.Command) error {
 	return nil
 }
 
-// resolveWorkspace finds the festivals/ directory using the existing detection chain.
-// This will be replaced with workspace.FindWorkspace() in sequence 02_workspace_detection.
-func resolveWorkspace() (*WorkspaceInfo, error) {
+// resolveWorkspace finds the workspace using the full detection chain:
+// campaign (.campaign/) → marked (.workspace) → nearest (festivals/).
+func resolveWorkspace(ctx context.Context) (*WorkspaceInfo, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return nil, err
 	}
 
-	// Use existing workspace detection (marked workspace or nearest)
-	festivalsPath, err := workspace.FindFestivals(cwd)
-	if err != nil || festivalsPath == "" {
-		return nil, fmt.Errorf("no festivals directory found")
+	ws, err := workspace.FindWorkspace(ctx, cwd)
+	if err != nil {
+		return nil, fmt.Errorf("no workspace found")
+	}
+
+	wsType := WorkspaceTypeStandalone
+	if ws.Type == workspace.WorkspaceTypeCampaign {
+		wsType = WorkspaceTypeCampaign
 	}
 
 	return &WorkspaceInfo{
-		Root:          filepath.Dir(festivalsPath),
-		FestivalsPath: festivalsPath,
-		Type:          WorkspaceTypeStandalone, // Will be updated in sequence 02
+		Root:          ws.Root,
+		FestivalsPath: ws.FestivalsPath,
+		Type:          wsType,
 	}, nil
 }
 
@@ -127,7 +132,7 @@ func resolveFestivalScope(cmd *cobra.Command) error {
 	ctx := cmd.Context()
 
 	// First resolve workspace
-	ws, err := resolveWorkspace()
+	ws, err := resolveWorkspace(ctx)
 	if err != nil {
 		return workspaceScopeError()
 	}


### PR DESCRIPTION
## Summary

- `fest create` and all TUI functions were broken when run from outside the `festivals/` directory
- Fixed scope annotation on parent `create` command (Festival → Workspace)
- `resolveWorkspace()` now uses `workspace.FindWorkspace()` for full detection chain: `.campaign/` → `.workspace` marker → nearest `festivals/`
- Replaced restrictive `tpl.FindFestivalsRoot(cwd)` calls in all 13 TUI files with context-based helpers that read the already-resolved workspace from scope middleware

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `fest create festival --name test --json` works from workspace root
- [x] `fest create festival --name test --json` works from `projects/fest/` subdirectory