### PR TITLE
fix: review mode integration tests blocked by planning status guard

### DIFF
--- a/tests/integration/guidance_helpers_test.go
+++ b/tests/integration/guidance_helpers_test.go
@@ -240,6 +240,13 @@ func setupReviewFestival(t *testing.T, tc *TestContainer, festName string) strin
 	err = writeFileInContainer(tc, festPath+"/FESTIVAL_RULES.md", rulesContent)
 	require.NoError(t, err, "should create FESTIVAL_RULES.md")
 
+	// Write fest.yaml without status_history so checkPlanningStatus doesn't block
+	// review phases. (CurrentStatus() returns "" when no history exists, which bypasses
+	// the planning-status guard in next.go. This matches setupImplementationFestival's pattern.)
+	festYaml := "version: \"1.0\"\n"
+	err = writeFileInContainer(tc, festPath+"/fest.yaml", festYaml)
+	require.NoError(t, err, "should write fest.yaml")
+
 	_, err = tc.RunFestInDir(festPath, "create", "phase", "--name", "REVIEW", "--type", "review")
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Summary
- Fixed `TestReviewMode_InitialDisplay` and `TestReviewMode_PhaseTypeDetection` integration tests that were failing with `Festival must be in active status to execute implementation phases`
- Root cause: `setupReviewFestival()` created festivals in `planning/` without handling the status metadata, causing `checkPlanningStatus()` in `next.go` to block review phases
- Fix: Write a minimal `fest.yaml` without `status_history` in `setupReviewFestival()` so `CurrentStatus()` returns `""` (bypasses the planning guard), matching the pattern already used by `setupImplementationFestival()`

## Test plan
- [x] Both previously-failing tests pass individually
- [x] Full integration test suite passes (43/43)
- [x] No regressions in unit tests