### PR TITLE
fix(lint): gopls sweep - resolve all diagnostics

### DIFF
--- a/internal/commands/gendocs.go
+++ b/internal/commands/gendocs.go
@@ -45,7 +45,7 @@ func runGendocs(cmd *cobra.Command, args []string) error {
 	stalePattern := filepath.Join(gendocsOutput, "fest_*.md")
 	if staleFiles, _ := filepath.Glob(stalePattern); len(staleFiles) > 0 {
 		for _, f := range staleFiles {
-			os.Remove(f)
+			_ = os.Remove(f)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Ran systematic gopls lint sweep across all 101 packages (including test files) — all clean
- Fixed unchecked `os.Remove` error in `internal/commands/gendocs.go` (errcheck violation)

## Verification

- `just lint gopls-all` — 101 packages clean (prod + test files)
- `just lint all` — golangci-lint 0 issues
- `just test unit` — 1919/1919 tests passed
- `just build` — successful