### PR TITLE
test: add regression tests for chain create and cross-validate parse errors

### DIFF
--- a/internal/chain/discovery_test.go
+++ b/internal/chain/discovery_test.go
@@ -1,0 +1,62 @@
+package chain
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const malformedChainYAML = `
+chain_version: "1.0"
+metadata:
+  id: BAD0001
+  name: bad
+  created_at: 2026-01-01T00:00:00Z
+  status: planning
+festivals:
+  - ref: a
+    id: A0001
+    name: alpha
+edges:
+  - from: a
+    to: a
+    type: hard
+  oops: [
+`
+
+func TestDiscoverAllStrictReturnsParseErrors(t *testing.T) {
+	root := t.TempDir()
+	chainsDir := filepath.Join(root, "chains")
+	require.NoError(t, os.MkdirAll(chainsDir, 0o755))
+
+	validPath := filepath.Join(chainsDir, "valid-EC0001.yaml")
+	badPath := filepath.Join(chainsDir, "bad-BAD0001.yaml")
+	require.NoError(t, os.WriteFile(validPath, []byte(validChainYAML), 0o644))
+	require.NoError(t, os.WriteFile(badPath, []byte(malformedChainYAML), 0o644))
+
+	chains, parseErrors, err := DiscoverAllStrict(context.Background(), root)
+	require.NoError(t, err)
+	require.Len(t, chains, 1)
+	require.Len(t, parseErrors, 1)
+
+	assert.Equal(t, badPath, parseErrors[0].File)
+	assert.Contains(t, parseErrors[0].Error(), filepath.Base(badPath))
+	assert.Contains(t, parseErrors[0].Err.Error(), "parsing chain YAML")
+}
+
+func TestDiscoverAllSilentlySkipsParseErrors(t *testing.T) {
+	root := t.TempDir()
+	chainsDir := filepath.Join(root, "chains")
+	require.NoError(t, os.MkdirAll(chainsDir, 0o755))
+
+	require.NoError(t, os.WriteFile(filepath.Join(chainsDir, "valid-EC0001.yaml"), []byte(validChainYAML), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(chainsDir, "bad-BAD0001.yaml"), []byte(malformedChainYAML), 0o644))
+
+	chains, err := DiscoverAll(context.Background(), root)
+	require.NoError(t, err)
+	require.Len(t, chains, 1)
+}

--- a/internal/commands/chain/create.go
+++ b/internal/commands/chain/create.go
@@ -90,7 +90,7 @@ func runCreate(cmd *cobra.Command, name, goal string) error {
 	filename := fmt.Sprintf("%s-%s.yaml", slug, id)
 	path := filepath.Join(chainsDir, filename)
 
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	f, err := createChainFile(path)
 	if err != nil {
 		if os.IsExist(err) {
 			return fmt.Errorf("chain file already exists: %s", path)
@@ -142,6 +142,10 @@ func nextChainID(chainsDir, prefix string) string {
 		}
 	}
 	return fmt.Sprintf("%s%04d", prefix, maxNum+1)
+}
+
+func createChainFile(path string) (*os.File, error) {
+	return os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
 }
 
 // chainIDPrefix extracts a 2-letter uppercase prefix from the chain name.

--- a/internal/commands/chain/create_test.go
+++ b/internal/commands/chain/create_test.go
@@ -1,0 +1,49 @@
+package chain
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNextChainIDUsesMaxNumericSuffix(t *testing.T) {
+	chainsDir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(chainsDir, "alpha-beta-AB0001.yaml"), []byte("one"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(chainsDir, "alpha-beta-AB0003.yaml"), []byte("three"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(chainsDir, "other-XY0007.yaml"), []byte("other"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(chainsDir, "README.md"), []byte("ignore"), 0o644))
+
+	got := nextChainID(chainsDir, "AB")
+	assert.Equal(t, "AB0004", got)
+}
+
+func TestNextChainIDIgnoresMalformedPrefixMatches(t *testing.T) {
+	chainsDir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(chainsDir, "AB-not-a-number.yaml"), []byte("x"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(chainsDir, "alpha-beta-AB0002.yaml"), []byte("y"), 0o644))
+
+	got := nextChainID(chainsDir, "AB")
+	assert.Equal(t, "AB0003", got)
+}
+
+func TestCreateChainFileDoesNotOverwriteExistingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "alpha-beta-AB0001.yaml")
+	original := "original chain contents"
+	require.NoError(t, os.WriteFile(path, []byte(original), 0o644))
+
+	f, err := createChainFile(path)
+	if f != nil {
+		_ = f.Close()
+	}
+	require.Error(t, err)
+	assert.True(t, os.IsExist(err))
+
+	data, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	assert.Equal(t, original, string(data))
+}

--- a/internal/commands/chain/validate_test.go
+++ b/internal/commands/chain/validate_test.go
@@ -1,0 +1,89 @@
+package chain
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const validCrossValidateChainYAML = `
+chain_version: "1.0"
+metadata:
+  id: CH0001
+  name: valid-chain
+  created_at: 2026-01-01T00:00:00Z
+  status: planning
+  status_history: []
+festivals:
+  - ref: a
+    id: A0001
+    name: alpha
+edges: []
+`
+
+const malformedCrossValidateChainYAML = `
+chain_version: "1.0"
+metadata:
+  id: CH0002
+  name: malformed-chain
+  created_at: 2026-01-01T00:00:00Z
+  status: planning
+festivals:
+  - ref: b
+    id: B0001
+    name: beta
+edges:
+  - from: b
+    to: b
+    type: hard
+  broken: [
+`
+
+func TestRunCrossValidateReportsParseErrors(t *testing.T) {
+	festivalsRoot := filepath.Join(t.TempDir(), "festivals")
+	chainsDir := filepath.Join(festivalsRoot, "chains")
+	require.NoError(t, os.MkdirAll(filepath.Join(festivalsRoot, ".festival"), 0o755))
+	require.NoError(t, os.MkdirAll(chainsDir, 0o755))
+
+	require.NoError(t, os.WriteFile(filepath.Join(chainsDir, "valid-CH0001.yaml"), []byte(validCrossValidateChainYAML), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(chainsDir, "bad-CH0002.yaml"), []byte(malformedCrossValidateChainYAML), 0o644))
+
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(festivalsRoot))
+	t.Cleanup(func() {
+		_ = os.Chdir(origDir)
+	})
+
+	output, runErr := captureCrossValidateOutput(t)
+	require.Error(t, runErr)
+	assert.Contains(t, runErr.Error(), "failed to parse")
+	assert.Contains(t, output, "Parse errors:")
+	assert.Contains(t, output, "bad-CH0002.yaml")
+}
+
+func captureCrossValidateOutput(t *testing.T) (string, error) {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	runErr := runCrossValidate(context.Background())
+
+	require.NoError(t, w.Close())
+	os.Stdout = oldStdout
+
+	var buf bytes.Buffer
+	_, copyErr := io.Copy(&buf, r)
+	require.NoError(t, copyErr)
+
+	return buf.String(), runErr
+}


### PR DESCRIPTION
## Summary
- add regression tests for non-contiguous chain ID generation (`nextChainID`)
- add regression test to verify chain file creation is collision-safe (no overwrite/truncation)
- add strict discovery regression tests for malformed chain YAML handling
- add command-level regression test ensuring `fest chain validate --cross` surfaces parse errors and returns an error

## Validation
- `go test ./internal/commands/chain ./internal/chain`
- `go test ./...`

Closes #111