### PR TITLE
fix: use stderr renderer for picker so fgo has colors

### DIFF
--- a/internal/tui/picker/picker.go
+++ b/internal/tui/picker/picker.go
@@ -60,17 +60,20 @@ type Model struct {
 	borderStyle   lipgloss.Style
 }
 
-// New creates a new picker with the given items and scorer.
-func New(items []Item, scorer Scorer) Model {
+// New creates a new picker with the given items, scorer, and lipgloss renderer.
+// The renderer controls which output the color profile is detected from.
+// When rendering to stderr (e.g. fgo piping stdout), pass a renderer created
+// from os.Stderr so colors are detected against the actual TTY.
+func New(items []Item, scorer Scorer, renderer *lipgloss.Renderer) Model {
 	ti := textinput.New()
 	ti.Placeholder = "Type to filter..."
 	ti.Focus()
 	ti.CharLimit = 100
 	ti.Width = 50
-	ti.PromptStyle = lipgloss.NewStyle().Foreground(colorFocus)
-	ti.TextStyle = lipgloss.NewStyle().Foreground(colorText)
-	ti.PlaceholderStyle = lipgloss.NewStyle().Foreground(colorPlaceholder)
-	ti.Cursor.Style = lipgloss.NewStyle().Foreground(colorFocus)
+	ti.PromptStyle = renderer.NewStyle().Foreground(colorFocus)
+	ti.TextStyle = renderer.NewStyle().Foreground(colorText)
+	ti.PlaceholderStyle = renderer.NewStyle().Foreground(colorPlaceholder)
+	ti.Cursor.Style = renderer.NewStyle().Foreground(colorFocus)
 
 	m := Model{
 		items:      items,
@@ -79,14 +82,14 @@ func New(items []Item, scorer Scorer) Model {
 		scorer:     scorer,
 		maxVisible: 10, // Fixed height like fzf --height
 
-		promptStyle:   lipgloss.NewStyle().Foreground(colorFocus).Bold(true),
-		cursorStyle:   lipgloss.NewStyle().Foreground(colorFocus),
-		matchStyle:    lipgloss.NewStyle().Foreground(colorSelected).Bold(true),
-		selectedStyle: lipgloss.NewStyle().Foreground(colorSelected).Bold(true),
-		normalStyle:   lipgloss.NewStyle().Foreground(colorText),
-		countStyle:    lipgloss.NewStyle().Foreground(colorPlaceholder),
-		helpStyle:     lipgloss.NewStyle().Foreground(colorPlaceholder).Faint(true),
-		borderStyle:   lipgloss.NewStyle().Foreground(colorBorder),
+		promptStyle:   renderer.NewStyle().Foreground(colorFocus).Bold(true),
+		cursorStyle:   renderer.NewStyle().Foreground(colorFocus),
+		matchStyle:    renderer.NewStyle().Foreground(colorSelected).Bold(true),
+		selectedStyle: renderer.NewStyle().Foreground(colorSelected).Bold(true),
+		normalStyle:   renderer.NewStyle().Foreground(colorText),
+		countStyle:    renderer.NewStyle().Foreground(colorPlaceholder),
+		helpStyle:     renderer.NewStyle().Foreground(colorPlaceholder).Faint(true),
+		borderStyle:   renderer.NewStyle().Foreground(colorBorder),
 	}
 
 	return m
@@ -314,8 +317,12 @@ func (m Model) Confirmed() bool {
 func Run(items []Item, scorer Scorer) (*Item, error) {
 	debug := os.Getenv("FEST_DEBUG") != ""
 
+	// Create a renderer bound to stderr so the color profile is detected against
+	// the actual TTY, not stdout which may be a pipe (e.g. fgo captures stdout).
+	renderer := lipgloss.NewRenderer(os.Stderr)
+
 	start := time.Now()
-	m := New(items, scorer)
+	m := New(items, scorer, renderer)
 	if debug {
 		log.Printf("[DEBUG] picker.New: %v", time.Since(start))
 	}

--- a/internal/tui/picker/picker_test.go
+++ b/internal/tui/picker/picker_test.go
@@ -1,14 +1,18 @@
 package picker
 
 import (
+	"os"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 )
 
 func dummyScorer(q, target string) (int, []int) {
 	return 1, nil
 }
+
+var testRenderer = lipgloss.NewRenderer(os.Stderr)
 
 func TestTabCycling(t *testing.T) {
 	items := []Item{
@@ -16,7 +20,7 @@ func TestTabCycling(t *testing.T) {
 		{Name: "bravo", Value: "/b"},
 		{Name: "charlie", Value: "/c"},
 	}
-	m := New(items, dummyScorer)
+	m := New(items, dummyScorer, testRenderer)
 
 	if m.selected != 0 {
 		t.Fatalf("initial selected = %d, want 0", m.selected)
@@ -50,7 +54,7 @@ func TestShiftTabCycling(t *testing.T) {
 		{Name: "bravo", Value: "/b"},
 		{Name: "charlie", Value: "/c"},
 	}
-	m := New(items, dummyScorer)
+	m := New(items, dummyScorer, testRenderer)
 
 	shiftTabMsg := tea.KeyMsg{Type: tea.KeyShiftTab}
 
@@ -69,7 +73,7 @@ func TestShiftTabCycling(t *testing.T) {
 }
 
 func TestTabCycling_EmptyFiltered(t *testing.T) {
-	m := New(nil, dummyScorer)
+	m := New(nil, dummyScorer, testRenderer)
 	m.filtered = nil
 
 	tabMsg := tea.KeyMsg{Type: tea.KeyTab}
@@ -85,7 +89,7 @@ func TestSelected_Confirmed(t *testing.T) {
 		{Name: "alpha", Value: "/a"},
 		{Name: "bravo", Value: "/b"},
 	}
-	m := New(items, dummyScorer)
+	m := New(items, dummyScorer, testRenderer)
 
 	// Move to second item
 	tabMsg := tea.KeyMsg{Type: tea.KeyTab}
@@ -111,7 +115,7 @@ func TestSelected_Confirmed(t *testing.T) {
 
 func TestSelected_Cancelled(t *testing.T) {
 	items := []Item{{Name: "alpha", Value: "/a"}}
-	m := New(items, dummyScorer)
+	m := New(items, dummyScorer, testRenderer)
 
 	escMsg := tea.KeyMsg{Type: tea.KeyEsc}
 	updated, _ := m.Update(escMsg)
@@ -130,7 +134,7 @@ func TestView_RendersItems(t *testing.T) {
 		{Name: "alpha", Value: "/a"},
 		{Name: "bravo", Value: "/b"},
 	}
-	m := New(items, dummyScorer)
+	m := New(items, dummyScorer, testRenderer)
 
 	view := m.View()
 	if view == "" {


### PR DESCRIPTION
## Summary

- `fgo` picker now renders with full lipgloss colors instead of plain text
- Root cause: `lipgloss.NewStyle()` uses the default renderer bound to stdout, which is a pipe during `fgo` (color profile = Ascii)
- Fix: create `lipgloss.NewRenderer(os.Stderr)` and pass it to `picker.New()` so color detection uses the actual TTY
- All 8 style fields + textinput styles updated to use `renderer.NewStyle()`
- `fest tui` unaffected (renders to stdout directly)

## Test plan

- [ ] `fgo` shows colored TUI picker with styled prompt, cursor, and item highlighting
- [ ] `fgo ai` filtered view also has colors
- [ ] `fest tui` still works (regression check)
- [ ] All picker unit tests pass