### PR TITLE
feat: enforce planning-first festival creation

### DIFF
--- a/internal/commands/festival/create_festival.go
+++ b/internal/commands/festival/create_festival.go
@@ -43,7 +43,7 @@ type CreateFestivalOptions struct {
 	SkipMarkers bool   // Skip marker processing
 	DryRun      bool   // Show markers without creating file
 	JSONOutput  bool
-	Dest        string // "active" or "planning"
+	Dest        string // "planning" (default) or "ritual" (for ritual-type festivals)
 	AgentMode   bool   // Strict mode for AI agents
 }
 
@@ -93,7 +93,7 @@ func NewCreateFestivalCommand() *cobra.Command {
 	opts := &CreateFestivalOptions{}
 	cmd := &cobra.Command{
 		Use:   "festival",
-		Short: "Create a new festival scaffold under festivals/(active|planning)",
+		Short: "Create a new festival scaffold under festivals/planning",
 		Annotations: map[string]string{
 			"scope": string(scope.Workspace),
 		},
@@ -120,7 +120,7 @@ func NewCreateFestivalCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.SkipMarkers, "skip-markers", false, "Skip REPLACE marker processing")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Show template markers without creating file")
 	cmd.Flags().BoolVar(&opts.JSONOutput, "json", false, "Emit JSON output")
-	cmd.Flags().StringVar(&opts.Dest, "dest", "active", "Destination under festivals/: active, planning, or ritual")
+	cmd.Flags().StringVar(&opts.Dest, "dest", "planning", "Destination under festivals/: planning or ritual (use 'fest promote' to advance to active)")
 	cmd.Flags().BoolVar(&opts.AgentMode, "agent", false, "Strict mode: require markers, auto-validate, block on errors, JSON output")
 	return cmd
 }
