### PR TITLE
Move config root from ~/.config/obey/ to ~/.obey/

### DIFF
--- a/internal/commands/system/init.go
+++ b/internal/commands/system/init.go
@@ -64,7 +64,7 @@ Workspace Registration:
 	}
 
 	cmd.Flags().BoolVar(&opts.Force, "force", false, "overwrite existing festival directory")
-	cmd.Flags().StringVar(&opts.From, "from", "", "source directory (default: ~/.config/obey/fest)")
+	cmd.Flags().StringVar(&opts.From, "from", "", "source directory (default: ~/.obey/fest)")
 	cmd.Flags().BoolVar(&opts.Minimal, "minimal", false, "create minimal structure only")
 	cmd.Flags().BoolVar(&opts.NoChecksums, "no-checksums", false, "skip checksum generation")
 	cmd.Flags().BoolVar(&opts.Register, "register", false, "register existing festivals as active workspace")

--- a/internal/commands/system/sync.go
+++ b/internal/commands/system/sync.go
@@ -35,7 +35,7 @@ func NewSyncCommand() *cobra.Command {
 			"agent_allowed": "false",
 			"agent_reason":  "Downloads from GitHub, requires network and human judgment",
 		},
-		Long: `Download the latest fest methodology templates from GitHub to ~/.config/obey/fest/
+		Long: `Download the latest fest methodology templates from GitHub to ~/.obey/fest/
 
 This is a SYSTEM command that maintains fest itself, not your festival content.
 It fetches the complete .festival/ template structure from the configured

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,7 +98,7 @@ func ConfigDir() string {
 		return ".fest"
 	}
 
-	return filepath.Join(home, ".config", "obey", "fest")
+	return filepath.Join(home, ".obey", "fest")
 }
 
 // Load loads configuration from file

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -162,10 +162,10 @@ func TestConfigDir(t *testing.T) {
 		t.Errorf("Expected %s, got %s", testDir, dir)
 	}
 
-	// Test without environment variable — should resolve to ~/.config/obey/fest
+	// Test without environment variable — should resolve to ~/.obey/fest
 	os.Unsetenv("FEST_CONFIG_DIR")
 	dir = ConfigDir()
-	expected := filepath.Join(".config", "obey", "fest")
+	expected := filepath.Join(".obey", "fest")
 	if !filepath.IsAbs(dir) || !strings.HasSuffix(dir, expected) {
 		t.Errorf("Expected absolute path ending in %s, got %s", expected, dir)
 	}

--- a/tests/integration/helpers.go
+++ b/tests/integration/helpers.go
@@ -74,7 +74,7 @@ func NewTestContainer(t *testing.T) (*TestContainer, error) {
    {
     // Mount templates so fest init can use them without network
     Source:   testcontainers.GenericBindMountSource{HostPath: templatesPath},
-    Target:   "/root/.config/obey/fest/festivals/.festival",
+    Target:   "/root/.obey/fest/festivals/.festival",
     ReadOnly: true,
    },
   },
@@ -511,7 +511,7 @@ func NewSharedContainer() (*TestContainer, error) {
    {
     // Mount templates so fest init can use them without network
     Source:   testcontainers.GenericBindMountSource{HostPath: templatesPath},
-    Target:   "/root/.config/obey/fest/festivals/.festival",
+    Target:   "/root/.obey/fest/festivals/.festival",
     ReadOnly: true,
    },
   },

--- a/tests/integration/system_update_test.go
+++ b/tests/integration/system_update_test.go
@@ -20,7 +20,7 @@ func TestSystemUpdate_DeletesOrphanedFiles(t *testing.T) {
 	// Use unique paths to avoid conflicts with other tests
 	// Note: fest init appends "festivals" to the path, so we use a parent dir
 	parentDir := "/sysupdate-delete-test"
-	sourceDir := "/root/.config/obey/fest/festivals"
+	sourceDir := "/root/.obey/fest/festivals"
 	workspaceDir := parentDir + "/festivals" // init creates this
 
 	// Step 1: Create a minimal source template structure (simulating ~/.config/fest/festivals/)
@@ -114,7 +114,7 @@ func TestSystemUpdate_ShowsOrphanedInDryRun(t *testing.T) {
 	// Use unique paths to avoid conflicts with other tests
 	// Note: fest init appends "festivals" to the path, so we use a parent dir
 	parentDir := "/sysupdate-dryrun-test"
-	sourceDir := "/root/.config/obey/fest/festivals"
+	sourceDir := "/root/.obey/fest/festivals"
 	workspaceDir := parentDir + "/festivals" // init creates this
 
 	// Setup source templates


### PR DESCRIPTION
## Summary
- Moves fest config dir from `~/.config/obey/fest/` to `~/.obey/fest/`
- Single critical change in `internal/config/config.go`: `filepath.Join(home, ".obey", "fest")`
- Updates help text in init and sync commands
- Updates integration test paths (container mount targets and source dirs)

## Motivation
A dedicated `~/.obey/` directory matches the pattern of `~/.docker/`, `~/.cargo/`, `~/.kube/` — instantly discoverable and avoids XDG debates for a productized developer tool.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Zero `~/.config/obey` references remain in Go source