### PR TITLE
Add build profile command surface listing

### DIFF
--- a/.justfiles/build.just
+++ b/.justfiles/build.just
@@ -60,6 +60,50 @@ quick-stable:
 quick-dev:
     BUILD_TAGS=dev just build quick
 
+# Show the command surface for stable/dev build profiles
+[no-cd]
+profile-commands profile='all':
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    stable_file="$(mktemp)"
+    dev_file="$(mktemp)"
+    cleanup() {
+        rm -f "$stable_file" "$dev_file"
+    }
+    trap cleanup EXIT
+
+    go run ./cmd/fest __commands > "$stable_file"
+    go run -tags dev ./cmd/fest __commands > "$dev_file"
+
+    print_profile() {
+        local name="$1"
+        local file="$2"
+        echo "== ${name} profile ($(wc -l < "$file" | tr -d ' ') commands) =="
+        cat "$file"
+    }
+
+    case "{{profile}}" in
+        stable)
+            print_profile "stable" "$stable_file"
+            ;;
+        dev)
+            print_profile "dev" "$dev_file"
+            ;;
+        all)
+            print_profile "stable" "$stable_file"
+            echo
+            print_profile "dev" "$dev_file"
+            echo
+            echo "== dev-only commands ($(comm -13 "$stable_file" "$dev_file" | wc -l | tr -d ' ') commands) =="
+            comm -13 "$stable_file" "$dev_file" || true
+            ;;
+        *)
+            echo "Unknown profile '{{profile}}'. Use stable, dev, or all."
+            exit 1
+            ;;
+    esac
+
 # --- Cross-platform builds ---
 
 # Build for Linux AMD64

--- a/.justfiles/build.just
+++ b/.justfiles/build.just
@@ -63,46 +63,7 @@ quick-dev:
 # Show the command surface for stable/dev build profiles
 [no-cd]
 profile-commands profile='all':
-    #!/usr/bin/env bash
-    set -euo pipefail
-
-    stable_file="$(mktemp)"
-    dev_file="$(mktemp)"
-    cleanup() {
-        rm -f "$stable_file" "$dev_file"
-    }
-    trap cleanup EXIT
-
-    go run ./cmd/fest __commands > "$stable_file"
-    go run -tags dev ./cmd/fest __commands > "$dev_file"
-
-    print_profile() {
-        local name="$1"
-        local file="$2"
-        echo "== ${name} profile ($(wc -l < "$file" | tr -d ' ') commands) =="
-        cat "$file"
-    }
-
-    case "{{profile}}" in
-        stable)
-            print_profile "stable" "$stable_file"
-            ;;
-        dev)
-            print_profile "dev" "$dev_file"
-            ;;
-        all)
-            print_profile "stable" "$stable_file"
-            echo
-            print_profile "dev" "$dev_file"
-            echo
-            echo "== dev-only commands ($(comm -13 "$stable_file" "$dev_file" | wc -l | tr -d ' ') commands) =="
-            comm -13 "$stable_file" "$dev_file" || true
-            ;;
-        *)
-            echo "Unknown profile '{{profile}}'. Use stable, dev, or all."
-            exit 1
-            ;;
-    esac
+    @{{BUILDTOOL}} profile-commands {{profile}}
 
 # --- Cross-platform builds ---
 

