### PR TITLE
chore(lint): resolve staticcheck QF1001/QF1003 quick-fixes

### DIFF
--- a/internal/commands/system/sync.go
+++ b/internal/commands/system/sync.go
@@ -117,7 +117,8 @@ func runSync(ctx context.Context, _ *cobra.Command, opts *syncOptions) error {
 	// Resolve channel intent to a concrete tag before creating downloader
 	var resolvedRefType, resolvedRefName string
 	var downloader *github.Downloader
-	if intent.Mode == config.SyncModeChannel {
+	switch intent.Mode {
+	case config.SyncModeChannel:
 		channel := intent.Value
 		if channel == "" {
 			channel = version.DefaultChannel()
@@ -130,11 +131,11 @@ func runSync(ctx context.Context, _ *cobra.Command, opts *syncOptions) error {
 		resolvedRefType = "tag"
 		resolvedRefName = tag
 		downloader = github.NewDownloaderWithRef(repoURL, "tag", tag, repoPath)
-	} else if intent.Mode == config.SyncModeTag {
+	case config.SyncModeTag:
 		resolvedRefType = "tag"
 		resolvedRefName = intent.Value
 		downloader = github.NewDownloaderWithRef(repoURL, "tag", intent.Value, repoPath)
-	} else {
+	default:
 		resolvedRefType = "branch"
 		resolvedRefName = intent.Value
 		downloader = github.NewDownloaderWithRef(repoURL, "branch", intent.Value, repoPath)

--- a/tools/release-notes/internal/notes/notes.go
+++ b/tools/release-notes/internal/notes/notes.go
@@ -180,7 +180,7 @@ func Render(repo string, current TagInfo, previousTag string, changes []Change) 
 	}
 
 	highlights := highlightChanges(changes)
-	if len(highlights) > 0 && !(len(highlights) == 1 && countUserFacing(changes) == 1) {
+	if len(highlights) > 0 && (len(highlights) != 1 || countUserFacing(changes) != 1) {
 		writeLine("## Highlights")
 		writeLine("")
 		for _, change := range highlights {


### PR DESCRIPTION
## Summary

Two behavior-preserving refactors to clear staticcheck quick-fix warnings that now break \`just lint all\`:

- **\`internal/commands/system/sync.go:120\`** (QF1003) — converts an \`if/else if/else\` chain on \`intent.Mode\` to a tagged \`switch\`.
- **\`tools/release-notes/internal/notes/notes.go:183\`** (QF1001) — applies De Morgan's law: \`len(highlights) > 0 && !(len(highlights) == 1 && countUserFacing(changes) == 1)\` → \`len(highlights) > 0 && (len(highlights) != 1 || countUserFacing(changes) != 1)\`.

## Context

Both issues pre-existed this session's work — the files are byte-identical between the pre- and post-merge states of PR #157 (the obey-shared v0.4.0 dep bump). They started failing lint because \`go mod tidy\` on the v0.4.0 bump pulled in transitive deps that brought a newer staticcheck into reach.

## Test plan

- [x] \`just lint all\` → \`0 issues.\`
- [x] \`just test unit\` → **1999/1999 tests passed**
- [x] \`go build ./...\` clean