### PR TITLE
fix(docs): correct fest onboarding guidance

### DIFF
--- a/embedded/docs/intro/workflows.txt
+++ b/embedded/docs/intro/workflows.txt
@@ -8,17 +8,20 @@ This guide covers the most common workflows you'll use with fest.
 WORKFLOW 1: CREATING A NEW FESTIVAL
 ═══════════════════════════════════════════════════════════════════════════════
 
-  # 1. Navigate to festivals directory
-  fest go active
+  # 1. Navigate to the festivals workspace
+  fest go planning
 
   # 2. Create the festival
-  fest create festival --name "my-feature" --id "MF0001"
+  fest create festival --name "my-feature" --type standard
 
-  # 3. Add phases as needed
-  fest create phase --name "001_PLANNING" --type planning
-  fest create phase --name "002_IMPLEMENTATION" --type implementation
+  # 3. Go to the new festival
+  fest list
+  fest go my-feature
 
-  # 4. Validate the created structure
+  # 4. Add pending phases as needed
+  fest create phase --name "IMPLEMENT" --type implementation
+
+  # 5. Validate the created structure
   fest validate
 
 ═══════════════════════════════════════════════════════════════════════════════
@@ -35,7 +38,7 @@ WORKFLOW 2: EXECUTING AN EXISTING FESTIVAL
   # (fest next shows you exactly what to do)
 
   # 4. Mark task complete when done
-  fest progress --complete
+  fest task completed
 
   # 5. Repeat steps 2-4 until festival complete
 
@@ -152,8 +155,8 @@ TIPS FOR AI AGENTS
      - SEQUENCE_GOAL.md for task group purpose
 
   4. Mark progress consistently
-     - fest progress --complete after each task
-     - fest progress --skip "reason" if blocked
+     - fest task completed after each task
+     - fest task blocked --reason "..." if blocked
 
   5. Use JSON output for programmatic access
      - fest next --json | jq '.task_path'

--- a/embedded/docs/understand/context.txt
+++ b/embedded/docs/understand/context.txt
@@ -8,7 +8,8 @@ questions, and handoff notes that persist between sessions.
 
 WHEN TO CREATE
 --------------
-CREATE CONTEXT.md FIRST, before detailed planning. It should capture:
+Create the festival scaffold with `fest create festival` first, then fill
+`CONTEXT.md` before detailed planning. It should capture:
 - Why this festival exists (problem being solved)
 - Key constraints and requirements
 - Initial assumptions being made
@@ -67,12 +68,14 @@ This injects your decisions and notes into agent context automatically.
 
 TEMPLATE
 --------
-Create CONTEXT.md from template:
+Preferred path:
 
   fest create festival --name "my-festival"  # Includes CONTEXT.md
 
-Or manually copy from:
+Recovery only, if an existing festival is missing CONTEXT.md:
   festivals/.festival/templates/CONTEXT_TEMPLATE.md
+
+Do not hand-create a new festival tree when a `fest create` command exists.
 
 WHY THIS MATTERS FOR AI AGENTS
 ------------------------------
@@ -88,5 +91,6 @@ With CONTEXT.md:
 - Humans can asynchronously answer questions
 - Festival purpose stays front and center
 
-TIP: Create CONTEXT.md FIRST and fill in the "Why this festival exists"
-section before doing any other planning. This keeps agents focused.
+TIP: After scaffolding the festival with `fest create festival`, fill in the
+"Why this festival exists" section in `CONTEXT.md` before doing other planning.
+This keeps agents focused.

--- a/embedded/docs/understand/overview.txt
+++ b/embedded/docs/understand/overview.txt
@@ -138,6 +138,9 @@ Token-Efficient Workflow
 
 Use the fest CLI instead of manual file creation:
 
+  Do not hand-create festival directories or goal files when a
+  'fest create' command exists.
+
   fest create festival --name "my-project" --type standard
   fest create phase --name "IMPLEMENT" --type implementation
   fest create sequence --name "api"

--- a/embedded/docs/understand/workflow.txt
+++ b/embedded/docs/understand/workflow.txt
@@ -1,7 +1,9 @@
-Festival Workflow - Just-in-Time Reading
-========================================
+Festival Workflow - Just-in-Time Reading and Phase Navigation
+=============================================================
 
 The just-in-time approach preserves context window for actual work.
+It also pairs with `fest workflow`, which is the primary CLI for
+WORKFLOW.md steps and GATES.md phase gates.
 
 When to Read What
 -----------------
@@ -28,6 +30,48 @@ ALWAYS Do This
   ✓ Close files after extracting what you need
   ✓ Focus context on actual work, not documentation
 
