### PR TITLE
fix: use yellow for ready fgo completions

### DIFF
--- a/internal/commands/navigation/completions.go
+++ b/internal/commands/navigation/completions.go
@@ -43,6 +43,7 @@ const (
 	ansiReset     = "\033[0m"
 	ansiDim       = "\033[2m"
 	ansiActive    = "\033[38;5;42m"  // bright green
+	ansiReady     = "\033[38;5;220m" // yellow
 	ansiPlanned   = "\033[38;5;33m"  // blue
 	ansiCompleted = "\033[38;5;205m" // magenta
 	ansiDungeon   = "\033[38;5;248m" // light grey
@@ -55,7 +56,7 @@ func statusANSI(status string) string {
 	case "active":
 		return ansiActive
 	case "ready":
-		return ansiActive
+		return ansiReady
 	case "planning":
 		return ansiPlanned
 	case "completed":

--- a/internal/commands/navigation/completions_test.go
+++ b/internal/commands/navigation/completions_test.go
@@ -7,6 +7,30 @@ import (
 	"testing"
 )
 
+func TestStatusANSI(t *testing.T) {
+	tests := []struct {
+		name   string
+		status string
+		want   string
+	}{
+		{name: "active", status: "active", want: ansiActive},
+		{name: "ready", status: "ready", want: ansiReady},
+		{name: "planning", status: "planning", want: ansiPlanned},
+		{name: "completed", status: "completed", want: ansiCompleted},
+		{name: "dungeon completed", status: "dungeon/completed", want: ansiDungeon},
+		{name: "unknown", status: "unknown", want: ansiDim},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := statusANSI(tt.status)
+			if got != tt.want {
+				t.Fatalf("statusANSI(%q) = %q, want %q", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFindCompletedFestivals(t *testing.T) {
 	tmpDir := t.TempDir()
 	completedDir := filepath.Join(tmpDir, "festivals", "dungeon", "completed")


### PR DESCRIPTION
## Summary
- use a dedicated yellow ANSI color for `ready` in `fgo` shell completions
- keep `ready` aligned with the existing fest TUI and `fest list` status coloring
- add a regression test for the completion status-to-color mapping

## Testing
- go test ./internal/commands/navigation