### PR TITLE
fix: use structured prompt blocks for lifecycle guard messages

### DIFF
--- a/internal/commands/next/next.go
+++ b/internal/commands/next/next.go
@@ -738,11 +738,33 @@ func checkPreActiveStatus(festivalPath, phasePath string) error {
 		return nil
 	}
 
+	festName := filepath.Base(festivalPath)
+
 	if status == "ready" {
-		return errors.Validation("Festival is in ready status.\n\nBefore executing, confirm:\n  - Is this the correct festival you should be working on?\n  - Did the user approve implementation of this festival?\n\nIf approved, promote to active: fest promote")
+		var sb strings.Builder
+		sb.WriteString("STOP — FESTIVAL NOT YET ACTIVE\n")
+		sb.WriteString("──────────────────────────────\n")
+		sb.WriteString(fmt.Sprintf("Festival %q is in ready status.\n", festName))
+		sb.WriteString("Lifecycle: planning -> ready -> [active] -> completed\n\n")
+		sb.WriteString("Before executing, confirm:\n")
+		sb.WriteString("  - Is this the correct festival you should be working on?\n")
+		sb.WriteString("  - Did the user approve implementation of this festival?\n\n")
+		sb.WriteString("If approved, promote to active: fest promote\n")
+		fmt.Print(sb.String())
+		return errors.Validation("festival is in ready status").
+			WithField("festival", festName)
 	}
 
-	return errors.Validation("Festival must be in active status to execute implementation phases. Run: fest promote")
+	var sb strings.Builder
+	sb.WriteString("STOP — FESTIVAL NOT YET ACTIVE\n")
+	sb.WriteString("──────────────────────────────\n")
+	sb.WriteString(fmt.Sprintf("Festival %q is in planning status.\n", festName))
+	sb.WriteString("Lifecycle: [planning] -> ready -> active -> completed\n\n")
+	sb.WriteString("Implementation phases require active status.\n")
+	sb.WriteString("Promote to ready first: fest promote\n")
+	fmt.Print(sb.String())
+	return errors.Validation("festival is in planning status").
+		WithField("festival", festName)
 }
 
 // printFeedbackReminder appends the full feedback reminder (criteria + recording instructions)

--- a/internal/commands/next/next_test.go
+++ b/internal/commands/next/next_test.go
@@ -1,6 +1,7 @@
 package next
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -323,14 +324,14 @@ func TestCheckPreActiveStatus(t *testing.T) {
 			status:         "planning",
 			phaseType:      "implementation",
 			expectBlocked:  true,
-			expectContains: "Festival must be in active status",
+			expectContains: "festival is in planning status",
 		},
 		{
 			name:           "planning+review is blocked",
 			status:         "planning",
 			phaseType:      "review",
 			expectBlocked:  true,
-			expectContains: "Festival must be in active status",
+			expectContains: "festival is in planning status",
 		},
 		{
 			name:          "planning+ingest is allowed",
@@ -367,14 +368,14 @@ func TestCheckPreActiveStatus(t *testing.T) {
 			status:         "ready",
 			phaseType:      "implementation",
 			expectBlocked:  true,
-			expectContains: "Festival is in ready status",
+			expectContains: "festival is in ready status",
 		},
 		{
 			name:           "ready+review is blocked",
 			status:         "ready",
 			phaseType:      "review",
 			expectBlocked:  true,
-			expectContains: "Festival is in ready status",
+			expectContains: "festival is in ready status",
 		},
 		{
 			name:          "ready+ingest is allowed",
@@ -485,19 +486,39 @@ func TestCheckPreActiveStatus_ReadyMessage(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Capture stdout to verify prompt block content
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
 	err := checkPreActiveStatus(festDir, phaseDir)
+
+	w.Close()
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	os.Stdout = old
+	output := buf.String()
+
 	if err == nil {
 		t.Fatal("expected blocked error for ready+implementation, got nil")
 	}
 
-	msg := err.Error()
-	if !strings.Contains(msg, "ready status") {
-		t.Errorf("expected message to mention ready status, got: %v", msg)
+	// Error should be short
+	if !strings.Contains(err.Error(), "festival is in ready status") {
+		t.Errorf("expected short error about ready status, got: %v", err)
 	}
-	if !strings.Contains(msg, "fest promote") {
-		t.Errorf("expected message to include promote instruction, got: %v", msg)
+
+	// Prompt block on stdout should contain the detailed guidance
+	if !strings.Contains(output, "STOP") {
+		t.Errorf("expected prompt block header, got: %s", output)
 	}
-	if !strings.Contains(msg, "Did the user approve") {
-		t.Errorf("expected message to ask about user approval, got: %v", msg)
+	if !strings.Contains(output, "fest promote") {
+		t.Errorf("expected promote instruction in prompt block, got: %s", output)
+	}
+	if !strings.Contains(output, "Did the user approve") {
+		t.Errorf("expected user approval check in prompt block, got: %s", output)
+	}
+	if !strings.Contains(output, "planning -> ready -> [active] -> completed") {
+		t.Errorf("expected lifecycle in prompt block, got: %s", output)
 	}
 }


### PR DESCRIPTION
## Summary
- Follow-up to #98 addressing the review comment about guard message clarity
- Replaces inline `errors.Validation()` messages with structured prompt blocks matching the `emitValidationBlock` pattern used elsewhere in `fest next`
- Each guard now prints a `STOP` header with lifecycle diagram showing current position (e.g. `[planning] -> ready -> active -> completed`) and actionable next steps
- Error returns are kept short for programmatic use

## Example output (planning status)
```
STOP — FESTIVAL NOT YET ACTIVE
──────────────────────────────
Festival "my-festival" is in planning status.
Lifecycle: [planning] -> ready -> active -> completed

Implementation phases require active status.
Promote to ready first: fest promote
```

## Test plan
- [x] All 15 `TestCheckPreActiveStatus` cases pass
- [x] `TestCheckPreActiveStatus_ReadyMessage` updated to capture stdout and verify prompt block content (STOP header, lifecycle, promote instruction, user approval check)
- [x] `TestCheckPreActiveStatus_NoPhasePath` still passes