### PR TITLE
fix(gendocs): filter dev-only commands from stable docs

### DIFF
--- a/internal/commands/gendocs.go
+++ b/internal/commands/gendocs.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/Obedience-Corp/fest/internal/commands/release"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 )
@@ -15,6 +16,7 @@ var (
 	gendocsOutput string
 	gendocsFormat string
 	gendocsSingle bool
+	gendocsStable bool
 )
 
 func init() {
@@ -31,6 +33,7 @@ func init() {
 	gendocsCmd.Flags().StringVar(&gendocsOutput, "output", "docs", "output directory")
 	gendocsCmd.Flags().StringVar(&gendocsFormat, "format", "markdown", "output format: markdown or yaml")
 	gendocsCmd.Flags().BoolVar(&gendocsSingle, "single", false, "generate a single combined reference file")
+	gendocsCmd.Flags().BoolVar(&gendocsStable, "stable", false, "exclude dev-only commands from generated docs")
 	rootCmd.AddCommand(gendocsCmd)
 }
 
@@ -51,6 +54,10 @@ func runGendocs(cmd *cobra.Command, args []string) error {
 
 	stripANSIFromTree(rootCmd)
 	disableAutoGenTag(rootCmd)
+
+	if gendocsStable {
+		hideDevOnlyCommands(rootCmd)
+	}
 
 	switch gendocsFormat {
 	case "markdown":
@@ -103,6 +110,19 @@ func disableAutoGenTag(cmd *cobra.Command) {
 	cmd.DisableAutoGenTag = true
 	for _, child := range cmd.Commands() {
 		disableAutoGenTag(child)
+	}
+}
+
+// hideDevOnlyCommands removes commands annotated as dev-only from the tree.
+// Cobra's doc generators only skip Hidden commands, not annotated ones,
+// so we remove dev-only commands entirely before generating stable docs.
+func hideDevOnlyCommands(parent *cobra.Command) {
+	for _, child := range parent.Commands() {
+		if child.Annotations[release.AnnotationReleaseChannel] == release.ReleaseChannelDevOnly {
+			parent.RemoveCommand(child)
+		} else {
+			hideDevOnlyCommands(child)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `--stable` flag to `fest gendocs` that removes commands annotated with `release_channel=dev_only` before generating documentation
- Fixes the root cause of `fest_explore.md` leaking into stable doc builds
- Cobra's `GenMarkdownTree` only skips `Hidden` commands, not custom-annotated ones — this walks the tree and removes dev-only commands before generation

## Context

Part of the stable release readiness work (F-02 from the release review). The `festival` repo generates stable docs using a dev-tagged binary, and without this filter, dev-only commands like `explore` appear in stable documentation.

## Test plan

- [x] `fest gendocs --stable` produces no `explore` docs
- [x] `fest gendocs` (dev mode) still includes `explore` docs
- [x] All 1940 unit tests pass