### PR TITLE
fix: preserve auto_link config on save, fix 9 integration test failures

### DIFF
--- a/internal/config/festival_config.go
+++ b/internal/config/festival_config.go
@@ -95,6 +95,14 @@ type AutoLinkConfig struct {
 	validatePathExistsSet bool `yaml:"-"`
 }
 
+// IsZero implements the yaml.IsZeroer interface so that omitempty only drops
+// the auto_link section when it was never explicitly present in the source YAML.
+// Without this, setting enabled: false (a zero value) causes the entire section
+// to be silently dropped on re-save, reverting to defaults on next load.
+func (c AutoLinkConfig) IsZero() bool {
+	return !c.present
+}
+
 // DefaultAutoLinkConfig returns the default auto-link configuration.
 // Auto-link is enabled by default, requiring fest_working_dir on implementation phases.
 func DefaultAutoLinkConfig() AutoLinkConfig {

--- a/internal/config/festival_config_test.go
+++ b/internal/config/festival_config_test.go
@@ -690,6 +690,37 @@ func TestLoadFestivalConfig_AutoLinkExplicitDisabledPreserved(t *testing.T) {
 	}
 }
 
+func TestAutoLinkConfig_RoundTripPreservesDisabled(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Write config with auto_link disabled
+	data := []byte("version: \"1.0\"\nauto_link:\n  enabled: false\n")
+	if err := os.WriteFile(filepath.Join(tmpDir, FestivalConfigFileName), data, 0644); err != nil {
+		t.Fatalf("write initial config: %v", err)
+	}
+
+	// Load → save → load round-trip (simulates fest status set active)
+	cfg, err := LoadFestivalConfig(tmpDir, "")
+	if err != nil {
+		t.Fatalf("first load: %v", err)
+	}
+	if cfg.AutoLink.Enabled {
+		t.Fatal("after first load: AutoLink.Enabled = true, want false")
+	}
+
+	if err := SaveFestivalConfig(tmpDir, "", cfg); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	cfg2, err := LoadFestivalConfig(tmpDir, "")
+	if err != nil {
+		t.Fatalf("second load: %v", err)
+	}
+	if cfg2.AutoLink.Enabled {
+		t.Fatal("after round-trip: AutoLink.Enabled = true, want false — auto_link section was lost on save")
+	}
+}
+
 func TestLoadFestivalConfig_AutoLinkSectionDefaultsWhenPresent(t *testing.T) {
 	tmpDir := t.TempDir()
 	data := []byte("version: \"1.0\"\nauto_link:\n  validate_path_exists: false\n")

--- a/tests/integration/guidance_helpers_test.go
+++ b/tests/integration/guidance_helpers_test.go
@@ -549,10 +549,35 @@ func ensureQualityGatesInFestivalConfig(tc *TestContainer, festPath string) erro
 	if err != nil {
 		return err
 	}
-	if strings.Contains(content, "quality_gates:") {
-		return nil
+	if !strings.Contains(content, "quality_gates:") {
+		if err := appendFileInContainer(tc, festYAMLPath, implementationQualityGatesYAML); err != nil {
+			return err
+		}
 	}
-	return appendFileInContainer(tc, festYAMLPath, implementationQualityGatesYAML)
+	return disableAutoLinkInFestivalConfig(tc, festPath)
+}
+
+// disableAutoLinkInFestivalConfig sets auto_link.enabled to false in fest.yaml.
+// Integration tests run in Docker containers without real campaign project directories,
+// so auto-link validation (which requires fest_working_dir) must be disabled.
+func disableAutoLinkInFestivalConfig(tc *TestContainer, festPath string) error {
+	festYAMLPath := festPath + "/fest.yaml"
+	content, err := tc.ReadFile(festYAMLPath)
+	if err != nil {
+		return err
+	}
+
+	// Parse existing YAML, set auto_link.enabled = false, write back
+	var cfg map[string]interface{}
+	if err := yaml.Unmarshal([]byte(content), &cfg); err != nil {
+		return err
+	}
+	cfg["auto_link"] = map[string]interface{}{"enabled": false}
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	return writeFileInContainer(tc, festYAMLPath, string(data))
 }
 
 // ensureGateTemplates creates quality gate template files in the festival's gates/ directory.

--- a/tests/integration/guidance_implementation_test.go
+++ b/tests/integration/guidance_implementation_test.go
@@ -93,8 +93,10 @@ func TestImplementationMode_PhaseBoundaries(t *testing.T) {
 
 	festPath := findFestivalPath(t, container, festivalsPath+"/planning", "test-impl-phases")
 
-	// Write fest.yaml with quality gates enabled
+	// Write fest.yaml with quality gates enabled and auto-link disabled (no real project dirs in container)
 	festYaml := `version: "1.0"
+auto_link:
+  enabled: false
 quality_gates:
   enabled: true
   auto_append: true
@@ -196,8 +198,8 @@ func TestImplementationMode_Completion(t *testing.T) {
 
 	festPath := findFestivalPath(t, container, festivalsPath+"/planning", "test-impl-done")
 
-	// Write fest.yaml with quality gates enabled
-	festYaml := "version: \"1.0\"\nquality_gates:\n  enabled: true\n  auto_append: true\n  implementation:\n    - id: testing\n      template: gates/implementation/QUALITY_GATE_TESTING\n      enabled: true\n    - id: review\n      template: gates/implementation/QUALITY_GATE_REVIEW\n      enabled: true\n    - id: iterate\n      template: gates/implementation/QUALITY_GATE_ITERATE\n      enabled: true\n    - id: fest-commit\n      template: gates/implementation/QUALITY_GATE_FEST_COMMIT\n      enabled: true\n"
+	// Write fest.yaml with quality gates enabled and auto-link disabled (no real project dirs in container)
+	festYaml := "version: \"1.0\"\nauto_link:\n  enabled: false\nquality_gates:\n  enabled: true\n  auto_append: true\n  implementation:\n    - id: testing\n      template: gates/implementation/QUALITY_GATE_TESTING\n      enabled: true\n    - id: review\n      template: gates/implementation/QUALITY_GATE_REVIEW\n      enabled: true\n    - id: iterate\n      template: gates/implementation/QUALITY_GATE_ITERATE\n      enabled: true\n    - id: fest-commit\n      template: gates/implementation/QUALITY_GATE_FEST_COMMIT\n      enabled: true\n"
 	err = writeFileInContainer(container, festPath+"/fest.yaml", festYaml)
 	require.NoError(t, err)
 

--- a/tests/integration/template_validation_test.go
+++ b/tests/integration/template_validation_test.go
@@ -38,6 +38,8 @@ func setupTemplateFestival(t *testing.T, tc *TestContainer, festName string) str
 
 	// Write fest.yaml with quality gates enabled
 	festYaml := `version: "1.0"
+auto_link:
+  enabled: false
 quality_gates:
   enabled: true
   auto_append: true
@@ -142,16 +144,18 @@ func TestNextTemplateOutputIsValid(t *testing.T) {
 
 	// Add quality gate task stubs (required by validator for fest next)
 	// Files must match taskParsePattern: ^(\d{2})_(.+)\.md$
+	// Frontmatter must include fest_managed + fest_gate_id (used by gates.GetGateID)
 	for _, gate := range []struct {
-		num                int
-		name, gType, title string
+		num      int
+		name, id string
+		title    string
 	}{
 		{2, "testing", "testing", "Testing"},
 		{3, "review", "review", "Code Review"},
 		{4, "iterate", "iterate", "Iterate"},
 		{5, "fest_commit", "fest-commit", "Fest Commit"},
 	} {
-		gateContent := fmt.Sprintf("---\nfest_type: gate\nfest_gate_type: %s\nfest_status: pending\n---\n# Quality Gate: %s\n- [ ] Gate passed\n", gate.gType, gate.title)
+		gateContent := fmt.Sprintf("---\nfest_managed: true\nfest_gate_id: %s\nfest_type: gate\nfest_status: pending\n---\n# Quality Gate: %s\n- [ ] Gate passed\n", gate.id, gate.title)
 		err = writeFileInContainer(tc, fmt.Sprintf("%s/%02d_%s.md", seqPath, gate.num, gate.name), gateContent)
 		require.NoError(t, err)
 	}
@@ -228,16 +232,18 @@ func TestAllCommandsProduceValidOutput(t *testing.T) {
 
 	// Add quality gate task stubs (required by validator for fest next)
 	// Files must match taskParsePattern: ^(\d{2})_(.+)\.md$
+	// Frontmatter must include fest_managed + fest_gate_id (used by gates.GetGateID)
 	for _, gate := range []struct {
-		num                int
-		name, gType, title string
+		num      int
+		name, id string
+		title    string
 	}{
 		{2, "testing", "testing", "Testing"},
 		{3, "review", "review", "Code Review"},
 		{4, "iterate", "iterate", "Iterate"},
 		{5, "fest_commit", "fest-commit", "Fest Commit"},
 	} {
-		gateContent := fmt.Sprintf("---\nfest_type: gate\nfest_gate_type: %s\nfest_status: pending\n---\n# Quality Gate: %s\n- [ ] Gate passed\n", gate.gType, gate.title)
+		gateContent := fmt.Sprintf("---\nfest_managed: true\nfest_gate_id: %s\nfest_type: gate\nfest_status: pending\n---\n# Quality Gate: %s\n- [ ] Gate passed\n", gate.id, gate.title)
 		err = writeFileInContainer(tc, fmt.Sprintf("%s/%02d_%s.md", seqPath, gate.num, gate.name), gateContent)
 		require.NoError(t, err)
 	}


### PR DESCRIPTION
## Summary

- **Production bug fix**: `AutoLinkConfig.IsZero()` implements `yaml.IsZeroer` so `omitempty` only drops the `auto_link` section when it was never explicitly present in source YAML. Previously, setting `enabled: false` caused the entire section to be silently dropped on re-save (e.g. during `fest status set active`), reverting to defaults on next load.
- **Integration test fixes**: Disable auto-link validation in test fest.yaml configs (Docker containers have no real project directories). Fix gate frontmatter to use `fest_gate_id` instead of `fest_gate_type`.

## Test plan

- [x] New unit test `TestAutoLinkConfig_RoundTripPreservesDisabled` verifies load→save→load preserves `enabled: false`
- [x] All 9 previously failing integration tests now pass
- [x] Full integration suite (44 tests) passes
- [x] All unit tests pass