### PR TITLE
docs: rewrite methodology README with current state of Festival

### DIFF
--- a/methodology/README.md
+++ b/methodology/README.md
@@ -74,7 +74,7 @@ my-platform/                           # Campaign root
 │   └── ...                            # Add any workflows you need
 ├── docs/                              # Human-authored documentation
 ├── ai_docs/                           # AI research and documentation
-└── CLAUDE.md                          # Agent instructions
+└── AGENTS.md                          # Agent instructions
 ```
 
 The `workflow/` directory ships with sensible defaults (intents, design, code_reviews, pipelines) but is fully extensible - add directories for any recurring process your campaign needs. Real campaigns include things like `proposals/`, `postman/`, `bugs/`, `feedback/`, `pitch/`, and `simulations/`.
@@ -428,7 +428,7 @@ my-campaign/
 │   └── .../                            # Custom: add your own
 ├── docs/
 ├── ai_docs/
-└── CLAUDE.md                           # Agent instructions
+└── AGENTS.md                           # Agent instructions
 ```
 
 ### Inside a Festival


### PR DESCRIPTION
## Summary

The methodology README was written in September 2025 when Festival was first formalized. The essence was correct but it was missing significant evolution. This is an additive rewrite that preserves all valuable original content while adding what's changed.

### Added
- **Campaigns section** - the top-level workspace concept, directory structure, camp CLI
- **Intents** - lightweight idea capture (inbox -> active -> ready -> done/killed)
- **Design documents** - quick iteration in workflow/design/
- **Phase types** - 6 types (planning, implementation, research, ingest, review, non_coding_action) with structural conventions
- **Workflow vs Implementation distinction** - WORKFLOW.md for guided phases vs numbered sequences for building
- **Quality gates** - testing/review/iterate pattern at end of every implementation sequence
- **Festival types** - standard, implementation, research, ritual with auto-scaffolded phases
- **Naming conventions** - 3-digit phases, 2-digit sequences, 2-digit tasks

### Updated
- **Directory structure** - now shows `ready/`, `ritual/`, `dungeon/{completed,archived,someday}` instead of flat `completed/` and `dungeon/`
- **Getting Started** - uses fest/camp CLI commands instead of manual `cp -r` and `cat`
- **License badge** - removed MIT reference, updated to BSL 1.1

### Preserved (unchanged)
- Task example (JWT auth spec)
- Comparison table (Festival vs Traditional PM vs Ad-hoc AI)
- Core benefits list
- Autonomy levels
- Context preservation (CONTEXT.md)
- Realistic expectations
- Mermaid diagram
- "How It Works" flow

## Test plan
- [ ] Read through and verify no valuable original content was lost
- [ ] Verify directory structures match actual scaffolding
- [ ] Verify all fest/camp CLI commands referenced are real
- [ ] Check that campaign concepts align with camp CLI capabilities
- [ ] Confirm no MIT license references remain