### PR TITLE
feat: add --dungeon flag to promote and fgo dungeon status shortcuts

### DIFF
--- a/internal/commands/config/shell.go
+++ b/internal/commands/config/shell.go
@@ -96,7 +96,7 @@ _fgo_completions() {
         completions=$(command fest go completions 2>/dev/null)
     elif [[ ${COMP_CWORD} -eq 2 ]]; then
         case "${COMP_WORDS[1]}" in
-            active|planning|completed|dungeon)
+            active|planning|ready|completed|someday|archived|dungeon)
                 completions=$(command fest go completions --status "${COMP_WORDS[1]}" 2>/dev/null)
                 ;;
         esac
@@ -119,7 +119,7 @@ if [[ -n "$ZSH_VERSION" ]]; then
         elif (( CURRENT == 3 )); then
             # Second arg: if first arg is a status dir, show its festivals
             case "${words[2]}" in
-                active|planning|completed|dungeon)
+                active|planning|ready|completed|someday|archived|dungeon)
                     cmd_args="--color --status ${words[2]}"
                     ;;
                 *) return ;;
@@ -237,7 +237,7 @@ fgo() {
             # Normal navigation (festival/phase/status directories)
             # Note: Don't use 2>&1 - stderr must flow to terminal for TUI picker to render
             local dest
-            if [[ -n "$2" && "$1" =~ ^(active|planning|completed|dungeon)$ ]]; then
+            if [[ -n "$2" && "$1" =~ ^(active|planning|ready|completed|someday|archived|dungeon)$ ]]; then
                 # Status dir + festival name: combine (e.g., active my-fest → active/my-fest)
                 dest=$(command fest go "$1/$2" --print)
             else
@@ -283,7 +283,7 @@ fest() {
                     ;;
                 *)
                     local dest
-                    if [ -n "$2" ] && echo "$1" | grep -qE '^(active|planning|completed|dungeon)$'; then
+                    if [ -n "$2" ] && echo "$1" | grep -qE '^(active|planning|ready|completed|someday|archived|dungeon)$'; then
                         dest=$(command fest go "$1/$2" --print 2>/dev/null)
                     else
                         dest=$(command fest go "$@" --print 2>/dev/null)
@@ -319,7 +319,7 @@ function __fgo_completions
     else if test $count -eq 2
         # Second arg: if first arg is a status dir, show its festivals
         switch $tokens[2]
-            case active planning completed dungeon
+            case active planning ready completed someday archived dungeon
                 command fest go completions --status $tokens[2] 2>/dev/null
         end
     end
@@ -394,7 +394,7 @@ function fgo
             set -l target
             if test (count $argv) -ge 2
                 switch $argv[1]
-                    case active planning completed dungeon
+                    case active planning ready completed someday archived dungeon
                         set target "$argv[1]/$argv[2]"
                     case '*'
                         set target $argv
@@ -441,7 +441,7 @@ function fest
                     set -l dest
                     if test (count $argv) -ge 2
                         switch $argv[1]
-                            case active planning completed dungeon
+                            case active planning ready completed someday archived dungeon
                                 set dest (command fest go "$argv[1]/$argv[2]" --print 2>/dev/null)
                             case '*'
                                 set dest (command fest go $argv --print 2>/dev/null)

--- a/internal/commands/navigation/completions.go
+++ b/internal/commands/navigation/completions.go
@@ -83,8 +83,8 @@ func runGoCompletions(descriptions, color bool, statusFilter string) error {
 		return runStatusCompletions(festivalsDir, statusFilter, descriptions, color)
 	}
 
-	// Primary status directories only (completed/dungeon available via second-arg completion)
-	statuses := id.PrimaryStatusDirs
+	// Primary status directories + dungeon aliases for direct navigation
+	statuses := append(id.PrimaryStatusDirs, "completed", "someday", "archived")
 
 	statusSet := make(map[string]bool, len(statuses))
 	for _, s := range statuses {
@@ -143,7 +143,9 @@ func runGoCompletions(descriptions, color bool, statusFilter string) error {
 
 // runStatusCompletions outputs only festivals from a specific status directory.
 func runStatusCompletions(festivalsDir, status string, descriptions, color bool) error {
-	targets := navigation.CollectFestivalsInStatus(festivalsDir, status)
+	// Resolve dungeon aliases (completed → dungeon/completed, etc.)
+	resolved := id.ResolveStatusPath(status)
+	targets := navigation.CollectFestivalsInStatus(festivalsDir, resolved)
 	c := statusANSI(status)
 	for _, t := range targets {
 		switch {

--- a/internal/commands/navigation/go.go
+++ b/internal/commands/navigation/go.go
@@ -280,6 +280,14 @@ func resolveGoTarget(target, festivalsDir string) (string, error) {
 		}
 	}
 
+	// Resolve dungeon status aliases (completed → dungeon/completed, etc.)
+	if resolved := id.ResolveStatusPath(target); resolved != target {
+		fullPath := filepath.Join(festivalsDir, resolved)
+		if info, err := os.Stat(fullPath); err == nil && info.IsDir() {
+			return fullPath, nil
+		}
+	}
+
 	// Try to resolve as festival name (searches active/, planning/, completed/)
 	if festPath := resolveFestivalByName(target, festivalsDir); festPath != "" {
 		return festPath, nil

--- a/internal/commands/navigation/go_test.go
+++ b/internal/commands/navigation/go_test.go
@@ -283,6 +283,50 @@ func TestResolveFestivalByName(t *testing.T) {
 	}
 }
 
+func TestResolveGoTargetDungeonAliases(t *testing.T) {
+	tmpDir := t.TempDir()
+	festivalsDir := filepath.Join(tmpDir, "festivals")
+
+	// Create dungeon status directories
+	dungeonDirs := []string{
+		filepath.Join(festivalsDir, "dungeon", "completed"),
+		filepath.Join(festivalsDir, "dungeon", "archived"),
+		filepath.Join(festivalsDir, "dungeon", "someday"),
+	}
+	for _, d := range dungeonDirs {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tests := []struct {
+		target   string
+		expected string
+		wantErr  bool
+	}{
+		{"completed", filepath.Join(festivalsDir, "dungeon", "completed"), false},
+		{"archived", filepath.Join(festivalsDir, "dungeon", "archived"), false},
+		{"someday", filepath.Join(festivalsDir, "dungeon", "someday"), false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.target, func(t *testing.T) {
+			result, err := resolveGoTarget(tc.target, festivalsDir)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("resolveGoTarget(%q) expected error, got nil", tc.target)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("resolveGoTarget(%q) unexpected error: %v", tc.target, err)
+				} else if result != tc.expected {
+					t.Errorf("resolveGoTarget(%q) = %q, want %q", tc.target, result, tc.expected)
+				}
+			}
+		})
+	}
+}
+
 func TestResolveGoTargetWithFestivalName(t *testing.T) {
 	tmpDir := t.TempDir()
 	festivalsDir := filepath.Join(tmpDir, "festivals")

--- a/internal/commands/promote/promote.go
+++ b/internal/commands/promote/promote.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
 	"github.com/Obedience-Corp/fest/internal/commands/show"
@@ -13,6 +14,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/config"
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/frontmatter"
+	"github.com/Obedience-Corp/fest/internal/id"
 	"github.com/Obedience-Corp/fest/internal/progress"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
@@ -30,6 +32,7 @@ type promoteOptions struct {
 	force    bool
 	json     bool
 	noCommit bool
+	dungeon  string
 }
 
 // NewPromoteCommand creates the fest promote command.
@@ -43,7 +46,12 @@ func NewPromoteCommand() *cobra.Command {
 Each transition validates readiness:
   planning → ready:    Festival goal must be defined
   ready → active:      Festival is ready to begin execution
-  active → completed:  All tasks must be completed`,
+  active → completed:  All tasks must be completed
+
+Use --dungeon to send a festival directly to a dungeon status:
+  fest promote --dungeon someday     Shelve for later
+  fest promote --dungeon archived    Archive the festival
+  fest promote --dungeon completed   Mark as completed (skips task validation)`,
 		Annotations: map[string]string{
 			"scope": string(scope.Festival),
 		},
@@ -55,6 +63,7 @@ Each transition validates readiness:
 	cmd.Flags().BoolVar(&opts.force, "force", false, "skip readiness validation")
 	cmd.Flags().BoolVar(&opts.json, "json", false, "output as JSON")
 	cmd.Flags().BoolVar(&opts.noCommit, "no-commit", false, "skip auto-commit after promotion")
+	cmd.Flags().StringVar(&opts.dungeon, "dungeon", "", "send to dungeon status (completed, archived, someday)")
 
 	return cmd
 }
@@ -81,36 +90,50 @@ func runPromote(ctx context.Context, opts *promoteOptions) error {
 	festival := loc.Festival
 	currentStatus := festival.Status
 
-	// Determine next status
-	nextStatus, ok := validTransitions[currentStatus]
-	if !ok {
-		if opts.json {
-			return shared.EncodeJSON(os.Stdout, map[string]any{
-				"success": false,
-				"error":   fmt.Sprintf("cannot promote festival with status %q", currentStatus),
-				"status":  currentStatus,
-			})
-		}
-		return errors.Validation("cannot promote festival").
-			WithField("status", currentStatus).
-			WithField("hint", "only planning, ready, and active festivals can be promoted")
-	}
+	var nextStatus string
 
-	// Validate readiness unless forced
-	if !opts.force {
-		if err := validateReadiness(ctx, festival, currentStatus, nextStatus); err != nil {
+	if opts.dungeon != "" {
+		// Dungeon override: resolve the dungeon status
+		resolved := id.ResolveStatusPath(opts.dungeon)
+		if !strings.HasPrefix(resolved, "dungeon/") {
+			return errors.Validation("invalid dungeon status").
+				WithField("value", opts.dungeon).
+				WithField("hint", "valid values: completed, archived, someday")
+		}
+		nextStatus = resolved
+	} else {
+		// Standard lifecycle promotion
+		var ok bool
+		nextStatus, ok = validTransitions[currentStatus]
+		if !ok {
 			if opts.json {
 				return shared.EncodeJSON(os.Stdout, map[string]any{
 					"success": false,
-					"error":   err.Error(),
-					"from":    currentStatus,
-					"to":      nextStatus,
-					"hint":    "use --force to skip validation",
+					"error":   fmt.Sprintf("cannot promote festival with status %q", currentStatus),
+					"status":  currentStatus,
 				})
 			}
-			fmt.Printf("%s %s\n", ui.Warning("Promotion blocked"), ui.Dim(err.Error()))
-			fmt.Printf("\n  %s\n", ui.Dim("Use --force to skip validation"))
-			return nil
+			return errors.Validation("cannot promote festival").
+				WithField("status", currentStatus).
+				WithField("hint", "only planning, ready, and active festivals can be promoted")
+		}
+
+		// Validate readiness unless forced (skip for dungeon moves)
+		if !opts.force {
+			if err := validateReadiness(ctx, festival, currentStatus, nextStatus); err != nil {
+				if opts.json {
+					return shared.EncodeJSON(os.Stdout, map[string]any{
+						"success": false,
+						"error":   err.Error(),
+						"from":    currentStatus,
+						"to":      nextStatus,
+						"hint":    "use --force to skip validation",
+					})
+				}
+				fmt.Printf("%s %s\n", ui.Warning("Promotion blocked"), ui.Dim(err.Error()))
+				fmt.Printf("\n  %s\n", ui.Dim("Use --force to skip validation"))
+				return nil
+			}
 		}
 	}
 

--- a/internal/commands/promote/promote_test.go
+++ b/internal/commands/promote/promote_test.go
@@ -3,9 +3,11 @@ package promote
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Obedience-Corp/fest/internal/commands/show"
+	"github.com/Obedience-Corp/fest/internal/id"
 )
 
 func TestValidTransitions(t *testing.T) {
@@ -92,12 +94,36 @@ func TestNewPromoteCommand(t *testing.T) {
 	}
 
 	// Check flags exist
-	forceFlag := cmd.Flags().Lookup("force")
-	if forceFlag == nil {
-		t.Error("expected --force flag")
+	flags := []string{"force", "json", "dungeon"}
+	for _, name := range flags {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("expected --%s flag", name)
+		}
 	}
-	jsonFlag := cmd.Flags().Lookup("json")
-	if jsonFlag == nil {
-		t.Error("expected --json flag")
+}
+
+func TestDungeonFlagValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		dungeon string
+		wantErr bool
+	}{
+		{"valid completed", "completed", false},
+		{"valid archived", "archived", false},
+		{"valid someday", "someday", false},
+		{"invalid status", "active", true},
+		{"invalid arbitrary", "nonsense", true},
+		{"invalid planning", "planning", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolved := id.ResolveStatusPath(tt.dungeon)
+			isDungeon := strings.HasPrefix(resolved, "dungeon/")
+			if isDungeon == tt.wantErr {
+				t.Errorf("dungeon=%q: resolved=%q, isDungeon=%v, wantErr=%v",
+					tt.dungeon, resolved, isDungeon, tt.wantErr)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `--dungeon` flag to `fest promote` for sending festivals directly to dungeon statuses (`completed`, `archived`, `someday`) without going through the full lifecycle chain
- Makes `fgo completed`, `fgo someday`, `fgo archived` resolve directly to their `dungeon/*` paths instead of requiring `fgo dungeon/completed`
- Updates shell integration (bash/zsh/fish) to recognize dungeon aliases for two-arg combining (`fgo someday my-fest`)
- Adds dungeon aliases to tab completions

## Test plan
- [x] `just build` — clean build, no warnings
- [x] All existing tests pass
- [x] New `TestDungeonFlagValidation` — validates only dungeon statuses accepted
- [x] New `TestResolveGoTargetDungeonAliases` — validates alias resolution to `dungeon/*` paths
- [ ] Manual: `fest promote --dungeon someday` from a planning festival
- [ ] Manual: `fgo completed` navigates to `festivals/dungeon/completed/`
- [ ] Manual: `fgo someday my-fest` resolves correctly