### PR TITLE
Fix flaky integration tests with sync in Reset()

### DIFF
--- a/tests/integration/helpers.go
+++ b/tests/integration/helpers.go
@@ -581,9 +581,12 @@ func buildTemplatesPathShared() (string, error) {
 
 // Reset clears container state between tests.
 // This removes all test artifacts while keeping the container and binary intact.
+// The trailing `sync` ensures filesystem buffers are flushed before the next test
+// begins — required for consistency on macOS/Colima where Docker exec runs through
+// a virtualization layer (overlayfs in a Linux VM).
 func (tc *TestContainer) Reset() error {
  exitCode, _, err := tc.container.Exec(tc.ctx, []string{
-  "sh", "-c", "rm -rf /test /output /festivals /workspace /testproject /outer /tmp/* 2>/dev/null; mkdir -p /test",
+  "sh", "-c", "rm -rf /test /output /festivals /workspace /testproject /outer /tmp/* 2>/dev/null; mkdir -p /test; sync",
  })
  if err != nil {
   return fmt.Errorf("failed to reset container: %w", err)

--- a/tests/integration/lifecycle/helpers_test.go
+++ b/tests/integration/lifecycle/helpers_test.go
@@ -100,9 +100,12 @@ func (tc *TestContainer) Cleanup() {
 }
 
 // Reset clears container state between tests.
+// The trailing `sync` ensures filesystem buffers are flushed before the next test
+// begins — required for consistency on macOS/Colima where Docker exec runs through
+// a virtualization layer (overlayfs in a Linux VM).
 func (tc *TestContainer) Reset() error {
 	exitCode, _, err := tc.container.Exec(tc.ctx, []string{
-		"sh", "-c", "rm -rf /test /output /festivals /workspace /testproject /outer /tmp/* 2>/dev/null; mkdir -p /test /festivals",
+		"sh", "-c", "rm -rf /test /output /festivals /workspace /testproject /outer /tmp/* 2>/dev/null; mkdir -p /test /festivals; sync",
 	})
 	if err != nil {
 		return fmt.Errorf("failed to reset container: %w", err)


### PR DESCRIPTION
## Summary

- Adds `sync` to the shell command in `Reset()` in both `tests/integration/helpers.go` and `tests/integration/lifecycle/helpers_test.go`
- On macOS/Colima, Docker exec runs through a virtualization layer (overlayfs in a Linux VM) where filesystem operations can return before writes are fully consistent
- `sync` blocks until all dirty filesystem buffers are flushed, providing a kernel-level consistency guarantee before the next test begins

## Test plan

- [ ] Run `just test-integration` multiple times to confirm flaky failures no longer reproduce
- [ ] Verify no measurable regression in test suite runtime (~50-200ms overhead per `Reset()` call)