### PR TITLE
fix: eliminate duplicate error output from fest next

### DIFF
--- a/cmd/fest/main.go
+++ b/cmd/fest/main.go
@@ -1,15 +1,19 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/Obedience-Corp/fest/internal/commands"
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
 )
 
 func main() {
 	if err := commands.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		if !errors.Is(err, festerrors.ErrAlreadyPrinted) {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
 		os.Exit(1)
 	}
 }

--- a/internal/commands/next/next.go
+++ b/internal/commands/next/next.go
@@ -693,8 +693,7 @@ func emitValidationBlock(festivalPath string, result *validator.Result) error {
 	sb.WriteString("\nRun 'fest validate' for full details, then fix the issues.\n")
 	sb.WriteString("Do not proceed with tasks until the festival passes validation.\n")
 	fmt.Print(sb.String())
-	return errors.Validation("festival has unfixed validation errors").
-		WithField("festival", filepath.Base(festivalPath))
+	return errors.ErrAlreadyPrinted
 }
 
 // isPhaseMarkedComplete checks PHASE_GOAL.md frontmatter for fest_status: completed.
@@ -776,8 +775,7 @@ func checkPreActiveStatus(ctx context.Context, festivalPath, phasePath string) e
 		sb.WriteString("  - Did the user approve implementation of this festival?\n\n")
 		sb.WriteString("If approved, promote to active: fest promote\n")
 		fmt.Print(sb.String())
-		return errors.Validation("festival is in ready status").
-			WithField("festival", festName)
+		return errors.ErrAlreadyPrinted
 	}
 
 	var sb strings.Builder
@@ -788,8 +786,7 @@ func checkPreActiveStatus(ctx context.Context, festivalPath, phasePath string) e
 	sb.WriteString("Implementation phases require active status.\n")
 	sb.WriteString("Promote to ready first: fest promote\n")
 	fmt.Print(sb.String())
-	return errors.Validation("festival is in planning status").
-		WithField("festival", festName)
+	return errors.ErrAlreadyPrinted
 }
 
 // printFeedbackReminder appends the full feedback reminder (criteria + recording instructions)

--- a/internal/commands/next/next_preactive_test.go
+++ b/internal/commands/next/next_preactive_test.go
@@ -2,10 +2,13 @@ package next
 
 import (
 	"context"
+	stderrors "errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/errors"
 )
 
 func TestCheckPreActiveStatus(t *testing.T) {
@@ -117,8 +120,8 @@ func TestCheckPreActiveStatus(t *testing.T) {
 			if tt.expectBlocked {
 				if err == nil {
 					t.Error("expected blocked error, got nil")
-				} else if tt.expectContains != "" && !strings.Contains(err.Error(), tt.expectContains) {
-					t.Errorf("expected error containing %q, got: %v", tt.expectContains, err)
+				} else if !stderrors.Is(err, errors.ErrAlreadyPrinted) {
+					t.Errorf("expected ErrAlreadyPrinted, got: %v", err)
 				}
 			} else if err != nil {
 				t.Errorf("expected no error, got: %v", err)
@@ -187,8 +190,8 @@ func TestCheckPreActiveStatus_ReadyMessage(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected blocked error for ready+implementation, got nil")
 	}
-	if !strings.Contains(err.Error(), "festival is in ready status") {
-		t.Errorf("expected short error about ready status, got: %v", err)
+	if !stderrors.Is(err, errors.ErrAlreadyPrinted) {
+		t.Errorf("expected ErrAlreadyPrinted, got: %v", err)
 	}
 	if !strings.Contains(output, "STOP") {
 		t.Errorf("expected prompt block header, got: %s", output)

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -63,9 +63,11 @@ func IsVerbose() bool {
 }
 
 var rootCmd = &cobra.Command{
-	Use:     "fest",
-	Short:   "Festival Methodology CLI - goal-oriented project management for AI agents",
-	Version: fmt.Sprintf("%s (built %s, commit %s)", version.Version, version.BuildDate, version.Commit),
+	Use:           "fest",
+	Short:         "Festival Methodology CLI - goal-oriented project management for AI agents",
+	Version:       fmt.Sprintf("%s (built %s, commit %s)", version.Version, version.BuildDate, version.Commit),
+	SilenceErrors: true,
+	SilenceUsage:  true,
 }
 
 // Execute runs the root command

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -6,6 +6,10 @@ import (
 	"fmt"
 )
 
+// ErrAlreadyPrinted is a sentinel error indicating the message was already
+// printed to the user. main.go should skip re-printing but still exit non-zero.
+var ErrAlreadyPrinted = fmt.Errorf("already printed")
+
 // Error codes for categorization.
 const (
 	ErrCodeNotFound   = "NOT_FOUND"


### PR DESCRIPTION
## Summary

- Fixes `fest next` outputting blocking messages 3 times (formatted block + cobra error/usage + main.go stderr)
- Adds `ErrAlreadyPrinted` sentinel error so functions that already printed a formatted block don't get re-printed by cobra or main.go
- Sets `SilenceErrors: true` and `SilenceUsage: true` on the root cobra command

## Changes

| File | Change |
|------|--------|
| `internal/errors/errors.go` | Add `ErrAlreadyPrinted` sentinel |
| `internal/commands/root.go` | Set `SilenceErrors`/`SilenceUsage` on root cmd |
| `cmd/fest/main.go` | Skip printing for `ErrAlreadyPrinted` errors |
| `internal/commands/next/next.go` | Return `ErrAlreadyPrinted` from `checkPreActiveStatus` and `emitValidationBlock` |
| `internal/commands/next/next_preactive_test.go` | Update assertions to check sentinel error |

## Test plan

- [x] `just build` passes
- [x] `just test all-raw` passes (unit + integration)
- [x] Manual verification: `fest next` in a planning-status festival shows only the formatted block, no duplicates, no help menu, exits with code 1