### PR TITLE
feat: wire plugin dispatch into command execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ go.work
 go.work.sum
 
 CLAUDE.md
+
+# Worktrees
+.worktrees/

--- a/internal/commands/plugin.go
+++ b/internal/commands/plugin.go
@@ -79,9 +79,13 @@ func findFirstPositionalArg(args []string) (string, int) {
 		}
 
 		flagName := strings.TrimPrefix(strings.TrimPrefix(arg, "--"), "-")
-		if f := pflags.Lookup(flagName); f != nil && f.NoOptDefVal == "" {
+		f := pflags.Lookup(flagName)
+		if f == nil {
+			// Unknown flag — bail out and let Cobra report the error.
+			return "", 0
+		}
+		if f.NoOptDefVal == "" {
 			i++
-			continue
 		}
 	}
 	return "", 0

--- a/internal/commands/plugin.go
+++ b/internal/commands/plugin.go
@@ -75,6 +75,10 @@ func findFirstPositionalArg(args []string) (string, int) {
 		}
 
 		if strings.Contains(arg, "=") {
+			eqName := strings.TrimPrefix(strings.TrimPrefix(strings.SplitN(arg, "=", 2)[0], "--"), "-")
+			if pflags.Lookup(eqName) == nil {
+				return "", 0
+			}
 			continue
 		}
 

--- a/internal/commands/plugin.go
+++ b/internal/commands/plugin.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strings"
 
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/plugins"
 )
 
@@ -36,11 +37,10 @@ func dispatchPlugin() error {
 		pluginArgs = os.Args[argIdx:]
 	}
 
-	if !dispatcher.CanHandle(pluginArgs) {
-		return nil
-	}
-
 	if err := dispatcher.Dispatch(pluginArgs); err != nil {
+		if festerrors.Is(err, festerrors.ErrCodeNotFound) {
+			return nil
+		}
 		return err
 	}
 	return errPluginHandled

--- a/internal/commands/plugin.go
+++ b/internal/commands/plugin.go
@@ -9,26 +9,14 @@ import (
 	"github.com/Obedience-Corp/fest/internal/plugins"
 )
 
-// errPluginHandled is a sentinel indicating a plugin ran successfully.
-// Execute() converts this to nil so main() sees a clean exit.
 var errPluginHandled = errors.New("plugin handled")
 
