### PR TITLE
fix: sync frontmatter status and unify progress calculation

### DIFF
--- a/internal/commands/next/next.go
+++ b/internal/commands/next/next.go
@@ -179,6 +179,20 @@ func runNext(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "finding next task")
 	}
 
+	// Override graph-based progress with authoritative progress from the Manager,
+	// which includes workflow phase steps (INGEST, PLAN) for consistency with fest show/progress.
+	mgr, mgrErr := progress.NewManager(ctx, festivalPath)
+	if mgrErr == nil {
+		festProgress, fpErr := mgr.GetFestivalProgress(ctx, festivalPath)
+		if fpErr == nil && festProgress.Overall != nil {
+			result.Progress = &selection.ProgressInfo{
+				TotalTasks:     festProgress.Overall.Total,
+				CompletedTasks: festProgress.Overall.Completed,
+				Percentage:     float64(festProgress.Overall.Percentage),
+			}
+		}
+	}
+
 	// If selector says festival is complete, check for remaining incomplete workflow phases
 	if result.FestivalComplete {
 		incompleteWorkflow, wErr := findFirstIncompleteWorkflowPhase(ctx, festivalPath)

--- a/internal/guidance/selection/selector.go
+++ b/internal/guidance/selection/selector.go
@@ -163,44 +163,14 @@ func (s *Selector) FindNext(ctx context.Context, currentPath string) (*NextTaskR
 	// Find parallel tasks
 	parallelTasks := s.findParallelTasks(prioritized, primary)
 
-	// Calculate progress
-	progress := s.calculateProgress(graph)
-
 	result := &NextTaskResult{
 		Task:          taskInfo,
 		ParallelTasks: parallelTasks,
 		Reason:        s.generateReason(primary, location),
 		Location:      location,
-		Progress:      progress,
 	}
 
 	return result, nil
-}
-
-// calculateProgress computes progress statistics from the graph
-func (s *Selector) calculateProgress(graph *deps.Graph) *ProgressInfo {
-	if graph == nil || len(graph.Tasks) == 0 {
-		return nil
-	}
-
-	total := len(graph.Tasks)
-	completed := 0
-	for _, task := range graph.Tasks {
-		if task.Status == "complete" {
-			completed++
-		}
-	}
-
-	percentage := 0.0
-	if total > 0 {
-		percentage = float64(completed) / float64(total) * 100
-	}
-
-	return &ProgressInfo{
-		TotalTasks:     total,
-		CompletedTasks: completed,
-		Percentage:     percentage,
-	}
 }
 
 // FindNextInSequence finds the next task within the current sequence

--- a/internal/progress/manager.go
+++ b/internal/progress/manager.go
@@ -2,9 +2,13 @@ package progress
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/frontmatter"
 )
 
 // Manager handles progress operations for a festival
@@ -93,7 +97,11 @@ func (m *Manager) UpdateProgress(ctx context.Context, taskID string, progress in
 	}
 
 	m.store.SetTask(task)
-	return m.store.Save(ctx)
+	if err := m.store.Save(ctx); err != nil {
+		return err
+	}
+	m.SyncFrontmatterStatus(taskID, task.Status)
+	return nil
 }
 
 // MarkComplete marks a task as complete
@@ -135,7 +143,11 @@ func (m *Manager) MarkComplete(ctx context.Context, taskID string) error {
 	})
 
 	m.store.SetTask(task)
-	return m.store.Save(ctx)
+	if err := m.store.Save(ctx); err != nil {
+		return err
+	}
+	m.SyncFrontmatterStatus(taskID, task.Status)
+	return nil
 }
 
 // MarkInProgress marks a task as in progress
@@ -169,7 +181,11 @@ func (m *Manager) MarkInProgress(ctx context.Context, taskID string) error {
 	})
 
 	m.store.SetTask(task)
-	return m.store.Save(ctx)
+	if err := m.store.Save(ctx); err != nil {
+		return err
+	}
+	m.SyncFrontmatterStatus(taskID, task.Status)
+	return nil
 }
 
 // ReportBlocker reports a blocker for a task
@@ -209,7 +225,11 @@ func (m *Manager) ReportBlocker(ctx context.Context, taskID, message string) err
 	})
 
 	m.store.SetTask(task)
-	return m.store.Save(ctx)
+	if err := m.store.Save(ctx); err != nil {
+		return err
+	}
+	m.SyncFrontmatterStatus(taskID, task.Status)
+	return nil
 }
 
 // ResetTask resets a task back to pending status, clearing all progress data.
@@ -243,7 +263,11 @@ func (m *Manager) ResetTask(ctx context.Context, taskID string) error {
 	})
 
 	m.store.SetTask(task)
-	return m.store.Save(ctx)
+	if err := m.store.Save(ctx); err != nil {
+		return err
+	}
+	m.SyncFrontmatterStatus(taskID, task.Status)
+	return nil
 }
 
 // ClearBlocker clears a blocker for a task
