### PR TITLE
fix: consolidate divergent validation systems

### DIFF
--- a/internal/commands/validation/commands.go
+++ b/internal/commands/validation/commands.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/frontmatter"
 	tpl "github.com/Obedience-Corp/fest/internal/template"
 	"github.com/Obedience-Corp/fest/internal/ui"
+	"github.com/Obedience-Corp/fest/internal/validator"
 	"github.com/spf13/cobra"
 )
 
@@ -99,6 +100,23 @@ type ValidationResult struct {
 	FixesApplied []FixApplied      `json:"fixes_applied,omitempty"`
 	Suggestions  []string          `json:"suggestions,omitempty"`
 	MarkerInfo   *MarkerInfo       `json:"marker_info,omitempty"`
+}
+
+// convertIssues converts validator.Issue slice to the command-layer ValidationIssue slice.
+// This bridges between the validator package's canonical types and the CLI output types.
+func convertIssues(issues []validator.Issue) []ValidationIssue {
+	out := make([]ValidationIssue, len(issues))
+	for i, issue := range issues {
+		out[i] = ValidationIssue{
+			Level:       issue.Level,
+			Code:        issue.Code,
+			Path:        issue.Path,
+			Message:     issue.Message,
+			Fix:         issue.Fix,
+			AutoFixable: issue.AutoFixable,
+		}
+	}
+	return out
 }
 
 type validateOptions struct {
@@ -270,7 +288,6 @@ func runValidateAll(ctx context.Context, opts *validateOptions) error {
 	validateTaskFilesChecks(ctx, festivalPath, result)
 	validateQualityGatesChecks(ctx, festivalPath, result, opts.fix)
 	validateTemplateMarkers(festivalPath, result)
-	validateImplementationStructure(festivalPath, result)
 	validateOrderingChecks(ctx, festivalPath, result)
 
 	// Calculate score
@@ -424,54 +441,6 @@ func getPhaseType(festivalPath, relPath string) frontmatter.PhaseType {
 		return frontmatter.PhaseTypeImplementation
 	}
 	return fm.PhaseType
-}
-
-// validateImplementationStructure checks that implementation phases have sequences.
-func validateImplementationStructure(festivalPath string, result *ValidationResult) {
-	entries, err := os.ReadDir(festivalPath)
-	if err != nil {
-		return
-	}
-
-	phasePattern := regexp.MustCompile(`^\d{3}_`)
-	seqPattern := regexp.MustCompile(`^\d{2}_`)
-
-	for _, entry := range entries {
-		if !entry.IsDir() || !phasePattern.MatchString(entry.Name()) {
-			continue
-		}
-
-		phasePath := filepath.Join(festivalPath, entry.Name())
-		phaseType := getPhaseType(festivalPath, entry.Name())
-
-		if phaseType != frontmatter.PhaseTypeImplementation {
-			continue
-		}
-
-		// Check for sequence directories
-		seqEntries, err := os.ReadDir(phasePath)
-		if err != nil {
-			continue
-		}
-
-		hasSequences := false
-		for _, seqEntry := range seqEntries {
-			if seqEntry.IsDir() && seqPattern.MatchString(seqEntry.Name()) {
-				hasSequences = true
-				break
-			}
-		}
-
-		if !hasSequences {
-			result.Issues = append(result.Issues, ValidationIssue{
-				Level:   LevelError,
-				Code:    CodeMissingTaskFiles,
-				Path:    entry.Name(),
-				Message: fmt.Sprintf("Implementation phase %s has no sequence directories", entry.Name()),
-				Fix:     fmt.Sprintf("Create sequences with: fest create sequence --path %s", entry.Name()),
-			})
-		}
-	}
 }
 
 // Score calculation

--- a/internal/commands/validation/commands_test.go
+++ b/internal/commands/validation/commands_test.go
@@ -137,47 +137,6 @@ func TestValidateTemplateMarkers_ResearchPhaseWarnsOnMarkers(t *testing.T) {
 	}
 }
 
