### PR TITLE
feat: soft-warning transitions for fest status set

### DIFF
--- a/internal/commands/status/handlers_festival.go
+++ b/internal/commands/status/handlers_festival.go
@@ -153,18 +153,22 @@ func handleFestivalStatusChange(ctx context.Context, display *ui.UI, festival *s
 		return emitAlreadyAtStatus(display, opts, newStatus)
 	}
 
-	// Validate transition against internal schema (--force skips)
+	// Validate transition and confirm unless forced
 	if !opts.force {
-		if err := validateTransition(ctx, festival.Status, newStatus); err != nil {
+		standard, validOpts, err := isStandardTransition(ctx, festival.Status, newStatus)
+		if err != nil {
 			return err
 		}
-	}
-
-	// Confirm unless forced
-	if !opts.force {
-		if !confirmFestivalMove(display, festival, newStatus) {
-			display.Info("Operation cancelled.")
-			return nil
+		if !standard {
+			if !confirmNonStandardTransition(display, festival, newStatus, validOpts) {
+				display.Info("Operation cancelled.")
+				return nil
+			}
+		} else {
+			if !confirmFestivalMove(display, festival, newStatus) {
+				display.Info("Operation cancelled.")
+				return nil
+			}
 		}
 	}
 
@@ -204,21 +208,34 @@ func resolveDungeonSubstatus(ctx context.Context) (string, error) {
 	return selected, nil
 }
 
-// validateTransition checks if a transition is valid against the internal festival schema.
-func validateTransition(ctx context.Context, fromStatus, toStatus string) error {
+// isStandardTransition checks if a transition is defined in the festival workflow schema.
+// Returns true if the transition is standard, along with the valid options for the current status.
+func isStandardTransition(ctx context.Context, fromStatus, toStatus string) (standard bool, validOpts []string, err error) {
 	if err := ctx.Err(); err != nil {
-		return errors.Wrap(err, "context cancelled")
+		return false, nil, errors.Wrap(err, "context cancelled")
 	}
 	schema := workflow.FestivalSchema()
-	if !schema.IsValidTransition(fromStatus, toStatus) {
-		validOpts := transitionOptsForStatus(schema, fromStatus)
-		return errors.Validation("transition not allowed by workflow schema").
-			WithField("from", fromStatus).
-			WithField("to", toStatus).
-			WithField("valid_options", strings.Join(validOpts, ", ")).
-			WithField("hint", "use --force to override")
+	if schema.IsValidTransition(fromStatus, toStatus) {
+		return true, nil, nil
 	}
-	return nil
+	return false, transitionOptsForStatus(schema, fromStatus), nil
+}
+
+// confirmNonStandardTransition warns about a non-standard transition and asks for confirmation.
+func confirmNonStandardTransition(display *ui.UI, festival *show.FestivalInfo, newStatus string, validOpts []string) bool {
+	display.Warning("Non-standard transition: %s to %s is not defined in the workflow schema.",
+		festival.Status, newStatus)
+	if len(validOpts) > 0 {
+		fmt.Printf("  Standard transitions from %s:\n", ui.GetStateStyle(festival.Status).Render(festival.Status))
+		for _, opt := range validOpts {
+			fmt.Printf("    -> %s\n", ui.GetStateStyle(opt).Render(opt))
+		}
+		fmt.Println()
+	}
+	prompt := fmt.Sprintf("Proceed with non-standard move of %s to %s?",
+		ui.Value(festival.Name, ui.FestivalColor),
+		ui.GetStateStyle(newStatus).Render(newStatus))
+	return display.Confirm("%s", prompt)
 }
 
 // transitionOptsForStatus returns the valid transition targets for a given status.

--- a/internal/commands/status/status.go
+++ b/internal/commands/status/status.go
@@ -126,9 +126,10 @@ Use flags to override auto-detection:
   --path     Target by explicit file path
 
 These flags are mutually exclusive - only one level can be targeted at a time.`,
-		Example: `  fest status set active               # Set current festival to active
+		Example: `  fest status set ready                # Set current festival to ready
+  fest status set active               # Set current festival to active
   fest status set active -i            # Force interactive selection
-  fest status set completed --force    # Set without confirmation
+  fest status set planning --force     # Override without prompts (e.g., backward transition)
   fest status set in_progress          # Set phase/sequence/task status
 
   # Level-specific status setting:
@@ -153,7 +154,7 @@ These flags are mutually exclusive - only one level can be targeted at a time.`,
 		},
 	}
 
-	cmd.Flags().BoolVar(&opts.force, "force", false, "skip confirmation prompts and transition validation")
+	cmd.Flags().BoolVar(&opts.force, "force", false, "skip all prompts including non-standard transition warnings")
 	cmd.Flags().BoolVar(&opts.json, "json", false, "output in JSON format")
 	cmd.Flags().BoolVarP(&opts.interactive, "interactive", "i", false, "force interactive festival selection")
 

--- a/internal/commands/status/status_test.go
+++ b/internal/commands/status/status_test.go
@@ -195,33 +195,40 @@ func TestFestivalsRootFromPath(t *testing.T) {
 	}
 }
 
-func TestValidateTransition(t *testing.T) {
+func TestIsStandardTransition(t *testing.T) {
 	// Uses internal FestivalSchema which has transition_opts defined
 	tests := []struct {
-		name    string
-		from    string
-		to      string
-		wantErr bool
+		name     string
+		from     string
+		to       string
+		standard bool
 	}{
-		{"active to dungeon allowed", "active", "dungeon", false},
-		{"active to dungeon/completed allowed", "active", "dungeon/completed", false},
-		{"active to ritual allowed", "active", "ritual", false},
-		{"planning to active allowed", "planning", "active", false},
-		{"planning to ready allowed", "planning", "ready", false},
-		{"planning to dungeon allowed", "planning", "dungeon", false},
-		{"ready to active allowed", "ready", "active", false},
-		{"ready to dungeon allowed", "ready", "dungeon", false},
-		{"ritual to active allowed", "ritual", "active", false},
-		{"active to planning disallowed", "active", "planning", true},
-		{"ritual to dungeon disallowed", "ritual", "dungeon", true},
+		{"active to dungeon allowed", "active", "dungeon", true},
+		{"active to dungeon/completed allowed", "active", "dungeon/completed", true},
+		{"active to ritual allowed", "active", "ritual", true},
+		{"planning to active allowed", "planning", "active", true},
+		{"planning to ready allowed", "planning", "ready", true},
+		{"planning to dungeon allowed", "planning", "dungeon", true},
+		{"ready to active allowed", "ready", "active", true},
+		{"ready to dungeon allowed", "ready", "dungeon", true},
+		{"ritual to active allowed", "ritual", "active", true},
+		{"active to planning non-standard", "active", "planning", false},
+		{"ritual to dungeon non-standard", "ritual", "dungeon", false},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateTransition(context.Background(), tc.from, tc.to)
-			if (err != nil) != tc.wantErr {
-				t.Errorf("validateTransition(%q, %q) error = %v, wantErr %v",
-					tc.from, tc.to, err, tc.wantErr)
+			standard, validOpts, err := isStandardTransition(context.Background(), tc.from, tc.to)
+			if err != nil {
+				t.Fatalf("isStandardTransition(%q, %q) unexpected error: %v", tc.from, tc.to, err)
+			}
+			if standard != tc.standard {
+				t.Errorf("isStandardTransition(%q, %q) standard = %v, want %v",
+					tc.from, tc.to, standard, tc.standard)
+			}
+			if !standard && len(validOpts) == 0 {
+				t.Errorf("isStandardTransition(%q, %q) returned non-standard but no valid options",
+					tc.from, tc.to)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Non-standard transitions (e.g., `active` → `planning`) now show a warning with valid alternatives and ask for confirmation, instead of hard-blocking with an error
- `--force` still skips all prompts including warnings
- Updated help text examples and `--force` flag description to reflect the new behavior

## Changes

- **`handlers_festival.go`**: Renamed `validateTransition` → `isStandardTransition` (returns `bool` + valid opts instead of error); added `confirmNonStandardTransition` for the warn+confirm UX; refactored `handleFestivalStatusChange` into a single decision flow
- **`status.go`**: Updated examples and `--force` description
- **`status_test.go`**: Renamed `TestValidateTransition` → `TestIsStandardTransition`; asserts `standard bool` + valid options instead of error

## Test plan

- [x] `go test ./internal/commands/status/ -v` — all tests pass
- [x] `go build ./...` — clean build
- [ ] Manual: `fest status set planning` from an active festival — should warn + confirm
- [ ] Manual: `fest status set active` from planning — should confirm normally (standard transition)
- [ ] Manual: `fest status set planning --force` — should skip all prompts