### PR TITLE
fix: standardize YAML output to 2-space indentation

### DIFF
--- a/internal/commands/chain/complete.go
+++ b/internal/commands/chain/complete.go
@@ -10,7 +10,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/ui"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"github.com/Obedience-Corp/fest/internal/yamlutil"
 )
 
 func newCompleteCmd() *cobra.Command {
@@ -73,7 +73,7 @@ func runComplete(ctx context.Context, chainID string, force bool, notes string) 
 	}
 
 	// Marshal updated chain.
-	data, err := yaml.Marshal(c)
+	data, err := yamlutil.Marshal(c)
 	if err != nil {
 		return errors.Wrap(err, "marshaling chain").WithCode(errors.ErrCodeInternal)
 	}

--- a/internal/commands/markers/scaffold.go
+++ b/internal/commands/markers/scaffold.go
@@ -13,7 +13,7 @@ import (
 	tpl "github.com/Obedience-Corp/fest/internal/template"
 	"github.com/Obedience-Corp/fest/internal/ui"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"github.com/Obedience-Corp/fest/internal/yamlutil"
 )
 
 // ScaffoldMeta contains metadata about the scaffold output
@@ -159,7 +159,7 @@ func runScaffold(scaffoldOpts *scaffoldOptions, opts *markersOptions) error {
 	// Generate output
 	var outputBytes []byte
 	if format == "yaml" {
-		outputBytes, err = yaml.Marshal(output)
+		outputBytes, err = yamlutil.Marshal(output)
 	} else {
 		outputBytes, err = json.MarshalIndent(output, "", "  ")
 	}

--- a/internal/commands/research/link.go
+++ b/internal/commands/research/link.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/ui"
 	"github.com/spf13/cobra"
+	"github.com/Obedience-Corp/fest/internal/yamlutil"
 	"gopkg.in/yaml.v3"
 )
 
@@ -211,7 +212,7 @@ func updateDocumentLinks(content string, phases, sequences, tasks []string, unli
 	}
 
 	// Serialize frontmatter
-	newFrontmatter, err := yaml.Marshal(frontmatter)
+	newFrontmatter, err := yamlutil.Marshal(frontmatter)
 	if err != nil {
 		return "", 0, 0, errors.Wrap(err, "serializing frontmatter")
 	}

--- a/internal/commands/system/repair_execute.go
+++ b/internal/commands/system/repair_execute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/progress"
 	"github.com/Obedience-Corp/fest/internal/ui"
 	"github.com/Obedience-Corp/fest/internal/workflow"
-	"gopkg.in/yaml.v3"
+	"github.com/Obedience-Corp/fest/internal/yamlutil"
 )
 
 // executeRepair performs the actual repair operations.
@@ -101,7 +101,7 @@ func executeCreateSchema(ctx context.Context, festivalsRoot string, plan *repair
 	}
 
 	schema := workflow.FestivalSchema()
-	data, err := yaml.Marshal(schema)
+	data, err := yamlutil.Marshal(schema)
 	if err != nil {
 		return fmt.Errorf("marshaling schema: %w", err)
 	}

--- a/internal/config/festival_config.go
+++ b/internal/config/festival_config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/pathutil"
+	"github.com/Obedience-Corp/fest/internal/yamlutil"
 	"gopkg.in/yaml.v3"
 )
 
@@ -149,7 +150,7 @@ func SaveFestivalConfig(festivalPath, campaignRoot string, cfg *FestivalConfig) 
 	}
 
 	// Marshal to YAML
-	data, err := yaml.Marshal(&saveCopy)
+	data, err := yamlutil.Marshal(&saveCopy)
 	if err != nil {
 		return errors.Wrap(err, "marshaling festival config")
 	}

--- a/internal/config/workspace_config.go
+++ b/internal/config/workspace_config.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/yamlutil"
 	"gopkg.in/yaml.v3"
 )
 
