### PR TITLE
fix: fgo + fest list support dungeon date buckets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.6
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0
-	github.com/Obedience-Corp/camp v0.2.0-dev.1
+	github.com/Obedience-Corp/camp v0.2.2
 	github.com/Obedience-Corp/obey-shared v0.2.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/Obedience-Corp/camp v0.2.0-dev.1 h1:nmp5/UGxqdvnzL+7AR8RQiuMAidrVf63Hf7VYcsMZAg=
-github.com/Obedience-Corp/camp v0.2.0-dev.1/go.mod h1:DgTq4XJlPVFtQtXb+y1Ea49tP5XkJ1dXvX6aysN68Xg=
+github.com/Obedience-Corp/camp v0.2.2 h1:JMo1tpEjmroHH77spOIjNgC6Ldt/OJn5NtUnrZfVDhA=
+github.com/Obedience-Corp/camp v0.2.2/go.mod h1:TQTVQ90emA8wj9I1kcwx+Uv3PNIkhcp2nQbdVI/4WC8=
 github.com/Obedience-Corp/obey-shared v0.2.0 h1:ko8yX8l6q7MwJefD6PlCneiK+MwqS30Vj/RB1017tXk=
 github.com/Obedience-Corp/obey-shared v0.2.0/go.mod h1:0APvJIvDWwc6bBoFiwyAW6qfl+wtRPhMShuRKyv9Psw=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=

