### PR TITLE
feat(release): generate structured release notes

### DIFF
--- a/.justfiles/release.just
+++ b/.justfiles/release.just
@@ -15,6 +15,11 @@ ldflags := "-s -w -X " + version_pkg + ".Version=" + version + " -X " + version_
 default:
     @just --list --unsorted --justfile {{source_file()}}
 
+[private]
+[no-cd]
+notes tag repo="Obedience-Corp/fest":
+    go run ./tools/release-notes --repo "{{repo}}" --tag "{{tag}}" --output dist/release-notes.md
+
 # --- Build & packaging ---
 
 # Build for macOS Intel
@@ -158,7 +163,8 @@ dev level="":
     echo "Creating dev release: $new"
     git tag -a "$new" -m "$new"
     git push origin "$new"
-    gh release create "$new" --title "$new" --generate-notes --prerelease
+    just --justfile {{source_file()}} notes "$new"
+    gh release create "$new" --title "$new" --notes-file dist/release-notes.md --prerelease
     echo "Released $new"
 
 # Create an RC release tag from the current branch
@@ -181,7 +187,8 @@ rc version n="1":
     echo "Creating rc release: $tag"
     git tag -a "$tag" -m "$tag"
     git push origin "$tag"
-    gh release create "$tag" --title "$tag" --generate-notes --prerelease
+    just --justfile {{source_file()}} notes "$tag"
+    gh release create "$tag" --title "$tag" --notes-file dist/release-notes.md --prerelease
     echo "Released $tag"
 
 # Create a stable release tag (patch|minor|major)
@@ -220,7 +227,8 @@ stable level="patch":
     echo "Creating stable release: $new"
     git tag -a "$new" -m "$new"
     git push origin "$new"
-    gh release create "$new" --title "$new" --generate-notes --latest
+    just --justfile {{source_file()}} notes "$new"
+    gh release create "$new" --title "$new" --notes-file dist/release-notes.md --latest
     echo "Released $new"
 
 # Promote the latest RC for a version to stable by stripping the -rc.N suffix
@@ -250,7 +258,8 @@ promote-rc version="":
     echo "Promoting $latest_rc -> $stable_tag"
     git tag -a "$stable_tag" -m "Promote $latest_rc to stable $stable_tag"
     git push origin "$stable_tag"
-    gh release create "$stable_tag" --title "$stable_tag" --generate-notes --latest
+    just --justfile {{source_file()}} notes "$stable_tag"
+    gh release create "$stable_tag" --title "$stable_tag" --notes-file dist/release-notes.md --latest
     echo "Released $stable_tag"
 
 # Promote latest dev version to stable (strips -dev.N suffix)
@@ -277,7 +286,8 @@ promote:
     echo "Promoting $latest_dev -> $base"
     git tag -a "$base" -m "Promote $latest_dev to stable $base"
     git push origin "$base"
-    gh release create "$base" --title "$base" --generate-notes --latest
+    just --justfile {{source_file()}} notes "$base"
+    gh release create "$base" --title "$base" --notes-file dist/release-notes.md --latest
     echo "Released $base"
 
 # Show current version for each channel