--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ Subcommand modules:
 
 ```bash
 just build        # Build variants (local, cross-platform, profiles)
+just build profile-commands   # Show stable/dev CLI command surfaces
 just install      # Install fest (stable, dev, current)
 just test         # Testing commands
 just release      # Release packaging and versioning

--- a/internal/buildutil/main.go
+++ b/internal/buildutil/main.go
@@ -26,7 +26,7 @@ func main() {
 	ui.Init(noColor)
 
 	if flag.NArg() == 0 {
-		log.Fatalf("usage: buildutil <build|build-only|test|integration|clean|all>")
+		log.Fatalf("usage: buildutil <build|build-only|profile-commands|test|integration|clean|all>")
 	}
 
 	cmd := flag.Arg(0)
@@ -46,6 +46,13 @@ func main() {
 
 	case "build-only":
 		err = tasks.BuildOnly(verbose)
+
+	case "profile-commands":
+		profile := "all"
+		if flag.NArg() > 1 {
+			profile = flag.Arg(1)
+		}
+		err = tasks.ProfileCommands(profile)
 
 	case "test":
 		err = tasks.Test(verbose)

--- a/internal/buildutil/tasks/profile_commands.go
+++ b/internal/buildutil/tasks/profile_commands.go
@@ -1,0 +1,114 @@
+package tasks
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// ProfileCommands prints the visible command surface for the requested build
+// profile and can also show the dev-only delta between stable and dev.
+func ProfileCommands(profile string) error {
+	switch profile {
+	case "", "all":
+		stable, err := commandSurface("")
+		if err != nil {
+			return err
+		}
+
+		dev, err := commandSurface("dev")
+		if err != nil {
+			return err
+		}
+
+		printCommandProfile("stable", stable)
+		fmt.Println()
+		printCommandProfile("dev", dev)
+		fmt.Println()
+
+		devOnly := diffCommandSurfaces(stable, dev)
+		fmt.Printf("== dev-only commands (%d commands) ==\n", len(devOnly))
+		for _, path := range devOnly {
+			fmt.Println(path)
+		}
+		return nil
+
+	case "stable":
+		commands, err := commandSurface("")
+		if err != nil {
+			return err
+		}
+		printCommandProfile("stable", commands)
+		return nil
+
+	case "dev":
+		commands, err := commandSurface("dev")
+		if err != nil {
+			return err
+		}
+		printCommandProfile("dev", commands)
+		return nil
+
+	default:
+		return fmt.Errorf("unknown profile %q (use stable, dev, or all)", profile)
+	}
+}
+
+func commandSurface(buildTag string) ([]string, error) {
+	args := []string{"run"}
+	if buildTag != "" {
+		args = append(args, "-tags", buildTag)
+	}
+	args = append(args, "./cmd/fest", "__commands")
+
+	cmd := exec.Command("go", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("collect %s command surface: %w\n%s", profileName(buildTag), err, strings.TrimSpace(string(output)))
+	}
+
+	return parseCommandSurfaceOutput(output), nil
+}
+
+func parseCommandSurfaceOutput(output []byte) []string {
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	commands := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		commands = append(commands, line)
+	}
+	return commands
+}
+
+func diffCommandSurfaces(base, candidate []string) []string {
+	baseSet := make(map[string]struct{}, len(base))
+	for _, path := range base {
+		baseSet[path] = struct{}{}
+	}
+
+	diff := make([]string, 0, len(candidate))
+	for _, path := range candidate {
+		if _, exists := baseSet[path]; exists {
+			continue
+		}
+		diff = append(diff, path)
+	}
+	return diff
+}
+
+func printCommandProfile(name string, commands []string) {
+	fmt.Printf("== %s profile (%d commands) ==\n", name, len(commands))
+	for _, path := range commands {
+		fmt.Println(path)
+	}
+}
+
+func profileName(buildTag string) string {
+	if buildTag == "" {
+		return "stable"
+	}
+	return buildTag
+}

--- a/internal/buildutil/tasks/profile_commands_test.go
+++ b/internal/buildutil/tasks/profile_commands_test.go
@@ -1,0 +1,74 @@
+package tasks
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestParseCommandSurfaceOutput(t *testing.T) {
+	output := []byte("\nfest alpha\n\n  fest beta  \nfest gamma\n")
+
+	got := parseCommandSurfaceOutput(output)
+	want := []string{"fest alpha", "fest beta", "fest gamma"}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseCommandSurfaceOutput() = %#v, want %#v", got, want)
+	}
+}
+
+func TestDiffCommandSurfaces(t *testing.T) {
+	base := []string{"fest alpha", "fest beta"}
+	candidate := []string{"fest alpha", "fest beta", "fest explore", "fest explore active"}
+
+	got := diffCommandSurfaces(base, candidate)
+	want := []string{"fest explore", "fest explore active"}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("diffCommandSurfaces() = %#v, want %#v", got, want)
+	}
+}
+
+func TestPrintCommandProfile(t *testing.T) {
+	output := captureStdout(t, func() {
+		printCommandProfile("stable", []string{"fest alpha", "fest beta"})
+	})
+
+	want := "== stable profile (2 commands) ==\nfest alpha\nfest beta\n"
+	if output != want {
+		t.Fatalf("printCommandProfile() = %q, want %q", output, want)
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	original := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe(): %v", err)
+	}
+	os.Stdout = w
+
+	defer func() {
+		os.Stdout = original
+	}()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("io.Copy(): %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("close reader: %v", err)
+	}
+
+	return buf.String()
+}

--- a/internal/commands/command_surface.go
+++ b/internal/commands/command_surface.go
@@ -1,0 +1,58 @@
+package commands
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	commandSurfaceCmd := &cobra.Command{
+		Use:    "__commands",
+		Short:  "Output visible CLI command paths",
+		Hidden: true,
+		Annotations: map[string]string{
+			"scope": "global",
+		},
+		RunE: runCommandSurface,
+	}
+	rootCmd.AddCommand(commandSurfaceCmd)
+}
+
+func runCommandSurface(cmd *cobra.Command, args []string) error {
+	for _, path := range collectVisibleCommandPaths(cmd.Root()) {
+		if _, err := fmt.Fprintln(cmd.OutOrStdout(), path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func collectVisibleCommandPaths(root *cobra.Command) []string {
+	paths := make([]string, 0, len(root.Commands()))
+	walkVisibleCommandPaths(root, root.Name(), &paths)
+	sort.Strings(paths)
+	return paths
+}
+
+func walkVisibleCommandPaths(parent *cobra.Command, prefix string, paths *[]string) {
+	for _, child := range parent.Commands() {
+		if shouldSkipCommandSurfaceEntry(child) {
+			continue
+		}
+
+		path := strings.TrimSpace(prefix + " " + child.Name())
+		*paths = append(*paths, path)
+		walkVisibleCommandPaths(child, path, paths)
+	}
+}
+
+func shouldSkipCommandSurfaceEntry(cmd *cobra.Command) bool {
+	if cmd.Hidden {
+		return true
+	}
+
+	return cmd.Name() == "help"
+}

--- a/internal/commands/command_surface_dev_test.go
+++ b/internal/commands/command_surface_dev_test.go
@@ -1,0 +1,13 @@
+//go:build dev
+
+package commands
+
+import "testing"
+
+func TestCollectVisibleCommandPathsDevIncludesDevOnlyCommands(t *testing.T) {
+	paths := collectVisibleCommandPaths(rootCmd)
+
+	if !containsCommandPath(paths, "fest explore") {
+		t.Fatal("dev command surface should include fest explore")
+	}
+}

--- a/internal/commands/command_surface_stable_test.go
+++ b/internal/commands/command_surface_stable_test.go
@@ -1,0 +1,17 @@
+//go:build !dev
+
+package commands
+
+import "testing"
+
+func TestCollectVisibleCommandPathsStableOmitsDevOnlyCommands(t *testing.T) {
+	paths := collectVisibleCommandPaths(rootCmd)
+
+	if !containsCommandPath(paths, "fest create") {
+		t.Fatal("expected stable command surface to include fest create")
+	}
+
+	if containsCommandPath(paths, "fest explore") {
+		t.Fatal("stable command surface should not include fest explore")
+	}
+}

--- a/internal/commands/command_surface_test.go
+++ b/internal/commands/command_surface_test.go
@@ -1,0 +1,36 @@
+package commands
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestCollectVisibleCommandPathsSorted(t *testing.T) {
+	paths := collectVisibleCommandPaths(rootCmd)
+	if !sort.StringsAreSorted(paths) {
+		t.Fatal("command paths should be sorted")
+	}
+}
+
+func TestCollectVisibleCommandPathsExcludesHiddenCommands(t *testing.T) {
+	paths := collectVisibleCommandPaths(rootCmd)
+	for _, hiddenPath := range []string{
+		"fest __commands",
+		"fest __manifest",
+		"fest gendocs",
+		"fest help",
+	} {
+		if containsCommandPath(paths, hiddenPath) {
+			t.Fatalf("hidden command %q should not be listed", hiddenPath)
+		}
+	}
+}
+
+func containsCommandPath(paths []string, want string) bool {
+	for _, path := range paths {
+		if path == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What changed

This adds a `just build profile-commands` recipe to make the stable and dev command surfaces easy to inspect and compare.

It is backed by a hidden `fest __commands` helper that prints the visible Cobra command paths for the current build profile, so the output comes from the real registered command tree instead of a hand-maintained list.

## Why

`fest` has distinct stable and dev build profiles, and we needed an easy way to verify exactly which commands are present in each profile.

## Impact

Users can now run:

- `just build profile-commands`
- `just build profile-commands stable`
- `just build profile-commands dev`

The default output prints both profiles and the dev-only delta.

## Validation

- `go test ./internal/commands ./internal/commands/release`
- `go test -tags dev ./internal/commands ./internal/commands/release`
- `just build profile-commands dev`