+Workflow Navigation
+-------------------
+
+Use `fest next` to see the current instruction, then use `fest workflow`
+to inspect or advance workflow-based work.
+
+`fest workflow` handles:
+
+  WORKFLOW.md        Step-by-step execution inside a phase
+  GATES.md           Phase-level approval gates after phase work is done
+
+Supported patterns:
+
+  • Built-in workflow phases such as ingest, planning, and research
+  • Custom numbered phases that include a WORKFLOW.md
+  • Phase gates in any numbered phase that include a GATES.md
+
+Common commands:
+
+  fest workflow status
+  fest workflow show
+  fest workflow advance
+  fest workflow approve
+  fest workflow reject --reason "..."
+  fest workflow reset
+  fest workflow skip --reason "already completed externally"
+
+Auto-Routing Rules
+------------------
+
+When run from the festival root, `fest workflow` auto-detects the first
+incomplete navigable phase. Use `--phase 001_NAME` to target a specific phase.
+
+Routing priority:
+
+  1. Incomplete WORKFLOW.md takes priority
+  2. GATES.md is used after workflow is complete or absent
+  3. Gates become available only after the phase's other work is complete
+
+Do not manually track workflow or gate completion in files when the CLI
+already supports the phase. Use `fest workflow` so progress state stays valid.
+
 Execution Pattern
 -----------------
 
@@ -36,16 +80,19 @@ PLANNING a new festival:
 1. Fill CONTEXT.md FIRST within that scaffold - capture why this festival exists
    This prevents losing focus on the festival's purpose.
    See: fest understand context
+2. Add phases, sequences, and tasks with `fest create`
+3. When a phase uses WORKFLOW.md or GATES.md, use `fest next` and
+   `fest workflow` instead of manually tracking step progress
 
 EXECUTING an existing festival:
 1. Read FESTIVAL_GOAL.md to understand the objective
 2. Read CONTEXT.md for decisions and current state
-3. Check TODO.md for current status
-4. Navigate to the current phase/sequence
-5. Read ONLY the current task file
-6. Execute the task
+3. Run `fest next` to find the current task, workflow step, or gate
+4. If the current work is a workflow step or gate, use `fest workflow show`
+5. Execute the work
+6. Use `fest workflow advance` or `approve`/`reject` when a checkpoint blocks
 7. Update CONTEXT.md with decisions/blockers
-8. Mark complete and move to next
+8. Mark regular task files complete with the task CLI and move to next
 
 Using fest CLI Efficiently
 --------------------------
@@ -55,6 +102,8 @@ The CLI is self-documenting. Use --help instead of reading docs:
   fest --help                    # All commands
   fest create --help             # Create subcommands
   fest create festival --help    # Specific command details
+  fest workflow --help           # Workflow and gate commands
+  fest workflow status --phase 001_INGEST
   fest gates --help              # Quality gate management
 
 JSON output provides structured responses:

--- a/embedded/docs/understand/workflow.txt
+++ b/embedded/docs/understand/workflow.txt
@@ -32,7 +32,8 @@ Execution Pattern
 -----------------
 
 PLANNING a new festival:
-0. Create CONTEXT.md FIRST - capture why this festival exists
+0. Create the festival scaffold FIRST with `fest create festival`
+1. Fill CONTEXT.md FIRST within that scaffold - capture why this festival exists
    This prevents losing focus on the festival's purpose.
    See: fest understand context
 
@@ -59,3 +60,6 @@ The CLI is self-documenting. Use --help instead of reading docs:
 JSON output provides structured responses:
 
   fest create phase --name "IMPLEMENT" --json
+
+Do not hand-create festival directories or goal files when a `fest create`
+command exists.

--- a/internal/commands/understand/commands.go
+++ b/internal/commands/understand/commands.go
@@ -27,7 +27,7 @@ START HERE if you're new to Festival Methodology:
 QUICK REFERENCE:
   fest understand checklist      Validation checklist before starting
   fest understand rules          Naming conventions for automation
-  fest understand workflow       Just-in-time reading pattern
+  fest understand workflow       Just-in-time reading + workflow/gates
 
 The understand command helps you grasp WHEN and WHY to use specific
 approaches. For command syntax, use --help on any command.

--- a/internal/commands/understand/workflow.go
+++ b/internal/commands/understand/workflow.go
@@ -11,8 +11,10 @@ import (
 func newUnderstandWorkflowCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "workflow",
-		Short: "Just-in-time reading and execution patterns",
-		Long:  `Learn the just-in-time approach to reading templates and documentation, preserving context for actual work.`,
+		Short: "Just-in-time reading plus workflow/gate execution",
+		Long: `Learn the just-in-time approach to reading templates and documentation,
+preserving context for actual work, and how to use 'fest workflow' for
+WORKFLOW.md phases and GATES.md phase gates.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			printWorkflow(findDotFestivalDir())
 		},


### PR DESCRIPTION
## Summary
- fix `fest intro workflows` so the new-festival flow uses valid `fest create festival` syntax and current task mutation commands
- tighten `fest understand workflow` and `fest understand context` to say scaffold first, then fill `CONTEXT.md`
- repeat the CLI-first rule in `fest understand overview` so agents are told not to hand-create festival directories or goal files when `fest create` exists

## Testing
- go test ./internal/commands/intro ./internal/commands/understand

## Notes
- This PR fixes the in-repo onboarding/docs sources identified in the audit.
- The stale installed public skill under `~/.codex/skills/public/fest-cli-planner/` is outside the fest repo and is not included in this PR.