-func TestValidateImplementationStructure_NoSequencesFails(t *testing.T) {
-	dir := setupTestFestival(t, testFestivalOpts{
-		phaseType:    "implementation",
-		withSequence: false,
-	})
-	result := &ValidationResult{
-		OK:     true,
-		Valid:  true,
-		Issues: []ValidationIssue{},
-	}
-	validateImplementationStructure(dir, result)
-
-	hasError := false
-	for _, issue := range result.Issues {
-		if issue.Code == CodeMissingTaskFiles && issue.Level == LevelError {
-			hasError = true
-		}
-	}
-	if !hasError {
-		t.Error("expected error for implementation phase without sequences")
-	}
-}
-
-func TestValidateImplementationStructure_PlanningPhaseSkipped(t *testing.T) {
-	dir := setupTestFestival(t, testFestivalOpts{
-		phaseType:    "planning",
-		phaseDirName: "001_PLANNING",
-		withSequence: false,
-	})
-	result := &ValidationResult{
-		OK:     true,
-		Valid:  true,
-		Issues: []ValidationIssue{},
-	}
-	validateImplementationStructure(dir, result)
-
-	if len(result.Issues) > 0 {
-		t.Errorf("planning phase without sequences should not cause issues; got: %+v", result.Issues)
-	}
-}
-
 func TestValidateAll_CleanFestivalPasses(t *testing.T) {
 	dir := setupTestFestival(t, testFestivalOpts{
 		phaseType:    "implementation",
@@ -197,7 +156,6 @@ func TestValidateAll_CleanFestivalPasses(t *testing.T) {
 	validateCompletenessChecks(ctx, dir, result)
 	validateTaskFilesChecks(ctx, dir, result)
 	validateTemplateMarkers(dir, result)
-	validateImplementationStructure(dir, result)
 
 	// Check for errors (warnings are acceptable)
 	for _, issue := range result.Issues {

--- a/internal/commands/validation/validate_checklist.go
+++ b/internal/commands/validation/validate_checklist.go
@@ -3,13 +3,11 @@ package validation
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/Obedience-Corp/fest/internal/festival"
-	"github.com/Obedience-Corp/fest/internal/gates"
 	"github.com/Obedience-Corp/fest/internal/ui"
+	"github.com/Obedience-Corp/fest/internal/validator"
 	"github.com/spf13/cobra"
 )
 
@@ -60,19 +58,19 @@ func runValidateChecklist(ctx context.Context, opts *validateOptions) error {
 	}
 
 	// Run all checks and populate checklist
-	templatesFilled := checkTemplatesFilled(festivalPath)
+	templatesFilled := validator.CheckTemplatesFilled(festivalPath)
 	result.Checklist.TemplatesFilled = &templatesFilled
 
 	// Goals achievable is a manual check - always null
 	result.Checklist.GoalsAchievable = nil
 
-	taskFilesExist := checkTaskFilesExist(ctx, festivalPath)
+	taskFilesExist := validator.CheckTaskFilesExist(festivalPath)
 	result.Checklist.TaskFilesExist = &taskFilesExist
 
-	orderCorrect := checkOrderCorrect(ctx, festivalPath)
+	orderCorrect := validator.CheckOrderCorrect(festivalPath)
 	result.Checklist.OrderCorrect = &orderCorrect
 
-	parallelCorrect := checkParallelCorrect(festivalPath)
+	parallelCorrect := validator.CheckParallelCorrect(festivalPath)
 	result.Checklist.ParallelCorrect = &parallelCorrect
 
 	if opts.jsonOutput {
@@ -81,89 +79,6 @@ func runValidateChecklist(ctx context.Context, opts *validateOptions) error {
 
 	printChecklistResult(result.Checklist)
 	return nil
-}
-
-// Checklist check functions
-
-func checkTemplatesFilled(festivalPath string) bool {
-	markers := []string{"[FILL:", "[GUIDANCE:", "{{ "}
-	filled := true
-
-	filepath.Walk(festivalPath, func(path string, info os.FileInfo, err error) error {
-		if err != nil || info.IsDir() || !strings.HasSuffix(path, ".md") {
-			return nil
-		}
-
-		relPath, _ := filepath.Rel(festivalPath, path)
-		if strings.HasPrefix(relPath, ".") || strings.Contains(relPath, "/.") {
-			return nil
-		}
-		// Skip gates/ directory - these are intentional template files
-		if strings.HasPrefix(relPath, "gates/") || strings.HasPrefix(relPath, "gates"+string(filepath.Separator)) {
-			return nil
-		}
-
-		content, err := os.ReadFile(path)
-		if err != nil {
-			return nil
-		}
-
-		contentStr := string(content)
-		for _, marker := range markers {
-			if strings.Contains(contentStr, marker) {
-				filled = false
-				return filepath.SkipAll
-			}
-		}
-		return nil
-	})
-
-	return filled
-}
-
-func checkTaskFilesExist(ctx context.Context, festivalPath string) bool {
-	parser := festival.NewParser()
-	phases, _ := parser.ParsePhases(ctx, festivalPath)
-	policy := gates.DefaultPolicy()
-
-	for _, phase := range phases {
-		sequences, _ := parser.ParseSequences(ctx, phase.Path)
-		for _, seq := range sequences {
-			if isExcludedSequence(seq.Name, policy.ExcludePatterns) {
-				continue
-			}
-			tasks, _ := parser.ParseTasks(ctx, seq.Path)
-			if len(tasks) == 0 {
-				return false
-			}
-		}
-	}
-	return true
-}
-
-func checkOrderCorrect(ctx context.Context, festivalPath string) bool {
-	parser := festival.NewParser()
-	phases, err := parser.ParsePhases(ctx, festivalPath)
-	if err != nil {
-		return true // Can't check, assume OK
-	}
-
-	// Check phases are sequential
-	lastNum := 0
-	for _, phase := range phases {
-		if phase.Number < lastNum {
-			return false
-		}
-		lastNum = phase.Number
-	}
-
-	return true
-}
-
-func checkParallelCorrect(festivalPath string) bool {
-	// For now, always return true - parallel validation is complex
-	// and false positives would be confusing
-	return true
 }
 
 // Output functions for checklist

--- a/internal/commands/validation/validate_completeness.go
+++ b/internal/commands/validation/validate_completeness.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
-	"github.com/Obedience-Corp/fest/internal/festival"
 	"github.com/Obedience-Corp/fest/internal/ui"
+	"github.com/Obedience-Corp/fest/internal/validator"
 	"github.com/spf13/cobra"
 )
 
@@ -75,58 +75,15 @@ func runValidateCompleteness(ctx context.Context, opts *validateOptions) error {
 }
 
 func validateCompletenessChecks(ctx context.Context, festivalPath string, result *ValidationResult) {
-	// Check FESTIVAL_OVERVIEW.md
-	overviewPath := filepath.Join(festivalPath, "FESTIVAL_OVERVIEW.md")
-	if !validateFileExists(overviewPath) {
+	issues, err := validator.ValidateCompleteness(ctx, festivalPath)
+	if err != nil {
 		result.Issues = append(result.Issues, ValidationIssue{
 			Level:   LevelError,
 			Code:    CodeMissingFile,
-			Path:    overviewPath,
-			Message: "FESTIVAL_OVERVIEW.md is required",
-			Fix:     "Create FESTIVAL_OVERVIEW.md with project goals and success criteria",
+			Path:    festivalPath,
+			Message: fmt.Sprintf("Failed to validate completeness: %v", err),
 		})
+		return
 	}
-
-	// Check FESTIVAL_RULES.md (warning, not error)
-	rulesPath := filepath.Join(festivalPath, "FESTIVAL_RULES.md")
-	if !validateFileExists(rulesPath) {
-		result.Issues = append(result.Issues, ValidationIssue{
-			Level:   LevelWarning,
-			Code:    CodeMissingFile,
-			Path:    rulesPath,
-			Message: "FESTIVAL_RULES.md is recommended",
-		})
-	}
-
-	parser := festival.NewParser()
-	phases, _ := parser.ParsePhases(ctx, festivalPath)
-
-	for _, phase := range phases {
-		// Check PHASE_GOAL.md
-		phaseGoalPath := filepath.Join(phase.Path, "PHASE_GOAL.md")
-		if !validateFileExists(phaseGoalPath) {
-			result.Issues = append(result.Issues, ValidationIssue{
-				Level:   LevelError,
-				Code:    CodeMissingGoal,
-				Path:    phaseGoalPath,
-				Message: fmt.Sprintf("PHASE_GOAL.md required in %s", phase.FullName),
-				Fix:     fmt.Sprintf("fest create phase --name %q --json", phase.Name),
-			})
-		}
-
-		// Check sequences
-		sequences, _ := parser.ParseSequences(ctx, phase.Path)
-		for _, seq := range sequences {
-			seqGoalPath := filepath.Join(seq.Path, "SEQUENCE_GOAL.md")
-			if !validateFileExists(seqGoalPath) {
-				result.Issues = append(result.Issues, ValidationIssue{
-					Level:   LevelError,
-					Code:    CodeMissingGoal,
-					Path:    seqGoalPath,
-					Message: fmt.Sprintf("SEQUENCE_GOAL.md required in %s", seq.FullName),
-					Fix:     fmt.Sprintf("fest create sequence --name %q --json", seq.Name),
-				})
-			}
-		}
-	}
+	result.Issues = append(result.Issues, convertIssues(issues)...)
 }

--- a/internal/commands/validation/validate_gates.go
+++ b/internal/commands/validation/validate_gates.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
-	"github.com/Obedience-Corp/fest/internal/festival"
-	"github.com/Obedience-Corp/fest/internal/gates"
 	"github.com/Obedience-Corp/fest/internal/ui"
+	"github.com/Obedience-Corp/fest/internal/validator"
 	"github.com/spf13/cobra"
 )
 
@@ -84,108 +82,29 @@ func runValidateQualityGates(ctx context.Context, opts *validateOptions) error {
 }
 
 func validateQualityGatesChecks(ctx context.Context, festivalPath string, result *ValidationResult, autoFix bool) {
-	parser := festival.NewParser()
-	phases, _ := parser.ParsePhases(ctx, festivalPath)
-	defaultPolicy := gates.DefaultPolicy()
+	issues, err := validator.ValidateQualityGates(ctx, festivalPath)
+	if err != nil {
+		result.Issues = append(result.Issues, ValidationIssue{
+			Level:   LevelError,
+			Code:    CodeMissingQualityGate,
+			Path:    festivalPath,
+			Message: fmt.Sprintf("Failed to validate quality gates: %v", err),
+		})
+		return
+	}
 
-	for _, phase := range phases {
-		// Detect the actual phase type from frontmatter or directory name
-		phaseType := gates.DetectPhaseType(phase.Path)
+	converted := convertIssues(issues)
+	result.Issues = append(result.Issues, converted...)
 
-		// Only validate implementation phases
-		if phaseType != "implementation" {
-			continue
-		}
-
-		// Get the expected gates for this phase type
-		expectedGates := gates.GetGatesForPhaseType(phaseType)
-		gateIDs := make(map[string]bool)
-		for _, gate := range expectedGates {
-			if gate.Enabled {
-				gateIDs[gate.ID] = true
-			}
-		}
-
-		sequences, _ := parser.ParseSequences(ctx, phase.Path)
-		for _, seq := range sequences {
-			// Check sequence exclusion patterns from default policy
-			if isExcludedSequence(seq.Name, defaultPolicy.ExcludePatterns) {
-				continue
-			}
-
-			// Check for quality gate tasks
-			tasks, _ := parser.ParseTasks(ctx, seq.Path)
-			hasGates := false
-			for _, task := range tasks {
-				// Check if task name contains any gate ID
-				for gateID := range gateIDs {
-					if strings.Contains(strings.ToLower(task.Name), strings.ReplaceAll(gateID, "_", "")) ||
-						strings.Contains(task.Name, gateID) {
-						hasGates = true
-						break
-					}
-				}
-			}
-
-			if !hasGates && len(tasks) > 0 {
-				relPath, _ := filepath.Rel(festivalPath, seq.Path)
-				// Phase-type-aware error message
-				phaseTypeTitle := titleCase(phaseType)
-				result.Issues = append(result.Issues, ValidationIssue{
-					Level:       LevelError,
-					Code:        CodeMissingQualityGate,
-					Path:        relPath,
-					Message:     fmt.Sprintf("%s sequence missing quality gates", phaseTypeTitle),
-					Fix:         "fest gates apply --sequence " + relPath + " --approve",
-					AutoFixable: true,
+	if autoFix {
+		for _, issue := range converted {
+			if issue.AutoFixable {
+				result.FixesApplied = append(result.FixesApplied, FixApplied{
+					Code:   issue.Code,
+					Path:   issue.Path,
+					Action: "Quality gates would be added (--fix not yet implemented)",
 				})
-
-				if autoFix {
-					// TODO: Call fest gates apply
-					result.FixesApplied = append(result.FixesApplied, FixApplied{
-						Code:   CodeMissingQualityGate,
-						Path:   relPath,
-						Action: "Quality gates would be added (--fix not yet implemented)",
-					})
-				}
 			}
 		}
 	}
-}
-
-// titleCase converts a string to title case (first letter uppercase)
-func titleCase(s string) string {
-	if s == "" {
-		return s
-	}
-	// Handle snake_case by replacing underscores with spaces and capitalizing
-	s = strings.ReplaceAll(s, "_", " ")
-	words := strings.Fields(s)
-	for i, word := range words {
-		if len(word) > 0 {
-			words[i] = strings.ToUpper(string(word[0])) + strings.ToLower(word[1:])
-		}
-	}
-	return strings.Join(words, " ")
-}
-
-// isExcludedSequence checks if a sequence name matches exclusion patterns
-func isExcludedSequence(name string, patterns []string) bool {
-	for _, pattern := range patterns {
-		// Simple glob matching
-		if strings.HasPrefix(pattern, "*") {
-			suffix := strings.TrimPrefix(pattern, "*")
-			if strings.HasSuffix(name, suffix) {
-				return true
-			}
-		} else if strings.HasSuffix(pattern, "*") {
-			prefix := strings.TrimSuffix(pattern, "*")
-			if strings.HasPrefix(name, prefix) {
-				return true
-			}
-		} else if name == pattern {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/commands/validation/validate_structure.go
+++ b/internal/commands/validation/validate_structure.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"regexp"
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
-	"github.com/Obedience-Corp/fest/internal/festival"
 	"github.com/Obedience-Corp/fest/internal/ui"
+	"github.com/Obedience-Corp/fest/internal/validator"
 	"github.com/spf13/cobra"
 )
 
@@ -75,61 +74,15 @@ func runValidateStructure(ctx context.Context, opts *validateOptions) error {
 }
 
 func validateStructureChecks(ctx context.Context, festivalPath string, result *ValidationResult) {
-	parser := festival.NewParser()
-
-	// Parse festival structure
-	phases, err := parser.ParsePhases(ctx, festivalPath)
+	issues, err := validator.ValidateStructure(ctx, festivalPath)
 	if err != nil {
 		result.Issues = append(result.Issues, ValidationIssue{
 			Level:   LevelError,
 			Code:    CodeNamingConvention,
 			Path:    festivalPath,
-			Message: fmt.Sprintf("Failed to parse phases: %v", err),
+			Message: fmt.Sprintf("Failed to validate structure: %v", err),
 		})
 		return
 	}
-
-	// Check phase naming (should be UPPERCASE after number)
-	phaseUpperPattern := regexp.MustCompile(`^\d{3}_[A-Z][A-Z0-9_]*$`)
-	for _, phase := range phases {
-		if !phaseUpperPattern.MatchString(phase.FullName) {
-			result.Issues = append(result.Issues, ValidationIssue{
-				Level:   LevelError,
-				Code:    CodeNamingConvention,
-				Path:    phase.Path,
-				Message: fmt.Sprintf("Phase name should be UPPERCASE: %s", phase.FullName),
-				Fix:     "Rename phase directory to use UPPERCASE (e.g., 001_PHASE_NAME)",
-			})
-		}
-
-		// Check sequences
-		sequences, _ := parser.ParseSequences(ctx, phase.Path)
-		seqLowerPattern := regexp.MustCompile(`^\d{2}_[a-z][a-z0-9_]*$`)
-		for _, seq := range sequences {
-			if !seqLowerPattern.MatchString(seq.FullName) {
-				result.Issues = append(result.Issues, ValidationIssue{
-					Level:   LevelError,
-					Code:    CodeNamingConvention,
-					Path:    seq.Path,
-					Message: fmt.Sprintf("Sequence name should be lowercase: %s", seq.FullName),
-					Fix:     "Rename sequence directory to use lowercase (e.g., 01_sequence_name)",
-				})
-			}
-
-			// Check tasks
-			tasks, _ := parser.ParseTasks(ctx, seq.Path)
-			taskLowerPattern := regexp.MustCompile(`^\d{2}_[a-z][a-z0-9_]*\.md$`)
-			for _, task := range tasks {
-				if !taskLowerPattern.MatchString(task.FullName) {
-					result.Issues = append(result.Issues, ValidationIssue{
-						Level:   LevelError,
-						Code:    CodeNamingConvention,
-						Path:    task.Path,
-						Message: fmt.Sprintf("Task name should be lowercase: %s", task.FullName),
-						Fix:     "Rename task file to use lowercase (e.g., 01_task_name.md)",
-					})
-				}
-			}
-		}
-	}
+	result.Issues = append(result.Issues, convertIssues(issues)...)
 }

--- a/internal/commands/validation/validate_tasks.go
+++ b/internal/commands/validation/validate_tasks.go
@@ -6,9 +6,8 @@ import (
 	"path/filepath"
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
-	"github.com/Obedience-Corp/fest/internal/festival"
-	"github.com/Obedience-Corp/fest/internal/gates"
 	"github.com/Obedience-Corp/fest/internal/ui"
+	"github.com/Obedience-Corp/fest/internal/validator"
 	"github.com/spf13/cobra"
 )
 
@@ -91,33 +90,17 @@ func runValidateTasks(ctx context.Context, opts *validateOptions) error {
 }
 
 func validateTaskFilesChecks(ctx context.Context, festivalPath string, result *ValidationResult) {
-	parser := festival.NewParser()
-	phases, _ := parser.ParsePhases(ctx, festivalPath)
-	policy := gates.DefaultPolicy()
-
-	for _, phase := range phases {
-		sequences, _ := parser.ParseSequences(ctx, phase.Path)
-		for _, seq := range sequences {
-			// Check if this is an implementation sequence
-			if isExcludedSequence(seq.Name, policy.ExcludePatterns) {
-				continue
-			}
-
-			// Check for task files
-			tasks, _ := parser.ParseTasks(ctx, seq.Path)
-			if len(tasks) == 0 {
-				relPath, _ := filepath.Rel(festivalPath, seq.Path)
-				result.Issues = append(result.Issues, ValidationIssue{
-					Level:       LevelError,
-					Code:        CodeMissingTaskFiles,
-					Path:        relPath,
-					Message:     "Implementation sequence has SEQUENCE_GOAL.md but no task files",
-					Fix:         fmt.Sprintf("fest create task --name \"design\" --path %s --json", relPath),
-					AutoFixable: false,
-				})
-			}
-		}
+	issues, err := validator.ValidateTasks(ctx, festivalPath)
+	if err != nil {
+		result.Issues = append(result.Issues, ValidationIssue{
+			Level:   LevelError,
+			Code:    CodeMissingTaskFiles,
+			Path:    festivalPath,
+			Message: fmt.Sprintf("Failed to validate tasks: %v", err),
+		})
+		return
 	}
+	result.Issues = append(result.Issues, convertIssues(issues)...)
 }
 
 func printTaskValidationSection(display *ui.UI, issues []ValidationIssue) {


### PR DESCRIPTION
## Summary

- Makes `commands/validation/` delegate **all** core validation to `internal/validator/`, eliminating duplicated logic that caused `fest validate` and `fest next` to produce contradictory results
- Adds `convertIssues()` bridge between validator and command-layer type systems
- Removes `validateImplementationStructure` (redundant with `validator.ValidateCompleteness`)
- Deletes duplicate `isExcludedSequence` and `titleCase` helpers from command layer
- Keeps CLI-specific features (MarkerInfo, phase-aware marker severity, auto-fix orchestration) in the command layer

Net result: **-411 lines, +65 lines** — 7 files changed

Closes #101

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/validator/...` — all pass
- [x] `go test ./internal/commands/validation/...` — all 5 tests pass  
- [x] `go test ./...` — full suite passes, zero failures
- [ ] Manual: `cd festivals/active/<festival> && fest validate && fest next` — both should agree