@@ -165,11 +165,16 @@ func resolveCreateConfig(ctx context.Context, opts *CreateFestivalOptions) (*cre
 
 	slug := Slugify(opts.Name)
 	destCategory := strings.ToLower(strings.TrimSpace(opts.Dest))
-	if opts.Type == "ritual" && destCategory == "active" {
+	if opts.Type == "ritual" {
 		destCategory = "ritual"
 	}
-	if destCategory != "planning" && destCategory != "active" && destCategory != "ritual" {
-		destCategory = "active"
+	if destCategory == "active" {
+		return nil, errors.Validation("cannot create festival directly in active/").
+			WithHint("Festivals must be created in planning/ first. Use 'fest promote' to advance through the lifecycle: planning → ready → active")
+	}
+	if destCategory != "planning" && destCategory != "ritual" {
+		return nil, errors.Validation(fmt.Sprintf("invalid destination: %q", destCategory)).
+			WithHint("Valid destinations: planning (default), ritual (for ritual-type festivals)")
 	}
 
 	var festivalID string

--- a/internal/commands/festival/create_festival_id_test.go
+++ b/internal/commands/festival/create_festival_id_test.go
@@ -72,7 +72,7 @@ func TestCreateFestival_DirectoryNaming(t *testing.T) {
 			// Run create festival
 			opts := &CreateFestivalOptions{
 				Name:        tt.festivalName,
-				Dest:        "active",
+				Dest:        "planning",
 				SkipMarkers: true,
 				JSONOutput:  true, // Suppress console output
 			}
@@ -84,14 +84,14 @@ func TestCreateFestival_DirectoryNaming(t *testing.T) {
 
 			// Verify directory was created with ID suffix
 			slug := Slugify(tt.festivalName)
-			activeDir := filepath.Join(festivalsRoot, "active")
-			entries, err := os.ReadDir(activeDir)
+			planningDir := filepath.Join(festivalsRoot, "planning")
+			entries, err := os.ReadDir(planningDir)
 			if err != nil {
-				t.Fatalf("Failed to read active dir: %v", err)
+				t.Fatalf("Failed to read planning dir: %v", err)
 			}
 
 			if len(entries) != 1 {
-				t.Fatalf("Expected 1 entry in active/, got %d", len(entries))
+				t.Fatalf("Expected 1 entry in planning/, got %d", len(entries))
 			}
 
 			dirName := entries[0].Name()
@@ -173,7 +173,7 @@ func TestCreateFestival_MetadataPopulation(t *testing.T) {
 	opts := &CreateFestivalOptions{
 		Name:        "test festival",
 		Goal:        "Test the metadata population",
-		Dest:        "active",
+		Dest:        "planning",
 		SkipMarkers: true,
 		JSONOutput:  true,
 	}
@@ -184,13 +184,13 @@ func TestCreateFestival_MetadataPopulation(t *testing.T) {
 	}
 
 	// Find the created directory
-	activeDir := filepath.Join(festivalsRoot, "active")
-	entries, err := os.ReadDir(activeDir)
+	planningDir := filepath.Join(festivalsRoot, "planning")
+	entries, err := os.ReadDir(planningDir)
 	if err != nil || len(entries) != 1 {
-		t.Fatalf("Expected 1 entry in active/")
+		t.Fatalf("Expected 1 entry in planning/")
 	}
 
-	festivalDir := filepath.Join(activeDir, entries[0].Name())
+	festivalDir := filepath.Join(planningDir, entries[0].Name())
 
 	// Load the fest.yaml
 	cfg, err := config.LoadFestivalConfig(festivalDir, "")
@@ -226,8 +226,8 @@ func TestCreateFestival_MetadataPopulation(t *testing.T) {
 
 	if len(cfg.Metadata.StatusHistory) > 0 {
 		firstChange := cfg.Metadata.StatusHistory[0]
-		if firstChange.Status != "active" && firstChange.Status != "planning" {
-			t.Errorf("First status should be 'active' or 'planning', got %q", firstChange.Status)
+		if firstChange.Status != "planning" {
+			t.Errorf("First status should be 'planning', got %q", firstChange.Status)
 		}
 		if firstChange.Timestamp.IsZero() {
 			t.Error("Status change timestamp should not be zero")
@@ -268,7 +268,7 @@ func TestCreateFestival_UniqueIDs(t *testing.T) {
 	// Create first festival with "GU" prefix
 	opts1 := &CreateFestivalOptions{
 		Name:        "guild usable",
-		Dest:        "active",
+		Dest:        "planning",
 		SkipMarkers: true,
 		JSONOutput:  true,
 	}
@@ -290,7 +290,7 @@ func TestCreateFestival_UniqueIDs(t *testing.T) {
 	// Create third festival with different prefix
 	opts3 := &CreateFestivalOptions{
 		Name:        "fest node",
-		Dest:        "active",
+		Dest:        "planning",
 		SkipMarkers: true,
 		JSONOutput:  true,
 	}
@@ -298,32 +298,15 @@ func TestCreateFestival_UniqueIDs(t *testing.T) {
 		t.Fatalf("Third RunCreateFestival failed: %v", err)
 	}
 
-	// Verify directory names
-	activeEntries, _ := os.ReadDir(filepath.Join(festivalsRoot, "active"))
+	// Verify directory names — all 3 should be in planning/
 	planningEntries, _ := os.ReadDir(filepath.Join(festivalsRoot, "planning"))
 
-	// Should have 2 in active, 1 in planning
-	if len(activeEntries) != 2 {
-		t.Errorf("Expected 2 entries in active/, got %d", len(activeEntries))
-	}
-	if len(planningEntries) != 1 {
-		t.Errorf("Expected 1 entry in planning/, got %d", len(planningEntries))
+	if len(planningEntries) != 3 {
+		t.Errorf("Expected 3 entries in planning/, got %d", len(planningEntries))
 	}
 
 	// Collect all IDs (extract from end of directory name after last hyphen)
 	ids := make(map[string]bool)
-	for _, e := range activeEntries {
-		name := e.Name()
-		lastHyphen := strings.LastIndex(name, "-")
-		if lastHyphen == -1 {
-			continue
-		}
-		id := name[lastHyphen+1:]
-		if ids[id] {
-			t.Errorf("Duplicate ID found: %s", id)
-		}
-		ids[id] = true
-	}
 	for _, e := range planningEntries {
 		name := e.Name()
 		lastHyphen := strings.LastIndex(name, "-")
@@ -396,7 +379,7 @@ func TestCreateFestival_BackwardsCompatibility(t *testing.T) {
 	// Create a new festival - should still work even with old festival present
 	opts := &CreateFestivalOptions{
 		Name:        "new festival",
-		Dest:        "active",
+		Dest:        "planning",
 		SkipMarkers: true,
 		JSONOutput:  true,
 	}
@@ -406,20 +389,24 @@ func TestCreateFestival_BackwardsCompatibility(t *testing.T) {
 		t.Fatalf("RunCreateFestival failed: %v", err)
 	}
 
-	// Verify both old and new festivals exist
-	entries, _ := os.ReadDir(filepath.Join(festivalsRoot, "active"))
-	if len(entries) != 2 {
-		t.Errorf("Expected 2 entries in active/, got %d", len(entries))
+	// Verify old festival still exists in active/
+	activeEntries, _ := os.ReadDir(filepath.Join(festivalsRoot, "active"))
+	if len(activeEntries) != 1 {
+		t.Errorf("Expected 1 entry in active/ (old festival), got %d", len(activeEntries))
 	}
-
-	// Old festival should still be there unchanged
 	oldExists := false
-	for _, e := range entries {
+	for _, e := range activeEntries {
 		if e.Name() == "old-festival" {
 			oldExists = true
 		}
 	}
 	if !oldExists {
-		t.Error("Old festival directory should still exist")
+		t.Error("Old festival directory should still exist in active/")
+	}
+
+	// Verify new festival was created in planning/
+	planningEntries, _ := os.ReadDir(filepath.Join(festivalsRoot, "planning"))
+	if len(planningEntries) != 1 {
+		t.Errorf("Expected 1 entry in planning/ (new festival), got %d", len(planningEntries))
 	}
 }

--- a/internal/commands/festival/create_festival_markers_test.go
+++ b/internal/commands/festival/create_festival_markers_test.go
@@ -185,7 +185,7 @@ func TestCreateFestivalZeroMarkers(t *testing.T) {
 				Name:       tt.festName,
 				Goal:       tt.festGoal,
 				Type:       tt.festType,
-				Dest:       "active",
+				Dest:       "planning",
 				JSONOutput: true,
 			}
 
@@ -195,15 +195,15 @@ func TestCreateFestivalZeroMarkers(t *testing.T) {
 			}
 
 			// Find created festival directory
-			activeDir := filepath.Join(festivalsDir, "active")
-			entries, err := os.ReadDir(activeDir)
+			planningDir := filepath.Join(festivalsDir, "planning")
+			entries, err := os.ReadDir(planningDir)
 			if err != nil {
-				t.Fatalf("failed to read active dir: %v", err)
+				t.Fatalf("failed to read planning dir: %v", err)
 			}
 			if len(entries) != 1 {
-				t.Fatalf("expected 1 entry in active/, got %d", len(entries))
+				t.Fatalf("expected 1 entry in planning/, got %d", len(entries))
 			}
-			festivalDir := filepath.Join(activeDir, entries[0].Name())
+			festivalDir := filepath.Join(planningDir, entries[0].Name())
 
 			// Scan all .md files for unfilled markers
 			findings := scanForUnfilledMarkers(t, festivalDir)

--- a/internal/commands/festival/create_test.go
+++ b/internal/commands/festival/create_test.go
@@ -349,7 +349,7 @@ func TestCreateFestival_GatesDirectory(t *testing.T) {
 		Name:        "test-festival",
 		Goal:        "Test goal",
 		SkipMarkers: true,
-		Dest:        "active",
+		Dest:        "planning",
 	}
 
 	err := RunCreateFestival(context.Background(), opts)
@@ -358,12 +358,12 @@ func TestCreateFestival_GatesDirectory(t *testing.T) {
 	}
 
 	// Find the created festival directory (now includes ID suffix)
-	activeDir := filepath.Join(festivalsDir, "active")
-	entries, err := os.ReadDir(activeDir)
+	planningDir := filepath.Join(festivalsDir, "planning")
+	entries, err := os.ReadDir(planningDir)
 	if err != nil || len(entries) != 1 {
-		t.Fatalf("expected 1 entry in active/: %v", err)
+		t.Fatalf("expected 1 entry in planning/: %v", err)
 	}
-	festivalDir := filepath.Join(activeDir, entries[0].Name())
+	festivalDir := filepath.Join(planningDir, entries[0].Name())
 
 	// Verify gates/ directory exists at festival root
 	gatesDir := filepath.Join(festivalDir, "gates")
@@ -437,7 +437,7 @@ func TestCreateFestival_FestYAMLGenerated(t *testing.T) {
 		Name:        "gates-test",
 		Goal:        "Test gates configuration",
 		SkipMarkers: true,
-		Dest:        "active",
+		Dest:        "planning",
 	}
 
 	err := RunCreateFestival(context.Background(), opts)
@@ -446,12 +446,12 @@ func TestCreateFestival_FestYAMLGenerated(t *testing.T) {
 	}
 
 	// Find the created festival directory (now includes ID suffix)
-	activeDir := filepath.Join(festivalsDir, "active")
-	entries, err := os.ReadDir(activeDir)
+	planningDir := filepath.Join(festivalsDir, "planning")
+	entries, err := os.ReadDir(planningDir)
 	if err != nil || len(entries) != 1 {
-		t.Fatalf("expected 1 entry in active/: %v", err)
+		t.Fatalf("expected 1 entry in planning/: %v", err)
 	}
-	festivalDir := filepath.Join(activeDir, entries[0].Name())
+	festivalDir := filepath.Join(planningDir, entries[0].Name())
 	festYAMLPath := filepath.Join(festivalDir, "fest.yaml")
 
 	if _, err := os.Stat(festYAMLPath); err != nil {
@@ -544,7 +544,7 @@ func TestCreateFestival_WithTypeStandard(t *testing.T) {
 		Goal:        "Test standard type",
 		Type:        "standard",
 		SkipMarkers: true,
-		Dest:        "active",
+		Dest:        "planning",
 		JSONOutput:  false,
 	}
 
@@ -554,12 +554,12 @@ func TestCreateFestival_WithTypeStandard(t *testing.T) {
 	}
 
 	// Find created festival directory
-	activeDir := filepath.Join(festivalsDir, "active")
-	entries, err := os.ReadDir(activeDir)
+	planningDir := filepath.Join(festivalsDir, "planning")
+	entries, err := os.ReadDir(planningDir)
 	if err != nil || len(entries) != 1 {
-		t.Fatalf("expected 1 entry in active/: %v", err)
+		t.Fatalf("expected 1 entry in planning/: %v", err)
 	}
-	festivalDir := filepath.Join(activeDir, entries[0].Name())
+	festivalDir := filepath.Join(planningDir, entries[0].Name())
 
 	// Verify INGEST and PLAN phases were auto-created
 	ingestPhase := filepath.Join(festivalDir, "001_INGEST")
@@ -601,7 +601,7 @@ func TestCreateFestival_WithoutType(t *testing.T) {
 		Name:        "no-type-test",
 		Goal:        "Test without type",
 		SkipMarkers: true,
-		Dest:        "active",
+		Dest:        "planning",
 		JSONOutput:  false,
 	}
 
@@ -611,12 +611,12 @@ func TestCreateFestival_WithoutType(t *testing.T) {
 	}
 
 	// Find created festival directory
-	activeDir := filepath.Join(festivalsDir, "active")
-	entries, err := os.ReadDir(activeDir)
+	planningDir := filepath.Join(festivalsDir, "planning")
+	entries, err := os.ReadDir(planningDir)
 	if err != nil || len(entries) != 1 {
-		t.Fatalf("expected 1 entry in active/: %v", err)
+		t.Fatalf("expected 1 entry in planning/: %v", err)
 	}
-	festivalDir := filepath.Join(activeDir, entries[0].Name())
+	festivalDir := filepath.Join(planningDir, entries[0].Name())
 
 	// Verify NO phases were auto-created
 	phases, err := os.ReadDir(festivalDir)
@@ -669,13 +669,46 @@ func TestCreateFestival_WithUnknownType(t *testing.T) {
 		Goal:        "Test bad type",
 		Type:        "unknown-type",
 		SkipMarkers: true,
-		Dest:        "active",
+		Dest:        "planning",
 		JSONOutput:  false,
 	}
 
 	err := RunCreateFestival(context.Background(), opts)
 	if err == nil {
 		t.Error("expected error for unknown festival type")
+	}
+}
+
+// TestCreateFestival_RejectsActiveDest verifies that creating a festival
+// with --dest active returns a validation error.
+func TestCreateFestival_RejectsActiveDest(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create festivals directory structure with templates
+	festivalsDir := filepath.Join(tmpDir, "festivals")
+	setupFestivalTemplates(t, festivalsDir)
+
+	// Change working directory
+	origDir, _ := os.Getwd()
+	defer os.Chdir(origDir)
+	os.Chdir(festivalsDir)
+
+	opts := &CreateFestivalOptions{
+		Name:        "should-fail",
+		Goal:        "Test active rejection",
+		SkipMarkers: true,
+		Dest:        "active",
+	}
+
+	err := RunCreateFestival(context.Background(), opts)
+	if err == nil {
+		t.Fatal("expected error when creating festival with --dest active")
+	}
+
+	// Verify the error message mentions planning and promote
+	errMsg := err.Error()
+	if !contains(errMsg, "active") {
+		t.Errorf("error should mention 'active', got: %s", errMsg)
 	}
 }
 

--- a/internal/commands/shared/flags.go
+++ b/internal/commands/shared/flags.go
@@ -37,7 +37,7 @@ type CreateFestivalOpts struct {
 	Type       string
 	VarsFile   string
 	JSONOutput bool
-	Dest       string
+	Dest       string // "planning" (default) or "ritual". Never "active" — use fest promote.
 }
 
 // CreatePhaseOpts holds options for the create phase command.

--- a/internal/commands/tui/charm_festival.go
+++ b/internal/commands/tui/charm_festival.go
@@ -24,7 +24,6 @@ func charmCreateFestival(ctx context.Context) error {
 	}
 
 	var name, goal, tags string
-	var dest string = "active"
 	festivalTypes := []string{"standard", "implementation", "research", "quick", "ritual"}
 	var festType string = festivalTypes[0]
 	form := huh.NewForm(
@@ -40,10 +39,6 @@ func charmCreateFestival(ctx context.Context) error {
 			huh.NewSelect[string]().Title("Festival type").
 				Options(toOptions(festivalTypes)...).
 				Value(&festType),
-			huh.NewSelect[string]().Title("Destination").Options(
-				huh.NewOption("active", "active"),
-				huh.NewOption("planning", "planning"),
-			).Value(&dest),
 		),
 	)
 	if err := uitheme.RunForm(ctx, form); err != nil {
@@ -81,7 +76,7 @@ func charmCreateFestival(ctx context.Context) error {
 		return err
 	}
 
-	opts := &shared.CreateFestivalOpts{Name: name, Goal: goal, Tags: tags, Type: festType, VarsFile: varsFile, Dest: dest}
+	opts := &shared.CreateFestivalOpts{Name: name, Goal: goal, Tags: tags, Type: festType, VarsFile: varsFile, Dest: "planning"}
 	return shared.RunCreateFestival(ctx, opts)
 }
 
@@ -99,7 +94,6 @@ func charmPlanFestivalWizard(ctx context.Context) error {
 		return err
 	}
 	var name, goal, tags string
-	var dest string = "planning"
 	festivalTypes := []string{"standard", "implementation", "research", "quick", "ritual"}
 	var festType string = festivalTypes[0]
 	base := huh.NewForm(
@@ -115,10 +109,6 @@ func charmPlanFestivalWizard(ctx context.Context) error {
 			huh.NewSelect[string]().Title("Festival type").
 				Options(toOptions(festivalTypes)...).
 				Value(&festType),
-			huh.NewSelect[string]().Title("Destination").Options(
-				huh.NewOption("planning", "planning"),
-				huh.NewOption("active", "active"),
-			).Value(&dest),
 		),
 	)
 	if err := uitheme.RunForm(ctx, base); err != nil {
@@ -153,11 +143,11 @@ func charmPlanFestivalWizard(ctx context.Context) error {
 		return err
 	}
 
-	if err := shared.RunCreateFestival(ctx, &shared.CreateFestivalOpts{Name: name, Goal: goal, Tags: tags, Type: festType, VarsFile: varsFile, Dest: dest}); err != nil {
+	if err := shared.RunCreateFestival(ctx, &shared.CreateFestivalOpts{Name: name, Goal: goal, Tags: tags, Type: festType, VarsFile: varsFile, Dest: "planning"}); err != nil {
 		return err
 	}
 	slug := slugify(name)
-	festivalDir := filepath.Join(festivalsRoot, dest, slug)
+	festivalDir := filepath.Join(festivalsRoot, "planning", slug)
 
 	// Add phases
 	var addPhases bool

--- a/tests/integration/guidance_helpers_test.go
+++ b/tests/integration/guidance_helpers_test.go
@@ -44,11 +44,11 @@ func setupImplementationFestival(t *testing.T, tc *TestContainer, festName strin
 	festivalsPath := setupWorkspace(t, tc, "/")
 
 	// Create festival using --dest flag (not --path which doesn't exist)
-	output, err := tc.RunFestInDir(festivalsPath, "create", "festival", "--name", festName, "--dest", "active")
+	output, err := tc.RunFestInDir(festivalsPath, "create", "festival", "--name", festName, "--dest", "planning")
 	require.NoError(t, err, "should create festival: %s", output)
 
 	// Find the actual festival path (fest adds an ID suffix like "test-fest-TF0001")
-	festPath := findFestivalPath(t, tc, festivalsPath+"/active", festName)
+	festPath := findFestivalPath(t, tc, festivalsPath+"/planning", festName)
 
 	// Write fest.yaml with quality gates enabled (gates should never be skippable)
 	festYaml := `version: "1.0"
@@ -129,11 +129,11 @@ func setupPlanFestival(t *testing.T, tc *TestContainer, festName string) string 
 	festivalsPath := setupWorkspace(t, tc, "/")
 
 	// Create festival using --dest flag
-	output, err := tc.RunFestInDir(festivalsPath, "create", "festival", "--name", festName, "--dest", "active")
+	output, err := tc.RunFestInDir(festivalsPath, "create", "festival", "--name", festName, "--dest", "planning")
 	require.NoError(t, err, "should create festival: %s", output)
 
 	// Find the actual festival path (fest adds an ID suffix)
-	festPath := findFestivalPath(t, tc, festivalsPath+"/active", festName)
+	festPath := findFestivalPath(t, tc, festivalsPath+"/planning", festName)
 
 	// Create FESTIVAL_OVERVIEW.md (required by validator)
 	overviewContent := "---\nfest_type: overview\n---\n\n# Test Festival Overview\n\n## Goals\n- Complete planning testing\n\n## Success Criteria\n- All planning steps completed\n"
@@ -178,11 +178,11 @@ func setupResearchFestival(t *testing.T, tc *TestContainer, festName string) str
 	festivalsPath := setupWorkspace(t, tc, "/")
 
 	// Create festival using --dest flag
-	output, err := tc.RunFestInDir(festivalsPath, "create", "festival", "--name", festName, "--dest", "active")
+	output, err := tc.RunFestInDir(festivalsPath, "create", "festival", "--name", festName, "--dest", "planning")
 	require.NoError(t, err, "should create festival: %s", output)
 
 	// Find the actual festival path (fest adds an ID suffix)
-	festPath := findFestivalPath(t, tc, festivalsPath+"/active", festName)
+	festPath := findFestivalPath(t, tc, festivalsPath+"/planning", festName)
 
 	// Create FESTIVAL_OVERVIEW.md (required by validator)
 	overviewContent := "---\nfest_type: overview\n---\n\n# Test Festival Overview\n\n## Goals\n- Complete research testing\n\n## Success Criteria\n- All research topics covered\n"
@@ -224,11 +224,11 @@ func setupReviewFestival(t *testing.T, tc *TestContainer, festName string) strin
 	festivalsPath := setupWorkspace(t, tc, "/")
 
 	// Create festival using --dest flag
-	output, err := tc.RunFestInDir(festivalsPath, "create", "festival", "--name", festName, "--dest", "active")
+	output, err := tc.RunFestInDir(festivalsPath, "create", "festival", "--name", festName, "--dest", "planning")
 	require.NoError(t, err, "should create festival: %s", output)
 
 	// Find the actual festival path (fest adds an ID suffix)
-	festPath := findFestivalPath(t, tc, festivalsPath+"/active", festName)
+	festPath := findFestivalPath(t, tc, festivalsPath+"/planning", festName)
 
 	// Create FESTIVAL_OVERVIEW.md (required by validator)
 	overviewContent := "---\nfest_type: overview\n---\n\n# Test Festival Overview\n\n## Goals\n- Complete review testing\n\n## Success Criteria\n- All review items checked\n"
@@ -271,11 +271,11 @@ func setupActionFestival(t *testing.T, tc *TestContainer, festName string) strin
 	festivalsPath := setupWorkspace(t, tc, "/")
 
 	// Create festival using --dest flag
-	output, err := tc.RunFestInDir(festivalsPath, "create", "festival", "--name", festName, "--dest", "active")
+	output, err := tc.RunFestInDir(festivalsPath, "create", "festival", "--name", festName, "--dest", "planning")
 	require.NoError(t, err, "should create festival: %s", output)
 
 	// Find the actual festival path (fest adds an ID suffix)
-	festPath := findFestivalPath(t, tc, festivalsPath+"/active", festName)
+	festPath := findFestivalPath(t, tc, festivalsPath+"/planning", festName)
 
 	// Create FESTIVAL_OVERVIEW.md (required by validator)
 	overviewContent := "---\nfest_type: overview\n---\n\n# Test Festival Overview\n\n## Goals\n- Complete action testing\n\n## Success Criteria\n- All actions executed\n"
@@ -318,11 +318,11 @@ func setupIngestFestival(t *testing.T, tc *TestContainer, festName string) strin
 	festivalsPath := setupWorkspace(t, tc, "/")
 
 	// Create festival using --dest flag
-	output, err := tc.RunFestInDir(festivalsPath, "create", "festival", "--name", festName, "--dest", "active")
+	output, err := tc.RunFestInDir(festivalsPath, "create", "festival", "--name", festName, "--dest", "planning")
 	require.NoError(t, err, "should create festival: %s", output)
 
 	// Find the actual festival path (fest adds an ID suffix)
-	festPath := findFestivalPath(t, tc, festivalsPath+"/active", festName)
+	festPath := findFestivalPath(t, tc, festivalsPath+"/planning", festName)
 
 	// Create FESTIVAL_OVERVIEW.md (required by validator)
 	overviewContent := "---\nfest_type: overview\n---\n\n# Test Festival Overview\n\n## Goals\n- Complete ingest testing\n\n## Success Criteria\n- All items ingested\n"
@@ -565,11 +565,11 @@ func setupMultiModeFestival(t *testing.T, tc *TestContainer, festName string) st
 	festivalsPath := setupWorkspace(t, tc, "/")
 
 	// Create festival using --dest flag
-	output, err := tc.RunFestInDir(festivalsPath, "create", "festival", "--name", festName, "--dest", "active")
+	output, err := tc.RunFestInDir(festivalsPath, "create", "festival", "--name", festName, "--dest", "planning")
 	require.NoError(t, err, "should create festival: %s", output)
 
 	// Find the actual festival path (fest adds an ID suffix)
-	festPath := findFestivalPath(t, tc, festivalsPath+"/active", festName)
+	festPath := findFestivalPath(t, tc, festivalsPath+"/planning", festName)
 
 	// Create FESTIVAL_OVERVIEW.md (required by validator)
 	overviewContent := "---\nfest_type: overview\n---\n\n# Test Festival Overview\n\n## Goals\n- Complete multi-mode testing\n\n## Success Criteria\n- All phase types navigated\n"
@@ -633,11 +633,11 @@ func setupLifecycleFestival(t *testing.T, tc *TestContainer, festName string) st
 	festivalsPath := setupWorkspace(t, tc, "/")
 
 	// Create festival using --dest flag
-	output, err := tc.RunFestInDir(festivalsPath, "create", "festival", "--name", festName, "--dest", "active")
+	output, err := tc.RunFestInDir(festivalsPath, "create", "festival", "--name", festName, "--dest", "planning")
 	require.NoError(t, err, "should create festival: %s", output)
 
 	// Find the actual festival path (fest adds an ID suffix)
-	festPath := findFestivalPath(t, tc, festivalsPath+"/active", festName)
+	festPath := findFestivalPath(t, tc, festivalsPath+"/planning", festName)
 
 	// Create FESTIVAL_OVERVIEW.md (required by validator)
 	overviewContent := "---\nfest_type: overview\n---\n\n# Test Festival Overview\n\n## Goals\n- Complete lifecycle testing\n\n## Success Criteria\n- All lifecycle phases completed\n"

--- a/tests/integration/guidance_implementation_test.go
+++ b/tests/integration/guidance_implementation_test.go
@@ -88,10 +88,10 @@ func TestImplementationMode_PhaseBoundaries(t *testing.T) {
 	festivalsPath := setupWorkspace(t, container, "/")
 
 	// Create festival with multiple phases
-	_, err := container.RunFestInDir(festivalsPath, "create", "festival", "--name", "test-impl-phases", "--dest", "active")
+	_, err := container.RunFestInDir(festivalsPath, "create", "festival", "--name", "test-impl-phases", "--dest", "planning")
 	require.NoError(t, err)
 
-	festPath := findFestivalPath(t, container, festivalsPath+"/active", "test-impl-phases")
+	festPath := findFestivalPath(t, container, festivalsPath+"/planning", "test-impl-phases")
 
 	// Write fest.yaml with quality gates enabled
 	festYaml := `version: "1.0"
@@ -191,10 +191,10 @@ func TestImplementationMode_Completion(t *testing.T) {
 	festivalsPath := setupWorkspace(t, container, "/")
 
 	// Create minimal festival with one task
-	_, err := container.RunFestInDir(festivalsPath, "create", "festival", "--name", "test-impl-done", "--dest", "active")
+	_, err := container.RunFestInDir(festivalsPath, "create", "festival", "--name", "test-impl-done", "--dest", "planning")
 	require.NoError(t, err)
 
-	festPath := findFestivalPath(t, container, festivalsPath+"/active", "test-impl-done")
+	festPath := findFestivalPath(t, container, festivalsPath+"/planning", "test-impl-done")
 
 	// Write fest.yaml with quality gates enabled
 	festYaml := "version: \"1.0\"\nquality_gates:\n  enabled: true\n  auto_append: true\n  implementation:\n    - id: testing\n      template: gates/implementation/QUALITY_GATE_TESTING\n      enabled: true\n    - id: review\n      template: gates/implementation/QUALITY_GATE_REVIEW\n      enabled: true\n    - id: iterate\n      template: gates/implementation/QUALITY_GATE_ITERATE\n      enabled: true\n    - id: fest-commit\n      template: gates/implementation/QUALITY_GATE_FEST_COMMIT\n      enabled: true\n"
@@ -261,10 +261,10 @@ func TestImplementationMode_EmptyFestival(t *testing.T) {
 	festivalsPath := setupWorkspace(t, container, "/")
 
 	// Create festival with phase but no tasks
-	_, err := container.RunFestInDir(festivalsPath, "create", "festival", "--name", "test-impl-empty", "--dest", "active")
+	_, err := container.RunFestInDir(festivalsPath, "create", "festival", "--name", "test-impl-empty", "--dest", "planning")
 	require.NoError(t, err)
 
-	festPath := findFestivalPath(t, container, festivalsPath+"/active", "test-impl-empty")
+	festPath := findFestivalPath(t, container, festivalsPath+"/planning", "test-impl-empty")
 
 	_, err = container.RunFestInDir(festPath, "create", "phase", "--name", "EMPTY_PHASE", "--type", "implementation")
 	require.NoError(t, err)

--- a/tests/integration/lifecycle/lifecycle_test.go
+++ b/tests/integration/lifecycle/lifecycle_test.go
@@ -17,7 +17,7 @@ func TestFullFestivalLifecycle(t *testing.T) {
 	container := GetSharedContainer(t)
 
 	// The festivals root is at /workspace/festivals with .festival marker
-	// Festivals are created under festivals/active/ or festivals/planning/
+	// Festivals are always created under festivals/planning/ (use fest promote to advance)
 	// Note: fest create festival adds a unique ID suffix (e.g., lifecycle-test-LT0001)
 	workspaceRoot := "/workspace"
 	festivalsRoot := workspaceRoot + "/festivals"
@@ -58,10 +58,10 @@ func TestFullFestivalLifecycle(t *testing.T) {
 	// Phase 2: Festival Creation - Create a new festival and verify structure
 	t.Run("CreateFestival", func(t *testing.T) {
 		// Create the festival from within the festivals root directory
-		// The fest create festival command uses --dest (active/planning) not --path
+		// The fest create festival command uses --dest (planning/ritual) not --path
 		output, err := container.RunFestInDir(festivalsRoot, "create", "festival",
 			"--name", "lifecycle-test",
-			"--dest", "active")
+			"--dest", "planning")
 		t.Logf("Festival creation output: %s", output)
 		if err != nil {
 			t.Logf("Festival creation error: %v", err)
@@ -69,15 +69,15 @@ func TestFullFestivalLifecycle(t *testing.T) {
 		require.NoError(t, err, "should create festival: %s", output)
 
 		// List what was created - fest generates a unique ID suffix
-		dirs, err := container.ListDirectories(festivalsRoot + "/active")
+		dirs, err := container.ListDirectories(festivalsRoot + "/planning")
 		require.NoError(t, err)
-		t.Logf("Directories in /festivals/active: %v", dirs)
+		t.Logf("Directories in /festivals/planning: %v", dirs)
 		require.NotEmpty(t, dirs, "should have at least one festival directory")
 
 		// Find the festival directory (should start with lifecycle-test-)
 		for _, dir := range dirs {
 			if strings.HasPrefix(dir, "lifecycle-test") {
-				festPath = festivalsRoot + "/active/" + dir
+				festPath = festivalsRoot + "/planning/" + dir
 				break
 			}
 		}

--- a/tests/integration/lifecycle_test.go
+++ b/tests/integration/lifecycle_test.go
@@ -51,11 +51,11 @@ func TestWorkflowMode(t *testing.T) {
 	festivalsPath := setupWorkspace(t, container, "/")
 
 	// Create festival
-	_, err := container.RunFestInDir(festivalsPath, "create", "festival", "--name", "workflow-test", "--dest", "active")
+	_, err := container.RunFestInDir(festivalsPath, "create", "festival", "--name", "workflow-test", "--dest", "planning")
 	require.NoError(t, err)
 
 	// Find the actual festival path (fest adds an ID suffix)
-	festPath := findFestivalPath(t, container, festivalsPath+"/active", "workflow-test")
+	festPath := findFestivalPath(t, container, festivalsPath+"/planning", "workflow-test")
 
 	// Create an implementation phase
 	_, err = container.RunFestInDir(festPath, "create", "phase", "--name", "WORKFLOW_PHASE", "--type", "implementation")

--- a/tests/integration/template_validation_test.go
+++ b/tests/integration/template_validation_test.go
@@ -30,11 +30,11 @@ func setupTemplateFestival(t *testing.T, tc *TestContainer, festName string) str
 	festivalsPath := setupWorkspace(t, tc, "/")
 
 	// Create festival using correct flags
-	_, err := tc.RunFestInDir(festivalsPath, "create", "festival", "--name", festName, "--dest", "active")
+	_, err := tc.RunFestInDir(festivalsPath, "create", "festival", "--name", festName, "--dest", "planning")
 	require.NoError(t, err, "failed to create festival")
 
 	// Find the actual festival path (fest adds an ID suffix)
-	festPath := findFestivalPath(t, tc, festivalsPath+"/active", festName)
+	festPath := findFestivalPath(t, tc, festivalsPath+"/planning", festName)
 
 	// Write fest.yaml with quality gates enabled
 	festYaml := `version: "1.0"


### PR DESCRIPTION
## Summary
- Festivals must now always be created in `planning/` first — `--dest active` returns a hard error directing users to `fest promote`
- Default `--dest` changed from `active` to `planning`; unknown values now return an error instead of silently falling back
- Destination dropdown removed from both TUI creation flows (quick create and plan wizard)
- Ritual type festivals unconditionally redirect to `ritual/` regardless of `--dest` value

## Test plan
- [x] `just build` passes with no warnings
- [x] All unit tests pass including new `TestCreateFestival_RejectsActiveDest`
- [x] All integration tests updated from `--dest active` to `--dest planning`
- [ ] Manual: `fest create festival --name "Test"` creates in `planning/`
- [ ] Manual: `fest create festival --name "Test" --dest active` returns error with promote hint
- [ ] Manual: `fest create festival --name "Test" --type ritual` creates in `ritual/`