### PR TITLE
fix: use commitkit lock-aware operations for auto-commit on status change

### DIFF
--- a/internal/commands/status/handlers_festival.go
+++ b/internal/commands/status/handlers_festival.go
@@ -1,11 +1,9 @@
 package status
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -440,6 +438,8 @@ func emitFestivalMoveSuccess(opts *statusOptions, festival *show.FestivalInfo, n
 // autoCommitStatusChange stages and commits the filesystem changes from a festival
 // status move. It follows the non-blocking pattern: failures produce warnings,
 // never blocking the status change itself.
+//
+// Uses commitkit for lock-aware git operations with automatic stale lock cleanup.
 func autoCommitStatusChange(ctx context.Context, festivalName, festivalID, oldStatus, newStatus string) (string, error) {
 	if err := ctx.Err(); err != nil {
 		return "", err
@@ -450,20 +450,21 @@ func autoCommitStatusChange(ctx context.Context, festivalName, festivalID, oldSt
 		return "", fmt.Errorf("workspace not available in context")
 	}
 
-	// Stage all changes from the directory move
-	addCmd := exec.CommandContext(ctx, "git", "-C", ws.Root, "add", "-A")
-	if out, err := addCmd.CombinedOutput(); err != nil {
-		return "", fmt.Errorf("git add: %s: %w", bytes.TrimSpace(out), err)
+	// Stage all changes from the directory move (lock-aware with retry).
+	if err := commitkit.StageAll(ctx, ws.Root); err != nil {
+		return "", fmt.Errorf("stage: %w", err)
 	}
 
-	// Check if anything is actually staged
-	diffCmd := exec.CommandContext(ctx, "git", "-C", ws.Root, "diff", "--cached", "--quiet")
-	if err := diffCmd.Run(); err == nil {
-		// Exit code 0 means no staged changes
+	// Check if anything is actually staged.
+	hasChanges, err := commitkit.HasStagedChanges(ctx, ws.Root)
+	if err != nil {
+		return "", fmt.Errorf("check staged: %w", err)
+	}
+	if !hasChanges {
 		return "", nil
 	}
 
-	// Build commit message
+	// Build commit message.
 	message := fmt.Sprintf("chore(fest): status change: %s", festivalName)
 	if festivalID != "" {
 		message = fmt.Sprintf("chore(fest): status change: %s (%s) %s -> %s", festivalName, festivalID, oldStatus, newStatus)
@@ -471,7 +472,7 @@ func autoCommitStatusChange(ctx context.Context, festivalName, festivalID, oldSt
 		message = fmt.Sprintf("chore(fest): status change: %s %s -> %s", festivalName, oldStatus, newStatus)
 	}
 
-	// Prepend campaign tag if in a campaign workspace
+	// Prepend campaign tag if in a campaign workspace.
 	if ws.Type == scope.WorkspaceTypeCampaign {
 		cid, err := commitkit.DetectCampaign(ctx)
 		if err == nil && cid != "" {
@@ -479,19 +480,17 @@ func autoCommitStatusChange(ctx context.Context, festivalName, festivalID, oldSt
 		}
 	}
 
-	// Commit
-	commitCmd := exec.CommandContext(ctx, "git", "-C", ws.Root, "commit", "-m", message)
-	if out, err := commitCmd.CombinedOutput(); err != nil {
-		return "", fmt.Errorf("git commit: %s: %w", bytes.TrimSpace(out), err)
+	// Commit (lock-aware with retry).
+	if err := commitkit.Commit(ctx, ws.Root, commitkit.CommitOptions{Message: message}); err != nil {
+		return "", fmt.Errorf("commit: %w", err)
 	}
 
-	// Get short hash
-	hashCmd := exec.CommandContext(ctx, "git", "-C", ws.Root, "rev-parse", "--short", "HEAD")
-	hashOut, err := hashCmd.Output()
+	// Get short hash for display.
+	hash, err := commitkit.ShortHash(ctx, ws.Root)
 	if err != nil {
-		// Commit succeeded but we couldn't get the hash — not critical
+		// Commit succeeded but we couldn't get the hash — not critical.
 		return "committed", nil
 	}
 
-	return strings.TrimSpace(string(hashOut)), nil
+	return hash, nil
 }


### PR DESCRIPTION
## Summary

- **Replaces raw git exec calls** in `autoCommitStatusChange()` with commitkit's lock-aware operations
- **Fixes index.lock failures** during festival status transitions by leveraging automatic stale lock detection, cleanup, and retry
- **Removes unused imports** (`bytes`, `os/exec`) from `handlers_festival.go`

## Context

When running `fest status set <status>` to change a festival's status, the CLI auto-commits the filesystem changes (directory moves between `planning/`, `active/`, `dungeon/completed/`, etc.). This auto-commit was using raw `exec.CommandContext` for `git add -A`, `git diff --cached --quiet`, `git commit -m`, and `git rev-parse --short HEAD`.

If a stale `index.lock` file existed (from a previously interrupted git operation, concurrent agent sessions, etc.), the auto-commit would fail immediately with no retry — producing a warning like:

```
Warning: auto-commit failed: git commit: fatal: Unable to create '.git/index.lock': File exists.
```

## Changes

**File:** `internal/commands/status/handlers_festival.go`

| Before (raw git) | After (commitkit) |
|---|---|
| `exec.CommandContext(ctx, "git", "-C", ws.Root, "add", "-A")` | `commitkit.StageAll(ctx, ws.Root)` |
| `exec.CommandContext(ctx, "git", "-C", ws.Root, "diff", "--cached", "--quiet")` | `commitkit.HasStagedChanges(ctx, ws.Root)` |
| `exec.CommandContext(ctx, "git", "-C", ws.Root, "commit", "-m", message)` | `commitkit.Commit(ctx, ws.Root, commitkit.CommitOptions{Message: message})` |
| `exec.CommandContext(ctx, "git", "-C", ws.Root, "rev-parse", "--short", "HEAD")` | `commitkit.ShortHash(ctx, ws.Root)` |

The commitkit functions wrap camp's `internal/git` package which provides:
- **Cycle-based retry**: 3 fast retries per cycle, 2 cycles max, with exponential backoff between cycles
- **Stale lock detection**: Uses `fuser`/`lsof` to determine if the lock is held by an active process
- **Automatic cleanup**: Safely removes stale locks between retry cycles
- **Error classification**: Distinguishes lock errors from other git failures, only retries on lock contention

## Dependencies

Requires [Obedience-Corp/camp#80](https://github.com/Obedience-Corp/camp/pull/80) — the commitkit API expansion that exposes these lock-aware functions.

## Test Plan

- [x] `go build ./...` clean — no compilation errors
- [x] `go test ./internal/commands/status/` — all existing tests pass
- [x] Commit message format unchanged (`chore(fest): status change: <name> (<id>) <old> -> <new>`)
- [x] Campaign tag prepending behavior unchanged
- [x] Non-blocking pattern preserved (failures produce warnings, don't block status change)
- [ ] Manual verification: create stale `.git/index.lock`, run `fest status set active` — should succeed after automatic cleanup