### PR TITLE
docs: shrink banner to width=400 via HTML tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 > **Part of [Festival](https://github.com/Obedience-Corp/festival)** - mission-based AI workspace management. Fest handles hierarchical planning and execution; [camp](https://github.com/Obedience-Corp/camp) handles workspace management. Together they give structure to how you work across multiple projects, contexts, and AI agents.
 
-![Festival Methodology Banner](docs/images/banner.jpg)
+<p align="center">
+  <img src="docs/images/banner.jpg" alt="Festival Methodology Banner" width="400">
+</p>
 
 [![Watch the demo](docs/images/demo_video_thumb.jpg)](https://youtu.be/30m3VNl2G6k?si=4taH1m1q4MRkbOhd&t=21)
 


### PR DESCRIPTION
## Summary

The `docs/images/banner.jpg` is 1024x1024 (square), which makes it render at full container width on GitHub — roughly 770px tall — so it eats the entire first screen of the README.

This PR replaces the markdown image syntax with a centered HTML `<img>` tag using `width="400"`. The image file is unchanged; only the rendered size shrinks.

```html
<p align="center">
  <img src="docs/images/banner.jpg" alt="Festival Methodology Banner" width="400">
</p>
```

## Test plan

- [ ] Open the PR's rendered README preview and confirm the banner is compact and centered
- [ ] Confirm the demo video thumbnail link below still renders correctly
- [ ] Verify no other content shifted