### PR TITLE
[OBEY-CAMPAIGN-8deed8b4-FE-FF0001] docs: close remaining create syntax drift

### DIFF
--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -115,7 +115,7 @@ The date directory uses `YYYY-MM-DD` format based on the timestamp. This is hand
 
 Ritual festivals are repeatable templates that live in `ritual/` permanently:
 
-1. **Create**: `fest create festival --type ritual` places the festival in `ritual/`
+1. **Create**: `fest create festival --name "my-ritual" --type ritual` places the festival in `ritual/`
 2. **Run**: `fest ritual run <name>` copies the template to `active/` with a hex counter suffix
 3. **Complete**: Each run follows the normal lifecycle (active -> completed)
 

--- a/embedded/docs/intro/intro.txt
+++ b/embedded/docs/intro/intro.txt
@@ -35,7 +35,7 @@ FESTIVAL TYPES
   research              Investigation and exploration
   ritual                Recurring/repeatable processes
 
-  Create: fest create festival --type <type> <name>
+  Create: fest create festival --name "<name>" --type <type>
 
 PHASE TYPES
 ───────────


### PR DESCRIPTION
## Summary
- fix the remaining stale positional `fest create festival` example in the embedded intro text
- fix the ritual lifecycle example to use the current required `--name` flag form

## Why
The earlier FF0001 beginner-path docs work merged, but these two `fest`-owned surfaces still showed invalid create syntax and kept FF0001 from being truly complete.

## Testing
- `rg -n 'fest create festival --type [^\\n]*' projects/fest -g '*.md' -g '*.txt'`
- `go run ./cmd/fest create festival --help`
