### PR TITLE
Add distinct colors for all festival statuses

### DIFF
--- a/internal/tui/explore/styles.go
+++ b/internal/tui/explore/styles.go
@@ -7,7 +7,11 @@ import "github.com/charmbracelet/lipgloss"
 var (
 	colorActive    = lipgloss.AdaptiveColor{Light: "#00AF00", Dark: "#00FF5F"}
 	colorPlanned   = lipgloss.AdaptiveColor{Light: "#AF8700", Dark: "#FFD700"}
+	colorReady     = lipgloss.AdaptiveColor{Light: "#AF8700", Dark: "#FFD700"}
+	colorRitual    = lipgloss.AdaptiveColor{Light: "#875FAF", Dark: "#AF87FF"}
 	colorCompleted = lipgloss.AdaptiveColor{Light: "#005FAF", Dark: "#00AFFF"}
+	colorArchived  = lipgloss.AdaptiveColor{Light: "#808080", Dark: "#949494"}
+	colorSomeday   = lipgloss.AdaptiveColor{Light: "#875F87", Dark: "#AF87AF"}
 	colorDungeon   = lipgloss.AdaptiveColor{Light: "#808080", Dark: "#949494"}
 	colorText      = lipgloss.AdaptiveColor{Light: "#000000", Dark: "#FFFFFF"}
 	colorDim       = lipgloss.AdaptiveColor{Light: "#808080", Dark: "#949494"}
@@ -23,8 +27,16 @@ func StatusStyle(status string) lipgloss.Style {
 		return lipgloss.NewStyle().Foreground(colorActive).Bold(true)
 	case "planning":
 		return lipgloss.NewStyle().Foreground(colorPlanned)
-	case "completed":
+	case "ready":
+		return lipgloss.NewStyle().Foreground(colorReady).Bold(true)
+	case "ritual":
+		return lipgloss.NewStyle().Foreground(colorRitual)
+	case "completed", "dungeon/completed":
 		return lipgloss.NewStyle().Foreground(colorCompleted)
+	case "archived", "dungeon/archived":
+		return lipgloss.NewStyle().Foreground(colorArchived).Faint(true)
+	case "someday", "dungeon/someday":
+		return lipgloss.NewStyle().Foreground(colorSomeday).Faint(true)
 	case "dungeon":
 		return lipgloss.NewStyle().Foreground(colorDungeon).Faint(true)
 	default:

--- a/internal/ui/palette.go
+++ b/internal/ui/palette.go
@@ -23,8 +23,10 @@ type Palette struct {
 	Active    lipgloss.TerminalColor
 	Ready     lipgloss.TerminalColor
 	Planning  lipgloss.TerminalColor
+	Ritual    lipgloss.TerminalColor
 	Completed lipgloss.TerminalColor
 	Archived  lipgloss.TerminalColor
+	Someday   lipgloss.TerminalColor
 	Dungeon   lipgloss.TerminalColor
 
 	// Entity colors
@@ -91,10 +93,12 @@ func defaultDarkPalette() Palette {
 	return Palette{
 		// Status colors - bright and visible
 		Active:    lipgloss.Color("42"),  // Bright green
-		Ready:     lipgloss.Color("33"),  // Blue (same as planning)
+		Ready:     lipgloss.Color("220"), // Yellow - distinct from planning blue
 		Planning:  lipgloss.Color("33"),  // Blue
+		Ritual:    lipgloss.Color("141"), // Purple-blue (lavender)
 		Completed: lipgloss.Color("205"), // Magenta/pink
 		Archived:  lipgloss.Color("250"), // Light grey (readable!)
+		Someday:   lipgloss.Color("139"), // Muted purple
 		Dungeon:   lipgloss.Color("248"), // Light grey (readable!)
 
 		// Entity colors
@@ -136,10 +140,12 @@ func lightPalette() Palette {
 	return Palette{
 		// Status colors - darker versions
 		Active:    lipgloss.Color("28"),  // Dark green
-		Ready:     lipgloss.Color("25"),  // Dark blue (same as planning)
+		Ready:     lipgloss.Color("172"), // Dark yellow - distinct from planning blue
 		Planning:  lipgloss.Color("25"),  // Dark blue
+		Ritual:    lipgloss.Color("97"),  // Dark purple
 		Completed: lipgloss.Color("128"), // Dark purple
 		Archived:  lipgloss.Color("241"), // Dark grey
+		Someday:   lipgloss.Color("96"),  // Dark muted purple
 		Dungeon:   lipgloss.Color("238"), // Darker grey
 
 		// Entity colors
@@ -171,10 +177,12 @@ func highContrastPalette() Palette {
 	return Palette{
 		// Status colors - maximum brightness
 		Active:    lipgloss.Color("46"),  // Bright green
-		Ready:     lipgloss.Color("39"),  // Bright blue (same as planning)
+		Ready:     lipgloss.Color("226"), // Bright yellow - distinct from planning blue
 		Planning:  lipgloss.Color("39"),  // Bright blue
+		Ritual:    lipgloss.Color("177"), // Bright purple
 		Completed: lipgloss.Color("201"), // Bright magenta
 		Archived:  lipgloss.Color("255"), // White
+		Someday:   lipgloss.Color("177"), // Bright purple
 		Dungeon:   lipgloss.Color("255"), // White
 
 		// Entity colors - bright versions

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -27,6 +27,12 @@ func GetCompletedColor() lipgloss.TerminalColor { return Current().Completed }
 // GetArchivedColor returns the color for archived/paused items.
 func GetArchivedColor() lipgloss.TerminalColor { return Current().Archived }
 
+// GetRitualColor returns the color for ritual/review items.
+func GetRitualColor() lipgloss.TerminalColor { return Current().Ritual }
+
+// GetSomedayColor returns the color for someday/deferred items.
+func GetSomedayColor() lipgloss.TerminalColor { return Current().Someday }
+
 // GetDungeonColor returns the color for dungeon (deep archive) items.
 func GetDungeonColor() lipgloss.TerminalColor { return Current().Dungeon }
 
@@ -36,11 +42,13 @@ func GetDungeonColor() lipgloss.TerminalColor { return Current().Dungeon }
 // New code should use the Get*Color() functions instead.
 var (
 	ActiveColor    = lipgloss.Color("42")  // Green - currently executing
-	ReadyColor     = lipgloss.Color("33")  // Blue - ready for execution (shares planning color)
+	ReadyColor     = lipgloss.Color("220") // Yellow - ready for execution (distinct from planning)
 	PlanningColor  = lipgloss.Color("33")  // Blue - future work
+	RitualColor    = lipgloss.Color("141") // Purple-blue - review/wrap-up
 	CompletedColor = lipgloss.Color("205") // Purple/Magenta - finished successfully
-	ArchivedColor  = lipgloss.Color("250") // Light grey - deprioritized/paused (updated from 245)
-	DungeonColor   = lipgloss.Color("248") // Light grey - deep archived (updated from 240)
+	ArchivedColor  = lipgloss.Color("250") // Light grey - deprioritized/paused
+	SomedayColor   = lipgloss.Color("139") // Muted purple - deferred
+	DungeonColor   = lipgloss.Color("248") // Light grey - deep archived
 )
 
 // Entity type colors for visual hierarchy in fest CLI output.
@@ -81,10 +89,14 @@ func GetStatusStyle(status string) lipgloss.Style {
 		return lipgloss.NewStyle().Foreground(p.Ready).Bold(true)
 	case "planning":
 		return lipgloss.NewStyle().Foreground(p.Planning).Bold(true)
-	case "completed":
+	case "ritual":
+		return lipgloss.NewStyle().Foreground(p.Ritual).Bold(true)
+	case "completed", "dungeon/completed":
 		return lipgloss.NewStyle().Foreground(p.Completed).Bold(true)
-	case "archived":
+	case "archived", "dungeon/archived":
 		return lipgloss.NewStyle().Foreground(p.Archived).Bold(true)
+	case "someday", "dungeon/someday":
+		return lipgloss.NewStyle().Foreground(p.Someday).Bold(true)
 	case "dungeon":
 		return lipgloss.NewStyle().Foreground(p.Dungeon).Bold(true)
 	default:
@@ -103,10 +115,14 @@ func GetStatusColor(status string) lipgloss.TerminalColor {
 		return p.Ready
 	case "planning":
 		return p.Planning
-	case "completed":
+	case "ritual":
+		return p.Ritual
+	case "completed", "dungeon/completed":
 		return p.Completed
-	case "archived":
+	case "archived", "dungeon/archived":
 		return p.Archived
+	case "someday", "dungeon/someday":
+		return p.Someday
 	case "dungeon":
 		return p.Dungeon
 	default:
@@ -147,8 +163,10 @@ var (
 	ActiveStyle    = lipgloss.NewStyle().Foreground(ActiveColor).Bold(true)
 	ReadyStyle     = lipgloss.NewStyle().Foreground(ReadyColor).Bold(true)
 	PlanningStyle  = lipgloss.NewStyle().Foreground(PlanningColor).Bold(true)
+	RitualStyle    = lipgloss.NewStyle().Foreground(RitualColor).Bold(true)
 	CompletedStyle = lipgloss.NewStyle().Foreground(CompletedColor).Bold(true)
 	ArchivedStyle  = lipgloss.NewStyle().Foreground(ArchivedColor).Bold(true)
+	SomedayStyle   = lipgloss.NewStyle().Foreground(SomedayColor).Bold(true)
 	DungeonStyle   = lipgloss.NewStyle().Foreground(DungeonColor).Bold(true)
 )
 


### PR DESCRIPTION
## Summary
- **Ready** status now uses yellow (220/172/226) instead of sharing blue with planning
- **Ritual** status gets new purple-blue color (141/97/177) across all themes
- **Someday** status gets new muted purple color (139/96/177) across all themes
- Added compound status handling (`dungeon/completed`, `dungeon/archived`, `dungeon/someday`) in both `GetStatusStyle` and `GetStatusColor`
- TUI explore panel now handles all statuses: `ready`, `ritual`, `archived`, `someday`, and compound dungeon variants

## Files changed
- `internal/ui/palette.go` — Added `Ritual` and `Someday` fields, changed `Ready` from blue to yellow
- `internal/ui/styles.go` — Added missing switch cases, legacy vars, getters, and styles
- `internal/tui/explore/styles.go` — Added adaptive colors and status cases for all missing statuses

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/ui/` passes
- [x] `go test ./internal/tui/explore/` passes
- [ ] Manual verification with `fest status list` for colored output