-// dispatchPlugin checks whether the first non-flag argument is an unknown
-// subcommand backed by a fest-<name> binary on PATH (or in a manifest).
-// If so, it executes the plugin and returns errPluginHandled (success) or
-// the execution error. Returns nil to fall through to Cobra's normal dispatch.
-//
-// Global flags appearing before the plugin name (e.g. --verbose, --config)
-// are consumed by fest's own arg scanner and are NOT forwarded to the plugin.
-// Only arguments after the plugin name are passed through. This matches git's
-// plugin convention.
 func dispatchPlugin() error {
 	name, argIdx := firstSubcommand()
 	if name == "" {
 		return nil
 	}
 
-	// Never intercept help, completion, or Cobra internals.
 	switch name {
 	case "help", "completion", "__complete", "__completeNoDesc":
 		return nil
@@ -38,13 +26,11 @@ func dispatchPlugin() error {
 		return nil
 	}
 
-	// Initialize plugin discovery and check for a matching plugin.
 	dispatcher := plugins.NewDispatcher()
 	if err := dispatcher.Initialize(); err != nil {
-		return nil // Discovery failure is not fatal; fall through to Cobra.
+		return nil
 	}
 
-	// Build the args slice starting from the plugin name onward.
 	var pluginArgs []string
 	if argIdx < len(os.Args) {
 		pluginArgs = os.Args[argIdx:]
@@ -60,20 +46,13 @@ func dispatchPlugin() error {
 	return errPluginHandled
 }
 
-// firstSubcommand returns the first non-flag argument from os.Args and its
-// index. Returns ("", 0) if no subcommand is present.
-//
-// It consults the root command's persistent flags so that flags which take
-// values (e.g. --config <file>) have their value skipped rather than being
-// mistaken for a subcommand name.
 func firstSubcommand() (string, int) {
 	return findFirstPositionalArg(os.Args)
 }
 
-// findFirstPositionalArg scans args (where args[0] is the program name) and
-// returns the first positional (non-flag) argument and its index.
-// It correctly skips values consumed by flags like --config <file> and
-// handles --flag=value, --, and boolean flags.
+// findFirstPositionalArg returns the first positional (non-flag) arg and its
+// index. It consults rootCmd's persistent flags to skip flag values like
+// --config <file> that would otherwise look like subcommand names.
 func findFirstPositionalArg(args []string) (string, int) {
 	if len(args) < 2 {
 		return "", 0
@@ -84,7 +63,6 @@ func findFirstPositionalArg(args []string) (string, int) {
 	for i := 1; i < len(args); i++ {
 		arg := args[i]
 
-		// "--" terminates flag parsing; the next arg is the first positional.
 		if arg == "--" {
 			if i+1 < len(args) {
 				return args[i+1], i + 1
@@ -96,18 +74,12 @@ func findFirstPositionalArg(args []string) (string, int) {
 			return arg, i
 		}
 
-		// It's a flag. Determine whether it consumes the next argument.
-		// Flags using --flag=value syntax never consume the next arg.
 		if strings.Contains(arg, "=") {
 			continue
 		}
 
-		// Strip leading dashes to get the flag name.
 		flagName := strings.TrimPrefix(strings.TrimPrefix(arg, "--"), "-")
-
-		// Look up the flag in persistent flags to check if it takes a value.
 		if f := pflags.Lookup(flagName); f != nil && f.NoOptDefVal == "" {
-			// Flag takes a value — skip the next argument.
 			i++
 			continue
 		}
@@ -115,8 +87,6 @@ func findFirstPositionalArg(args []string) (string, int) {
 	return "", 0
 }
 
-// isKnownCommand reports whether name matches a registered Cobra subcommand
-// (by name or alias).
 func isKnownCommand(name string) bool {
 	for _, cmd := range rootCmd.Commands() {
 		if cmd.Name() == name {

--- a/internal/commands/plugin.go
+++ b/internal/commands/plugin.go
@@ -1,0 +1,130 @@
+package commands
+
+import (
+	"errors"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/Obedience-Corp/fest/internal/plugins"
+)
+
+// errPluginHandled is a sentinel indicating a plugin ran successfully.
+// Execute() converts this to nil so main() sees a clean exit.
+var errPluginHandled = errors.New("plugin handled")
+
+// dispatchPlugin checks whether the first non-flag argument is an unknown
+// subcommand backed by a fest-<name> binary on PATH (or in a manifest).
+// If so, it executes the plugin and returns errPluginHandled (success) or
+// the execution error. Returns nil to fall through to Cobra's normal dispatch.
+//
+// Global flags appearing before the plugin name (e.g. --verbose, --config)
+// are consumed by fest's own arg scanner and are NOT forwarded to the plugin.
+// Only arguments after the plugin name are passed through. This matches git's
+// plugin convention.
+func dispatchPlugin() error {
+	name, argIdx := firstSubcommand()
+	if name == "" {
+		return nil
+	}
+
+	// Never intercept help, completion, or Cobra internals.
+	switch name {
+	case "help", "completion", "__complete", "__completeNoDesc":
+		return nil
+	}
+
+	if isKnownCommand(name) {
+		return nil
+	}
+
+	// Initialize plugin discovery and check for a matching plugin.
+	dispatcher := plugins.NewDispatcher()
+	if err := dispatcher.Initialize(); err != nil {
+		return nil // Discovery failure is not fatal; fall through to Cobra.
+	}
+
+	// Build the args slice starting from the plugin name onward.
+	var pluginArgs []string
+	if argIdx < len(os.Args) {
+		pluginArgs = os.Args[argIdx:]
+	}
+
+	if !dispatcher.CanHandle(pluginArgs) {
+		return nil
+	}
+
+	if err := dispatcher.Dispatch(pluginArgs); err != nil {
+		return err
+	}
+	return errPluginHandled
+}
+
+// firstSubcommand returns the first non-flag argument from os.Args and its
+// index. Returns ("", 0) if no subcommand is present.
+//
+// It consults the root command's persistent flags so that flags which take
+// values (e.g. --config <file>) have their value skipped rather than being
+// mistaken for a subcommand name.
+func firstSubcommand() (string, int) {
+	return findFirstPositionalArg(os.Args)
+}
+
+// findFirstPositionalArg scans args (where args[0] is the program name) and
+// returns the first positional (non-flag) argument and its index.
+// It correctly skips values consumed by flags like --config <file> and
+// handles --flag=value, --, and boolean flags.
+func findFirstPositionalArg(args []string) (string, int) {
+	if len(args) < 2 {
+		return "", 0
+	}
+
+	pflags := rootCmd.PersistentFlags()
+
+	for i := 1; i < len(args); i++ {
+		arg := args[i]
+
+		// "--" terminates flag parsing; the next arg is the first positional.
+		if arg == "--" {
+			if i+1 < len(args) {
+				return args[i+1], i + 1
+			}
+			return "", 0
+		}
+
+		if len(arg) == 0 || arg[0] != '-' {
+			return arg, i
+		}
+
+		// It's a flag. Determine whether it consumes the next argument.
+		// Flags using --flag=value syntax never consume the next arg.
+		if strings.Contains(arg, "=") {
+			continue
+		}
+
+		// Strip leading dashes to get the flag name.
+		flagName := strings.TrimPrefix(strings.TrimPrefix(arg, "--"), "-")
+
+		// Look up the flag in persistent flags to check if it takes a value.
+		if f := pflags.Lookup(flagName); f != nil && f.NoOptDefVal == "" {
+			// Flag takes a value — skip the next argument.
+			i++
+			continue
+		}
+	}
+	return "", 0
+}
+
+// isKnownCommand reports whether name matches a registered Cobra subcommand
+// (by name or alias).
+func isKnownCommand(name string) bool {
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Name() == name {
+			return true
+		}
+		if slices.Contains(cmd.Aliases, name) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/commands/plugin_test.go
+++ b/internal/commands/plugin_test.go
@@ -100,10 +100,10 @@ func TestFindFirstPositionalArg(t *testing.T) {
 			wantIdx:  0,
 		},
 		{
-			name:     "unknown flag treated as flag not subcommand",
+			name:     "unknown flag aborts plugin dispatch",
 			args:     []string{"fest", "--unknown", "graph"},
-			wantName: "graph",
-			wantIdx:  2,
+			wantName: "",
+			wantIdx:  0,
 		},
 	}
 

--- a/internal/commands/plugin_test.go
+++ b/internal/commands/plugin_test.go
@@ -105,6 +105,12 @@ func TestFindFirstPositionalArg(t *testing.T) {
 			wantName: "",
 			wantIdx:  0,
 		},
+		{
+			name:     "unknown flag with equals aborts plugin dispatch",
+			args:     []string{"fest", "--unknown=value", "graph"},
+			wantName: "",
+			wantIdx:  0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/commands/plugin_test.go
+++ b/internal/commands/plugin_test.go
@@ -1,0 +1,119 @@
+package commands
+
+import "testing"
+
+func TestIsKnownCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		// Registered subcommand names
+		{"create", true},
+		{"show", true},
+		{"status", true},
+		{"next", true},
+		{"validate", true},
+		{"go", true},
+
+		// Unknown names — should fall through to plugin dispatch
+		{"graph", false},
+		{"foo", false},
+		{"bar", false},
+		{"nonexistent", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isKnownCommand(tt.name)
+			if got != tt.want {
+				t.Errorf("isKnownCommand(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindFirstPositionalArg(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantName string
+		wantIdx  int
+	}{
+		{
+			name:     "no args",
+			args:     []string{"fest"},
+			wantName: "",
+			wantIdx:  0,
+		},
+		{
+			name:     "simple subcommand",
+			args:     []string{"fest", "graph"},
+			wantName: "graph",
+			wantIdx:  1,
+		},
+		{
+			name:     "bool flag then subcommand",
+			args:     []string{"fest", "--verbose", "graph"},
+			wantName: "graph",
+			wantIdx:  2,
+		},
+		{
+			name:     "config flag with separate value then subcommand",
+			args:     []string{"fest", "--config", "/tmp/fest.json", "graph"},
+			wantName: "graph",
+			wantIdx:  3,
+		},
+		{
+			name:     "config flag with = value then subcommand",
+			args:     []string{"fest", "--config=/tmp/fest.json", "graph"},
+			wantName: "graph",
+			wantIdx:  2,
+		},
+		{
+			name:     "multiple flags then subcommand",
+			args:     []string{"fest", "--no-color", "--config", "/etc/fest.json", "--verbose", "graph", "build"},
+			wantName: "graph",
+			wantIdx:  5,
+		},
+		{
+			name:     "double dash terminates flags",
+			args:     []string{"fest", "--", "graph"},
+			wantName: "graph",
+			wantIdx:  2,
+		},
+		{
+			name:     "double dash with no following arg",
+			args:     []string{"fest", "--"},
+			wantName: "",
+			wantIdx:  0,
+		},
+		{
+			name:     "only flags no subcommand",
+			args:     []string{"fest", "--verbose", "--no-color"},
+			wantName: "",
+			wantIdx:  0,
+		},
+		{
+			name:     "config flag value not mistaken for subcommand",
+			args:     []string{"fest", "--config", "myfile"},
+			wantName: "",
+			wantIdx:  0,
+		},
+		{
+			name:     "unknown flag treated as flag not subcommand",
+			args:     []string{"fest", "--unknown", "graph"},
+			wantName: "graph",
+			wantIdx:  2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotIdx := findFirstPositionalArg(tt.args)
+			if gotName != tt.wantName || gotIdx != tt.wantIdx {
+				t.Errorf("findFirstPositionalArg(%v) = (%q, %d), want (%q, %d)",
+					tt.args, gotName, gotIdx, tt.wantName, tt.wantIdx)
+			}
+		})
+	}
+}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 
 	chaincmd "github.com/Obedience-Corp/fest/internal/commands/chain"
@@ -72,6 +73,15 @@ var rootCmd = &cobra.Command{
 
 // Execute runs the root command
 func Execute() error {
+	// Try git-style plugin dispatch for unknown subcommands.
+	// A fest-<name> binary on PATH becomes "fest <name> [args...]".
+	if err := dispatchPlugin(); err != nil {
+		if errors.Is(err, errPluginHandled) {
+			return nil
+		}
+		return err
+	}
+
 	return rootCmd.Execute()
 }
 


### PR DESCRIPTION
## Summary

Wires fest's existing `internal/plugins` package into the main command execution path. Unknown subcommands are now checked against `fest-*` binaries on PATH before falling through to Cobra, matching camp's git-style plugin pattern.

## Changes

- `internal/commands/plugin.go` — `dispatchPlugin()` hook called before `rootCmd.Execute()`, with `findFirstPositionalArg` for flag-aware arg parsing and `isKnownCommand` to avoid intercepting registered subcommands
- `internal/commands/root.go` — `Execute()` calls `dispatchPlugin()` before Cobra dispatch
- `internal/commands/plugin_test.go` — table-driven tests for arg parsing and known command detection

## Review feedback addressed

- Unknown root flags (e.g. `--verboes` typo) now abort plugin dispatch so Cobra reports the error instead of silently dispatching to a plugin
- Covers both `--unknown value` and `--unknown=value` syntax

## Test plan

- [x] All 1972 unit tests pass
- [x] All 46 integration tests pass
- [x] New tests cover `isKnownCommand`, `findFirstPositionalArg`, and unknown flag rejection
- [ ] Manual: install a `fest-*` binary on PATH and verify `fest <name>` dispatches to it