### PR TITLE
Include ritual/ in fuzzy navigation and active-workflow status checks

### DIFF
--- a/internal/commands/config/shell.go
+++ b/internal/commands/config/shell.go
@@ -96,7 +96,7 @@ _fgo_completions() {
         completions=$(command fest go completions 2>/dev/null)
     elif [[ ${COMP_CWORD} -eq 2 ]]; then
         case "${COMP_WORDS[1]}" in
-            active|planning|ready|completed|someday|archived|dungeon)
+            active|planning|ready|ritual|completed|someday|archived|dungeon)
                 completions=$(command fest go completions --status "${COMP_WORDS[1]}" 2>/dev/null)
                 ;;
         esac
@@ -119,7 +119,7 @@ if [[ -n "$ZSH_VERSION" ]]; then
         elif (( CURRENT == 3 )); then
             # Second arg: if first arg is a status dir, show its festivals
             case "${words[2]}" in
-                active|planning|ready|completed|someday|archived|dungeon)
+                active|planning|ready|ritual|completed|someday|archived|dungeon)
                     cmd_args="--color --status ${words[2]}"
                     ;;
                 *) return ;;
@@ -237,7 +237,7 @@ fgo() {
             # Normal navigation (festival/phase/status directories)
             # Note: Don't use 2>&1 - stderr must flow to terminal for TUI picker to render
             local dest
-            if [[ -n "$2" && "$1" =~ ^(active|planning|ready|completed|someday|archived|dungeon)$ ]]; then
+            if [[ -n "$2" && "$1" =~ ^(active|planning|ready|ritual|completed|someday|archived|dungeon)$ ]]; then
                 # Status dir + festival name: combine (e.g., active my-fest → active/my-fest)
                 dest=$(command fest go "$1/$2" --print)
             else
@@ -283,7 +283,7 @@ fest() {
                     ;;
                 *)
                     local dest
-                    if [ -n "$2" ] && echo "$1" | grep -qE '^(active|planning|ready|completed|someday|archived|dungeon)$'; then
+                    if [ -n "$2" ] && echo "$1" | grep -qE '^(active|planning|ready|ritual|completed|someday|archived|dungeon)$'; then
                         dest=$(command fest go "$1/$2" --print 2>/dev/null)
                     else
                         dest=$(command fest go "$@" --print 2>/dev/null)
@@ -319,7 +319,7 @@ function __fgo_completions
     else if test $count -eq 2
         # Second arg: if first arg is a status dir, show its festivals
         switch $tokens[2]
-            case active planning ready completed someday archived dungeon
+            case active planning ready ritual completed someday archived dungeon
                 command fest go completions --status $tokens[2] 2>/dev/null
         end
     end
@@ -394,7 +394,7 @@ function fgo
             set -l target
             if test (count $argv) -ge 2
                 switch $argv[1]
-                    case active planning ready completed someday archived dungeon
+                    case active planning ready ritual completed someday archived dungeon
                         set target "$argv[1]/$argv[2]"
                     case '*'
                         set target $argv
@@ -441,7 +441,7 @@ function fest
                     set -l dest
                     if test (count $argv) -ge 2
                         switch $argv[1]
-                            case active planning ready completed someday archived dungeon
+                            case active planning ready ritual completed someday archived dungeon
                                 set dest (command fest go "$argv[1]/$argv[2]" --print 2>/dev/null)
                             case '*'
                                 set dest (command fest go $argv --print 2>/dev/null)

--- a/internal/commands/list/list.go
+++ b/internal/commands/list/list.go
@@ -52,11 +52,11 @@ func NewListCommand() *cobra.Command {
 
 Works from anywhere - finds the festivals workspace automatically.
 
-STATUS can be: active, planning, completed, dungeon, dungeon/completed, dungeon/archived, dungeon/someday
+STATUS can be: active, ready, planning, ritual, completed, dungeon, dungeon/completed, dungeon/archived, dungeon/someday
 
-By default, shows only active and planning festivals.
+By default, shows active, ready, planning, and ritual festivals.
 Use --all to include completed and dungeon festivals.`,
-		Example: `  fest list                                       # List active and planning festivals
+		Example: `  fest list                                       # List active, ready, planning, and ritual festivals
   fest list --all                                  # List all festivals
   fest list --filter-project camp                  # Festivals linked to "camp" project
   fest list --since 2026-01-01                     # Festivals created since Jan 1

--- a/internal/commands/markers/markers.go
+++ b/internal/commands/markers/markers.go
@@ -141,7 +141,7 @@ func resolveFestivalPath(pathArg string) (string, error) {
 		// Check if we're inside an active festival
 		rel, _ := filepath.Rel(root, cwd)
 		parts := strings.Split(rel, string(filepath.Separator))
-		if len(parts) >= 2 && (parts[0] == "active" || parts[0] == "ready" || parts[0] == "planning") {
+		if len(parts) >= 2 && (parts[0] == "active" || parts[0] == "ready" || parts[0] == "planning" || parts[0] == "ritual") {
 			festivalPath := filepath.Join(root, parts[0], parts[1])
 			return festivalPath, nil
 		}

--- a/internal/commands/show/detect.go
+++ b/internal/commands/show/detect.go
@@ -377,7 +377,7 @@ func parseFestivalInfo(ctx context.Context, festivalDir, campaignRoot string) (*
 	parentDir := filepath.Dir(festivalDir)
 	parentName := filepath.Base(parentDir)
 	switch parentName {
-	case "active", "ready", "planning":
+	case "active", "ready", "planning", "ritual":
 		info.Status = parentName
 	case "completed", "archived", "someday":
 		// Could be dungeon/completed, dungeon/archived, dungeon/someday

--- a/internal/id/generator.go
+++ b/internal/id/generator.go
@@ -29,8 +29,11 @@ var idPattern = regexp.MustCompile(`-([A-Z]{2})(\d{4,})$`)
 // StatusDirectories are ALL directories that can contain festivals (full lifecycle)
 var StatusDirectories = []string{"planning", "ready", "active", "ritual", "dungeon/completed", "dungeon/archived", "dungeon/someday"}
 
-// PrimaryStatusDirs are directories for active work (used in navigation, fuzzy search)
-var PrimaryStatusDirs = []string{"active", "ready", "planning"}
+// PrimaryStatusDirs are non-terminal directories surfaced in navigation,
+// fuzzy search, `fest list` defaults, and shell completion. Kept in sync
+// with WorkingStatusDirectories so fgo fuzzy matching can reach ritual
+// festivals alongside active/ready/planning.
+var PrimaryStatusDirs = []string{"active", "ready", "planning", "ritual"}
 
 // WorkingStatusDirectories are non-terminal directories (excludes dungeon/*).
 var WorkingStatusDirectories = []string{"planning", "ready", "active", "ritual"}

--- a/internal/navigation/fuzzy_test.go
+++ b/internal/navigation/fuzzy_test.go
@@ -160,6 +160,52 @@ func TestFormatMatchList(t *testing.T) {
 	assert.Len(t, got, 5)
 }
 
+func TestCollectNavigationTargets_IncludesRitual(t *testing.T) {
+	tmpDir := t.TempDir()
+	festivalsDir := tmpDir
+
+	// Active festival (baseline — must still be found)
+	_ = os.MkdirAll(filepath.Join(festivalsDir, "active", "my-feature-MF0001"), 0755)
+
+	// Ritual festival definition — follows the documented on-disk format
+	// (see docs/ritual.md): festivals/ritual/{name}-RI-{XX}{NNNN}
+	ritualName := "weekly-review-RI-WR0001"
+	_ = os.MkdirAll(filepath.Join(festivalsDir, "ritual", ritualName), 0755)
+
+	// Non-festival dir in ritual/ — must be filtered out by ID suffix check.
+	_ = os.MkdirAll(filepath.Join(festivalsDir, "ritual", "not-a-festival"), 0755)
+
+	targets := CollectNavigationTargets(festivalsDir)
+
+	names := make(map[string]string) // name -> path
+	for _, tgt := range targets {
+		names[tgt.Name] = tgt.Path
+	}
+
+	// Regression guard: active festivals still collected.
+	assert.Contains(t, names, "my-feature-MF0001",
+		"active festival must remain in navigation targets")
+
+	// The actual fix under test: ritual festivals appear in fuzzy targets.
+	assert.Contains(t, names, ritualName,
+		"ritual festival must be included so fgo fuzzy navigation can reach it")
+
+	// ritual/ status directory itself should also be navigable by name
+	// (parity with active/ready/planning appearing as status targets).
+	assert.Contains(t, names, "ritual",
+		"ritual status directory must be a navigable target")
+
+	// Non-festival dirs in ritual/ must be filtered out.
+	assert.NotContains(t, names, "not-a-festival",
+		"directories without a valid ID suffix must not appear")
+
+	// Path correctness: ritual festival path points inside festivals/ritual/.
+	assert.Equal(t,
+		filepath.Join(festivalsDir, "ritual", ritualName),
+		names[ritualName],
+		"ritual festival path should point to festivals/ritual/{name}")
+}
+
 func TestCollectFestivalsInStatus(t *testing.T) {
 	tmpDir := t.TempDir()
 	festivalsDir := tmpDir


### PR DESCRIPTION
## Summary

`fgo` fuzzy navigation silently skipped festivals under `festivals/ritual/`. The root cause: `PrimaryStatusDirs` in `internal/id/generator.go` was `{active, ready, planning}` — missing `ritual`. `CollectNavigationTargets` (`internal/navigation/fuzzy.go`), `fest list` defaults, `go_link`, shell completion, and phase-shortcut resolution all consume this list, so ritual festivals were invisible to fuzzy search across the board.

Ritual festivals are non-terminal workflow items (already reflected in `WorkingStatusDirectories`). They should be first-class navigation targets alongside `active/`, `ready/`, and `planning/`.

## Root cause

```go
// Before
var PrimaryStatusDirs = []string{"active", "ready", "planning"}

// After
var PrimaryStatusDirs = []string{"active", "ready", "planning", "ritual"}
```

Investigation turned up three further sites hardcoding the same stale triple that were latent bugs for ritual festivals (e.g. `show.DetectCurrentLocation` would leave `Status` empty for a ritual festival). Those are fixed in the same PR for consistency.

## Changes

| File | Change |
|---|---|
| `internal/id/generator.go` | Add `"ritual"` to `PrimaryStatusDirs`; document sync with `WorkingStatusDirectories` |
| `internal/navigation/fuzzy_test.go` | **New test** — `TestCollectNavigationTargets_IncludesRitual` |
| `internal/commands/show/detect.go` | Recognise `ritual/` parent when deriving festival status |
| `internal/commands/markers/markers.go` | Recognise `ritual/` as an active-festival location |
| `internal/commands/list/list.go` | Update help/examples to include ritual and ready in defaults (previously stale) |
| `internal/commands/config/shell.go` | Add `ritual` to bash/zsh/fish status-dir case arms so `fgo <status> <name>` combining and tab completion work for rituals |

## Test plan

- [x] **RED then GREEN** for the new test — `TestCollectNavigationTargets_IncludesRitual` fails on current `main`, passes after `PrimaryStatusDirs` change
- [x] `just test unit` — 1995/1995 tests pass
- [x] `just build quick` — clean binary
- [x] Smoke against real campaign:
  - `fest go weekly --print` (ritual festival) → resolves to `festivals/ritual/weekly-review-RI-WR0001` ✓
  - `fest go ritual --print` → resolves to `festivals/ritual` (status dir as nav target) ✓
  - `fest go corp --print` (active festival regression guard) → resolves to `festivals/active/corp-site-build-CS0003` ✓

## Notes

- Existing lint errors in `internal/commands/system/sync.go` and `tools/release-notes/internal/notes/notes.go` are pre-existing on `main` and out of scope for this PR.
- `fls` completion helpers at `shell.go:144` and `330` have pre-existing gaps (missing `ready`, `someday`, `archived`) unrelated to ritual; left for a follow-up to keep this PR focused.