### PR TITLE
fix: limit fgo tab completion to primary status directories

### DIFF
--- a/internal/commands/navigation/completions.go
+++ b/internal/commands/navigation/completions.go
@@ -82,16 +82,11 @@ func runGoCompletions(descriptions, color bool, statusFilter string) error {
 		return runStatusCompletions(festivalsDir, statusFilter, descriptions, color)
 	}
 
-	// Status directories
+	// Primary status directories only (completed/dungeon available via second-arg completion)
 	statuses := []string{
 		"active",
 		"ready",
 		"planned",
-		"completed",
-		"dungeon",
-		"dungeon/completed",
-		"dungeon/archived",
-		"dungeon/someday",
 	}
 
 	statusSet := make(map[string]bool, len(statuses))

--- a/internal/commands/navigation/completions_test.go
+++ b/internal/commands/navigation/completions_test.go
@@ -285,10 +285,17 @@ func TestCompleteGoTarget_WithFestivals(t *testing.T) {
 		resultSet[r] = true
 	}
 
-	// Status directories should be present
-	for _, status := range []string{"active", "planned", "completed", "dungeon"} {
+	// Primary status directories should be present (completed/dungeon excluded from default)
+	for _, status := range []string{"active", "planned"} {
 		if !resultSet[status] {
 			t.Errorf("expected status directory %q in completions, got: %v", status, results)
+		}
+	}
+
+	// Archival status directories should NOT be present in default completions
+	for _, status := range []string{"completed", "dungeon"} {
+		if resultSet[status] {
+			t.Errorf("unexpected archival status directory %q in default completions, got: %v", status, results)
 		}
 	}
 

--- a/internal/navigation/fuzzy.go
+++ b/internal/navigation/fuzzy.go
@@ -134,8 +134,8 @@ func CollectNavigationTargets(festivalsDir string) []FuzzyTarget {
 		}
 	}
 
-	// Status directories after (for "fest go active", "fest go planned", etc.)
-	statusDirs := []string{"active", "ready", "planned", "completed", "dungeon", "dungeon/completed", "dungeon/archived", "dungeon/someday"}
+	// Primary status directories only (completed/dungeon available via "fgo completed <TAB>")
+	statusDirs := []string{"active", "ready", "planned"}
 	for _, status := range statusDirs {
 		statusPath := filepath.Join(festivalsDir, status)
 		if info, err := os.Stat(statusPath); err == nil && info.IsDir() {


### PR DESCRIPTION
## Summary
- Remove `completed`, `dungeon`, and `dungeon/*` from default `fgo <TAB>` completion to reduce clutter
- Only primary status directories (`active`, `ready`, `planned`) appear in first-argument completion
- Archival statuses still accessible via `fgo completed <TAB>` (second-argument) and direct navigation

## Test plan
- [ ] `fest go completions` shows only active/ready/planned + festival names
- [ ] `fest go completions --status completed` still lists completed festivals
- [ ] `fgo completed` direct navigation still works
- [ ] `just test` passes