### PR TITLE
feat(promote): wire up autocommit for fest promote

### DIFF
--- a/internal/commands/promote/promote.go
+++ b/internal/commands/promote/promote.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/commands/status"
 	"github.com/Obedience-Corp/fest/internal/config"
 	"github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/frontmatter"
 	"github.com/Obedience-Corp/fest/internal/progress"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
@@ -119,11 +120,26 @@ func runPromote(ctx context.Context, opts *promoteOptions) error {
 		return errors.Wrap(err, "promoting festival")
 	}
 
-	// Extract festival ID from config for commit message
+	// Update FESTIVAL_GOAL.md frontmatter with the new status
+	festivalGoalPath := filepath.Join(newPath, "FESTIVAL_GOAL.md")
+	if _, statErr := os.Stat(festivalGoalPath); statErr == nil {
+		if fmErr := status.UpdateGoalFrontmatter(ctx, festivalGoalPath, frontmatter.Status(nextStatus)); fmErr != nil {
+			fmt.Printf("%s %s\n", ui.Dim("Warning: could not update FESTIVAL_GOAL.md frontmatter:"), ui.Dim(fmErr.Error()))
+		}
+	}
+
+	// Update fest.yaml metadata with the new status
 	var festivalID string
 	if festCfg, cfgErr := config.LoadFestivalConfig(newPath, ""); cfgErr == nil {
 		festivalID = festCfg.Metadata.ID
+		festCfg.Metadata.AddStatusChange(nextStatus, newPath, "")
+		if saveErr := config.SaveFestivalConfig(newPath, "", festCfg); saveErr != nil {
+			fmt.Printf("%s %s\n", ui.Dim("Warning: could not update fest.yaml status:"), ui.Dim(saveErr.Error()))
+		}
 	}
+
+	// Update navigation links after successful move
+	status.UpdateNavigationAfterMove(festival.Name, nextStatus, newPath)
 
 	// Auto-commit the status change unless --no-commit was specified
 	var commitHash string

--- a/internal/commands/status/handlers_entity.go
+++ b/internal/commands/status/handlers_entity.go
@@ -102,7 +102,7 @@ func handlePhaseStatusSetWithPath(ctx context.Context, display *ui.UI, festivalP
 		return emitPhaseStatusAlready(display, opts, phaseName, newStatus)
 	}
 
-	if err := updateGoalFrontmatter(ctx, goalPath, frontmatter.Status(newStatus)); err != nil {
+	if err := UpdateGoalFrontmatter(ctx, goalPath, frontmatter.Status(newStatus)); err != nil {
 		return err
 	}
 
@@ -348,7 +348,7 @@ func handlePhaseStatusSet(ctx context.Context, display *ui.UI, cwd, newStatus st
 		return emitPhaseStatusAlready(display, opts, phaseName, newStatus)
 	}
 
-	if err := updateGoalFrontmatter(ctx, goalPath, frontmatter.Status(newStatus)); err != nil {
+	if err := UpdateGoalFrontmatter(ctx, goalPath, frontmatter.Status(newStatus)); err != nil {
 		return err
 	}
 
@@ -470,7 +470,7 @@ func handleSequenceStatusSet(ctx context.Context, display *ui.UI, cwd, newStatus
 		return emitSequenceStatusAlready(display, opts, seqName, newStatus)
 	}
 
-	if err := updateGoalFrontmatter(ctx, goalPath, frontmatter.Status(newStatus)); err != nil {
+	if err := UpdateGoalFrontmatter(ctx, goalPath, frontmatter.Status(newStatus)); err != nil {
 		return err
 	}
 

--- a/internal/commands/status/handlers_festival.go
+++ b/internal/commands/status/handlers_festival.go
@@ -77,7 +77,7 @@ func applyStatusToFestival(ctx context.Context, display *ui.UI, festival *show.F
 }
 
 // updateGoalFrontmatter reads a goal file, updates its fest_status in frontmatter, and writes it back.
-func updateGoalFrontmatter(ctx context.Context, goalPath string, newStatus frontmatter.Status) error {
+func UpdateGoalFrontmatter(ctx context.Context, goalPath string, newStatus frontmatter.Status) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -324,7 +324,7 @@ func executeFestivalMove(ctx context.Context, festival *show.FestivalInfo, newSt
 	// Update FESTIVAL_GOAL.md frontmatter with the new status
 	festivalGoalPath := filepath.Join(newPath, "FESTIVAL_GOAL.md")
 	if _, err := os.Stat(festivalGoalPath); err == nil {
-		if fmErr := updateGoalFrontmatter(ctx, festivalGoalPath, frontmatter.Status(newStatus)); fmErr != nil {
+		if fmErr := UpdateGoalFrontmatter(ctx, festivalGoalPath, frontmatter.Status(newStatus)); fmErr != nil {
 			// Log but don't fail — the directory move already succeeded
 			fmt.Printf("%s %s\n", ui.Dim("Warning: could not update FESTIVAL_GOAL.md frontmatter:"), ui.Dim(fmErr.Error()))
 		}
@@ -341,7 +341,7 @@ func executeFestivalMove(ctx context.Context, festival *show.FestivalInfo, newSt
 	}
 
 	// Update navigation links after successful move
-	linkAction := updateNavigationAfterMove(festival.Name, newStatus, newPath)
+	linkAction := UpdateNavigationAfterMove(festival.Name, newStatus, newPath)
 
 	// Auto-commit the status change unless --no-commit was specified
 	var commitHash string
@@ -361,7 +361,7 @@ func executeFestivalMove(ctx context.Context, festival *show.FestivalInfo, newSt
 // On completion, the link is removed (project freed). On other transitions, the
 // festival path is updated so the link stays accurate.
 // Returns a human-readable description of the action taken, or empty string.
-func updateNavigationAfterMove(festivalName, newStatus, newPath string) string {
+func UpdateNavigationAfterMove(festivalName, newStatus, newPath string) string {
 	nav, err := navigation.LoadNavigation()
 	if err != nil {
 		// Navigation not available (no campaign context, etc.) - skip silently


### PR DESCRIPTION
## Summary
- Wires up the same autocommit behavior that `fest status set` already has into the `fest promote` command
- Exports `AutoCommitStatusChange` from the status package so promote can call it
- Adds `--no-commit` flag to promote for parity with status set
- Displays commit hash in both text and JSON output

## Test plan
- [x] `just build` passes
- [x] `go test ./internal/commands/promote/... ./internal/commands/status/...` passes
- [ ] Manual: run `fest promote` on a planning festival, verify autocommit is created
- [ ] Manual: run `fest promote --no-commit`, verify no commit is created