--- a/internal/commands/list/list.go
+++ b/internal/commands/list/list.go
@@ -193,9 +193,12 @@ func sortByDate(festivals []*show.FestivalInfo) {
 // empty StatusDate fall to the bottom and are further ordered by ModTime
 // desc so non-bucketed dungeon entries still have a deterministic position.
 func sortByStatusDate(festivals []*show.FestivalInfo) {
-	sort.Slice(festivals, func(i, j int) bool {
+	sort.SliceStable(festivals, func(i, j int) bool {
 		a, b := festivals[i].StatusDate, festivals[j].StatusDate
 		if a == b {
+			if festivals[i].ModTime.Equal(festivals[j].ModTime) {
+				return festivals[i].Name < festivals[j].Name
+			}
 			return festivals[i].ModTime.After(festivals[j].ModTime)
 		}
 		if a == "" {

--- a/internal/commands/list/list.go
+++ b/internal/commands/list/list.go
@@ -188,6 +188,26 @@ func sortByDate(festivals []*show.FestivalInfo) {
 	})
 }
 
+// sortByStatusDate orders festivals by their dungeon bucket date, newest
+// first. ISO YYYY-MM-DD values compare lexicographically. Festivals with an
+// empty StatusDate fall to the bottom and are further ordered by ModTime
+// desc so non-bucketed dungeon entries still have a deterministic position.
+func sortByStatusDate(festivals []*show.FestivalInfo) {
+	sort.Slice(festivals, func(i, j int) bool {
+		a, b := festivals[i].StatusDate, festivals[j].StatusDate
+		if a == b {
+			return festivals[i].ModTime.After(festivals[j].ModTime)
+		}
+		if a == "" {
+			return false
+		}
+		if b == "" {
+			return true
+		}
+		return a > b
+	})
+}
+
 // applySorting applies the requested sort order to a festival list.
 func applySorting(festivals []*show.FestivalInfo, sortBy string, alpha bool) {
 	switch sortBy {
@@ -303,7 +323,13 @@ func listDungeon(ctx context.Context, festivalsDir string, opts *listOptions, ca
 			return err
 		}
 		if len(festivals) > 0 {
-			applySorting(festivals, opts.sortBy, opts.alpha)
+			// Default dungeon listings order by bucket date (newest first);
+			// explicit --sort or --alpha still wins.
+			if opts.sortBy == "" && !opts.alpha {
+				sortByStatusDate(festivals)
+			} else {
+				applySorting(festivals, opts.sortBy, opts.alpha)
+			}
 			allFestivals[status] = festivals
 			order = append(order, status)
 			totalCount += len(festivals)
@@ -348,7 +374,13 @@ func listByStatus(ctx context.Context, festivalsDir, status string, opts *listOp
 		return err
 	}
 
-	applySorting(festivals, opts.sortBy, opts.alpha)
+	// Dungeon listings default to newest bucket date first; explicit sort
+	// flags still take precedence.
+	if opts.sortBy == "" && !opts.alpha && strings.HasPrefix(status, "dungeon/") {
+		sortByStatusDate(festivals)
+	} else {
+		applySorting(festivals, opts.sortBy, opts.alpha)
+	}
 
 	// Fetch detailed progress if requested
 	var progressMap map[string]*progress.FestivalProgress
@@ -441,6 +473,9 @@ func festivalsToMap(festivals []*show.FestivalInfo) []map[string]interface{} {
 			"path":   f.Path,
 			"status": f.Status,
 		}
+		if f.StatusDate != "" {
+			m["status_date"] = f.StatusDate
+		}
 		if f.Stats != nil {
 			m["progress"] = f.Stats.Progress
 		}
@@ -488,6 +523,9 @@ func festivalsToMapWithProgress(festivals []*show.FestivalInfo, progressMap map[
 			"name":   f.Name,
 			"path":   f.Path,
 			"status": f.Status,
+		}
+		if f.StatusDate != "" {
+			m["status_date"] = f.StatusDate
 		}
 		if f.Stats != nil {
 			m["progress"] = f.Stats.Progress

--- a/internal/commands/list/list_test.go
+++ b/internal/commands/list/list_test.go
@@ -387,3 +387,96 @@ func TestFestivalsToMapWithProgress_IncludesTimestamps(t *testing.T) {
 		t.Error("missing updated_at in progress JSON map")
 	}
 }
+
+func TestFestivalsToMap_IncludesStatusDate(t *testing.T) {
+	festivals := []*show.FestivalInfo{
+		{
+			Name:       "dungeoned-fest",
+			Path:       "/tmp/dungeon/completed/2026-02-10/dungeoned-fest",
+			Status:     "dungeon/completed",
+			StatusDate: "2026-02-10",
+		},
+	}
+	result := festivalsToMap(festivals)
+	got, ok := result[0]["status_date"]
+	if !ok {
+		t.Fatal("missing status_date in JSON map")
+	}
+	if got != "2026-02-10" {
+		t.Errorf("status_date = %v, want %q", got, "2026-02-10")
+	}
+}
+
+func TestFestivalsToMap_OmitsEmptyStatusDate(t *testing.T) {
+	festivals := []*show.FestivalInfo{
+		{Name: "active-fest", Path: "/tmp/active/fest", Status: "active"},
+	}
+	result := festivalsToMap(festivals)
+	if _, ok := result[0]["status_date"]; ok {
+		t.Error("empty StatusDate should be omitted from JSON map")
+	}
+}
+
+func TestFestivalsToMapWithProgress_IncludesStatusDate(t *testing.T) {
+	festivals := []*show.FestivalInfo{
+		{
+			Name:       "dungeoned-fest",
+			Path:       "/tmp/dungeon/completed/2026-02-10/dungeoned-fest",
+			Status:     "dungeon/completed",
+			StatusDate: "2026-02-10",
+		},
+	}
+	result := festivalsToMapWithProgress(festivals, nil)
+	got, ok := result[0]["status_date"]
+	if !ok {
+		t.Fatal("missing status_date in progress JSON map")
+	}
+	if got != "2026-02-10" {
+		t.Errorf("status_date = %v, want %q", got, "2026-02-10")
+	}
+}
+
+func TestSortByStatusDate_NewestBucketFirst(t *testing.T) {
+	now := time.Now()
+	festivals := []*show.FestivalInfo{
+		{Name: "older", StatusDate: "2026-01-19", ModTime: now},
+		{Name: "newest", StatusDate: "2026-02-10", ModTime: now.Add(-time.Hour)},
+		{Name: "middle", StatusDate: "2026-01-26", ModTime: now},
+		{Name: "no-bucket", StatusDate: "", ModTime: now},
+	}
+	sortByStatusDate(festivals)
+	want := []string{"newest", "middle", "older", "no-bucket"}
+	for i, name := range want {
+		if festivals[i].Name != name {
+			t.Errorf("position %d: got %q, want %q", i, festivals[i].Name, name)
+		}
+	}
+}
+
+func TestSortByStatusDate_EqualBucketsFallBackToModTime(t *testing.T) {
+	base := time.Now()
+	festivals := []*show.FestivalInfo{
+		{Name: "older-mod", StatusDate: "2026-02-10", ModTime: base.Add(-time.Hour)},
+		{Name: "newer-mod", StatusDate: "2026-02-10", ModTime: base},
+	}
+	sortByStatusDate(festivals)
+	if festivals[0].Name != "newer-mod" {
+		t.Errorf("tie-break by ModTime: position 0 = %q, want %q", festivals[0].Name, "newer-mod")
+	}
+}
+
+func TestSortByStatusDate_EmptyStatusDateSinksToEnd(t *testing.T) {
+	festivals := []*show.FestivalInfo{
+		{Name: "empty-first", StatusDate: ""},
+		{Name: "dated", StatusDate: "2026-01-01"},
+		{Name: "empty-last", StatusDate: ""},
+	}
+	sortByStatusDate(festivals)
+	if festivals[0].Name != "dated" {
+		t.Errorf("position 0: got %q, want %q", festivals[0].Name, "dated")
+	}
+	if festivals[1].StatusDate != "" || festivals[2].StatusDate != "" {
+		t.Errorf("empty StatusDate entries should be at positions 1-2, got %q, %q",
+			festivals[1].StatusDate, festivals[2].StatusDate)
+	}
+}

--- a/internal/commands/navigation/go.go
+++ b/internal/commands/navigation/go.go
@@ -359,6 +359,8 @@ func resolveFestivalByName(name, festivalsDir string) string {
 		}
 
 		// Dungeon substatuses: descend one level into date buckets.
+		// Pick the newest bucket when the same name exists in multiple
+		// buckets, matching the "newest first" semantics in sortByStatusDate.
 		if !strings.HasPrefix(status, "dungeon/") {
 			continue
 		}
@@ -366,14 +368,20 @@ func resolveFestivalByName(name, festivalsDir string) string {
 		if err != nil {
 			continue
 		}
+		var best, bestBucket string
 		for _, entry := range entries {
 			if !entry.IsDir() || !show.LooksLikeDateDir(entry.Name()) {
 				continue
 			}
 			datedPath := filepath.Join(statusDir, entry.Name(), name)
 			if info, err := os.Stat(datedPath); err == nil && info.IsDir() {
-				return datedPath
+				if entry.Name() > bestBucket {
+					best, bestBucket = datedPath, entry.Name()
+				}
 			}
+		}
+		if best != "" {
+			return best
 		}
 	}
 	return ""

--- a/internal/commands/navigation/go.go
+++ b/internal/commands/navigation/go.go
@@ -342,12 +342,38 @@ func resolveFuzzy(pattern, festivalsDir string) (string, error) {
 	return result, err
 }
 
-// resolveFestivalByName searches for a festival by name in status directories
+// resolveFestivalByName searches for a festival by name in status directories.
+// For dungeon substatuses it also descends one level into YYYY-MM-DD date
+// buckets, matching the on-disk layout used when festivals are moved to the
+// dungeon. Fuzzy search intentionally excludes the dungeon (see
+// internal/navigation/fuzzy.go); exact-name lookup does not.
 func resolveFestivalByName(name, festivalsDir string) string {
 	for _, status := range id.StatusDirectories {
-		festPath := filepath.Join(festivalsDir, status, name)
+		statusDir := filepath.Join(festivalsDir, status)
+
+		// Direct child: active/ready/planning/ritual, or any flat dungeon
+		// entry that was moved without a date bucket.
+		festPath := filepath.Join(statusDir, name)
 		if info, err := os.Stat(festPath); err == nil && info.IsDir() {
 			return festPath
+		}
+
+		// Dungeon substatuses: descend one level into date buckets.
+		if !strings.HasPrefix(status, "dungeon/") {
+			continue
+		}
+		entries, err := os.ReadDir(statusDir)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() || !show.LooksLikeDateDir(entry.Name()) {
+				continue
+			}
+			datedPath := filepath.Join(statusDir, entry.Name(), name)
+			if info, err := os.Stat(datedPath); err == nil && info.IsDir() {
+				return datedPath
+			}
 		}
 	}
 	return ""

--- a/internal/commands/navigation/go_test.go
+++ b/internal/commands/navigation/go_test.go
@@ -360,6 +360,27 @@ func TestResolveFestivalByName_FindsDungeonDateBucket_Someday(t *testing.T) {
 	}
 }
 
+func TestResolveFestivalByName_PicksNewestBucketOnCollision(t *testing.T) {
+	tmpDir := t.TempDir()
+	festivalsDir := filepath.Join(tmpDir, "festivals")
+	name := "cloned-fest-CF0001"
+
+	// Same festival name exists in two date buckets — the resolver should
+	// return the newest one to match sortByStatusDate's newest-first order.
+	olderPath := filepath.Join(festivalsDir, "dungeon", "completed", "2026-01-10", name)
+	newerPath := filepath.Join(festivalsDir, "dungeon", "completed", "2026-03-15", name)
+	for _, d := range []string{olderPath, newerPath} {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got := resolveFestivalByName(name, festivalsDir)
+	if got != newerPath {
+		t.Errorf("resolveFestivalByName() = %q, want %q (newest bucket should win)", got, newerPath)
+	}
+}
+
 func TestResolveFestivalByName_PrefersActiveOverDungeon(t *testing.T) {
 	tmpDir := t.TempDir()
 	festivalsDir := filepath.Join(tmpDir, "festivals")

--- a/internal/commands/navigation/go_test.go
+++ b/internal/commands/navigation/go_test.go
@@ -327,6 +327,74 @@ func TestResolveGoTargetDungeonAliases(t *testing.T) {
 	}
 }
 
+func TestResolveFestivalByName_FindsDungeonDateBucket(t *testing.T) {
+	tmpDir := t.TempDir()
+	festivalsDir := filepath.Join(tmpDir, "festivals")
+
+	// Mirror the real on-disk layout: dungeon/<substatus>/YYYY-MM-DD/<name>
+	target := filepath.Join(festivalsDir, "dungeon", "completed", "2026-02-10",
+		"feb-9th-gathered-improvements-FG0001")
+	if err := os.MkdirAll(target, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := resolveFestivalByName("feb-9th-gathered-improvements-FG0001", festivalsDir)
+	if got != target {
+		t.Errorf("resolveFestivalByName() = %q, want %q", got, target)
+	}
+}
+
+func TestResolveFestivalByName_FindsDungeonDateBucket_Someday(t *testing.T) {
+	tmpDir := t.TempDir()
+	festivalsDir := filepath.Join(tmpDir, "festivals")
+
+	target := filepath.Join(festivalsDir, "dungeon", "someday", "2026-04-01",
+		"maybe-later-ML0001")
+	if err := os.MkdirAll(target, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := resolveFestivalByName("maybe-later-ML0001", festivalsDir)
+	if got != target {
+		t.Errorf("resolveFestivalByName() = %q, want %q", got, target)
+	}
+}
+
+func TestResolveFestivalByName_PrefersActiveOverDungeon(t *testing.T) {
+	tmpDir := t.TempDir()
+	festivalsDir := filepath.Join(tmpDir, "festivals")
+	name := "shared-name-SH0001"
+
+	activePath := filepath.Join(festivalsDir, "active", name)
+	dungeonPath := filepath.Join(festivalsDir, "dungeon", "completed", "2026-02-01", name)
+	for _, d := range []string{activePath, dungeonPath} {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got := resolveFestivalByName(name, festivalsDir)
+	if got != activePath {
+		t.Errorf("resolveFestivalByName() = %q, want %q (active should win over dungeon)", got, activePath)
+	}
+}
+
+func TestResolveFestivalByName_IgnoresNonDateDirsInDungeon(t *testing.T) {
+	tmpDir := t.TempDir()
+	festivalsDir := filepath.Join(tmpDir, "festivals")
+
+	// A non-date directory (e.g., a README-shaped folder) should not be
+	// descended as if it were a bucket.
+	notes := filepath.Join(festivalsDir, "dungeon", "completed", "notes", "my-fest")
+	if err := os.MkdirAll(notes, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := resolveFestivalByName("my-fest", festivalsDir); got != "" {
+		t.Errorf("resolveFestivalByName() = %q, want empty (non-date-dir subdirs should not be descended)", got)
+	}
+}
+
 func TestResolveGoTargetWithFestivalName(t *testing.T) {
 	tmpDir := t.TempDir()
 	festivalsDir := filepath.Join(tmpDir, "festivals")

--- a/internal/commands/show/detect.go
+++ b/internal/commands/show/detect.go
@@ -18,8 +18,9 @@ import (
 // dateDirPattern matches YYYY-MM-DD or YYYY-MM formatted date directory names.
 var dateDirPattern = regexp.MustCompile(`^\d{4}-\d{2}(-\d{2})?$`)
 
-// looksLikeDateDir checks if a directory name matches a date directory pattern.
-func looksLikeDateDir(name string) bool {
+// LooksLikeDateDir reports whether a directory name matches the dungeon
+// date-bucket shape (YYYY-MM-DD, or legacy YYYY-MM).
+func LooksLikeDateDir(name string) bool {
 	return dateDirPattern.MatchString(name)
 }
 
@@ -108,7 +109,7 @@ func findLinkedFestivalPath(festivalsRoot, name string) string {
 				continue
 			}
 			for _, entry := range entries {
-				if entry.IsDir() && looksLikeDateDir(entry.Name()) {
+				if entry.IsDir() && LooksLikeDateDir(entry.Name()) {
 					datePath := filepath.Join(statusDir, entry.Name(), name)
 					if info, err := os.Stat(datePath); err == nil && info.IsDir() {
 						if isValidFestival(datePath) {
@@ -176,8 +177,9 @@ func FindFestivalByName(ctx context.Context, festivalsDir, name, campaignRoot st
 			}
 
 			// If this is a date directory, search inside it
-			if looksLikeDateDir(entry.Name()) {
-				subEntries, subErr := os.ReadDir(filepath.Join(statusDir, entry.Name()))
+			if LooksLikeDateDir(entry.Name()) {
+				bucket := entry.Name()
+				subEntries, subErr := os.ReadDir(filepath.Join(statusDir, bucket))
 				if subErr != nil {
 					continue
 				}
@@ -186,13 +188,14 @@ func FindFestivalByName(ctx context.Context, festivalsDir, name, campaignRoot st
 						continue
 					}
 					if sub.Name() == name || strings.HasPrefix(sub.Name(), name+"_") || strings.Contains(sub.Name(), name) {
-						festivalDir := filepath.Join(statusDir, entry.Name(), sub.Name())
+						festivalDir := filepath.Join(statusDir, bucket, sub.Name())
 						if isValidFestival(festivalDir) {
 							info, err := parseFestivalInfo(ctx, festivalDir, campaignRoot)
 							if err != nil {
 								continue
 							}
 							info.Status = status
+							info.StatusDate = bucket
 							return info, nil
 						}
 					}
@@ -239,8 +242,9 @@ func ListFestivalsByStatus(ctx context.Context, festivalsDir, status, campaignRo
 			}
 			info.Status = status
 			festivals = append(festivals, info)
-		} else if looksLikeDateDir(entry.Name()) {
+		} else if LooksLikeDateDir(entry.Name()) {
 			// Recurse into date subdirectory
+			bucket := entry.Name()
 			subEntries, subErr := os.ReadDir(festivalDir)
 			if subErr != nil {
 				continue
@@ -263,6 +267,7 @@ func ListFestivalsByStatus(ctx context.Context, festivalsDir, status, campaignRo
 					}
 				}
 				info.Status = status
+				info.StatusDate = bucket
 				festivals = append(festivals, info)
 			}
 		}
@@ -295,8 +300,9 @@ func ListFestivalsByStatusLight(_ context.Context, festivalsDir, status string) 
 		if isValidFestival(festivalDir) {
 			info := lightFestivalInfo(festivalDir, entry.Name(), status)
 			festivals = append(festivals, info)
-		} else if looksLikeDateDir(entry.Name()) {
+		} else if LooksLikeDateDir(entry.Name()) {
 			// Recurse into date subdirectory
+			bucket := entry.Name()
 			subEntries, subErr := os.ReadDir(festivalDir)
 			if subErr != nil {
 				continue
@@ -310,6 +316,7 @@ func ListFestivalsByStatusLight(_ context.Context, festivalsDir, status string) 
 					continue
 				}
 				info := lightFestivalInfo(subDir, sub.Name(), status)
+				info.StatusDate = bucket
 				festivals = append(festivals, info)
 			}
 		}
@@ -384,12 +391,13 @@ func parseFestivalInfo(ctx context.Context, festivalDir, campaignRoot string) (*
 		info.Status = "dungeon"
 	default:
 		// Check if parent is a date directory (YYYY-MM-DD or YYYY-MM)
-		if looksLikeDateDir(parentName) {
+		if LooksLikeDateDir(parentName) {
 			// Walk up one more level to find the status name
 			statusName := filepath.Base(filepath.Dir(parentDir))                // e.g., "completed"
 			grandparent := filepath.Base(filepath.Dir(filepath.Dir(parentDir))) // e.g., "dungeon"
 			if grandparent == "dungeon" && isKnownDungeonStatus(statusName) {
 				info.Status = "dungeon/" + statusName
+				info.StatusDate = parentName
 			} else {
 				info.Status = "unknown"
 			}

--- a/internal/commands/show/format.go
+++ b/internal/commands/show/format.go
@@ -129,13 +129,18 @@ func FormatFestivalList(status string, festivals []*FestivalInfo) string {
 		return sb.String()
 	}
 
+	isDungeon := strings.HasPrefix(status, "dungeon/")
 	for _, f := range festivals {
 		progress := ""
 		if f.Stats != nil {
 			progress = ui.Dim(fmt.Sprintf(" [%.0f%%]", f.Stats.Progress))
 		}
+		moved := ""
+		if isDungeon && f.StatusDate != "" {
+			moved = ui.Dim(fmt.Sprintf("  moved %s", f.StatusDate))
+		}
 		styledName := ui.GetStatusStyle(status).Render(f.Name)
-		fmt.Fprintf(&sb, "  %s%s\n", styledName, progress)
+		fmt.Fprintf(&sb, "  %s%s%s\n", styledName, moved, progress)
 	}
 
 	return sb.String()
@@ -156,10 +161,15 @@ func FormatFestivalListWithProgress(status string, festivals []*FestivalInfo, pr
 		return sb.String()
 	}
 
+	isDungeon := strings.HasPrefix(status, "dungeon/")
 	for _, f := range festivals {
 		styledName := ui.GetStatusStyle(status).Render(f.Name)
 		fmt.Fprintf(&sb, "  %s\n", styledName)
 
+		// Show moved-to-status date for dungeon festivals.
+		if isDungeon && f.StatusDate != "" {
+			fmt.Fprintf(&sb, "    %s %s\n", ui.Label("Moved"), ui.Dim(f.StatusDate))
+		}
 		// Show timestamps
 		if !f.CreatedAt.IsZero() {
 			fmt.Fprintf(&sb, "    %s %s\n", ui.Label("Created"), ui.Dim(formatTimestamp(f.CreatedAt)))

--- a/internal/commands/show/show_listing_test.go
+++ b/internal/commands/show/show_listing_test.go
@@ -130,4 +130,125 @@ func TestFindFestivalByName_DateDirectories(t *testing.T) {
 	if info.Status != "dungeon/completed" {
 		t.Errorf("Status = %q, want %q", info.Status, "dungeon/completed")
 	}
+	if info.StatusDate != "2026-02-28" {
+		t.Errorf("StatusDate = %q, want %q", info.StatusDate, "2026-02-28")
+	}
+}
+
+// TestListFestivalsByStatus_PopulatesStatusDate verifies that ListFestivalsByStatus
+// records the dated bucket name on each FestivalInfo returned from a dungeon
+// status, and leaves StatusDate empty for non-bucketed entries.
+func TestListFestivalsByStatus_PopulatesStatusDate(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	dateDirFest := filepath.Join(tmpDir, "dungeon", "completed", "2026-02-28", "fest-in-date-dir")
+	directFest := filepath.Join(tmpDir, "dungeon", "completed", "fest-direct")
+
+	for _, d := range []string{dateDirFest, directFest} {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(d, FestivalGoalFile), []byte("# Test"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	festivals, err := ListFestivalsByStatus(context.Background(), tmpDir, "dungeon/completed", "")
+	if err != nil {
+		t.Fatalf("ListFestivalsByStatus() error = %v", err)
+	}
+
+	byName := map[string]*FestivalInfo{}
+	for _, f := range festivals {
+		byName[f.Name] = f
+	}
+
+	bucketed, ok := byName["fest-in-date-dir"]
+	if !ok {
+		t.Fatalf("bucketed festival not found; got %v", byName)
+	}
+	if bucketed.StatusDate != "2026-02-28" {
+		t.Errorf("StatusDate for bucketed festival = %q, want %q", bucketed.StatusDate, "2026-02-28")
+	}
+
+	direct, ok := byName["fest-direct"]
+	if !ok {
+		t.Fatalf("direct festival not found; got %v", byName)
+	}
+	if direct.StatusDate != "" {
+		t.Errorf("StatusDate for non-bucketed festival = %q, want empty", direct.StatusDate)
+	}
+}
+
+// TestListFestivalsByStatusLight_PopulatesStatusDate is the same assertion
+// against the light (no-stats) discovery path.
+func TestListFestivalsByStatusLight_PopulatesStatusDate(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	festDir := filepath.Join(tmpDir, "dungeon", "someday", "2026-04-01", "maybe-later-ML0001")
+	if err := os.MkdirAll(festDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(festDir, FestivalGoalFile), []byte("# Test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	festivals, err := ListFestivalsByStatusLight(context.Background(), tmpDir, "dungeon/someday")
+	if err != nil {
+		t.Fatalf("ListFestivalsByStatusLight() error = %v", err)
+	}
+	if len(festivals) != 1 {
+		t.Fatalf("expected 1 festival, got %d", len(festivals))
+	}
+	if got := festivals[0].StatusDate; got != "2026-04-01" {
+		t.Errorf("StatusDate = %q, want %q", got, "2026-04-01")
+	}
+}
+
+// TestParseFestivalInfo_StatusDateFromBucket verifies that the single-festival
+// parse path records StatusDate when walked directly into a dated bucket.
+func TestParseFestivalInfo_StatusDateFromBucket(t *testing.T) {
+	tmpDir := t.TempDir()
+	festDir := filepath.Join(tmpDir, "dungeon", "completed", "2026-02-28", "lone-fest-LF0001")
+	if err := os.MkdirAll(festDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(festDir, FestivalGoalFile), []byte("# Test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := parseFestivalInfo(context.Background(), festDir, "")
+	if err != nil {
+		t.Fatalf("parseFestivalInfo() error = %v", err)
+	}
+	if info.Status != "dungeon/completed" {
+		t.Errorf("Status = %q, want %q", info.Status, "dungeon/completed")
+	}
+	if info.StatusDate != "2026-02-28" {
+		t.Errorf("StatusDate = %q, want %q", info.StatusDate, "2026-02-28")
+	}
+}
+
+// TestParseFestivalInfo_NoStatusDateForActive verifies that non-dungeon
+// festivals do not get a StatusDate.
+func TestParseFestivalInfo_NoStatusDateForActive(t *testing.T) {
+	tmpDir := t.TempDir()
+	festDir := filepath.Join(tmpDir, "active", "active-fest-AF0001")
+	if err := os.MkdirAll(festDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(festDir, FestivalGoalFile), []byte("# Test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := parseFestivalInfo(context.Background(), festDir, "")
+	if err != nil {
+		t.Fatalf("parseFestivalInfo() error = %v", err)
+	}
+	if info.Status != "active" {
+		t.Errorf("Status = %q, want %q", info.Status, "active")
+	}
+	if info.StatusDate != "" {
+		t.Errorf("StatusDate = %q, want empty", info.StatusDate)
+	}
 }

--- a/internal/commands/show/stats.go
+++ b/internal/commands/show/stats.go
@@ -21,10 +21,15 @@ type FestivalInfo struct {
 	Name         string    `json:"name"`                    // Directory name (used for linking)
 	MetadataName string    `json:"metadata_name,omitempty"` // Name from fest.yaml metadata (clean name without ID)
 	Status       string    `json:"status"`
-	Priority     string    `json:"priority,omitempty"`
-	Path         string    `json:"path"`
-	ProjectPath  string    `json:"project_path,omitempty"` // Linked project directory from fest.yaml
-	ModTime      time.Time `json:"mod_time"`               // Directory modification time
+	// StatusDate is the dated bucket a festival lives under when it is in a
+	// dungeon substatus. Format is the raw on-disk directory name
+	// (YYYY-MM-DD for new entries, or YYYY-MM for legacy entries).
+	// Empty for festivals that are not stored inside a dated bucket.
+	StatusDate  string    `json:"status_date,omitempty"`
+	Priority    string    `json:"priority,omitempty"`
+	Path        string    `json:"path"`
+	ProjectPath string    `json:"project_path,omitempty"` // Linked project directory from fest.yaml
+	ModTime     time.Time `json:"mod_time"`               // Directory modification time
 	// CreatedAt is when the festival was first created (from fest_created frontmatter or directory mod time).
 	CreatedAt time.Time `json:"created_at,omitempty"`
 	// UpdatedAt is the last modification time (from fest_updated frontmatter or directory mod time).

--- a/internal/commands/show/stats.go
+++ b/internal/commands/show/stats.go
@@ -25,6 +25,11 @@ type FestivalInfo struct {
 	// dungeon substatus. Format is the raw on-disk directory name
 	// (YYYY-MM-DD for new entries, or YYYY-MM for legacy entries).
 	// Empty for festivals that are not stored inside a dated bucket.
+	//
+	// Canonical population: parseFestivalInfo detects the date-dir parent
+	// via LooksLikeDateDir and sets StatusDate automatically.
+	// ListFestivalsByStatusLight uses lightFestivalInfo (no parseFestivalInfo),
+	// so it sets StatusDate manually in its date-dir recursion block.
 	StatusDate  string    `json:"status_date,omitempty"`
 	Priority    string    `json:"priority,omitempty"`
 	Path        string    `json:"path"`


### PR DESCRIPTION
## Summary

- **`fgo <festival-name>`** now resolves festivals nested inside dungeon date buckets (`dungeon/<substatus>/YYYY-MM-DD/<name>/`). Previously `resolveFestivalByName` only stat'd the direct child of each status dir, making every dungeon festival invisible to bare-name navigation. Fuzzy search continues to exclude the dungeon by design.
- **`fest list completed|someday|archived`** now shows the `moved YYYY-MM-DD` bucket date inline and orders entries newest-bucket-first. The bucket name is carried on a new `FestivalInfo.StatusDate` field populated in every discovery path (`ListFestivalsByStatus`, `ListFestivalsByStatusLight`, `FindFestivalByName`, `parseFestivalInfo`). Non-dungeon listings are untouched.
- **`fest list --json`** now exposes `status_date` on dungeon entries (`omitempty` elsewhere).
- **`sortByStatusDate`** is the new default order for dungeon listings. Explicit `--sort` / `--alpha` still takes precedence.
- `looksLikeDateDir` is exported as `show.LooksLikeDateDir` so the navigation package can reuse one regex source of truth.

Design package: `workflow/design/fest-bug-4-11-2026/` in obey-campaign.

## Before / After

**Before** (dungeon festivals invisible to `fgo`, no bucket date shown):
\`\`\`
$ fgo feb-9th-gathered-improvements-FG0001
error: target not found

$ fest list completed | head -3
DUNGEON/COMPLETED Festivals (90)
────────────────────────────────────────
  feb-9th-gathered-improvements-FG0001
\`\`\`

**After**:
\`\`\`
$ fgo feb-9th-gathered-improvements-FG0001 --print
/Users/.../festivals/dungeon/completed/2026-02-10/feb-9th-gathered-improvements-FG0001

$ fest list completed | head -3
DUNGEON/COMPLETED Festivals (90)
────────────────────────────────────────
  camp-workitems-manual-priority-CW0002  moved 2026-04-07 [100%]
\`\`\`

## Test plan

- [x] \`just test all\` — 1993 unit + 46 integration tests pass
- [x] \`golangci-lint run ./internal/commands/{show,navigation,list}/...\` — 0 issues
- [x] Manual E2E against the obey-campaign workspace dungeon (90 completed + 6 someday + 9 archived entries)
- [x] \`fest list completed\` shows \`moved YYYY-MM-DD\` and sorts newest bucket first
- [x] \`fest go <dungeoned-name> --print\` resolves the nested path
- [x] \`fest list --json completed\` exposes \`status_date\` on every entry
- [x] \`fest list completed --sort name\` still overrides (explicit flag wins)
- [x] \`fest list active\` / \`fest list\` / \`fest go 002\` — byte-identical to pre-fix behavior
- [x] Fuzzy partial matches on dungeon names still fail (deliberate — preserves original design)

## Acceptance

- Additive data-model change (new \`StatusDate string\` field, \`omitempty\`).
- No on-disk layout change, no migrations.
- Only net-new code path: `resolveFestivalByName` gains a date-bucket descent for dungeon statuses.
- Rendering changes are gated on `strings.HasPrefix(status, "dungeon/")` so non-dungeon output is untouched.