### PR TITLE
Fix fest show/progress --watch silently falling back to polling

### DIFF
--- a/internal/commands/progress/watch.go
+++ b/internal/commands/progress/watch.go
@@ -4,6 +4,7 @@ package progress
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -18,11 +19,15 @@ import (
 func runWatchMode(ctx context.Context, mgr *progress.Manager, loc *show.LocationInfo, opts *progressOptions) error {
 	festDir := loc.Festival.Path
 
-	// Determine which files to watch for progress changes
-	// Workflow state is now merged into progress_events.jsonl, so only one file to watch.
+	// Ensure .fest state directory exists so fsnotify has something to watch
+	stateDir := filepath.Join(festDir, ".fest")
+	os.MkdirAll(stateDir, 0755)
+
+	// Watch festival root (fest.yaml, phases), state directory, and progress events file
 	watchPaths := []string{
-		filepath.Join(festDir, ".fest", "progress_events.jsonl"),
-		filepath.Join(festDir, ".fest"), // Watch the directory for new files
+		festDir,  // Festival root
+		stateDir, // State directory
+		filepath.Join(stateDir, "progress_events.jsonl"),
 	}
 
 	// Initial render
@@ -51,7 +56,7 @@ func runWatchMode(ctx context.Context, mgr *progress.Manager, loc *show.Location
 	})
 
 	if err != nil {
-		// Fall back to polling mode
+		fmt.Fprintf(os.Stderr, "File watching unavailable (%v), using polling fallback\n", err)
 		return runPollingMode(ctx, mgr, loc, opts)
 	}
 	defer w.Close()

--- a/internal/commands/show/watch.go
+++ b/internal/commands/show/watch.go
@@ -4,6 +4,7 @@ package show
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -21,9 +22,14 @@ const pollingInterval = 2 * time.Second
 // runWatchMode watches for file changes and refreshes the festival display.
 // Falls back to polling if file watching is not available.
 func runWatchMode(ctx context.Context, festival *FestivalInfo, opts *showOptions) error {
-	// Determine which files/directories to watch
+	// Ensure .fest state directory exists so fsnotify has something to watch
+	stateDir := filepath.Join(festival.Path, ".fest")
+	os.MkdirAll(stateDir, 0755)
+
+	// Watch festival root (fest.yaml, phases) and state directory (progress events)
 	watchPaths := []string{
-		filepath.Join(festival.Path, ".fest"), // State directory
+		festival.Path, // Festival root
+		stateDir,      // State directory
 	}
 
 	// Initial render
@@ -52,7 +58,7 @@ func runWatchMode(ctx context.Context, festival *FestivalInfo, opts *showOptions
 	})
 
 	if err != nil {
-		// Fall back to polling mode
+		fmt.Fprintf(os.Stderr, "File watching unavailable (%v), using polling fallback\n", err)
 		return runPollingMode(ctx, festival, opts)
 	}
 	defer w.Close()


### PR DESCRIPTION
- Ensure .fest directory exists before setting up fsnotify watcher
- Watch festival root directory in addition to .fest for broader coverage
- Log fallback reason to stderr when polling mode is used