@@ -73,7 +74,7 @@ func SaveWorkspaceConfig(festivalsRoot string, cfg *WorkspaceConfig) error {
 	configPath := filepath.Join(dotFestivalPath, WorkspaceConfigFileName)
 
 	// Marshal to YAML
-	data, err := yaml.Marshal(cfg)
+	data, err := yamlutil.Marshal(cfg)
 	if err != nil {
 		return errors.Wrap(err, "marshaling workspace config")
 	}

--- a/internal/extensions/types.go
+++ b/internal/extensions/types.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/yamlutil"
 )
 
 const (
@@ -69,7 +70,7 @@ func LoadExtensionManifest(path string) (*ExtensionManifest, error) {
 
 // SaveExtensionManifest saves an extension manifest to a file
 func SaveExtensionManifest(path string, manifest *ExtensionManifest) error {
-	data, err := yaml.Marshal(manifest)
+	data, err := yamlutil.Marshal(manifest)
 	if err != nil {
 		return errors.Wrap(err, "marshaling manifest")
 	}

--- a/internal/feedback/feedback.go
+++ b/internal/feedback/feedback.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/yamlutil"
 	"gopkg.in/yaml.v3"
 )
 
@@ -105,7 +106,7 @@ func (s *Store) Init(ctx context.Context, criteria []string) (*Config, error) {
 
 	// Save config
 	configPath := filepath.Join(s.feedbackDir, ConfigFile)
-	data, err := yaml.Marshal(config)
+	data, err := yamlutil.Marshal(config)
 	if err != nil {
 		return nil, errors.Wrap(err, "marshaling config")
 	}
@@ -192,7 +193,7 @@ func (s *Store) AddObservation(ctx context.Context, obs *Observation) error {
 
 	// Save observation
 	obsPath := filepath.Join(s.observationsDir, obs.ID+".yaml")
-	data, err := yaml.Marshal(obs)
+	data, err := yamlutil.Marshal(obs)
 	if err != nil {
 		return errors.Wrap(err, "marshaling observation")
 	}
@@ -263,7 +264,7 @@ func (s *Store) Export(ctx context.Context, format string) (string, error) {
 		return string(data), nil
 
 	case "yaml":
-		data, err := yaml.Marshal(observations)
+		data, err := yamlutil.Marshal(observations)
 		if err != nil {
 			return "", errors.Wrap(err, "marshaling YAML")
 		}

--- a/internal/frontmatter/inject.go
+++ b/internal/frontmatter/inject.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"gopkg.in/yaml.v3"
+	"github.com/Obedience-Corp/fest/internal/yamlutil"
 )
 
 // Inject adds frontmatter to content
@@ -26,7 +26,7 @@ func Inject(content []byte, fm *Frontmatter) ([]byte, error) {
 
 // Marshal converts frontmatter to YAML bytes
 func Marshal(fm *Frontmatter) ([]byte, error) {
-	return yaml.Marshal(fm)
+	return yamlutil.Marshal(fm)
 }
 
 // Format returns formatted frontmatter as a string

--- a/internal/gates/markers.go
+++ b/internal/gates/markers.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/Obedience-Corp/fest/internal/yamlutil"
 	"gopkg.in/yaml.v3"
 )
 
@@ -88,7 +89,7 @@ func AddMarkers(content string, gateID string) string {
 		FestVersion: "1.0",
 	}
 
-	markerYAML, err := yaml.Marshal(markers)
+	markerYAML, err := yamlutil.Marshal(markers)
 	if err != nil {
 		return content
 	}
@@ -136,7 +137,7 @@ func insertMarkersIntoFrontmatter(content string, markers FileMarkers) string {
 	existing["fest_version"] = markers.FestVersion
 
 	// Serialize
-	newYAML, err := yaml.Marshal(existing)
+	newYAML, err := yamlutil.Marshal(existing)
 	if err != nil {
 		return content
 	}
@@ -195,7 +196,7 @@ func StripMarkers(content string) string {
 	}
 
 	// Serialize remaining frontmatter
-	newYAML, err := yaml.Marshal(existing)
+	newYAML, err := yamlutil.Marshal(existing)
 	if err != nil {
 		return content
 	}

--- a/internal/gates/policy.go
+++ b/internal/gates/policy.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Obedience-Corp/fest/internal/config"
 	"github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/yamlutil"
 	"gopkg.in/yaml.v3"
 )
 
@@ -218,7 +219,7 @@ func LoadPolicy(path string) (*GatePolicy, error) {
 
 // SavePolicy saves a gate policy to a file
 func SavePolicy(path string, policy *GatePolicy) error {
-	data, err := yaml.Marshal(policy)
+	data, err := yamlutil.Marshal(policy)
 	if err != nil {
 		return errors.Wrap(err, "marshaling policy").
 			WithOp("SavePolicy").

--- a/internal/guidance/orchestration/state.go
+++ b/internal/guidance/orchestration/state.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/registry"
+	"github.com/Obedience-Corp/fest/internal/yamlutil"
 	"gopkg.in/yaml.v3"
 )
 
@@ -106,7 +107,7 @@ func (m *StateManager) Save(ctx context.Context) error {
 			WithField("path", festDir)
 	}
 
-	data, err := yaml.Marshal(m.state)
+	data, err := yamlutil.Marshal(m.state)
 	if err != nil {
 		return errors.Parse("marshaling execution state", err)
 	}

--- a/internal/guidance/state.go
+++ b/internal/guidance/state.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/Obedience-Corp/fest/internal/yamlutil"
 	"gopkg.in/yaml.v3"
 )
 
@@ -138,7 +139,7 @@ func (sm *DefaultStateManager) Save(ctx context.Context) error {
 
 	sm.state.LastUpdated = time.Now()
 
-	data, err := yaml.Marshal(sm.state)
+	data, err := yamlutil.Marshal(sm.state)
 	if err != nil {
 		return err
 	}

--- a/internal/guidance/workflow/state.go
+++ b/internal/guidance/workflow/state.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Obedience-Corp/fest/internal/yamlutil"
 	"gopkg.in/yaml.v3"
 )
 
@@ -175,7 +176,7 @@ func saveFestivalState(ctx context.Context, festivalPath string, state *Festival
 		return err
 	}
 
-	data, err := yaml.Marshal(state)
+	data, err := yamlutil.Marshal(state)
 	if err != nil {
 		return err
 	}

--- a/internal/navigation/state.go
+++ b/internal/navigation/state.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/pathutil"
 	"github.com/Obedience-Corp/fest/internal/workspace"
+	"github.com/Obedience-Corp/fest/internal/yamlutil"
 	"gopkg.in/yaml.v3"
 )
 
@@ -142,7 +143,7 @@ func (n *Navigation) Save() error {
 		}
 	}
 
-	data, err := yaml.Marshal(saveCopy)
+	data, err := yamlutil.Marshal(saveCopy)
 	if err != nil {
 		return errors.Wrap(err, "marshaling navigation state")
 	}

--- a/internal/parser/output.go
+++ b/internal/parser/output.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"encoding/json"
 
-	"gopkg.in/yaml.v3"
+	"github.com/Obedience-Corp/fest/internal/yamlutil"
 )
 
 // FormatJSON formats the entity as JSON
@@ -16,7 +16,7 @@ func FormatJSON(entity interface{}, compact bool) ([]byte, error) {
 
 // FormatYAML formats the entity as YAML
 func FormatYAML(entity interface{}) ([]byte, error) {
-	return yaml.Marshal(entity)
+	return yamlutil.Marshal(entity)
 }
 
 // Format outputs in the specified format

--- a/internal/plugins/manifest.go
+++ b/internal/plugins/manifest.go
@@ -7,6 +7,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/yamlutil"
 )
 
 const (
@@ -53,7 +54,7 @@ func LoadManifest(path string) (*PluginManifest, error) {
 
 // SaveManifest saves a plugin manifest to a file
 func SaveManifest(path string, manifest *PluginManifest) error {
-	data, err := yaml.Marshal(manifest)
+	data, err := yamlutil.Marshal(manifest)
 	if err != nil {
 		return errors.Wrap(err, "marshaling manifest")
 	}

--- a/internal/workflow/service.go
+++ b/internal/workflow/service.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"github.com/Obedience-Corp/fest/internal/yamlutil"
 )
 
 // Service provides all workflow operations.
@@ -257,7 +257,7 @@ func (s *Service) Init(ctx context.Context, opts InitOptions) (*InitResult, erro
 	}
 
 	// Write schema file
-	data, err := yaml.Marshal(schema)
+	data, err := yamlutil.Marshal(schema)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal schema: %w", err)
 	}
@@ -606,7 +606,7 @@ func (s *Service) Migrate(ctx context.Context, opts MigrateOptions) (*MigrateRes
 	if !opts.DryRun {
 		// Create schema and remaining directories
 		schema := DefaultSchema()
-		data, err := yaml.Marshal(schema)
+		data, err := yamlutil.Marshal(schema)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal schema: %w", err)
 		}
@@ -766,7 +766,7 @@ func (s *Service) MigrateV1ToV2(ctx context.Context, dryRun bool) (*MigrateV1ToV
 	// Update schema to v2
 	if !dryRun {
 		newSchema := DefaultSchemaV2()
-		data, err := yaml.Marshal(newSchema)
+		data, err := yamlutil.Marshal(newSchema)
 		if err != nil {
 			return nil, fmt.Errorf("marshaling v2 schema: %w", err)
 		}

--- a/internal/yamlutil/marshal.go
+++ b/internal/yamlutil/marshal.go
@@ -1,0 +1,22 @@
+// Package yamlutil provides YAML marshaling helpers with standard 2-space indentation.
+package yamlutil
+
+import (
+	"bytes"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Marshal serializes v to YAML with 2-space indentation (community standard).
+func Marshal(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	if err := enc.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/internal/yamlutil/marshal_test.go
+++ b/internal/yamlutil/marshal_test.go
@@ -1,0 +1,29 @@
+package yamlutil
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMarshal_TwoSpaceIndent(t *testing.T) {
+	data := map[string]any{
+		"parent": map[string]any{
+			"child": "value",
+		},
+	}
+
+	out, err := Marshal(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	s := string(out)
+
+	// Must use 2-space indent, not 4
+	if !strings.Contains(s, "  child: value") {
+		t.Errorf("expected 2-space indent, got:\n%s", s)
+	}
+	if strings.Contains(s, "    child") {
+		t.Errorf("found 4-space indent (should be 2):\n%s", s)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/yamlutil` package with a `Marshal` helper that uses `yaml.NewEncoder` with `SetIndent(2)` for community-standard 2-space YAML formatting
- Replaces all 24 production `yaml.Marshal()` calls across 18 files with `yamlutil.Marshal()`
- Eliminates IDE reformatting churn on fest-generated YAML files (e.g. `navigation.yaml`)

## Test plan
- [x] `go build ./...` passes
- [x] All existing tests pass
- [x] New `yamlutil` package includes test verifying 2-space indentation
- [ ] Run `fest nav link` and verify `navigation.yaml` uses 2-space indent
- [ ] Confirm IDE no longer auto-reformats fest-generated YAML files