--- a/tools/release-notes/internal/notes/notes.go
+++ b/tools/release-notes/internal/notes/notes.go
@@ -1,0 +1,460 @@
+package notes
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+type ReleaseMode string
+
+const (
+	ModeStable ReleaseMode = "stable"
+	ModeRC     ReleaseMode = "rc"
+	ModeDev    ReleaseMode = "dev"
+)
+
+type ChangeCategory string
+
+const (
+	CategoryFeature     ChangeCategory = "feature"
+	CategoryFix         ChangeCategory = "fix"
+	CategoryDocs        ChangeCategory = "docs"
+	CategoryMaintenance ChangeCategory = "maintenance"
+	CategoryOther       ChangeCategory = "other"
+)
+
+type TagInfo struct {
+	Raw       string
+	Mode      ReleaseMode
+	Major     int
+	Minor     int
+	Patch     int
+	Iteration int
+}
+
+type Change struct {
+	Text     string
+	PRNumber int
+	Category ChangeCategory
+}
+
+var (
+	stableTagRe   = regexp.MustCompile(`^v(\d+)\.(\d+)\.(\d+)$`)
+	rcTagRe       = regexp.MustCompile(`^v(\d+)\.(\d+)\.(\d+)-rc\.(\d+)$`)
+	devTagRe      = regexp.MustCompile(`^v(\d+)\.(\d+)\.(\d+)-dev\.(\d+)$`)
+	subjectRe     = regexp.MustCompile(`^(feat|fix|docs|refactor|chore|test|build|ci|perf)(?:\(([^)]+)\))?:\s*(.+)$`)
+	prSuffixRe    = regexp.MustCompile(`\s+\(#(\d+)\)$`)
+	bracketLeadRe = regexp.MustCompile(`^\[[^]]+\]\s*`)
+)
+
+func ParseTag(raw string) (TagInfo, error) {
+	if match := stableTagRe.FindStringSubmatch(raw); match != nil {
+		return TagInfo{
+			Raw:   raw,
+			Mode:  ModeStable,
+			Major: mustAtoi(match[1]),
+			Minor: mustAtoi(match[2]),
+			Patch: mustAtoi(match[3]),
+		}, nil
+	}
+
+	if match := rcTagRe.FindStringSubmatch(raw); match != nil {
+		return TagInfo{
+			Raw:       raw,
+			Mode:      ModeRC,
+			Major:     mustAtoi(match[1]),
+			Minor:     mustAtoi(match[2]),
+			Patch:     mustAtoi(match[3]),
+			Iteration: mustAtoi(match[4]),
+		}, nil
+	}
+
+	if match := devTagRe.FindStringSubmatch(raw); match != nil {
+		return TagInfo{
+			Raw:       raw,
+			Mode:      ModeDev,
+			Major:     mustAtoi(match[1]),
+			Minor:     mustAtoi(match[2]),
+			Patch:     mustAtoi(match[3]),
+			Iteration: mustAtoi(match[4]),
+		}, nil
+	}
+
+	return TagInfo{}, fmt.Errorf("invalid release tag %q", raw)
+}
+
+func FindPreviousTag(target TagInfo, tags []string) string {
+	switch target.Mode {
+	case ModeStable:
+		return findPreviousStable(target, tags)
+	case ModeRC:
+		if prev := findPreviousSameLine(target, tags, ModeRC); prev != "" {
+			return prev
+		}
+		return findPreviousStable(target, tags)
+	case ModeDev:
+		if prev := findPreviousSameLine(target, tags, ModeDev); prev != "" {
+			return prev
+		}
+		return findPreviousStable(target, tags)
+	default:
+		return ""
+	}
+}
+
+func ParseCommitSubject(subject string) (Change, bool) {
+	subject = strings.TrimSpace(subject)
+	for {
+		trimmed := bracketLeadRe.ReplaceAllString(subject, "")
+		if trimmed == subject {
+			break
+		}
+		subject = strings.TrimSpace(trimmed)
+	}
+
+	if subject == "" || strings.HasPrefix(subject, "Merge ") {
+		return Change{}, false
+	}
+
+	prNumber := 0
+	if match := prSuffixRe.FindStringSubmatch(subject); match != nil {
+		prNumber = mustAtoi(match[1])
+		subject = strings.TrimSpace(prSuffixRe.ReplaceAllString(subject, ""))
+	}
+
+	if match := subjectRe.FindStringSubmatch(subject); match != nil {
+		kind := match[1]
+		scope := strings.ToLower(match[2])
+		text := normalizeText(match[3])
+
+		return Change{
+			Text:     sentenceCase(text),
+			PRNumber: prNumber,
+			Category: classify(kind, scope, text),
+		}, text != ""
+	}
+
+	text := normalizeText(subject)
+	if text == "" {
+		return Change{}, false
+	}
+
+	return Change{
+		Text:     sentenceCase(text),
+		PRNumber: prNumber,
+		Category: classify("", "", text),
+	}, true
+}
+
+func Render(repo string, current TagInfo, previousTag string, changes []Change) (string, error) {
+	if repo == "" {
+		return "", fmt.Errorf("repo is required")
+	}
+
+	changes = dedupeChanges(changes)
+
+	var b strings.Builder
+	writeLine := func(s string) {
+		b.WriteString(s)
+		b.WriteByte('\n')
+	}
+
+	writeLine("## Release " + current.Raw)
+	writeLine("")
+	writeLine(fmt.Sprintf("This %s release includes the following changes.", channelLabel(current.Mode)))
+	writeLine("")
+
+	if previousTag != "" {
+		writeLine("Summary:")
+		for _, line := range summaryLines(changes) {
+			writeLine("- " + line)
+		}
+		writeLine("")
+		writeLine(fmt.Sprintf("Compare: https://github.com/%s/compare/%s...%s", repo, previousTag, current.Raw))
+		writeLine("")
+	} else {
+		writeLine("This is the first release covered by the structured release-notes generator.")
+		writeLine("")
+	}
+
+	highlights := highlightChanges(changes)
+	if len(highlights) > 0 && !(len(highlights) == 1 && countUserFacing(changes) == 1) {
+		writeLine("## Highlights")
+		writeLine("")
+		for _, change := range highlights {
+			writeLine("- " + renderChange(repo, change))
+		}
+		writeLine("")
+	}
+
+	sections := []struct {
+		title    string
+		category ChangeCategory
+	}{
+		{title: "Features", category: CategoryFeature},
+		{title: "Fixes", category: CategoryFix},
+		{title: "Documentation", category: CategoryDocs},
+		{title: "Maintenance", category: CategoryMaintenance},
+		{title: "Other Changes", category: CategoryOther},
+	}
+
+	for _, section := range sections {
+		entries := filterChanges(changes, section.category)
+		if len(entries) == 0 {
+			continue
+		}
+		writeLine("## " + section.title)
+		writeLine("")
+		for _, change := range entries {
+			writeLine("- " + renderChange(repo, change))
+		}
+		writeLine("")
+	}
+
+	return strings.TrimSpace(b.String()) + "\n", nil
+}
+
+func findPreviousStable(target TagInfo, tags []string) string {
+	for _, raw := range tags {
+		if raw == target.Raw {
+			continue
+		}
+		candidate, err := ParseTag(raw)
+		if err != nil || candidate.Mode != ModeStable {
+			continue
+		}
+		if compareVersion(candidate, target) < 0 {
+			return raw
+		}
+	}
+	return ""
+}
+
+func findPreviousSameLine(target TagInfo, tags []string, mode ReleaseMode) string {
+	for _, raw := range tags {
+		if raw == target.Raw {
+			continue
+		}
+		candidate, err := ParseTag(raw)
+		if err != nil || candidate.Mode != mode {
+			continue
+		}
+		if compareVersion(candidate, target) == 0 && candidate.Iteration < target.Iteration {
+			return raw
+		}
+	}
+	return ""
+}
+
+func compareVersion(left, right TagInfo) int {
+	switch {
+	case left.Major != right.Major:
+		if left.Major < right.Major {
+			return -1
+		}
+		return 1
+	case left.Minor != right.Minor:
+		if left.Minor < right.Minor {
+			return -1
+		}
+		return 1
+	case left.Patch != right.Patch:
+		if left.Patch < right.Patch {
+			return -1
+		}
+		return 1
+	default:
+		return 0
+	}
+}
+
+func classify(kind, scope, text string) ChangeCategory {
+	switch {
+	case kind == "feat":
+		return CategoryFeature
+	case kind == "fix" && scope == "docs":
+		return CategoryDocs
+	case kind == "fix" || kind == "perf":
+		return CategoryFix
+	case kind == "docs":
+		return CategoryDocs
+	case kind == "refactor" || kind == "chore" || kind == "test" || kind == "build" || kind == "ci":
+		return CategoryMaintenance
+	}
+
+	lower := strings.ToLower(text)
+	if strings.Contains(lower, "doc") || strings.Contains(lower, "readme") {
+		return CategoryDocs
+	}
+	return CategoryOther
+}
+
+func normalizeText(text string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(text)), " ")
+}
+
+func sentenceCase(text string) string {
+	runes := []rune(text)
+	if len(runes) == 0 {
+		return text
+	}
+	runes[0] = unicode.ToUpper(runes[0])
+	return string(runes)
+}
+
+func summaryLines(changes []Change) []string {
+	counts := map[ChangeCategory]int{}
+	for _, change := range changes {
+		counts[change.Category]++
+	}
+
+	var lines []string
+	appendSummary := func(category ChangeCategory, singular, plural string) {
+		if counts[category] == 0 {
+			return
+		}
+		label := plural
+		if counts[category] == 1 {
+			label = singular
+		}
+		lines = append(lines, fmt.Sprintf("%d %s", counts[category], label))
+	}
+
+	appendSummary(CategoryFeature, "feature", "features")
+	appendSummary(CategoryFix, "fix", "fixes")
+	appendSummary(CategoryDocs, "documentation update", "documentation updates")
+	appendSummary(CategoryMaintenance, "maintenance change", "maintenance changes")
+	appendSummary(CategoryOther, "other change", "other changes")
+
+	if len(lines) == 0 {
+		return []string{"No user-facing changes were detected in the tagged git range"}
+	}
+
+	return lines
+}
+
+func highlightChanges(changes []Change) []Change {
+	var highlights []Change
+	for _, change := range changes {
+		if change.Category == CategoryMaintenance || change.Category == CategoryOther {
+			continue
+		}
+		highlights = append(highlights, change)
+		if len(highlights) == 3 {
+			return highlights
+		}
+	}
+
+	if len(highlights) > 0 {
+		return highlights
+	}
+
+	if len(changes) > 3 {
+		return changes[:3]
+	}
+	return changes
+}
+
+func filterChanges(changes []Change, category ChangeCategory) []Change {
+	var filtered []Change
+	for _, change := range changes {
+		if change.Category == category {
+			filtered = append(filtered, change)
+		}
+	}
+	return filtered
+}
+
+func dedupeChanges(changes []Change) []Change {
+	if len(changes) < 2 {
+		return changes
+	}
+
+	var deduped []Change
+	indexByKey := map[string]int{}
+
+	for _, change := range changes {
+		key := normalizedChangeKey(change)
+		if idx, ok := indexByKey[key]; ok {
+			deduped[idx] = preferChange(deduped[idx], change)
+			continue
+		}
+
+		indexByKey[key] = len(deduped)
+		deduped = append(deduped, change)
+	}
+
+	return deduped
+}
+
+func normalizedChangeKey(change Change) string {
+	return strings.ToLower(strings.TrimSpace(change.Text))
+}
+
+func preferChange(current, candidate Change) Change {
+	switch {
+	case current.PRNumber == 0 && candidate.PRNumber != 0:
+		return candidate
+	case current.PRNumber != 0 && candidate.PRNumber == 0:
+		return current
+	case categoryRank(candidate.Category) < categoryRank(current.Category):
+		return candidate
+	default:
+		return current
+	}
+}
+
+func categoryRank(category ChangeCategory) int {
+	switch category {
+	case CategoryFeature:
+		return 0
+	case CategoryFix:
+		return 1
+	case CategoryDocs:
+		return 2
+	case CategoryMaintenance:
+		return 3
+	default:
+		return 4
+	}
+}
+
+func countUserFacing(changes []Change) int {
+	count := 0
+	for _, change := range changes {
+		if change.Category == CategoryFeature || change.Category == CategoryFix || change.Category == CategoryDocs {
+			count++
+		}
+	}
+	return count
+}
+
+func renderChange(repo string, change Change) string {
+	if change.PRNumber == 0 {
+		return change.Text
+	}
+	return fmt.Sprintf("%s ([#%d](https://github.com/%s/pull/%d))", change.Text, change.PRNumber, repo, change.PRNumber)
+}
+
+func channelLabel(mode ReleaseMode) string {
+	switch mode {
+	case ModeStable:
+		return "stable"
+	case ModeRC:
+		return "release candidate"
+	case ModeDev:
+		return "development"
+	default:
+		return "unknown"
+	}
+}
+
+func mustAtoi(s string) int {
+	var n int
+	for _, r := range s {
+		n = n*10 + int(r-'0')
+	}
+	return n
+}

