### PR TITLE
feat: monorepo support in fest link, promote autocommit & metadata fix

### DIFF
--- a/internal/commands/navigation/go_link.go
+++ b/internal/commands/navigation/go_link.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -281,6 +282,12 @@ type festivalInfo struct {
 	path        string
 }
 
+// projectEntry represents a project directory that can be linked to a festival.
+type projectEntry struct {
+	path  string // Absolute path to the project directory
+	label string // Display label (e.g., "camp" or "obey-platform-monorepo@obey")
+}
+
 // collectFestivals finds all festivals in primary status directories
 func collectFestivals(festivalsDir string) ([]festivalInfo, error) {
 	var festivals []festivalInfo
@@ -329,28 +336,28 @@ func resolveFestivalPath(festivalsDir, festivalName string) string {
 }
 
 // selectProjectDirectory shows an interactive picker for selecting a project directory.
-// It lists only the directories inside campaignRoot/projects/.
+// It lists directories inside campaignRoot/projects/, expanding monorepos into sub-entries.
 func selectProjectDirectory(festivalPath, festivalName string) (string, error) {
 	// Find campaign root by walking up from festival path
 	// festivalPath is like: /path/to/campaign/festivals/active/festival-name
 	// We want campaign root: /path/to/campaign
 	campaignRoot := campaignRootFromFestival(festivalPath)
 
-	directories, err := collectProjectDirectories(campaignRoot)
+	entries, err := collectProjectDirectories(campaignRoot)
 	if err != nil {
 		return "", festErrors.Wrap(err, "collecting project directories")
 	}
 
-	if len(directories) == 0 {
+	if len(entries) == 0 {
 		return "", festErrors.NotFound("project directories").
 			WithField("hint", "no directories found in projects/")
 	}
 
-	// Build options — show just the project name
-	options := make([]huh.Option[string], 0, len(directories))
-	for _, dir := range directories {
-		label := pathStyle.Render(filepath.Base(dir))
-		options = append(options, huh.NewOption(label, dir))
+	// Build options — show project label (with monorepo@sub notation)
+	options := make([]huh.Option[string], 0, len(entries))
+	for _, entry := range entries {
+		label := pathStyle.Render(entry.label)
+		options = append(options, huh.NewOption(label, entry.path))
 	}
 
 	var selectedDir string
@@ -383,20 +390,56 @@ func campaignRootFromFestival(festivalPath string) string {
 	return filepath.Dir(festivalsDir)                        // → campaign root
 }
 
-// collectProjectDirectories returns the directories inside campaignRoot/projects/.
-func collectProjectDirectories(campaignRoot string) ([]string, error) {
+// collectProjectDirectories returns project directories inside campaignRoot/projects/,
+// expanding monorepos (detected via .gitmodules) into sub-project entries using the
+// name@submodule convention (matching camp CLI's project listing).
+func collectProjectDirectories(campaignRoot string) ([]projectEntry, error) {
 	projectsDir := filepath.Join(campaignRoot, "projects")
 	entries, err := os.ReadDir(projectsDir)
 	if err != nil {
 		return nil, err
 	}
 
-	var dirs []string
+	var results []projectEntry
 	for _, entry := range entries {
 		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
 			continue
 		}
-		dirs = append(dirs, filepath.Join(projectsDir, entry.Name()))
+
+		dirName := entry.Name()
+		dirPath := filepath.Join(projectsDir, dirName)
+
+		results = append(results, projectEntry{path: dirPath, label: dirName})
+
+		// Expand monorepo sub-projects
+		for _, sub := range listSubmodulePaths(dirPath) {
+			results = append(results, projectEntry{
+				path:  filepath.Join(dirPath, sub),
+				label: dirName + "@" + sub,
+			})
+		}
 	}
-	return dirs, nil
+	return results, nil
+}
+
+// listSubmodulePaths parses .gitmodules to discover submodule paths.
+// Returns nil if no .gitmodules exists or parsing fails.
+func listSubmodulePaths(projectDir string) []string {
+	cmd := exec.Command("git", "-C", projectDir, "config", "-f", ".gitmodules", "--list")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil
+	}
+
+	var paths []string
+	for _, line := range strings.Split(string(output), "\n") {
+		if !strings.Contains(line, ".path=") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) == 2 {
+			paths = append(paths, parts[1])
+		}
+	}
+	return paths
 }

--- a/internal/commands/navigation/go_link_test.go
+++ b/internal/commands/navigation/go_link_test.go
@@ -2,6 +2,7 @@ package navigation
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 )
@@ -110,7 +111,6 @@ func TestCollectProjectDirectories(t *testing.T) {
 		"ai_docs/research",
 		"dungeon/old-stuff",
 	}
-	// Also add a regular file inside projects/
 	for _, d := range dirs {
 		if err := os.MkdirAll(filepath.Join(tmpDir, d), 0755); err != nil {
 			t.Fatal(err)
@@ -126,20 +126,90 @@ func TestCollectProjectDirectories(t *testing.T) {
 		t.Fatalf("collectProjectDirectories() error = %v", err)
 	}
 
-	// Should only contain the 3 non-hidden project directories
-	want := map[string]bool{
-		filepath.Join(tmpDir, "projects", "camp"):        true,
-		filepath.Join(tmpDir, "projects", "fest"):        true,
-		filepath.Join(tmpDir, "projects", "obey-daemon"): true,
+	// Should only contain the 3 non-hidden project directories (no monorepo sub-entries)
+	want := map[string]string{
+		filepath.Join(tmpDir, "projects", "camp"):        "camp",
+		filepath.Join(tmpDir, "projects", "fest"):        "fest",
+		filepath.Join(tmpDir, "projects", "obey-daemon"): "obey-daemon",
 	}
 
 	if len(got) != len(want) {
-		t.Fatalf("collectProjectDirectories() returned %d dirs, want %d\ngot: %v", len(got), len(want), got)
+		t.Fatalf("collectProjectDirectories() returned %d entries, want %d\ngot: %v", len(got), len(want), got)
 	}
 
-	for _, dir := range got {
-		if !want[dir] {
-			t.Errorf("unexpected directory in results: %s", dir)
+	for _, entry := range got {
+		expectedLabel, ok := want[entry.path]
+		if !ok {
+			t.Errorf("unexpected entry: path=%s label=%s", entry.path, entry.label)
+			continue
+		}
+		if entry.label != expectedLabel {
+			t.Errorf("entry path=%s: label=%q, want %q", entry.path, entry.label, expectedLabel)
+		}
+	}
+}
+
+func TestCollectProjectDirectoriesMonorepo(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a standalone project
+	if err := os.MkdirAll(filepath.Join(tmpDir, "projects", "camp"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a monorepo with submodules
+	monorepoDir := filepath.Join(tmpDir, "projects", "my-monorepo")
+	if err := os.MkdirAll(monorepoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Initialize git and create .gitmodules
+	if err := exec.Command("git", "init", monorepoDir).Run(); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	for _, sub := range []string{"obey", "festui"} {
+		if err := exec.Command("git", "-C", monorepoDir, "config", "-f", ".gitmodules",
+			"submodule."+sub+".path", sub).Run(); err != nil {
+			t.Fatalf("git config submodule path: %v", err)
+		}
+		if err := exec.Command("git", "-C", monorepoDir, "config", "-f", ".gitmodules",
+			"submodule."+sub+".url", "https://example.com/"+sub+".git").Run(); err != nil {
+			t.Fatalf("git config submodule url: %v", err)
+		}
+		if err := os.MkdirAll(filepath.Join(monorepoDir, sub), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := collectProjectDirectories(tmpDir)
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+
+	// Expect: camp, my-monorepo (root), my-monorepo@obey, my-monorepo@festui
+	want := map[string]string{
+		filepath.Join(tmpDir, "projects", "camp"):                   "camp",
+		filepath.Join(tmpDir, "projects", "my-monorepo"):            "my-monorepo",
+		filepath.Join(tmpDir, "projects", "my-monorepo", "obey"):    "my-monorepo@obey",
+		filepath.Join(tmpDir, "projects", "my-monorepo", "festui"):  "my-monorepo@festui",
+	}
+
+	if len(got) != len(want) {
+		var labels []string
+		for _, e := range got {
+			labels = append(labels, e.label)
+		}
+		t.Fatalf("got %d entries %v, want %d", len(got), labels, len(want))
+	}
+
+	for _, entry := range got {
+		expectedLabel, ok := want[entry.path]
+		if !ok {
+			t.Errorf("unexpected entry: path=%s label=%s", entry.path, entry.label)
+			continue
+		}
+		if entry.label != expectedLabel {
+			t.Errorf("path=%s: label=%q, want %q", entry.path, entry.label, expectedLabel)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- **feat(navigation):** Expand monorepo sub-projects in `fest link` picker — `collectProjectDirectories` now detects `.gitmodules` and lists sub-projects using the `name@submodule` convention (matching camp CLI)
- **feat(promote):** Wire up autocommit for `fest promote` command
- **fix(promote):** Update festival metadata (status field) during promotion

## Test plan

- [ ] `just build` passes
- [ ] `just test` passes (includes new `TestCollectProjectDirectoriesMonorepo`)
- [ ] Run `fest link` from inside a festival — verify monorepo sub-projects appear in picker
- [ ] Run `fest promote` — verify autocommit and metadata update work