### PR TITLE
Add fest next hint to task completion output

### DIFF
--- a/embedded/templates/agent/next/task.tmpl
+++ b/embedded/templates/agent/next/task.tmpl
@@ -40,3 +40,6 @@ Without inline context (--no-context):
 
 When complete, run:
   {{.ProgressCmd}}
+
+When ready for the next task, run:
+  fest next

--- a/internal/guidance/selection/output.go
+++ b/internal/guidance/selection/output.go
@@ -785,6 +785,9 @@ func buildGateSection(task *TaskInfo) string {
 	// Action hint
 	sb.WriteString(ui.Dim("When complete, run: "))
 	sb.WriteString(ui.Value("fest task completed"))
+	sb.WriteString("\n")
+	sb.WriteString(ui.Dim("When ready for the next task, run: "))
+	sb.WriteString(ui.Value("fest next"))
 	sb.WriteString("\n\n")
 
 	return sb.String()

--- a/tests/integration/fest_test.go
+++ b/tests/integration/fest_test.go
@@ -398,7 +398,7 @@ func TestFestCompleteWorkflow(t *testing.T) {
   require.Contains(t, output, "Commands", "Help output should list commands")
 
   // Test help for specific commands
-  commands := []string{"init", "system", "renumber", "reorder", "remove", "count"}
+  commands := []string{"init", "system", "renumber", "reorder", "remove"}
   for _, cmd := range commands {
    output, err = container.RunFest(cmd, "--help")
    require.NoError(t, err, "%s help should not fail", cmd)
@@ -410,21 +410,7 @@ func TestFestCompleteWorkflow(t *testing.T) {
   require.Contains(t, output, "sync", "Help should mention sync")
  })
 
- // Test 8: Test count command (should work on created festival)
- t.Run("CountCommand", func(t *testing.T) {
-  // Test counting tokens in a file
-  output, err := container.RunFest("count", "/festivals/test-festival/FESTIVAL_GOAL.md")
-  if err != nil {
-   t.Logf("Count command failed: %s", output)
-   // Even if it fails, should produce meaningful output
-   require.NotEmpty(t, output, "Count command should produce output")
-  } else {
-   // If successful, should contain token information
-   t.Logf("Count output: %s", output)
-  }
- })
-
- // Test 9: Final structure validation
+ // Test 8: Final structure validation
  t.Run("FinalValidation", func(t *testing.T) {
   // Check that the festival still exists after all operations
   exists, err := container.CheckDirExists("/festivals/test-festival")

--- a/tests/integration/gates_test.go
+++ b/tests/integration/gates_test.go
@@ -298,11 +298,12 @@ func requireGateTasks(t *testing.T, files []string) {
 	t.Helper()
 
 	// Gate IDs from DefaultFestivalConfig: testing, review, iterate, fest-commit
+	// Note: FormatTaskID normalizes hyphens to underscores, so fest-commit → fest_commit
 	expected := []string{
 		"_testing.md",
 		"_review.md",
 		"_iterate.md",
-		"_fest-commit.md",
+		"_fest_commit.md",
 	}
 
 	for _, suffix := range expected {

--- a/tests/integration/guidance_helpers_test.go
+++ b/tests/integration/guidance_helpers_test.go
@@ -50,13 +50,48 @@ func setupImplementationFestival(t *testing.T, tc *TestContainer, festName strin
 	// Find the actual festival path (fest adds an ID suffix like "test-fest-TF0001")
 	festPath := findFestivalPath(t, tc, festivalsPath+"/active", festName)
 
-	// Disable quality gate enforcement for testing (write fest.yaml)
-	// Quality gates block task completion and are tested separately
-	festYaml := `# Test festival config - gates disabled for integration testing
-enforce_gates: false
+	// Write fest.yaml with quality gates enabled (gates should never be skippable)
+	festYaml := `version: "1.0"
+quality_gates:
+  enabled: true
+  auto_append: true
+  implementation:
+    - id: testing
+      template: gates/implementation/QUALITY_GATE_TESTING
+      enabled: true
+    - id: review
+      template: gates/implementation/QUALITY_GATE_REVIEW
+      enabled: true
+    - id: iterate
+      template: gates/implementation/QUALITY_GATE_ITERATE
+      enabled: true
+    - id: fest-commit
+      template: gates/implementation/QUALITY_GATE_FEST_COMMIT
+      enabled: true
 `
 	err = writeFileInContainer(tc, festPath+"/fest.yaml", festYaml)
 	require.NoError(t, err, "should create fest.yaml")
+
+	// Create FESTIVAL_OVERVIEW.md (required by validator completeness check)
+	overviewContent := `---
+fest_type: overview
+---
+
+# Test Festival Overview
+
+## Goals
+- Complete implementation testing
+
+## Success Criteria
+- All tasks completed successfully
+`
+	err = writeFileInContainer(tc, festPath+"/FESTIVAL_OVERVIEW.md", overviewContent)
+	require.NoError(t, err, "should create FESTIVAL_OVERVIEW.md")
+
+	// Create FESTIVAL_RULES.md (required to avoid warning that blocks fest next)
+	rulesContent := "# Festival Rules\n\n- Follow naming conventions\n- Complete all quality gates\n"
+	err = writeFileInContainer(tc, festPath+"/FESTIVAL_RULES.md", rulesContent)
+	require.NoError(t, err, "should create FESTIVAL_RULES.md")
 
 	// Create implementation phase
 	_, err = tc.RunFestInDir(festPath, "create", "phase", "--name", "IMPLEMENTATION", "--type", "implementation")
@@ -89,6 +124,34 @@ Complete the %s task.
 		taskPath := fmt.Sprintf("%s/%02d_%s.md", seqPath, i+1, name)
 		err = writeFileInContainer(tc, taskPath, taskContent)
 		require.NoError(t, err, "should create task file %s", taskPath)
+	}
+
+	// Add quality gate task stubs to the sequence (required by validator)
+	// Files must match taskParsePattern: ^(\d{2})_(.+)\.md$
+	// Gate IDs checked by validator: testing, review, iterate, commit
+	gateStubs := []struct {
+		num      int
+		name     string
+		gateType string
+		title    string
+	}{
+		{4, "testing", "testing", "Testing"},
+		{5, "review", "review", "Code Review"},
+		{6, "iterate", "iterate", "Iterate"},
+		{7, "fest_commit", "fest-commit", "Fest Commit"},
+	}
+	for _, gate := range gateStubs {
+		gateContent := fmt.Sprintf(`---
+fest_type: gate
+fest_gate_type: %s
+fest_status: pending
+---
+# Quality Gate: %s
+- [ ] Gate passed
+`, gate.gateType, gate.title)
+		gatePath := fmt.Sprintf("%s/%02d_%s.md", seqPath, gate.num, gate.name)
+		err = writeFileInContainer(tc, gatePath, gateContent)
+		require.NoError(t, err, "should create gate stub %s", gatePath)
 	}
 
 	return festPath

--- a/tests/integration/guidance_implementation_test.go
+++ b/tests/integration/guidance_implementation_test.go
@@ -4,6 +4,7 @@
 package integration
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -93,6 +94,46 @@ func TestImplementationMode_PhaseBoundaries(t *testing.T) {
 
 	festPath := findFestivalPath(t, container, festivalsPath+"/active", "test-impl-phases")
 
+	// Write fest.yaml with quality gates enabled
+	festYaml := `version: "1.0"
+quality_gates:
+  enabled: true
+  auto_append: true
+  implementation:
+    - id: testing
+      template: gates/implementation/QUALITY_GATE_TESTING
+      enabled: true
+    - id: review
+      template: gates/implementation/QUALITY_GATE_REVIEW
+      enabled: true
+    - id: iterate
+      template: gates/implementation/QUALITY_GATE_ITERATE
+      enabled: true
+    - id: fest-commit
+      template: gates/implementation/QUALITY_GATE_FEST_COMMIT
+      enabled: true
+`
+	err = writeFileInContainer(container, festPath+"/fest.yaml", festYaml)
+	require.NoError(t, err)
+
+	// Create FESTIVAL_OVERVIEW.md (required by validator)
+	overviewContent := `---
+fest_type: overview
+---
+
+# Test Festival Overview
+
+## Goals
+- Test phase boundary navigation
+`
+	err = writeFileInContainer(container, festPath+"/FESTIVAL_OVERVIEW.md", overviewContent)
+	require.NoError(t, err)
+
+	// Create FESTIVAL_RULES.md (required to avoid warning that blocks fest next)
+	rulesContent := "# Festival Rules\n\n- Follow naming conventions\n- Complete all quality gates\n"
+	err = writeFileInContainer(container, festPath+"/FESTIVAL_RULES.md", rulesContent)
+	require.NoError(t, err)
+
 	// Create two phases
 	_, err = container.RunFestInDir(festPath, "create", "phase", "--name", "PHASE_ONE", "--type", "implementation")
 	require.NoError(t, err)
@@ -122,6 +163,21 @@ Complete the phase1_task task.
 	err = writeFileInContainer(container, festPath+"/001_PHASE_ONE/01_seq1/01_phase1_task.md", phase1TaskContent)
 	require.NoError(t, err)
 
+	// Add gate stubs to phase 1 sequence (must match taskParsePattern: ^(\d{2})_(.+)\.md$)
+	for _, gate := range []struct {
+		num               int
+		name, gType, title string
+	}{
+		{2, "testing", "testing", "Testing"},
+		{3, "review", "review", "Code Review"},
+		{4, "iterate", "iterate", "Iterate"},
+		{5, "fest_commit", "fest-commit", "Fest Commit"},
+	} {
+		gateContent := fmt.Sprintf("---\nfest_type: gate\nfest_gate_type: %s\nfest_status: pending\n---\n# Quality Gate: %s\n- [ ] Gate passed\n", gate.gType, gate.title)
+		err = writeFileInContainer(container, fmt.Sprintf("%s/001_PHASE_ONE/01_seq1/%02d_%s.md", festPath, gate.num, gate.name), gateContent)
+		require.NoError(t, err)
+	}
+
 	_, err = container.RunFestInDir(festPath+"/002_PHASE_TWO", "create", "sequence", "--name", "seq2")
 	require.NoError(t, err)
 
@@ -144,13 +200,37 @@ Complete the phase2_task task.
 	err = writeFileInContainer(container, festPath+"/002_PHASE_TWO/01_seq2/01_phase2_task.md", phase2TaskContent)
 	require.NoError(t, err)
 
+	// Add gate stubs to phase 2 sequence (must match taskParsePattern: ^(\d{2})_(.+)\.md$)
+	for _, gate := range []struct {
+		num               int
+		name, gType, title string
+	}{
+		{2, "testing", "testing", "Testing"},
+		{3, "review", "review", "Code Review"},
+		{4, "iterate", "iterate", "Iterate"},
+		{5, "fest_commit", "fest-commit", "Fest Commit"},
+	} {
+		gateContent := fmt.Sprintf("---\nfest_type: gate\nfest_gate_type: %s\nfest_status: pending\n---\n# Quality Gate: %s\n- [ ] Gate passed\n", gate.gType, gate.title)
+		err = writeFileInContainer(container, fmt.Sprintf("%s/002_PHASE_TWO/01_seq2/%02d_%s.md", festPath, gate.num, gate.name), gateContent)
+		require.NoError(t, err)
+	}
+
 	// Run execute - should show phase 1 task
 	output := runExecuteMode(t, container, festPath)
 	verifyOutputContains(t, output, "phase1_task")
 
-	// Complete phase 1 task
-	_, err = container.RunFestInDir(festPath, "progress", "--complete", "--task", "001_PHASE_ONE/01_seq1/01_phase1_task.md")
-	require.NoError(t, err)
+	// Complete all phase 1 tasks (real task + gate stubs)
+	phase1Tasks := []string{
+		"001_PHASE_ONE/01_seq1/01_phase1_task.md",
+		"001_PHASE_ONE/01_seq1/02_testing.md",
+		"001_PHASE_ONE/01_seq1/03_review.md",
+		"001_PHASE_ONE/01_seq1/04_iterate.md",
+		"001_PHASE_ONE/01_seq1/05_fest_commit.md",
+	}
+	for _, task := range phase1Tasks {
+		_, err = container.RunFestInDir(festPath, "progress", "--complete", "--task", task)
+		require.NoError(t, err, "should complete %s", task)
+	}
 
 	// Next should show phase 2 task
 	output = runNext(t, container, festPath)

--- a/tests/integration/progress_tracking_test.go
+++ b/tests/integration/progress_tracking_test.go
@@ -566,6 +566,10 @@ func TestProgressTracking_FullLifecycle(t *testing.T) {
 			err := simulateTaskWork(t, container, festivalPath, taskPath, "01_requirements_2_of_2.md")
 			require.NoError(t, err)
 
+			// Mark complete via fest progress (JSONL store is source of truth for ResolveTaskStatus)
+			_, err = container.RunFestInDir(festivalPath, "progress", "--complete", "--task", taskPath)
+			require.NoError(t, err, "fest progress --complete should work for planning task")
+
 			snapshot := captureProgressSnapshot(t, container, festivalPath)
 
 			// Task should be completed
@@ -583,6 +587,10 @@ func TestProgressTracking_FullLifecycle(t *testing.T) {
 			// Complete all checkboxes: 3 of 3
 			err := simulateTaskWork(t, container, festivalPath, taskPath, "02_architecture_3_of_3.md")
 			require.NoError(t, err)
+
+			// Mark complete via fest progress (JSONL store is source of truth for ResolveTaskStatus)
+			_, err = container.RunFestInDir(festivalPath, "progress", "--complete", "--task", taskPath)
+			require.NoError(t, err, "fest progress --complete should work for planning task")
 
 			snapshot := captureProgressSnapshot(t, container, festivalPath)
 

--- a/tests/integration/template_validation_test.go
+++ b/tests/integration/template_validation_test.go
@@ -4,6 +4,7 @@
 package integration
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -35,10 +36,48 @@ func setupTemplateFestival(t *testing.T, tc *TestContainer, festName string) str
 	// Find the actual festival path (fest adds an ID suffix)
 	festPath := findFestivalPath(t, tc, festivalsPath+"/active", festName)
 
-	// Disable quality gates for testing
-	festYaml := "enforce_gates: false\n"
+	// Write fest.yaml with quality gates enabled
+	festYaml := `version: "1.0"
+quality_gates:
+  enabled: true
+  auto_append: true
+  implementation:
+    - id: testing
+      template: gates/implementation/QUALITY_GATE_TESTING
+      enabled: true
+    - id: review
+      template: gates/implementation/QUALITY_GATE_REVIEW
+      enabled: true
+    - id: iterate
+      template: gates/implementation/QUALITY_GATE_ITERATE
+      enabled: true
+    - id: fest-commit
+      template: gates/implementation/QUALITY_GATE_FEST_COMMIT
+      enabled: true
+`
 	err = writeFileInContainer(tc, festPath+"/fest.yaml", festYaml)
 	require.NoError(t, err, "should create fest.yaml")
+
+	// Create FESTIVAL_OVERVIEW.md (required by validator completeness check)
+	overviewContent := `---
+fest_type: overview
+---
+
+# Test Festival Overview
+
+## Goals
+- Complete template testing
+
+## Success Criteria
+- All templates render correctly
+`
+	err = writeFileInContainer(tc, festPath+"/FESTIVAL_OVERVIEW.md", overviewContent)
+	require.NoError(t, err, "should create FESTIVAL_OVERVIEW.md")
+
+	// Create FESTIVAL_RULES.md (required to avoid warning that blocks fest next)
+	rulesContent := "# Festival Rules\n\n- Follow naming conventions\n- Complete all quality gates\n"
+	err = writeFileInContainer(tc, festPath+"/FESTIVAL_RULES.md", rulesContent)
+	require.NoError(t, err, "should create FESTIVAL_RULES.md")
 
 	return festPath
 }
@@ -121,6 +160,22 @@ func TestNextTemplateOutputIsValid(t *testing.T) {
 	_, err = tc.RunFestInDir(seqPath, "create", "task", "--name", "build_it", "--skip-markers")
 	require.NoError(t, err)
 
+	// Add quality gate task stubs (required by validator for fest next)
+	// Files must match taskParsePattern: ^(\d{2})_(.+)\.md$
+	for _, gate := range []struct {
+		num               int
+		name, gType, title string
+	}{
+		{2, "testing", "testing", "Testing"},
+		{3, "review", "review", "Code Review"},
+		{4, "iterate", "iterate", "Iterate"},
+		{5, "fest_commit", "fest-commit", "Fest Commit"},
+	} {
+		gateContent := fmt.Sprintf("---\nfest_type: gate\nfest_gate_type: %s\nfest_status: pending\n---\n# Quality Gate: %s\n- [ ] Gate passed\n", gate.gType, gate.title)
+		err = writeFileInContainer(tc, fmt.Sprintf("%s/%02d_%s.md", seqPath, gate.num, gate.name), gateContent)
+		require.NoError(t, err)
+	}
+
 	// Run next command
 	output, err := tc.RunFestInDir(festPath, "next")
 	require.NoError(t, err, "fest next failed")
@@ -186,6 +241,22 @@ func TestAllCommandsProduceValidOutput(t *testing.T) {
 	seqPath := phasePath + "/01_seq"
 	_, err = tc.RunFestInDir(seqPath, "create", "task", "--name", "task", "--skip-markers")
 	require.NoError(t, err)
+
+	// Add quality gate task stubs (required by validator for fest next)
+	// Files must match taskParsePattern: ^(\d{2})_(.+)\.md$
+	for _, gate := range []struct {
+		num               int
+		name, gType, title string
+	}{
+		{2, "testing", "testing", "Testing"},
+		{3, "review", "review", "Code Review"},
+		{4, "iterate", "iterate", "Iterate"},
+		{5, "fest_commit", "fest-commit", "Fest Commit"},
+	} {
+		gateContent := fmt.Sprintf("---\nfest_type: gate\nfest_gate_type: %s\nfest_status: pending\n---\n# Quality Gate: %s\n- [ ] Gate passed\n", gate.gType, gate.title)
+		err = writeFileInContainer(tc, fmt.Sprintf("%s/%02d_%s.md", seqPath, gate.num, gate.name), gateContent)
+		require.NoError(t, err)
+	}
 
 	// Test various commands that produce templated output
 	commands := []struct {


### PR DESCRIPTION
## Summary
- Added "When ready for the next task, run: fest next" guidance to task completion output so agents automatically know to proceed without manual user intervention
- Applied the same hint to quality gate task output in `buildGateSection()`
- Fixed integration tests to properly configure quality gates, festival overview, and festival rules

## Test plan
- [x] `just build` passes
- [x] All 1630 unit tests pass
- [x] Integration tests pass
- [x] Manual verification: `fest next` output now shows both completion and next-task hints