--- a/tools/release-notes/internal/notes/notes_test.go
+++ b/tools/release-notes/internal/notes/notes_test.go
@@ -1,0 +1,142 @@
+package notes
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseTag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		tag       string
+		mode      ReleaseMode
+		iteration int
+	}{
+		{tag: "v0.2.3", mode: ModeStable},
+		{tag: "v0.2.3-rc.2", mode: ModeRC, iteration: 2},
+		{tag: "v0.2.3-dev.4", mode: ModeDev, iteration: 4},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tag, func(t *testing.T) {
+			t.Parallel()
+
+			info, err := ParseTag(tt.tag)
+			if err != nil {
+				t.Fatalf("ParseTag() error = %v", err)
+			}
+			if info.Mode != tt.mode {
+				t.Fatalf("ParseTag().Mode = %q, want %q", info.Mode, tt.mode)
+			}
+			if info.Iteration != tt.iteration {
+				t.Fatalf("ParseTag().Iteration = %d, want %d", info.Iteration, tt.iteration)
+			}
+		})
+	}
+}
+
+func TestFindPreviousTag(t *testing.T) {
+	t.Parallel()
+
+	tags := []string{
+		"v0.3.0-dev.2",
+		"v0.3.0-dev.1",
+		"v0.2.1-rc.2",
+		"v0.2.1-rc.1",
+		"v0.2.0",
+		"v0.1.5",
+	}
+
+	stable, _ := ParseTag("v0.2.0")
+	if got := FindPreviousTag(stable, tags); got != "v0.1.5" {
+		t.Fatalf("FindPreviousTag(stable) = %q, want %q", got, "v0.1.5")
+	}
+
+	rc, _ := ParseTag("v0.2.1-rc.2")
+	if got := FindPreviousTag(rc, tags); got != "v0.2.1-rc.1" {
+		t.Fatalf("FindPreviousTag(rc) = %q, want %q", got, "v0.2.1-rc.1")
+	}
+
+	dev, _ := ParseTag("v0.3.0-dev.1")
+	if got := FindPreviousTag(dev, tags); got != "v0.2.0" {
+		t.Fatalf("FindPreviousTag(dev) = %q, want %q", got, "v0.2.0")
+	}
+}
+
+func TestParseCommitSubject(t *testing.T) {
+	t.Parallel()
+
+	change, ok := ParseCommitSubject("[OBEY-123] fix(docs): correct onboarding guidance (#146)")
+	if !ok {
+		t.Fatal("ParseCommitSubject() returned ok=false")
+	}
+	if change.Text != "Correct onboarding guidance" {
+		t.Fatalf("ParseCommitSubject().Text = %q, want %q", change.Text, "Correct onboarding guidance")
+	}
+	if change.PRNumber != 146 {
+		t.Fatalf("ParseCommitSubject().PRNumber = %d, want 146", change.PRNumber)
+	}
+	if change.Category != CategoryDocs {
+		t.Fatalf("ParseCommitSubject().Category = %q, want %q", change.Category, CategoryDocs)
+	}
+}
+
+func TestRender(t *testing.T) {
+	t.Parallel()
+
+	tag, err := ParseTag("v0.2.1")
+	if err != nil {
+		t.Fatalf("ParseTag() error = %v", err)
+	}
+
+	rendered, err := Render("Obedience-Corp/fest", tag, "v0.1.1", []Change{
+		{Text: "Wire plugin dispatch into command execution", PRNumber: 147, Category: CategoryFeature},
+		{Text: "Use yellow for ready fgo completions", PRNumber: 148, Category: CategoryFix},
+		{Text: "Correct fest onboarding guidance", PRNumber: 146, Category: CategoryDocs},
+	})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	wantSubstrings := []string{
+		"## Release v0.2.1",
+		"Compare: https://github.com/Obedience-Corp/fest/compare/v0.1.1...v0.2.1",
+		"## Highlights",
+		"## Features",
+		"## Fixes",
+		"## Documentation",
+		"Wire plugin dispatch into command execution ([#147](https://github.com/Obedience-Corp/fest/pull/147))",
+	}
+
+	for _, want := range wantSubstrings {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("Render() missing substring %q\n%s", want, rendered)
+		}
+	}
+}
+
+func TestRenderDeduplicatesChangesByText(t *testing.T) {
+	t.Parallel()
+
+	tag, err := ParseTag("v0.2.1")
+	if err != nil {
+		t.Fatalf("ParseTag() error = %v", err)
+	}
+
+	rendered, err := Render("Obedience-Corp/fest", tag, "v0.1.1", []Change{
+		{Text: "Wire plugin dispatch into command execution", Category: CategoryFeature},
+		{Text: "Wire plugin dispatch into command execution", PRNumber: 147, Category: CategoryFeature},
+	})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	want := "Wire plugin dispatch into command execution ([#147](https://github.com/Obedience-Corp/fest/pull/147))"
+	if strings.Count(rendered, want) != 1 {
+		t.Fatalf("Render() should keep one PR-linked entry, got:\n%s", rendered)
+	}
+	if strings.Count(rendered, "Wire plugin dispatch into command execution") != 1 {
+		t.Fatalf("Render() should suppress duplicate section entries when only one user-facing change exists, got:\n%s", rendered)
+	}
+}

