### PR TITLE
fix: resolve short-form dungeon statuses in fest list

### DIFF
--- a/internal/commands/list/list.go
+++ b/internal/commands/list/list.go
@@ -63,6 +63,9 @@ Use --all to include completed and dungeon festivals.`,
 			if len(args) > 0 {
 				status = strings.ToLower(args[0])
 			}
+			if status != "" {
+				status = id.ResolveStatusPath(status)
+			}
 			if status != "" && !isValidStatus(status) {
 				return errors.Validation("invalid status").
 					WithField("status", status).


### PR DESCRIPTION
## Summary
- `fest list completed`, `fest list archived`, and `fest list someday` were failing validation because the status was checked before being resolved to its full `dungeon/` path
- Added a call to `id.ResolveStatusPath()` before validation in the list command's `RunE` function
- Single 3-line change in `internal/commands/list/list.go`

## Test plan
- [x] `fest list completed` lists dungeon/completed festivals
- [x] `fest list archived` lists dungeon/archived festivals
- [x] `fest list someday` lists dungeon/someday festivals
- [x] `fest list active` still works (pass-through)
- [x] `fest list dungeon` still lists all dungeon children
- [x] All unit tests pass