@@ -278,7 +302,11 @@ func (m *Manager) ClearBlocker(ctx context.Context, taskID string) error {
 	})
 
 	m.store.SetTask(task)
-	return m.store.Save(ctx)
+	if err := m.store.Save(ctx); err != nil {
+		return err
+	}
+	m.SyncFrontmatterStatus(taskID, task.Status)
+	return nil
 }
 
 // GetTaskProgress retrieves progress for a specific task
@@ -294,4 +322,39 @@ func (m *Manager) AllTaskProgress() map[string]*TaskProgress {
 // Store returns the underlying store for advanced operations
 func (m *Manager) Store() *Store {
 	return m.store
+}
+
+// SyncFrontmatterStatus updates the fest_status field in a task file's
+// YAML frontmatter to match the progress store's status. This keeps the
+// file's frontmatter in sync with the JSONL event log.
+func (m *Manager) SyncFrontmatterStatus(taskID, status string) {
+	taskPath := filepath.Join(m.store.FestivalPath(), taskID)
+	if !strings.HasSuffix(taskPath, ".md") {
+		taskPath += ".md"
+	}
+
+	content, err := os.ReadFile(taskPath)
+	if err != nil {
+		return // File doesn't exist or can't be read — no-op
+	}
+
+	fm, remaining, err := frontmatter.Parse(content)
+	if err != nil || fm == nil {
+		return // No frontmatter or parse error — no-op
+	}
+
+	fmStatus := frontmatter.Status(status)
+	if fm.Status == fmStatus {
+		return // Already in sync
+	}
+
+	fm.Status = fmStatus
+	fm.Updated = time.Now()
+
+	newContent, err := frontmatter.Inject(remaining, fm)
+	if err != nil {
+		return
+	}
+
+	_ = os.WriteFile(taskPath, newContent, 0o644)
 }

--- a/internal/progress/manager_test.go
+++ b/internal/progress/manager_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/Obedience-Corp/fest/internal/frontmatter"
 )
 
 func TestManager_UpdateProgress(t *testing.T) {
@@ -420,5 +422,249 @@ func TestManager_ProgressUpdatePersistence(t *testing.T) {
 	}
 	if task.Status != StatusInProgress {
 		t.Errorf("Status = %q, want %q", task.Status, StatusInProgress)
+	}
+}
+
+func TestSyncFrontmatterStatus(t *testing.T) {
+	tests := []struct {
+		name           string
+		taskID         string
+		status         string
+		initialContent string
+		wantStatus     frontmatter.Status
+		wantNoChange   bool // true if file should not be changed
+		noFile         bool // true if no file should be created
+	}{
+		{
+			name:   "updates pending to completed",
+			taskID: "003_EXECUTE/01_sequence/01_task.md",
+			status: StatusCompleted,
+			initialContent: `---
+fest_type: task
+fest_id: 01_task
+fest_status: pending
+fest_created: 2026-02-20T00:00:00Z
+---
+
+# Task Content
+`,
+			wantStatus: frontmatter.StatusCompleted,
+		},
+		{
+			name:   "updates pending to in_progress",
+			taskID: "003_EXECUTE/01_sequence/02_task.md",
+			status: StatusInProgress,
+			initialContent: `---
+fest_type: task
+fest_id: 02_task
+fest_status: pending
+fest_created: 2026-02-20T00:00:00Z
+---
+
+# Task Content
+`,
+			wantStatus: frontmatter.StatusInProgress,
+		},
+		{
+			name:   "updates to blocked",
+			taskID: "003_EXECUTE/01_sequence/03_task.md",
+			status: StatusBlocked,
+			initialContent: `---
+fest_type: task
+fest_id: 03_task
+fest_status: in_progress
+fest_created: 2026-02-20T00:00:00Z
+---
+
+# Task Content
+`,
+			wantStatus: frontmatter.StatusBlocked,
+		},
+		{
+			name:   "resets to pending",
+			taskID: "003_EXECUTE/01_sequence/04_task.md",
+			status: StatusPending,
+			initialContent: `---
+fest_type: task
+fest_id: 04_task
+fest_status: completed
+fest_created: 2026-02-20T00:00:00Z
+---
+
+# Task Content
+`,
+			wantStatus: frontmatter.StatusPending,
+		},
+		{
+			name:       "no-ops when file does not exist",
+			taskID:     "003_EXECUTE/01_sequence/nonexistent.md",
+			status:     StatusCompleted,
+			noFile:     true,
+			wantNoChange: true,
+		},
+		{
+			name:           "no-ops when already in sync",
+			taskID:         "003_EXECUTE/01_sequence/05_task.md",
+			status:         StatusCompleted,
+			initialContent: `---
+fest_type: task
+fest_id: 05_task
+fest_status: completed
+fest_created: 2026-02-20T00:00:00Z
+---
+
+# Already completed
+`,
+			wantNoChange: true,
+		},
+		{
+			name:           "no-ops when no frontmatter",
+			taskID:         "003_EXECUTE/01_sequence/06_task.md",
+			status:         StatusCompleted,
+			initialContent: "# Just a plain markdown file\n",
+			wantNoChange:   true,
+		},
+		{
+			name:   "appends .md when missing from taskID",
+			taskID: "003_EXECUTE/01_sequence/07_task",
+			status: StatusCompleted,
+			initialContent: `---
+fest_type: task
+fest_id: 07_task
+fest_status: pending
+fest_created: 2026-02-20T00:00:00Z
+---
+
+# Task Content
+`,
+			wantStatus: frontmatter.StatusCompleted,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			tmpDir := t.TempDir()
+
+			mgr, err := NewManager(ctx, tmpDir)
+			if err != nil {
+				t.Fatalf("NewManager() error = %v", err)
+			}
+
+			// Resolve the file path, appending .md if needed
+			taskPath := filepath.Join(tmpDir, tt.taskID)
+			if filepath.Ext(taskPath) != ".md" {
+				taskPath += ".md"
+			}
+
+			if !tt.noFile {
+				// Create directory structure
+				if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
+					t.Fatalf("MkdirAll() error = %v", err)
+				}
+				if err := os.WriteFile(taskPath, []byte(tt.initialContent), 0o644); err != nil {
+					t.Fatalf("WriteFile() error = %v", err)
+				}
+			}
+
+			mgr.SyncFrontmatterStatus(tt.taskID, tt.status)
+
+			if tt.noFile {
+				// File should still not exist
+				if _, err := os.Stat(taskPath); err == nil {
+					t.Error("File should not have been created")
+				}
+				return
+			}
+
+			content, err := os.ReadFile(taskPath)
+			if err != nil {
+				t.Fatalf("ReadFile() error = %v", err)
+			}
+
+			if tt.wantNoChange {
+				if string(content) != tt.initialContent {
+					t.Error("File should not have been modified")
+				}
+				return
+			}
+
+			fm, _, err := frontmatter.Parse(content)
+			if err != nil {
+				t.Fatalf("Parse() error = %v", err)
+			}
+			if fm == nil {
+				t.Fatal("Expected frontmatter after sync")
+			}
+
+			if fm.Status != tt.wantStatus {
+				t.Errorf("fest_status = %q, want %q", fm.Status, tt.wantStatus)
+			}
+
+			if fm.Updated.IsZero() {
+				t.Error("fest_updated should be set after sync")
+			}
+		})
+	}
+}
+
+func TestMarkComplete_SyncsFrontmatter(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	// Create a task file with pending frontmatter
+	taskDir := filepath.Join(tmpDir, "003_EXECUTE", "01_sequence")
+	if err := os.MkdirAll(taskDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	taskContent := `---
+fest_type: task
+fest_id: 01_task
+fest_status: pending
+fest_created: 2026-02-20T00:00:00Z
+---
+
+# Task: Do something
+`
+	taskPath := filepath.Join(taskDir, "01_task.md")
+	if err := os.WriteFile(taskPath, []byte(taskContent), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	mgr, err := NewManager(ctx, tmpDir)
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	taskID := "003_EXECUTE/01_sequence/01_task.md"
+	if err := mgr.MarkComplete(ctx, taskID); err != nil {
+		t.Fatalf("MarkComplete() error = %v", err)
+	}
+
+	// Verify JSONL was updated
+	task, found := mgr.GetTaskProgress(taskID)
+	if !found {
+		t.Fatal("Task not found in progress store")
+	}
+	if task.Status != StatusCompleted {
+		t.Errorf("progress status = %q, want %q", task.Status, StatusCompleted)
+	}
+
+	// Verify frontmatter was updated
+	content, err := os.ReadFile(taskPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	fm, _, err := frontmatter.Parse(content)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if fm == nil {
+		t.Fatal("Expected frontmatter in task file")
+	}
+	if fm.Status != frontmatter.StatusCompleted {
+		t.Errorf("frontmatter fest_status = %q, want %q", fm.Status, frontmatter.StatusCompleted)
 	}
 }


### PR DESCRIPTION
## Summary
- **Bug 1**: `fest task completed` (and all status-changing commands) now update `fest_status` in the task file's YAML frontmatter, keeping it in sync with the JSONL event log
- **Bug 2**: `fest next` now reports the same progress percentage as `fest show` and `fest progress` by using `progress.Manager.GetFestivalProgress()` instead of a graph-only calculation that excluded workflow phase steps

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` — all tests pass (9 new test cases for frontmatter sync)
- [ ] Manual: run `fest task completed` on a task and verify `fest_status: completed` in the file's frontmatter
- [ ] Manual: run `fest next`, `fest show`, `fest progress` and confirm percentages match