### PR TITLE
Hybrid phases, create workflow, gate fixes

### DIFF
--- a/internal/commands/next/next.go
+++ b/internal/commands/next/next.go
@@ -204,6 +204,15 @@ func runNext(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Check if an earlier phase has incomplete after-workflow steps
+	// that should run before jumping to later phases
+	if result.Task != nil {
+		earlierWorkflow, ewErr := findEarlierIncompleteAfterWorkflow(ctx, festivalPath, result.Task.PhaseName)
+		if ewErr == nil && earlierWorkflow != "" {
+			return runWorkflowMode(ctx, festivalPath, earlierWorkflow)
+		}
+	}
+
 	// If selector says festival is complete, check for remaining incomplete workflow phases
 	if result.FestivalComplete {
 		incompleteWorkflow, wErr := findFirstIncompleteWorkflowPhase(ctx, festivalPath)
@@ -523,6 +532,58 @@ func findFirstIncompleteWorkflowPhase(ctx context.Context, festivalPath string) 
 		if !ok || state.TotalSteps == 0 || !state.IsComplete() {
 			return phasePath, nil
 		}
+	}
+
+	return "", nil
+}
+
+// findEarlierIncompleteAfterWorkflow scans phases in numerical order before the given phase
+// and returns the first one with an incomplete after-position workflow. This handles hybrid
+// phases where sequences are complete but the after-workflow steps remain.
+func findEarlierIncompleteAfterWorkflow(ctx context.Context, festivalPath, currentPhaseName string) (string, error) {
+	entries, err := os.ReadDir(festivalPath)
+	if err != nil {
+		return "", err
+	}
+
+	var phases []string
+	for _, entry := range entries {
+		if entry.IsDir() && isNumberedDir(entry.Name()) {
+			phases = append(phases, entry.Name())
+		}
+	}
+	sort.Strings(phases)
+
+	store := progress.NewStore(festivalPath)
+	storeLoaded := store.Load(ctx) == nil
+
+	for _, phaseName := range phases {
+		// Stop before the current task's phase
+		if phaseName >= currentPhaseName {
+			break
+		}
+
+		phasePath := filepath.Join(festivalPath, phaseName)
+		workflowPath := filepath.Join(phasePath, "WORKFLOW.md")
+		if _, statErr := os.Stat(workflowPath); statErr != nil {
+			continue
+		}
+
+		// Only consider after-position workflows (default)
+		position := shared.WorkflowPositionForPhase(phasePath)
+		if position == frontmatter.WorkflowPositionBefore {
+			continue
+		}
+
+		// Check if workflow is incomplete
+		if storeLoaded {
+			state, ok := store.WorkflowPhaseState(phaseName)
+			if ok && state.TotalSteps > 0 && state.IsComplete() {
+				continue // Workflow is complete
+			}
+		}
+
+		return phasePath, nil
 	}
 
 	return "", nil

--- a/internal/guidance/selection/output.go
+++ b/internal/guidance/selection/output.go
@@ -768,7 +768,9 @@ func buildGateSection(task *TaskInfo) string {
 	// Task location
 	taskRelPath := filepath.Join(task.PhaseName, task.SequenceName, task.Name+".md")
 	sb.WriteString(labelValue("Task", ui.Value(task.Name, ui.TaskColor)))
+	sb.WriteString("\n")
 	sb.WriteString(labelValue("Path", ui.Dim(taskRelPath)))
+	sb.WriteString("\n")
 	sb.WriteString(labelValue("Type", ui.Value(fmt.Sprintf("gate (%s)", fm.GateType))))
 	sb.WriteString("\n")
 


### PR DESCRIPTION
## Summary

- **`fest create workflow` command** — generates WORKFLOW.md files from structured JSON input (inline `--steps` or `--steps-file`). Supports `--position before|after`, `--json`/`--agent` modes, validates inputs, and produces parser-compatible output.
- **Configurable `fest_workflow_position`** — new frontmatter field (`before`|`after`, default: `after`) controls when workflow steps execute relative to sequences in hybrid phases.
- **Fixed `fest show` for hybrid phases** — phases with both WORKFLOW.md and task sequences now render both in the tree.
- **Fixed `fest next` hybrid routing** — correctly routes to incomplete after-position workflow steps on earlier phases before jumping to later phase tasks.
- **Fixed gate output formatting** — Task, Path, and Type labels now display on separate lines.
- **Simplified quality gate templates** — reduced from 50-130 lines to focused templates while keeping critical guidance: `fest commit` requirement, commit message format/types, test categories, review categories.
- **Moved autonomy to frontmatter** — `fest_autonomy` set in YAML frontmatter instead of parsed from inline markdown.
- **Removed hardcoded Go fallback gate templates** (`gate_templates.go`).

## Test plan

- [x] `just test all` — 1764 unit + 43 integration tests pass
- [x] `fest next` routes to incomplete workflow steps before later phase tasks
- [x] Gate output shows labels on separate lines
- [x] `fest create workflow` generates correct WORKFLOW.md from inline and file JSON
- [x] `fest show` renders hybrid phases correctly
- [x] Gate templates contain critical `fest commit` guidance