### PR TITLE
fix: handle skipped workflow steps in fest show

### DIFF
--- a/internal/commands/show/tree.go
+++ b/internal/commands/show/tree.go
@@ -120,7 +120,7 @@ func buildPhaseNode(ctx context.Context, phaseDir string, store *progress.Store,
 				stepNodes = append(stepNodes, buildStepNode(step))
 				stepStats.Total++
 				switch step.Status {
-				case wf.StepStatusCompleted:
+				case wf.StepStatusCompleted, wf.StepStatusSkipped:
 					stepStats.Completed++
 				case wf.StepStatusInProgress:
 					stepStats.InProgress++
@@ -187,6 +187,8 @@ func buildStepNode(step shared.WorkflowStepView) *DisplayNode {
 		status = "in_progress"
 	case wf.StepStatusBlocked:
 		status = "blocked"
+	case wf.StepStatusSkipped:
+		status = "skipped"
 	}
 
 	return &DisplayNode{
@@ -196,7 +198,7 @@ func buildStepNode(step shared.WorkflowStepView) *DisplayNode {
 		NodeType: "step",
 		Stats: StatusCounts{
 			Total:     1,
-			Completed: boolToInt(step.Status == wf.StepStatusCompleted),
+			Completed: boolToInt(step.Status == wf.StepStatusCompleted || step.Status == wf.StepStatusSkipped),
 		},
 	}
 }
@@ -281,7 +283,7 @@ func buildSequenceNode(seqDir string, store *progress.Store, festivalRoot string
 // through the tree gets marked, giving --inprogress a "next up" expansion.
 func markNextPending(node *DisplayNode) {
 	for _, child := range node.Children {
-		if child.Status != "completed" {
+		if child.Status != "completed" && child.Status != "skipped" {
 			child.IsNextPending = true
 			// Leaf nodes (tasks/steps) show as in_progress to indicate "work here next"
 			if child.NodeType == "task" || child.NodeType == "step" {

--- a/internal/ui/text.go
+++ b/internal/ui/text.go
@@ -68,6 +68,8 @@ func StateIcon(state string) string {
 		return ColoredText("●", InProgressColor)
 	case "blocked", "error", "failed":
 		return ColoredText("■", BlockedColor)
+	case "skipped":
+		return ColoredText("⤼", WarningColor)
 	case "pending", "todo", "queued":
 		return ColoredText("○", PendingColor)
 	default:


### PR DESCRIPTION
## Summary

- `fest show` dropped the `"skipped"` status from workflow steps, rendering them as pending (wrong icon, inflated pending counts)
- `--inprogress` treated skipped steps as incomplete, expanding them instead of collapsing
- Skipped steps now display with the `⤼` icon, count as terminal in stats, and are collapsed by `--inprogress`

## Changes

- **`buildStepNode()`** — Map `StepStatusSkipped` → `"skipped"` display status; count as completed in stats
- **`buildPhaseNode()`** — Count skipped steps alongside completed in phase-level stats
- **`markNextPending()`** — Treat `"skipped"` as terminal (like `"completed"`) so `--inprogress` skips them
- **`StateIcon()`** — Add `"skipped"` case with `⤼` icon in warning color

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/commands/show/...`
- [x] `go test ./internal/ui/...`
- [ ] Manual: `fest workflow skip --reason "testing"` then `fest show` and `fest show --inprogress` — skipped steps show ⤼ icon and collapse correctly