--- a/tools/release-notes/main.go
+++ b/tools/release-notes/main.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/Obedience-Corp/fest/tools/release-notes/internal/notes"
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, "ERROR:", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	fs := flag.NewFlagSet("release-notes", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	repo := fs.String("repo", "", "GitHub repository in owner/name form")
+	tag := fs.String("tag", "", "tag to render notes for")
+	outputPath := fs.String("output", "dist/release-notes.md", "output markdown path")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *repo == "" {
+		return fmt.Errorf("--repo is required")
+	}
+	if *tag == "" {
+		return fmt.Errorf("--tag is required")
+	}
+
+	current, err := notes.ParseTag(*tag)
+	if err != nil {
+		return err
+	}
+
+	targetCommit, err := tagCommit(*tag)
+	if err != nil {
+		return fmt.Errorf("resolve tag commit: %w", err)
+	}
+
+	tags, err := gitLines("tag", "-l", "v*", "--sort=-version:refname")
+	if err != nil {
+		return fmt.Errorf("list tags: %w", err)
+	}
+	previousTag, err := resolvePreviousTag(current, targetCommit, tags)
+	if err != nil {
+		return err
+	}
+
+	subjects, err := commitSubjects(*tag, previousTag)
+	if err != nil {
+		return err
+	}
+
+	var changes []notes.Change
+	seen := map[string]struct{}{}
+	for _, subject := range subjects {
+		change, ok := notes.ParseCommitSubject(subject)
+		if !ok {
+			continue
+		}
+		key := strings.ToLower(change.Text)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		changes = append(changes, change)
+	}
+
+	rendered, err := notes.Render(*repo, current, previousTag, changes)
+	if err != nil {
+		return err
+	}
+
+	absOutput := *outputPath
+	if !filepath.IsAbs(absOutput) {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("get working directory: %w", err)
+		}
+		absOutput = filepath.Join(cwd, absOutput)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(absOutput), 0o755); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+	if err := os.WriteFile(absOutput, []byte(rendered), 0o644); err != nil {
+		return fmt.Errorf("write output: %w", err)
+	}
+
+	fmt.Printf("Wrote release notes to %s\n", absOutput)
+	if previousTag != "" {
+		fmt.Printf("Compared %s...%s\n", previousTag, *tag)
+	}
+	return nil
+}
+
+func commitSubjects(tag, previousTag string) ([]string, error) {
+	args := []string{"log", "--format=%s"}
+	if previousTag != "" {
+		args = append(args, previousTag+".."+tag)
+	} else {
+		args = append(args, tag)
+	}
+	return gitLines(args...)
+}
+
+func resolvePreviousTag(current notes.TagInfo, targetCommit string, tags []string) (string, error) {
+	search := current
+	seen := map[string]struct{}{current.Raw: {}}
+
+	for {
+		candidate := notes.FindPreviousTag(search, tags)
+		if candidate == "" {
+			return "", nil
+		}
+		if _, exists := seen[candidate]; exists {
+			return "", nil
+		}
+		seen[candidate] = struct{}{}
+
+		candidateCommit, err := tagCommit(candidate)
+		if err != nil {
+			return "", fmt.Errorf("resolve previous tag commit %s: %w", candidate, err)
+		}
+		if candidateCommit != targetCommit {
+			return candidate, nil
+		}
+
+		search, err = notes.ParseTag(candidate)
+		if err != nil {
+			return "", err
+		}
+	}
+}
+
+func tagCommit(tag string) (string, error) {
+	lines, err := gitLines("rev-list", "-n", "1", tag)
+	if err != nil {
+		return "", err
+	}
+	if len(lines) == 0 {
+		return "", fmt.Errorf("tag %s has no commit", tag)
+	}
+	return strings.TrimSpace(lines[0]), nil
+}
+
+func gitLines(args ...string) ([]string, error) {
+	cmd := exec.Command("git", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("git %s: %w\n%s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" {
+		return nil, nil
+	}
+	return strings.Split(trimmed, "\n"), nil
+}

--- a/tools/release-notes/main_test.go
+++ b/tools/release-notes/main_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/tools/release-notes/internal/notes"
+)
+
+func TestResolvePreviousTagSkipsSameCommitTags(t *testing.T) {
+	t.Parallel()
+
+	repoDir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repoDir
+		cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, string(out))
+		}
+	}
+
+	run("init", "--initial-branch=main")
+	run("config", "user.name", "Test User")
+	run("config", "user.email", "test@example.com")
+
+	readme := filepath.Join(repoDir, "README.md")
+	if err := os.WriteFile(readme, []byte("v1\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	run("add", "README.md")
+	run("commit", "-m", "feat: first change")
+	run("tag", "v0.2.0")
+
+	if err := os.WriteFile(readme, []byte("v2\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	run("commit", "-am", "fix: second change")
+	run("tag", "v0.2.1")
+	run("tag", "v0.2.2")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if chdirErr := os.Chdir(cwd); chdirErr != nil {
+			t.Fatalf("restore cwd: %v", chdirErr)
+		}
+	})
+	if err := os.Chdir(repoDir); err != nil {
+		t.Fatalf("Chdir() error = %v", err)
+	}
+
+	target, err := notes.ParseTag("v0.2.2")
+	if err != nil {
+		t.Fatalf("ParseTag() error = %v", err)
+	}
+	targetCommit, err := tagCommit("v0.2.2")
+	if err != nil {
+		t.Fatalf("tagCommit() error = %v", err)
+	}
+	tags, err := gitLines("tag", "-l", "v*", "--sort=-version:refname")
+	if err != nil {
+		t.Fatalf("gitLines() error = %v", err)
+	}
+
+	previous, err := resolvePreviousTag(target, targetCommit, tags)
+	if err != nil {
+		t.Fatalf("resolvePreviousTag() error = %v", err)
+	}
+	if previous != "v0.2.0" {
+		t.Fatalf("resolvePreviousTag() = %q, want %q", previous, "v0.2.0")
+	}
+}


### PR DESCRIPTION
## Summary
- add a local release-notes generator that builds structured notes from the tagged git range
- switch release creation from GitHub auto-notes to checked-in generated notes files
- dedupe overlapping commit subjects so published notes stay readable

## Testing
- go test ./tools/release-notes/... ./internal/commands/release/...
- go run ./tools/release-notes --repo Obedience-Corp/fest --tag v0.2.1 --output /tmp/fest-release-notes.md