### PR TITLE
fix(lifecycle): close pre-active gate bypass via fest task and fest progress

### DIFF
--- a/internal/commands/next/next.go
+++ b/internal/commands/next/next.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/guidance"
 	"github.com/Obedience-Corp/fest/internal/guidance/selection"
 	"github.com/Obedience-Corp/fest/internal/id"
+	"github.com/Obedience-Corp/fest/internal/lifecycle"
 	"github.com/Obedience-Corp/fest/internal/pathutil"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	tpl "github.com/Obedience-Corp/fest/internal/template"
@@ -124,12 +125,12 @@ func runNext(cmd *cobra.Command, args []string) error {
 	}
 
 	// Resolve the next incomplete phase for phase-aware gates.
-	// Always use findFirstIncompletePhase rather than cwd — cwd may be inside
+	// Always use FindFirstIncompletePhase rather than cwd — cwd may be inside
 	// a later scaffolded phase that isn't the actual next actionable one.
 	nextPhasePath := ""
 	nextPhaseType := ""
 	nextPhaseName := ""
-	if found, _, findErr := findFirstIncompletePhase(ctx, festivalPath); findErr == nil && found != "" {
+	if found, _, findErr := lifecycle.FindFirstIncompletePhase(ctx, festivalPath); findErr == nil && found != "" {
 		nextPhasePath = found
 		nextPhaseType = guidance.DetectPhaseType(found)
 		nextPhaseName = filepath.Base(found)
@@ -144,7 +145,10 @@ func runNext(cmd *cobra.Command, args []string) error {
 	// Block implementation/review phases in pre-active festivals (planning or ready).
 	// Use the next incomplete phase, not cwd — cwd may be inside a later scaffolded
 	// implementation phase while an earlier preparatory phase is the real next step.
-	if err := checkPreActiveStatus(ctx, festivalPath, nextPhasePath); err != nil {
+	if err := lifecycle.EnforcePreActive(ctx, festivalPath, lifecycle.EnforceOptions{
+		PhasePath: nextPhasePath,
+		Reason:    "fest next",
+	}); err != nil {
 		return err
 	}
 
@@ -179,7 +183,7 @@ func runNext(cmd *cobra.Command, args []string) error {
 
 	// If at festival root (no phase detected), find the first incomplete phase respecting numerical order
 	if phasePath == "" {
-		nextPhase, isWorkflow, fipErr := findFirstIncompletePhase(ctx, festivalPath)
+		nextPhase, isWorkflow, fipErr := lifecycle.FindFirstIncompletePhase(ctx, festivalPath)
 		if fipErr == nil && nextPhase != "" && isWorkflow {
 			// Only route to workflow immediately if position=before
 			position := shared.WorkflowPositionForPhase(nextPhase)

--- a/internal/commands/next/phase.go
+++ b/internal/commands/next/phase.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
 	"github.com/Obedience-Corp/fest/internal/frontmatter"
+	"github.com/Obedience-Corp/fest/internal/lifecycle"
 	"github.com/Obedience-Corp/fest/internal/progress"
 )
 
@@ -36,61 +37,6 @@ func findSequencePath(cwd, festivalPath string) string {
 		current = parent
 	}
 	return ""
-}
-
-// findFirstIncompletePhase scans ALL phases in numerical order and returns the first incomplete phase.
-// It respects ordering across both workflow-based and task-based phases.
-// Returns (phasePath, isWorkflow, error). Empty phasePath means all phases are complete.
-func findFirstIncompletePhase(ctx context.Context, festivalPath string) (string, bool, error) {
-	entries, err := os.ReadDir(festivalPath)
-	if err != nil {
-		return "", false, err
-	}
-
-	var phases []string
-	for _, entry := range entries {
-		if entry.IsDir() && shared.IsNumberedDir(entry.Name()) {
-			phases = append(phases, filepath.Join(festivalPath, entry.Name()))
-		}
-	}
-
-	sort.Strings(phases)
-
-	// Load Store once for all workflow state lookups
-	store := progress.NewStore(festivalPath)
-	storeLoaded := store.Load(ctx) == nil
-
-	for _, phasePath := range phases {
-		phaseName := filepath.Base(phasePath)
-
-		workflowPath := filepath.Join(phasePath, "WORKFLOW.md")
-		if _, err := os.Stat(workflowPath); err == nil {
-			if storeLoaded {
-				state, ok := store.WorkflowPhaseState(phaseName)
-				if !ok || state.TotalSteps == 0 || !state.IsComplete() {
-					return phasePath, true, nil
-				}
-			} else {
-				return phasePath, true, nil // Can't load store, assume incomplete
-			}
-			// Workflow is complete — check if phase gate is incomplete
-			if hasIncompletePhaseGate(storeLoaded, store, phasePath, phaseName) {
-				return phasePath, false, nil
-			}
-			continue
-		}
-
-		if hasSequenceDirs(phasePath) && !arePhaseTasksComplete(storeLoaded, store, phasePath, phaseName) {
-			return phasePath, false, nil
-		}
-
-		// Sequences done / all tasks complete — check phase gate
-		if hasIncompletePhaseGate(storeLoaded, store, phasePath, phaseName) {
-			return phasePath, false, nil
-		}
-	}
-
-	return "", false, nil
 }
 
 // findFirstIncompleteWorkflowPhase scans phases in numerical order for the first with incomplete workflow.
@@ -184,42 +130,6 @@ func findEarlierIncompleteAfterWorkflow(ctx context.Context, festivalPath, curre
 	return "", nil
 }
 
-// hasSequenceDirs checks if a phase directory contains numbered subdirectories (sequences).
-func hasSequenceDirs(phasePath string) bool {
-	entries, err := os.ReadDir(phasePath)
-	if err != nil {
-		return false
-	}
-	for _, entry := range entries {
-		if entry.IsDir() && shared.IsNumberedDir(entry.Name()) {
-			return true
-		}
-	}
-	return false
-}
-
-// arePhaseTasksComplete checks whether all tasks in a phase's sequences
-// are marked complete in the progress store. Delegates to shared package.
-func arePhaseTasksComplete(storeLoaded bool, store *progress.Store, phasePath, phaseName string) bool {
-	return shared.ArePhaseTasksComplete(storeLoaded, store, phasePath, phaseName)
-}
-
-// hasIncompletePhaseGate checks if a phase has a GATES.md that is not yet complete.
-func hasIncompletePhaseGate(storeLoaded bool, store *progress.Store, phasePath, phaseName string) bool {
-	gatesPath := filepath.Join(phasePath, "GATES.md")
-	if _, err := os.Stat(gatesPath); err != nil {
-		return false // No GATES.md
-	}
-	if !storeLoaded {
-		return true // Can't check store, assume incomplete
-	}
-	state, ok := store.GatePhaseState(phaseName)
-	if !ok || state.TotalSteps == 0 || !state.IsComplete() {
-		return true
-	}
-	return false
-}
-
 // findEarlierIncompletePhaseGate scans phases in numerical order before the given phase
 // and returns the first one with an incomplete phase gate (GATES.md).
 // Phase gates run after all tasks, sequence gates, and workflows in a phase are complete.
@@ -254,7 +164,7 @@ func findEarlierIncompletePhaseGate(ctx context.Context, festivalPath, currentPh
 			continue
 		}
 
-		if hasIncompletePhaseGate(storeLoaded, store, phasePath, phaseName) {
+		if lifecycle.HasIncompletePhaseGate(storeLoaded, store, phasePath, phaseName) {
 			return phasePath, nil
 		}
 	}
@@ -287,7 +197,7 @@ func findFirstIncompletePhaseGate(ctx context.Context, festivalPath string) (str
 		if !isPhaseWorkAndWorkflowComplete(ctx, storeLoaded, store, phasePath, phaseName) {
 			continue
 		}
-		if hasIncompletePhaseGate(storeLoaded, store, phasePath, phaseName) {
+		if lifecycle.HasIncompletePhaseGate(storeLoaded, store, phasePath, phaseName) {
 			return phasePath, nil
 		}
 	}

--- a/internal/commands/next/validation.go
+++ b/internal/commands/next/validation.go
@@ -2,14 +2,11 @@
 package next
 
 import (
-	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
 
-	"github.com/Obedience-Corp/fest/internal/config"
 	"github.com/Obedience-Corp/fest/internal/errors"
-	"github.com/Obedience-Corp/fest/internal/guidance"
 	"github.com/Obedience-Corp/fest/internal/validator"
 )
 
@@ -133,56 +130,3 @@ func emitValidationBlock(festivalPath string, result *validator.Result) error {
 	return errors.ErrAlreadyPrinted
 }
 
-// checkPreActiveStatus blocks implementation/review phases when the festival is in planning or ready status.
-func checkPreActiveStatus(ctx context.Context, festivalPath, phasePath string) error {
-	festCfg, err := config.LoadFestivalConfig(festivalPath, "")
-	if err != nil {
-		return nil // Can't load config — don't block
-	}
-
-	status := festCfg.Metadata.CurrentStatus()
-	if status != "planning" && status != "ready" {
-		return nil
-	}
-
-	// Only block if we can detect the phase type
-	if phasePath == "" {
-		// At festival root — find the first *incomplete* phase (the current one)
-		found, _, findErr := findFirstIncompletePhase(ctx, festivalPath)
-		if findErr != nil || found == "" {
-			return nil
-		}
-		phasePath = found
-	}
-
-	phaseType := guidance.DetectPhaseType(phasePath)
-	if phaseType != "implementation" && phaseType != "review" {
-		return nil
-	}
-
-	festName := filepath.Base(festivalPath)
-
-	if status == "ready" {
-		var sb strings.Builder
-		sb.WriteString("STOP — FESTIVAL NOT YET ACTIVE\n")
-		sb.WriteString("──────────────────────────────\n")
-		fmt.Fprintf(&sb, "Festival %q is in ready status.\n", festName)
-		sb.WriteString("Lifecycle: planning -> ready -> [active] -> completed\n\n")
-		sb.WriteString("Before executing, confirm:\n")
-		sb.WriteString("  - Is this the correct festival you should be working on?\n")
-		sb.WriteString("  - Did the user approve implementation of this festival?\n\n")
-		sb.WriteString("If approved, promote to active: fest promote\n")
-		fmt.Print(sb.String())
-		return errors.ErrAlreadyPrinted
-	}
-
-	var sb strings.Builder
-	sb.WriteString("STOP — FESTIVAL NOT YET ACTIVE\n")
-	sb.WriteString("──────────────────────────────\n")
-	fmt.Fprintf(&sb, "Festival %q is in planning status.\n", festName)
-	sb.WriteString("Lifecycle: [planning] -> ready -> active -> completed\n\n")
-	sb.WriteString("Implementation phases require active status.\n")
-	sb.WriteString("Promote to ready first: fest promote\n")
-	fmt.Print(sb.String())
-	return errors.ErrAlreadyPrinted
-}

--- a/internal/commands/progress/progress.go
+++ b/internal/commands/progress/progress.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
 	"github.com/Obedience-Corp/fest/internal/commands/show"
 	"github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/lifecycle"
 	"github.com/Obedience-Corp/fest/internal/progress"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/spf13/cobra"
@@ -146,8 +147,15 @@ func runProgress(ctx context.Context, opts *progressOptions) error {
 			WithField("hint", "run from inside a festival directory")
 	}
 
-	// Create progress manager
-	mgr, err := progress.NewManager(ctx, loc.Festival.Path)
+	// Create progress manager. Mutation flows install the lifecycle gate so
+	// pre-active festivals reject task changes; read-only flows do not need it.
+	var mgr *progress.Manager
+	if opts.taskID != "" || opts.taskPath != "" {
+		mgr, err = progress.NewManagerWithGate(ctx, loc.Festival.Path,
+			lifecycle.NewGateWithReason(loc.Festival.Path, "fest progress"))
+	} else {
+		mgr, err = progress.NewManager(ctx, loc.Festival.Path)
+	}
 	if err != nil {
 		return errors.Wrap(err, "initializing progress manager")
 	}

--- a/internal/commands/progress/task_update.go
+++ b/internal/commands/progress/task_update.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/frontmatter"
 	"github.com/Obedience-Corp/fest/internal/gates"
+	"github.com/Obedience-Corp/fest/internal/lifecycle"
 	"github.com/Obedience-Corp/fest/internal/progress"
 	"github.com/Obedience-Corp/fest/internal/ui"
 )
@@ -20,6 +21,13 @@ import (
 func handleTaskUpdate(ctx context.Context, mgr *progress.Manager, festivalPath string, opts *progressOptions) error {
 	taskID, err := resolveTaskID(festivalPath, opts)
 	if err != nil {
+		return err
+	}
+
+	if err := lifecycle.EnforcePreActive(ctx, festivalPath, lifecycle.EnforceOptions{
+		TaskID: taskID,
+		Reason: progressReasonFor(opts),
+	}); err != nil {
 		return err
 	}
 
@@ -287,6 +295,25 @@ func statusForProgress(progressPct int) string {
 	default:
 		return progress.StatusPending
 	}
+}
+
+// progressReasonFor returns a label for the lifecycle gate based on the
+// active task-update flag, so the block message tells the agent which
+// command triggered it.
+func progressReasonFor(opts *progressOptions) string {
+	switch {
+	case opts.complete:
+		return "fest progress --complete"
+	case opts.inProgress:
+		return "fest progress --in-progress"
+	case opts.update != "":
+		return "fest progress --update"
+	case opts.blocker != "":
+		return "fest progress --blocker"
+	case opts.clear:
+		return "fest progress --clear"
+	}
+	return "fest progress"
 }
 
 func parsePercentage(s string) (int, error) {

--- a/internal/commands/status/handlers_entity.go
+++ b/internal/commands/status/handlers_entity.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/commands/show"
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/frontmatter"
+	"github.com/Obedience-Corp/fest/internal/lifecycle"
 	"github.com/Obedience-Corp/fest/internal/progress"
 	"github.com/Obedience-Corp/fest/internal/ui"
 )
@@ -142,8 +143,17 @@ func handleTaskStatusSet(ctx context.Context, display *ui.UI, cwd, newStatus str
 		return err
 	}
 
-	// Create progress manager
-	mgr, err := progress.NewManager(ctx, festivalPath)
+	if err := lifecycle.EnforcePreActive(ctx, festivalPath, lifecycle.EnforceOptions{
+		TaskID: taskID,
+		Reason: "fest status set",
+	}); err != nil {
+		return err
+	}
+
+	// Create progress manager with the lifecycle gate so mutations refuse
+	// pre-active festivals as defense in depth.
+	mgr, err := progress.NewManagerWithGate(ctx, festivalPath,
+		lifecycle.NewGateWithReason(festivalPath, "fest status set"))
 	if err != nil {
 		return errors.Wrap(err, "creating progress manager")
 	}

--- a/internal/commands/status/handlers_entity.go
+++ b/internal/commands/status/handlers_entity.go
@@ -93,6 +93,15 @@ func handlePhaseStatusSetWithPath(ctx context.Context, display *ui.UI, festivalP
 		return err
 	}
 
+	// Defense in depth: pre-active festivals may not mutate implementation
+	// phase frontmatter. Planning/research/ingest phases pass through.
+	if err := lifecycle.EnforcePreActive(ctx, festivalPath, lifecycle.EnforceOptions{
+		PhasePath: phasePath,
+		Reason:    "fest status set --phase",
+	}); err != nil {
+		return err
+	}
+
 	goalPath := filepath.Join(phasePath, "PHASE_GOAL.md")
 	oldStatus, err := readGoalStatus(ctx, goalPath)
 	if err != nil {
@@ -348,6 +357,15 @@ func handlePhaseStatusSet(ctx context.Context, display *ui.UI, cwd, newStatus st
 		return err
 	}
 
+	// Defense in depth: pre-active festivals may not mutate implementation
+	// phase frontmatter. Planning/research/ingest phases pass through.
+	if err := lifecycle.EnforcePreActive(ctx, festivalPath, lifecycle.EnforceOptions{
+		PhasePath: phasePath,
+		Reason:    "fest status set --phase",
+	}); err != nil {
+		return err
+	}
+
 	goalPath := filepath.Join(phasePath, "PHASE_GOAL.md")
 	oldStatus, err := readGoalStatus(ctx, goalPath)
 	if err != nil {
@@ -467,6 +485,16 @@ func handleSequenceStatusSet(ctx context.Context, display *ui.UI, cwd, newStatus
 	// Find the sequence directory
 	seqPath, seqName, err := resolveSequence(festivalPath, cwd, opts.sequence)
 	if err != nil {
+		return err
+	}
+
+	// Defense in depth: pre-active festivals may not mutate sequence
+	// frontmatter under implementation phases. The gate evaluates the
+	// parent phase's type so planning/research/ingest sequences pass through.
+	if err := lifecycle.EnforcePreActive(ctx, festivalPath, lifecycle.EnforceOptions{
+		PhasePath: filepath.Dir(seqPath),
+		Reason:    "fest status set --sequence",
+	}); err != nil {
 		return err
 	}
 

--- a/internal/commands/status/lifecycle_gate_test.go
+++ b/internal/commands/status/lifecycle_gate_test.go
@@ -1,0 +1,75 @@
+package status
+
+import (
+	"context"
+	stderrors "errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/ui"
+)
+
+// TestPhaseStatusSetGate is the regression test for the bypass that the
+// initial fix missed: an agent could mark an implementation phase
+// completed via fest status set --phase in a planning festival, walking
+// the phase frontmatter without ever consulting the lifecycle gate.
+func TestPhaseStatusSetGate(t *testing.T) {
+	cases := []struct {
+		name         string
+		status       string
+		phaseType    string
+		expectBlock  bool
+	}{
+		{name: "planning_blocks_impl_phase_completed", status: "planning", phaseType: "implementation", expectBlock: true},
+		{name: "ready_blocks_review_phase_completed", status: "ready", phaseType: "review", expectBlock: true},
+		{name: "active_allows_impl_phase_completed", status: "active", phaseType: "implementation", expectBlock: false},
+		{name: "planning_allows_ingest_phase_completed", status: "planning", phaseType: "ingest", expectBlock: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			festDir := setupPhaseFixture(t, tc.status, tc.phaseType)
+			if err := os.Chdir(festDir); err != nil {
+				t.Fatalf("chdir: %v", err)
+			}
+
+			err := handlePhaseStatusSet(context.Background(), &ui.UI{},
+				festDir, "completed", &statusOptions{phase: "001_PHASE", noCommit: true})
+
+			if tc.expectBlock {
+				if err == nil {
+					t.Fatal("expected lifecycle gate to block, got nil")
+				}
+				if !stderrors.Is(err, errors.ErrAlreadyPrinted) {
+					t.Errorf("expected ErrAlreadyPrinted, got: %v", err)
+				}
+			} else if stderrors.Is(err, errors.ErrAlreadyPrinted) {
+				t.Errorf("did not expect lifecycle block, got: %v", err)
+			}
+		})
+	}
+}
+
+func setupPhaseFixture(t *testing.T, status, phaseType string) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	festYAML := "name: status-gate-test\nid: SGT-001\nversion: \"1.0\"\nmetadata:\n  id: SGT-001\n  status_history:\n    - status: " + status + "\n      timestamp: 2026-02-10T00:00:00Z\n"
+	if err := os.WriteFile(filepath.Join(dir, "fest.yaml"), []byte(festYAML), 0o644); err != nil {
+		t.Fatalf("write fest.yaml: %v", err)
+	}
+
+	phaseDir := filepath.Join(dir, "001_PHASE")
+	if err := os.MkdirAll(phaseDir, 0o755); err != nil {
+		t.Fatalf("mkdir phase: %v", err)
+	}
+
+	phaseGoal := "---\nfest_type: phase_goal\nfest_id: 001_PHASE\nfest_phase_type: " + phaseType + "\nfest_status: planning\n---\n# Phase Goal\n"
+	if err := os.WriteFile(filepath.Join(phaseDir, "PHASE_GOAL.md"), []byte(phaseGoal), 0o644); err != nil {
+		t.Fatalf("write PHASE_GOAL.md: %v", err)
+	}
+
+	return dir
+}

--- a/internal/commands/task/blocked.go
+++ b/internal/commands/task/blocked.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
 	"github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/lifecycle"
 	"github.com/Obedience-Corp/fest/internal/progress"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
@@ -53,6 +54,13 @@ func runBlocked(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if err := lifecycle.EnforcePreActive(ctx, festivalPath, lifecycle.EnforceOptions{
+		TaskID: taskID,
+		Reason: "fest task blocked",
+	}); err != nil {
+		return err
+	}
+
 	// Require interactive mode
 	if blockedJSON {
 		result := map[string]any{
@@ -66,7 +74,8 @@ func runBlocked(cmd *cobra.Command, args []string) error {
 		return errors.Validation("interactive confirmation required for reporting blockers")
 	}
 
-	mgr, err := progress.NewManager(ctx, festivalPath)
+	mgr, err := progress.NewManagerWithGate(ctx, festivalPath,
+		lifecycle.NewGateWithReason(festivalPath, "fest task blocked"))
 	if err != nil {
 		return errors.Wrap(err, "loading progress")
 	}

--- a/internal/commands/task/completed.go
+++ b/internal/commands/task/completed.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/gates"
+	"github.com/Obedience-Corp/fest/internal/lifecycle"
 	"github.com/Obedience-Corp/fest/internal/progress"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
@@ -50,6 +51,13 @@ func runCompleted(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if err := lifecycle.EnforcePreActive(ctx, festivalPath, lifecycle.EnforceOptions{
+		TaskID: taskID,
+		Reason: "fest task completed",
+	}); err != nil {
+		return err
+	}
+
 	// Require interactive mode - no --json bypass for mutations
 	if completedJSON {
 		result := map[string]any{
@@ -63,7 +71,8 @@ func runCompleted(cmd *cobra.Command, args []string) error {
 		return errors.Validation("interactive confirmation required for task completion")
 	}
 
-	mgr, err := progress.NewManager(ctx, festivalPath)
+	mgr, err := progress.NewManagerWithGate(ctx, festivalPath,
+		lifecycle.NewGateWithReason(festivalPath, "fest task completed"))
 	if err != nil {
 		return errors.Wrap(err, "loading progress")
 	}

--- a/internal/commands/task/edit.go
+++ b/internal/commands/task/edit.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Obedience-Corp/fest/internal/config"
 	"github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/lifecycle"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
 	"github.com/Obedience-Corp/obey-shared/procutil"
@@ -41,6 +42,13 @@ func runEdit(cmd *cobra.Command, args []string) error {
 
 	taskID, taskFilePath, err := resolveTask(ctx, festivalPath, arg)
 	if err != nil {
+		return err
+	}
+
+	if err := lifecycle.EnforcePreActive(ctx, festivalPath, lifecycle.EnforceOptions{
+		TaskID: taskID,
+		Reason: "fest task edit",
+	}); err != nil {
 		return err
 	}
 

--- a/internal/commands/task/lifecycle_gate_test.go
+++ b/internal/commands/task/lifecycle_gate_test.go
@@ -1,0 +1,107 @@
+package task
+
+import (
+	"context"
+	stderrors "errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/scope"
+	"github.com/spf13/cobra"
+)
+
+// TestTaskShowGate is the regression for the explicit-arg bypass that
+// obey-agent flagged in the second review. Reading an implementation
+// task body in a planning festival is the bypass we're closing: an
+// agent that knows or guesses the task ID could read what to do
+// without ever hitting fest promote. The phase-type check inside
+// EnforcePreActive must still let planning/research/ingest tasks
+// through.
+func TestTaskShowGate(t *testing.T) {
+	cases := []struct {
+		name        string
+		status      string
+		phaseType   string
+		expectBlock bool
+	}{
+		{name: "planning_blocks_explicit_impl_task", status: "planning", phaseType: "implementation", expectBlock: true},
+		{name: "planning_blocks_explicit_review_task", status: "planning", phaseType: "review", expectBlock: true},
+		{name: "ready_blocks_explicit_impl_task", status: "ready", phaseType: "implementation", expectBlock: true},
+		{name: "active_allows_explicit_impl_task", status: "active", phaseType: "implementation", expectBlock: false},
+		{name: "planning_allows_explicit_planning_task", status: "planning", phaseType: "planning", expectBlock: false},
+		{name: "planning_allows_explicit_research_task", status: "planning", phaseType: "research", expectBlock: false},
+		{name: "planning_allows_explicit_ingest_task", status: "planning", phaseType: "ingest", expectBlock: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			festDir, taskRel := setupTaskFixture(t, tc.status, tc.phaseType)
+			if err := os.Chdir(festDir); err != nil {
+				t.Fatalf("chdir: %v", err)
+			}
+
+			cmd := &cobra.Command{}
+			ctx := scope.WithFestival(context.Background(), festDir)
+			cmd.SetContext(ctx)
+
+			// Suppress stdout so the captured block message does not pollute
+			// test output. The error value is what we assert on.
+			devnull, _ := os.Open(os.DevNull)
+			origOut := os.Stdout
+			os.Stdout = devnull
+			err := runShow(cmd, []string{taskRel})
+			os.Stdout = origOut
+			_ = devnull.Close()
+
+			if tc.expectBlock {
+				if err == nil {
+					t.Fatalf("expected lifecycle gate to block fest task show %s, got nil", taskRel)
+				}
+				if !stderrors.Is(err, errors.ErrAlreadyPrinted) {
+					t.Errorf("expected ErrAlreadyPrinted, got: %v", err)
+				}
+			} else if stderrors.Is(err, errors.ErrAlreadyPrinted) {
+				t.Errorf("did not expect lifecycle block, got: %v", err)
+			}
+		})
+	}
+}
+
+// setupTaskFixture creates a festival with one phase containing one
+// sequence containing one task file. Returns the festival dir and the
+// festival-relative task path used as the explicit arg for fest task show.
+func setupTaskFixture(t *testing.T, status, phaseType string) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	festYAML := "version: \"1.0\"\nname: task-gate-test\nid: TGT-001\nmetadata:\n  id: TGT-001\n  status_history:\n    - status: " + status + "\n      timestamp: 2026-02-10T00:00:00Z\n"
+	if err := os.WriteFile(filepath.Join(dir, "fest.yaml"), []byte(festYAML), 0o644); err != nil {
+		t.Fatalf("write fest.yaml: %v", err)
+	}
+
+	phaseDir := filepath.Join(dir, "001_PHASE")
+	seqDir := filepath.Join(phaseDir, "01_seq")
+	if err := os.MkdirAll(seqDir, 0o755); err != nil {
+		t.Fatalf("mkdir sequence: %v", err)
+	}
+
+	phaseGoal := "---\nfest_type: phase_goal\nfest_id: 001_PHASE\nfest_phase_type: " + phaseType + "\n---\n# Phase Goal\n"
+	if err := os.WriteFile(filepath.Join(phaseDir, "PHASE_GOAL.md"), []byte(phaseGoal), 0o644); err != nil {
+		t.Fatalf("write PHASE_GOAL.md: %v", err)
+	}
+
+	seqGoal := "---\nfest_type: sequence_goal\nfest_id: 01_seq\n---\n# Sequence Goal\n"
+	if err := os.WriteFile(filepath.Join(seqDir, "SEQUENCE_GOAL.md"), []byte(seqGoal), 0o644); err != nil {
+		t.Fatalf("write SEQUENCE_GOAL.md: %v", err)
+	}
+
+	taskName := "01_task.md"
+	taskBody := "---\nfest_type: task\nfest_id: 01_task\n---\n# Task body\n"
+	if err := os.WriteFile(filepath.Join(seqDir, taskName), []byte(taskBody), 0o644); err != nil {
+		t.Fatalf("write task: %v", err)
+	}
+
+	return dir, filepath.Join("001_PHASE", "01_seq", taskName)
+}

--- a/internal/commands/task/reset.go
+++ b/internal/commands/task/reset.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
 	"github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/lifecycle"
 	"github.com/Obedience-Corp/fest/internal/progress"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
@@ -48,6 +49,13 @@ func runReset(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if err := lifecycle.EnforcePreActive(ctx, festivalPath, lifecycle.EnforceOptions{
+		TaskID: taskID,
+		Reason: "fest task reset",
+	}); err != nil {
+		return err
+	}
+
 	// Require interactive mode
 	if resetJSON {
 		result := map[string]any{
@@ -61,7 +69,8 @@ func runReset(cmd *cobra.Command, args []string) error {
 		return errors.Validation("interactive confirmation required for task reset")
 	}
 
-	mgr, err := progress.NewManager(ctx, festivalPath)
+	mgr, err := progress.NewManagerWithGate(ctx, festivalPath,
+		lifecycle.NewGateWithReason(festivalPath, "fest task reset"))
 	if err != nil {
 		return errors.Wrap(err, "loading progress")
 	}

--- a/internal/commands/task/show.go
+++ b/internal/commands/task/show.go
@@ -56,15 +56,20 @@ func runShow(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := lifecycle.EnforcePreActive(ctx, festivalPath, lifecycle.EnforceOptions{
-		TaskID: taskID,
-		Reason: "fest task show",
-	}); err != nil {
-		return err
+	// Auto-resolve (no arg) effectively tells the agent "here's the next
+	// implementation task to work on" — gate that path so a planning-status
+	// festival cannot use it as a launchpad. Explicit-arg reads stay open;
+	// reading a task file is not a lifecycle mutation.
+	if arg == "" {
+		if err := lifecycle.EnforcePreActive(ctx, festivalPath, lifecycle.EnforceOptions{
+			TaskID: taskID,
+			Reason: "fest task show",
+		}); err != nil {
+			return err
+		}
 	}
 
-	mgr, err := progress.NewManagerWithGate(ctx, festivalPath,
-		lifecycle.NewGateWithReason(festivalPath, "fest task show"))
+	mgr, err := progress.NewManager(ctx, festivalPath)
 	if err != nil {
 		return errors.Wrap(err, "loading progress")
 	}

--- a/internal/commands/task/show.go
+++ b/internal/commands/task/show.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/frontmatter"
+	"github.com/Obedience-Corp/fest/internal/lifecycle"
 	"github.com/Obedience-Corp/fest/internal/progress"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
@@ -55,7 +56,15 @@ func runShow(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	mgr, err := progress.NewManager(ctx, festivalPath)
+	if err := lifecycle.EnforcePreActive(ctx, festivalPath, lifecycle.EnforceOptions{
+		TaskID: taskID,
+		Reason: "fest task show",
+	}); err != nil {
+		return err
+	}
+
+	mgr, err := progress.NewManagerWithGate(ctx, festivalPath,
+		lifecycle.NewGateWithReason(festivalPath, "fest task show"))
 	if err != nil {
 		return errors.Wrap(err, "loading progress")
 	}

--- a/internal/commands/task/show.go
+++ b/internal/commands/task/show.go
@@ -56,17 +56,17 @@ func runShow(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Auto-resolve (no arg) effectively tells the agent "here's the next
-	// implementation task to work on" — gate that path so a planning-status
-	// festival cannot use it as a launchpad. Explicit-arg reads stay open;
-	// reading a task file is not a lifecycle mutation.
-	if arg == "" {
-		if err := lifecycle.EnforcePreActive(ctx, festivalPath, lifecycle.EnforceOptions{
-			TaskID: taskID,
-			Reason: "fest task show",
-		}); err != nil {
-			return err
-		}
+	// Gate every resolved task ID — auto-resolve and explicit arg both.
+	// Reading an implementation/review task body during planning/ready lets
+	// an agent "case" the work without ever hitting the promote prompt; that
+	// is the bypass this PR closes. The phase-type check inside
+	// EnforcePreActive lets planning/research/ingest tasks through, so
+	// reviewing prep work in any status remains open.
+	if err := lifecycle.EnforcePreActive(ctx, festivalPath, lifecycle.EnforceOptions{
+		TaskID: taskID,
+		Reason: "fest task show",
+	}); err != nil {
+		return err
 	}
 
 	mgr, err := progress.NewManager(ctx, festivalPath)

--- a/internal/commands/workflow/advance.go
+++ b/internal/commands/workflow/advance.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Obedience-Corp/fest/internal/chaining"
 	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+	"github.com/Obedience-Corp/fest/internal/lifecycle"
 	"github.com/Obedience-Corp/fest/internal/progress"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
@@ -38,6 +39,13 @@ Note: If the current step has a blocking checkpoint, use 'fest workflow approve'
 func runAdvance(ctx context.Context) error {
 	nav, err := getWorkflowNavigator(ctx)
 	if err != nil {
+		return err
+	}
+
+	if err := lifecycle.EnforcePreActive(ctx, nav.Ctx.FestivalPath, lifecycle.EnforceOptions{
+		PhasePath: nav.Ctx.PhasePath,
+		Reason:    "fest workflow advance",
+	}); err != nil {
 		return err
 	}
 

--- a/internal/commands/workflow/advance.go
+++ b/internal/commands/workflow/advance.go
@@ -107,7 +107,8 @@ func showNextStep(ctx context.Context, nav *wf.Navigator, steps []wf.WorkflowSte
 		// Propagate phase completion to PHASE_GOAL.md frontmatter
 		gctx := nav.GetContext()
 		if gctx.FestivalPath != "" && gctx.PhasePath != "" {
-			if mgr, mgrErr := progress.NewManager(ctx, gctx.FestivalPath); mgrErr != nil {
+			if mgr, mgrErr := progress.NewManagerWithGate(ctx, gctx.FestivalPath,
+				lifecycle.NewGateWithReason(gctx.FestivalPath, "fest workflow advance")); mgrErr != nil {
 				fmt.Printf("%s %s\n", ui.Dim("Warning: could not initialize progress manager:"), ui.Dim(mgrErr.Error()))
 			} else {
 				if propErr := mgr.PropagatePhaseCompletion(ctx, gctx.PhasePath); propErr != nil {

--- a/internal/commands/workflow/approve.go
+++ b/internal/commands/workflow/approve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Obedience-Corp/fest/internal/lifecycle"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
 	"github.com/spf13/cobra"
@@ -33,6 +34,13 @@ After approval:
 func runApprove(ctx context.Context) error {
 	nav, err := getWorkflowNavigator(ctx)
 	if err != nil {
+		return err
+	}
+
+	if err := lifecycle.EnforcePreActive(ctx, nav.Ctx.FestivalPath, lifecycle.EnforceOptions{
+		PhasePath: nav.Ctx.PhasePath,
+		Reason:    "fest workflow approve",
+	}); err != nil {
 		return err
 	}
 

--- a/internal/commands/workflow/lifecycle_gate_test.go
+++ b/internal/commands/workflow/lifecycle_gate_test.go
@@ -1,0 +1,116 @@
+package workflow
+
+import (
+	"context"
+	stderrors "errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/scope"
+)
+
+// TestWorkflowGate_BlocksImplPhaseInPlanningFestival is the regression test
+// for the bypass that PR #162 originally missed: an agent could drive a
+// WORKFLOW.md-based implementation phase to completion via fest workflow
+// advance while the festival was still in planning status.
+func TestWorkflowGate_BlocksImplPhaseInPlanningFestival(t *testing.T) {
+	festDir := setupImplWorkflowFestival(t, "planning")
+	ctx := scope.WithFestival(context.Background(), festDir)
+	t.Setenv("PWD", festDir)
+	if err := os.Chdir(festDir); err != nil {
+		t.Fatalf("chdir festival: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		call func() error
+	}{
+		{"advance", func() error { return runAdvance(ctx) }},
+		{"approve", func() error { return runApprove(ctx) }},
+		{"reject", func() error { return runReject(ctx, "test") }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.call()
+			if err == nil {
+				t.Fatalf("expected lifecycle gate to block fest workflow %s in planning, got nil", tc.name)
+			}
+			if !stderrors.Is(err, errors.ErrAlreadyPrinted) {
+				t.Errorf("expected ErrAlreadyPrinted, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestWorkflowGate_AllowsImplPhaseInActiveFestival(t *testing.T) {
+	festDir := setupImplWorkflowFestival(t, "active")
+	ctx := scope.WithFestival(context.Background(), festDir)
+	if err := os.Chdir(festDir); err != nil {
+		t.Fatalf("chdir festival: %v", err)
+	}
+
+	// runAdvance against an empty workflow state should not be blocked by
+	// the lifecycle gate. (It may fail later for other reasons; we only
+	// care that the gate did not fire.)
+	err := runAdvance(ctx)
+	if stderrors.Is(err, errors.ErrAlreadyPrinted) {
+		t.Errorf("active festival: lifecycle gate fired unexpectedly: %v", err)
+	}
+}
+
+// setupImplWorkflowFestival builds a minimal festival with a single
+// implementation-typed phase containing a one-step WORKFLOW.md.
+func setupImplWorkflowFestival(t *testing.T, status string) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	festYAML := "name: lifecycle-test\nid: LFC-001\nversion: \"1.0\"\nmetadata:\n  id: LFC-001\n  status_history:\n    - status: " + status + "\n      timestamp: 2026-02-10T00:00:00Z\n"
+	if err := os.WriteFile(filepath.Join(dir, "fest.yaml"), []byte(festYAML), 0o644); err != nil {
+		t.Fatalf("write fest.yaml: %v", err)
+	}
+
+	phaseDir := filepath.Join(dir, "001_IMPL")
+	if err := os.MkdirAll(phaseDir, 0o755); err != nil {
+		t.Fatalf("mkdir phase: %v", err)
+	}
+
+	phaseGoal := `---
+fest_type: phase_goal
+fest_id: 001_IMPL
+fest_phase_type: implementation
+---
+
+# Implementation Phase
+`
+	if err := os.WriteFile(filepath.Join(phaseDir, "PHASE_GOAL.md"), []byte(phaseGoal), 0o644); err != nil {
+		t.Fatalf("write PHASE_GOAL.md: %v", err)
+	}
+
+	workflowMD := `---
+fest_type: workflow
+fest_id: LFC-WF
+fest_parent: 001_IMPL
+---
+
+# Implementation Workflow
+
+## Step 1: BUILD — Build the thing
+
+**Goal:** Build it.
+
+**Actions:**
+1. Build
+
+**Output:** Built thing
+
+**Checkpoint:** None
+`
+	if err := os.WriteFile(filepath.Join(phaseDir, "WORKFLOW.md"), []byte(workflowMD), 0o644); err != nil {
+		t.Fatalf("write WORKFLOW.md: %v", err)
+	}
+
+	return dir
+}

--- a/internal/commands/workflow/reject.go
+++ b/internal/commands/workflow/reject.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Obedience-Corp/fest/internal/lifecycle"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
 	"github.com/spf13/cobra"
@@ -41,6 +42,13 @@ The feedback will be recorded in the workflow state for reference.`,
 func runReject(ctx context.Context, reason string) error {
 	nav, err := getWorkflowNavigator(ctx)
 	if err != nil {
+		return err
+	}
+
+	if err := lifecycle.EnforcePreActive(ctx, nav.Ctx.FestivalPath, lifecycle.EnforceOptions{
+		PhasePath: nav.Ctx.PhasePath,
+		Reason:    "fest workflow reject",
+	}); err != nil {
 		return err
 	}
 

--- a/internal/commands/workflow/reset.go
+++ b/internal/commands/workflow/reset.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/Obedience-Corp/fest/internal/lifecycle"
 	"github.com/Obedience-Corp/fest/internal/progress"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
@@ -39,6 +40,13 @@ Use with caution as this cannot be undone.`,
 func runReset(ctx context.Context, force bool) error {
 	nav, err := getWorkflowNavigator(ctx)
 	if err != nil {
+		return err
+	}
+
+	if err := lifecycle.EnforcePreActive(ctx, nav.Ctx.FestivalPath, lifecycle.EnforceOptions{
+		PhasePath: nav.Ctx.PhasePath,
+		Reason:    "fest workflow reset",
+	}); err != nil {
 		return err
 	}
 

--- a/internal/commands/workflow/reset.go
+++ b/internal/commands/workflow/reset.go
@@ -75,10 +75,13 @@ func runReset(ctx context.Context, force bool) error {
 		return fmt.Errorf("resetting workflow: %w", err)
 	}
 
-	// Reset phase frontmatter status since phase is no longer complete
+	// Reset phase frontmatter status since phase is no longer complete.
+	// Manager is constructed with the lifecycle gate as defense in depth;
+	// the runReset gate above is the user-facing block.
 	phasePath := nav.Ctx.PhasePath
 	festivalPath := nav.Ctx.FestivalPath
-	if mgr, err := progress.NewManager(ctx, festivalPath); err == nil {
+	if mgr, err := progress.NewManagerWithGate(ctx, festivalPath,
+		lifecycle.NewGateWithReason(festivalPath, "fest workflow reset")); err == nil {
 		_ = mgr.ResetPhaseStatus(ctx, phasePath)
 	}
 

--- a/internal/commands/workflow/skip.go
+++ b/internal/commands/workflow/skip.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+	"github.com/Obedience-Corp/fest/internal/lifecycle"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
 	"github.com/spf13/cobra"
@@ -85,6 +86,13 @@ func runSkip(ctx context.Context, reason string, terminalState wf.StepStatus) er
 
 	nav, err := getWorkflowNavigator(ctx)
 	if err != nil {
+		return err
+	}
+
+	if err := lifecycle.EnforcePreActive(ctx, nav.Ctx.FestivalPath, lifecycle.EnforceOptions{
+		PhasePath: nav.Ctx.PhasePath,
+		Reason:    "fest workflow skip",
+	}); err != nil {
 		return err
 	}
 

--- a/internal/commands/workflow/workflow_test.go
+++ b/internal/commands/workflow/workflow_test.go
@@ -55,9 +55,18 @@ func setupWorkflowFestival(t *testing.T) string {
 
 	dir := t.TempDir()
 
-	// Create fest.yaml
-	festYAML := `name: test-festival
+	// Create fest.yaml. The status_history entry is required so the
+	// lifecycle gate can determine the festival's current status; tests
+	// previously omitted this and got a fail-closed gate from the new
+	// workflow command guards.
+	festYAML := `version: "1.0"
+name: test-festival
 id: TEST-001
+metadata:
+  id: TEST-001
+  status_history:
+    - status: active
+      timestamp: 2026-02-10T00:00:00Z
 `
 	if err := os.WriteFile(filepath.Join(dir, "fest.yaml"), []byte(festYAML), 0o644); err != nil {
 		t.Fatalf("write fest.yaml: %v", err)

--- a/internal/commands/workflow/workflow_test.go
+++ b/internal/commands/workflow/workflow_test.go
@@ -58,7 +58,8 @@ func setupWorkflowFestival(t *testing.T) string {
 	// Create fest.yaml. The status_history entry is required so the
 	// lifecycle gate can determine the festival's current status; tests
 	// previously omitted this and got a fail-closed gate from the new
-	// workflow command guards.
+	// workflow command guards. The fixture phase is "ingest" (preparatory)
+	// so the gate would let active status through regardless.
 	festYAML := `version: "1.0"
 name: test-festival
 id: TEST-001
@@ -452,7 +453,7 @@ func setupGateOnlyFestival(t *testing.T) string {
 
 	dir := t.TempDir()
 
-	festYAML := "name: gate-cmd-test\nid: GATE-CMD-001\n"
+	festYAML := "name: gate-cmd-test\nid: GATE-CMD-001\nversion: \"1.0\"\nmetadata:\n  id: GATE-CMD-001\n  status_history:\n    - status: active\n      timestamp: 2026-02-10T00:00:00Z\n"
 	if err := os.WriteFile(filepath.Join(dir, "fest.yaml"), []byte(festYAML), 0o644); err != nil {
 		t.Fatalf("write fest.yaml: %v", err)
 	}

--- a/internal/lifecycle/gate.go
+++ b/internal/lifecycle/gate.go
@@ -1,0 +1,161 @@
+package lifecycle
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/Obedience-Corp/fest/internal/config"
+	"github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/guidance"
+	"github.com/Obedience-Corp/fest/internal/progress"
+)
+
+// EnforceOptions controls which festival phase the gate evaluates.
+type EnforceOptions struct {
+	// PhasePath, if set, is used directly as the phase to evaluate.
+	PhasePath string
+	// TaskID, if set, derives PhasePath from the task's location.
+	// Takes precedence over the FindFirstIncompletePhase fallback.
+	TaskID string
+	// Reason is appended to the printed block message so the agent
+	// knows which command triggered the block.
+	Reason string
+}
+
+// EnforcePreActive returns an error wrapping errors.ErrAlreadyPrinted
+// when the festival's current status forbids work on the resolved phase.
+//
+// Resolution order for the phase to evaluate:
+//  1. opts.PhasePath if non-empty.
+//  2. opts.TaskID (resolved via festivalPath + first path segment).
+//  3. FindFirstIncompletePhase (festival root scan).
+//
+// Fail-closed: if the festival config or phase scan cannot be determined,
+// the gate blocks rather than silently allowing the operation.
+func EnforcePreActive(ctx context.Context, festivalPath string, opts EnforceOptions) error {
+	festCfg, err := config.LoadFestivalConfig(festivalPath, "")
+	if err != nil {
+		return emitFailClosed(festivalPath, opts.Reason,
+			"could not read fest.yaml; run 'fest validate'")
+	}
+	// LoadFestivalConfig returns a default config (no error) when fest.yaml
+	// is missing. That leaves status undeterminable — fail closed.
+	if !festCfg.Metadata.HasMetadata() || festCfg.Metadata.CurrentStatus() == "" {
+		return emitFailClosed(festivalPath, opts.Reason,
+			"festival metadata missing or incomplete; run 'fest validate'")
+	}
+
+	status := festCfg.Metadata.CurrentStatus()
+	if status != "planning" && status != "ready" {
+		return nil
+	}
+
+	phasePath := opts.PhasePath
+	if phasePath == "" && opts.TaskID != "" {
+		phasePath = phasePathFromTaskID(festivalPath, opts.TaskID)
+	}
+	if phasePath == "" {
+		found, _, findErr := FindFirstIncompletePhase(ctx, festivalPath)
+		if findErr != nil {
+			return emitFailClosed(festivalPath, opts.Reason,
+				"could not scan festival phases; run 'fest validate'")
+		}
+		if found == "" {
+			return nil
+		}
+		phasePath = found
+	}
+
+	phaseType := guidance.DetectPhaseType(phasePath)
+	if phaseType != "implementation" && phaseType != "review" {
+		return nil
+	}
+
+	return emitBlock(festivalPath, status, opts.Reason)
+}
+
+func phasePathFromTaskID(festivalPath, taskID string) string {
+	parts := strings.SplitN(taskID, "/", 2)
+	if parts[0] == "" {
+		return ""
+	}
+	return filepath.Join(festivalPath, parts[0])
+}
+
+func emitBlock(festivalPath, status, reason string) error {
+	festName := filepath.Base(festivalPath)
+
+	var sb strings.Builder
+	sb.WriteString("STOP — FESTIVAL NOT YET ACTIVE\n")
+	sb.WriteString("──────────────────────────────\n")
+
+	if status == "ready" {
+		fmt.Fprintf(&sb, "Festival %q is in ready status.\n", festName)
+		sb.WriteString("Lifecycle: planning -> ready -> [active] -> completed\n\n")
+		sb.WriteString("Before executing, confirm:\n")
+		sb.WriteString("  - Is this the correct festival you should be working on?\n")
+		sb.WriteString("  - Did the user approve implementation of this festival?\n\n")
+	} else {
+		fmt.Fprintf(&sb, "Festival %q is in planning status.\n", festName)
+		sb.WriteString("Lifecycle: [planning] -> ready -> active -> completed\n\n")
+		sb.WriteString("Implementation phases require active status.\n")
+	}
+
+	if reason != "" {
+		fmt.Fprintf(&sb, "Action %q requires the festival to be active.\n", reason)
+	}
+	sb.WriteString("Promote first: fest promote\n")
+
+	fmt.Print(sb.String())
+	return errors.ErrAlreadyPrinted
+}
+
+func emitFailClosed(festivalPath, reason, hint string) error {
+	festName := filepath.Base(festivalPath)
+
+	var sb strings.Builder
+	sb.WriteString("STOP — FESTIVAL STATUS UNDETERMINED\n")
+	sb.WriteString("───────────────────────────────────\n")
+	fmt.Fprintf(&sb, "Could not determine status for festival %q.\n", festName)
+	fmt.Fprintf(&sb, "Hint: %s\n", hint)
+	if reason != "" {
+		fmt.Fprintf(&sb, "Action %q is blocked until status can be verified.\n", reason)
+	}
+	sb.WriteString("\nIf this festival was promoted but a tool failed to read its status,\n")
+	sb.WriteString("run 'fest validate' to inspect, then retry.\n")
+	fmt.Print(sb.String())
+	return errors.ErrAlreadyPrinted
+}
+
+// Gate is the interface progress.Manager depends on for defense-in-depth
+// enforcement. It mirrors progress.Gate; lifecycle.NewGate returns a value
+// that satisfies progress.Gate.
+type Gate interface {
+	EnforceForTask(ctx context.Context, taskID string) error
+}
+
+type realGate struct {
+	festivalPath string
+	reason       string
+}
+
+// NewGate returns a Gate bound to the given festival. It satisfies
+// progress.Gate via the EnforceForTask method.
+func NewGate(festivalPath string) progress.Gate {
+	return &realGate{festivalPath: festivalPath, reason: "progress.Manager"}
+}
+
+// NewGateWithReason returns a Gate that surfaces a specific command name in
+// block messages. Useful for CLI sites that want the reason in the output.
+func NewGateWithReason(festivalPath, reason string) progress.Gate {
+	return &realGate{festivalPath: festivalPath, reason: reason}
+}
+
+func (g *realGate) EnforceForTask(ctx context.Context, taskID string) error {
+	return EnforcePreActive(ctx, g.festivalPath, EnforceOptions{
+		TaskID: taskID,
+		Reason: g.reason,
+	})
+}

--- a/internal/lifecycle/gate_test.go
+++ b/internal/lifecycle/gate_test.go
@@ -1,6 +1,7 @@
-package next
+package lifecycle
 
 import (
+	"bytes"
 	"context"
 	stderrors "errors"
 	"os"
@@ -9,10 +10,9 @@ import (
 	"testing"
 
 	"github.com/Obedience-Corp/fest/internal/errors"
-	"github.com/Obedience-Corp/fest/internal/validator"
 )
 
-func TestCheckPreActiveStatus(t *testing.T) {
+func TestEnforcePreActive(t *testing.T) {
 	tests := []struct {
 		name           string
 		status         string
@@ -116,7 +116,7 @@ func TestCheckPreActiveStatus(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err := checkPreActiveStatus(context.Background(), festDir, phaseDir)
+			err := EnforcePreActive(context.Background(), festDir, EnforceOptions{PhasePath: phaseDir})
 
 			if tt.expectBlocked {
 				if err == nil {
@@ -131,18 +131,32 @@ func TestCheckPreActiveStatus(t *testing.T) {
 	}
 }
 
-func TestCheckPreActiveStatus_NoConfig(t *testing.T) {
+func TestEnforcePreActive_NoConfig_FailsClosed(t *testing.T) {
 	festDir := t.TempDir()
-	err := checkPreActiveStatus(context.Background(), festDir, "")
-	if err != nil {
-		t.Errorf("expected no error without config, got: %v", err)
+
+	var err error
+	output := captureStdout(t, func() {
+		err = EnforcePreActive(context.Background(), festDir, EnforceOptions{Reason: "test"})
+	})
+
+	if err == nil {
+		t.Fatal("expected fail-closed error when fest.yaml is missing, got nil")
+	}
+	if !stderrors.Is(err, errors.ErrAlreadyPrinted) {
+		t.Errorf("expected ErrAlreadyPrinted, got: %v", err)
+	}
+	if !strings.Contains(output, "metadata missing") && !strings.Contains(output, "fest.yaml") {
+		t.Errorf("expected metadata/fest.yaml hint in output, got: %s", output)
+	}
+	if !strings.Contains(output, "fest validate") {
+		t.Errorf("expected 'fest validate' hint in output, got: %s", output)
 	}
 }
 
-func TestCheckPreActiveStatus_NoPhasePath(t *testing.T) {
+func TestEnforcePreActive_NoPhasePath_AutoDetect(t *testing.T) {
 	festDir := t.TempDir()
 	phaseDir := filepath.Join(festDir, "001_IMPL")
-	if err := os.MkdirAll(phaseDir, 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(phaseDir, "01_setup"), 0755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -156,17 +170,58 @@ func TestCheckPreActiveStatus_NoPhasePath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := os.MkdirAll(filepath.Join(phaseDir, "01_setup"), 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	err := checkPreActiveStatus(context.Background(), festDir, "")
+	err := EnforcePreActive(context.Background(), festDir, EnforceOptions{})
 	if err == nil {
 		t.Error("expected blocked error when auto-detecting implementation phase, got nil")
 	}
 }
 
-func TestCheckPreActiveStatus_ReadyMessage(t *testing.T) {
+func TestEnforcePreActive_TaskID_DerivesPhase(t *testing.T) {
+	festDir := t.TempDir()
+
+	implPhase := filepath.Join(festDir, "002_IMPL")
+	if err := os.MkdirAll(filepath.Join(implPhase, "01_seq"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	goalImpl := "---\nfest_phase_type: implementation\n---\n# Implementation Phase\n"
+	if err := os.WriteFile(filepath.Join(implPhase, "PHASE_GOAL.md"), []byte(goalImpl), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	planPhase := filepath.Join(festDir, "001_PLAN")
+	if err := os.MkdirAll(filepath.Join(planPhase, "01_seq"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	goalPlan := "---\nfest_phase_type: planning\n---\n# Planning Phase\n"
+	if err := os.WriteFile(filepath.Join(planPhase, "PHASE_GOAL.md"), []byte(goalPlan), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	festYAML := "version: \"1.0\"\nmetadata:\n  id: TS0001\n  status_history:\n    - status: planning\n      timestamp: 2026-02-10T00:00:00Z\n"
+	if err := os.WriteFile(filepath.Join(festDir, "fest.yaml"), []byte(festYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// TaskID points at the implementation phase even though planning phase is the
+	// scan-detected first incomplete. TaskID should win.
+	err := EnforcePreActive(context.Background(), festDir, EnforceOptions{
+		TaskID: "002_IMPL/01_seq/01_task.md",
+		Reason: "fest task completed",
+	})
+	if err == nil {
+		t.Error("expected block when TaskID resolves to implementation phase, got nil")
+	}
+
+	// TaskID points at the planning phase, should NOT block.
+	err = EnforcePreActive(context.Background(), festDir, EnforceOptions{
+		TaskID: "001_PLAN/01_seq/01_task.md",
+	})
+	if err != nil {
+		t.Errorf("expected no block when TaskID resolves to planning phase, got: %v", err)
+	}
+}
+
+func TestEnforcePreActive_ReadyMessage(t *testing.T) {
 	festDir := t.TempDir()
 	phaseDir := filepath.Join(festDir, "001_PHASE")
 	if err := os.MkdirAll(phaseDir, 0755); err != nil {
@@ -185,7 +240,10 @@ func TestCheckPreActiveStatus_ReadyMessage(t *testing.T) {
 
 	var err error
 	output := captureStdout(t, func() {
-		err = checkPreActiveStatus(context.Background(), festDir, phaseDir)
+		err = EnforcePreActive(context.Background(), festDir, EnforceOptions{
+			PhasePath: phaseDir,
+			Reason:    "fest task completed",
+		})
 	})
 
 	if err == nil {
@@ -198,45 +256,20 @@ func TestCheckPreActiveStatus_ReadyMessage(t *testing.T) {
 		t.Errorf("expected prompt block header, got: %s", output)
 	}
 	if !strings.Contains(output, "fest promote") {
-		t.Errorf("expected promote instruction in prompt block, got: %s", output)
+		t.Errorf("expected promote instruction, got: %s", output)
 	}
 	if !strings.Contains(output, "Did the user approve") {
-		t.Errorf("expected user approval check in prompt block, got: %s", output)
+		t.Errorf("expected user approval check, got: %s", output)
 	}
 	if !strings.Contains(output, "planning -> ready -> [active] -> completed") {
 		t.Errorf("expected lifecycle in prompt block, got: %s", output)
 	}
-}
-
-// TestValidationGateAllowsIngestPhaseWithMarkers verifies the full integration:
-// a planning-status festival with unfilled markers in FESTIVAL_GOAL.md and an
-// ingest-type current phase should NOT be blocked by the validation gate.
-// Uses a synthetic result with only marker errors to isolate the fix.
-func TestValidationGateAllowsIngestPhaseWithMarkers(t *testing.T) {
-	result := &validator.Result{
-		Issues: []validator.Issue{
-			{
-				Level:   validator.LevelError,
-				Code:    validator.CodeUnfilledTemplate,
-				Path:    "FESTIVAL_GOAL.md",
-				Message: "File contains 1 unfilled template markers ([FILL:)",
-			},
-		},
-	}
-
-	// With ingest phase, validation gate should NOT block (root markers are in scope)
-	if hasBlockingIssues(result, "ingest", "001_INGEST") {
-		t.Error("validation gate should not block ingest phase despite festival-root marker errors")
+	if !strings.Contains(output, "fest task completed") {
+		t.Errorf("expected reason in output, got: %s", output)
 	}
 }
 
-// TestCheckPreActiveStatus_MultiPhase_PlanningPhaseNotBlocked verifies the
-// regression scenario: a planning-status festival with a completed implementation
-// phase (001_IMPL) and an incomplete planning phase (002_PLAN). When run from the
-// festival root (no explicit phasePath), findFirstIncompletePhase should find
-// 002_PLAN (type=planning), NOT 001_IMPL (type=implementation), so the check
-// should NOT block.
-func TestCheckPreActiveStatus_MultiPhase_PlanningPhaseNotBlocked(t *testing.T) {
+func TestEnforcePreActive_MultiPhase_PlanningPhaseNotBlocked(t *testing.T) {
 	festDir := t.TempDir()
 
 	phase1 := filepath.Join(festDir, "001_IMPL")
@@ -268,22 +301,15 @@ func TestCheckPreActiveStatus_MultiPhase_PlanningPhaseNotBlocked(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := checkPreActiveStatus(context.Background(), festDir, "")
+	err := EnforcePreActive(context.Background(), festDir, EnforceOptions{})
 	if err != nil {
 		t.Errorf("expected no block for planning phase in planning-status festival, got: %v", err)
 	}
 }
 
-// TestCheckPreActiveStatus_CwdInsideLaterImplPhase verifies the cwd regression:
-// a planning-status festival with an incomplete ingest phase (001_INGEST) and a
-// later scaffolded implementation phase (002_IMPL). If the user runs fest next
-// from inside 002_IMPL, passing that phase path would incorrectly block.
-// The fix in runNext() passes findFirstIncompletePhase result instead of cwd.
-// This test validates both paths to document the expected behavior.
-func TestCheckPreActiveStatus_CwdInsideLaterImplPhase(t *testing.T) {
+func TestEnforcePreActive_CwdInsideLaterImplPhase(t *testing.T) {
 	festDir := t.TempDir()
 
-	// Incomplete ingest phase (the real next phase)
 	ingestPhase := filepath.Join(festDir, "001_INGEST")
 	if err := os.MkdirAll(filepath.Join(ingestPhase, "01_seq"), 0755); err != nil {
 		t.Fatal(err)
@@ -293,7 +319,6 @@ func TestCheckPreActiveStatus_CwdInsideLaterImplPhase(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Later scaffolded implementation phase (where cwd might be)
 	implPhase := filepath.Join(festDir, "002_IMPL")
 	if err := os.MkdirAll(filepath.Join(implPhase, "01_seq"), 0755); err != nil {
 		t.Fatal(err)
@@ -308,15 +333,43 @@ func TestCheckPreActiveStatus_CwdInsideLaterImplPhase(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Passing the impl phase path (simulating old cwd behavior) WOULD block
-	err := checkPreActiveStatus(context.Background(), festDir, implPhase)
+	// Passing the impl phase path WOULD block.
+	err := EnforcePreActive(context.Background(), festDir, EnforceOptions{PhasePath: implPhase})
 	if err == nil {
 		t.Error("expected block when passing implementation phase path directly")
 	}
 
-	// Passing the ingest phase path (what findFirstIncompletePhase returns) should NOT block
-	err = checkPreActiveStatus(context.Background(), festDir, ingestPhase)
+	// Passing the ingest phase path should NOT block.
+	err = EnforcePreActive(context.Background(), festDir, EnforceOptions{PhasePath: ingestPhase})
 	if err != nil {
 		t.Errorf("expected no block when passing ingest phase path, got: %v", err)
 	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close write pipe: %v", err)
+	}
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("read pipe: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("close read pipe: %v", err)
+	}
+
+	return buf.String()
 }

--- a/internal/lifecycle/gate_test.go
+++ b/internal/lifecycle/gate_test.go
@@ -131,6 +131,32 @@ func TestEnforcePreActive(t *testing.T) {
 	}
 }
 
+func TestEnforcePreActive_MalformedConfig_FailsClosed(t *testing.T) {
+	festDir := t.TempDir()
+	// Write malformed YAML so config.LoadFestivalConfig returns a parse error.
+	if err := os.WriteFile(filepath.Join(festDir, "fest.yaml"), []byte(": not yaml :\n  - [broken\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var err error
+	output := captureStdout(t, func() {
+		err = EnforcePreActive(context.Background(), festDir, EnforceOptions{Reason: "test"})
+	})
+
+	if err == nil {
+		t.Fatal("expected fail-closed error for malformed fest.yaml, got nil")
+	}
+	if !stderrors.Is(err, errors.ErrAlreadyPrinted) {
+		t.Errorf("expected ErrAlreadyPrinted, got: %v", err)
+	}
+	if !strings.Contains(output, "fest.yaml") {
+		t.Errorf("expected fest.yaml hint in output, got: %s", output)
+	}
+	if !strings.Contains(output, "fest validate") {
+		t.Errorf("expected 'fest validate' hint, got: %s", output)
+	}
+}
+
 func TestEnforcePreActive_NoConfig_FailsClosed(t *testing.T) {
 	festDir := t.TempDir()
 

--- a/internal/lifecycle/phase.go
+++ b/internal/lifecycle/phase.go
@@ -1,0 +1,103 @@
+// Package lifecycle enforces festival lifecycle rules across CLI commands.
+//
+// The pre-active gate blocks implementation/review work on festivals that
+// have not been promoted to active status. The gate is consulted from
+// every CLI mutation entry point and from progress.Manager mutation
+// methods so the rule cannot be bypassed by switching commands.
+package lifecycle
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/Obedience-Corp/fest/internal/commands/shared"
+	"github.com/Obedience-Corp/fest/internal/progress"
+)
+
+// FindFirstIncompletePhase scans ALL phases in numerical order and returns
+// the first incomplete phase. It respects ordering across both
+// workflow-based and task-based phases.
+//
+// Returns (phasePath, isWorkflow, error). Empty phasePath means all phases
+// are complete.
+func FindFirstIncompletePhase(ctx context.Context, festivalPath string) (string, bool, error) {
+	entries, err := os.ReadDir(festivalPath)
+	if err != nil {
+		return "", false, err
+	}
+
+	var phases []string
+	for _, entry := range entries {
+		if entry.IsDir() && shared.IsNumberedDir(entry.Name()) {
+			phases = append(phases, filepath.Join(festivalPath, entry.Name()))
+		}
+	}
+
+	sort.Strings(phases)
+
+	store := progress.NewStore(festivalPath)
+	storeLoaded := store.Load(ctx) == nil
+
+	for _, phasePath := range phases {
+		phaseName := filepath.Base(phasePath)
+
+		workflowPath := filepath.Join(phasePath, "WORKFLOW.md")
+		if _, err := os.Stat(workflowPath); err == nil {
+			if storeLoaded {
+				state, ok := store.WorkflowPhaseState(phaseName)
+				if !ok || state.TotalSteps == 0 || !state.IsComplete() {
+					return phasePath, true, nil
+				}
+			} else {
+				return phasePath, true, nil
+			}
+			if HasIncompletePhaseGate(storeLoaded, store, phasePath, phaseName) {
+				return phasePath, false, nil
+			}
+			continue
+		}
+
+		if hasSequenceDirs(phasePath) && !shared.ArePhaseTasksComplete(storeLoaded, store, phasePath, phaseName) {
+			return phasePath, false, nil
+		}
+
+		if HasIncompletePhaseGate(storeLoaded, store, phasePath, phaseName) {
+			return phasePath, false, nil
+		}
+	}
+
+	return "", false, nil
+}
+
+// HasIncompletePhaseGate checks if a phase has a GATES.md that is not yet
+// complete. Exported because other phase scanners in commands/next also
+// need it.
+func HasIncompletePhaseGate(storeLoaded bool, store *progress.Store, phasePath, phaseName string) bool {
+	gatesPath := filepath.Join(phasePath, "GATES.md")
+	if _, err := os.Stat(gatesPath); err != nil {
+		return false
+	}
+	if !storeLoaded {
+		return true
+	}
+	state, ok := store.GatePhaseState(phaseName)
+	if !ok || state.TotalSteps == 0 || !state.IsComplete() {
+		return true
+	}
+	return false
+}
+
+func hasSequenceDirs(phasePath string) bool {
+	entries, err := os.ReadDir(phasePath)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if entry.IsDir() && shared.IsNumberedDir(entry.Name()) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/progress/gate.go
+++ b/internal/progress/gate.go
@@ -1,0 +1,25 @@
+package progress
+
+import "context"
+
+// Gate enforces lifecycle rules on task mutations.
+//
+// The interface lives in the progress package to keep progress free of
+// any dependency on the lifecycle package, while still letting Manager
+// consult the gate inside its mutation methods. Implementations live in
+// internal/lifecycle/.
+type Gate interface {
+	// EnforceForTask returns a non-nil error if the task's festival
+	// status forbids the mutation. A nil return allows the mutation
+	// to proceed.
+	EnforceForTask(ctx context.Context, taskID string) error
+}
+
+// NoopGate is a Gate that always allows. It is the default when a
+// Manager is constructed via NewManager (i.e. without explicit
+// enforcement). CLI mutation entry points use NewManagerWithGate to
+// install a real gate.
+type NoopGate struct{}
+
+// EnforceForTask always returns nil.
+func (NoopGate) EnforceForTask(_ context.Context, _ string) error { return nil }

--- a/internal/progress/gate_manager_test.go
+++ b/internal/progress/gate_manager_test.go
@@ -1,0 +1,64 @@
+package progress
+
+import (
+	"context"
+	stderrors "errors"
+	"testing"
+)
+
+// blockingGate is a Gate that always blocks with a sentinel error.
+type blockingGate struct{}
+
+var errBlocked = stderrors.New("blocked by gate")
+
+func (blockingGate) EnforceForTask(_ context.Context, _ string) error {
+	return errBlocked
+}
+
+// TestManager_GateBlocksMutations verifies every mutation method on Manager
+// consults the gate before changing state. Without this wiring, a Manager
+// constructed with a real lifecycle gate would still let mutations through
+// when callers reach Manager directly (defense in depth).
+func TestManager_GateBlocksMutations(t *testing.T) {
+	ctx := context.Background()
+	mgr, err := NewManagerWithGate(ctx, t.TempDir(), blockingGate{})
+	if err != nil {
+		t.Fatalf("NewManagerWithGate: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		call func() error
+	}{
+		{"UpdateProgress", func() error { return mgr.UpdateProgress(ctx, "001/01/01_t.md", 50) }},
+		{"MarkComplete", func() error { return mgr.MarkComplete(ctx, "001/01/01_t.md") }},
+		{"MarkInProgress", func() error { return mgr.MarkInProgress(ctx, "001/01/01_t.md") }},
+		{"ReportBlocker", func() error { return mgr.ReportBlocker(ctx, "001/01/01_t.md", "x") }},
+		{"ResetTask", func() error { return mgr.ResetTask(ctx, "001/01/01_t.md") }},
+		{"ClearBlocker", func() error { return mgr.ClearBlocker(ctx, "001/01/01_t.md") }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.call()
+			if !stderrors.Is(err, errBlocked) {
+				t.Errorf("%s: expected gate to block (got %v)", tc.name, err)
+			}
+		})
+	}
+}
+
+// TestManager_NoopGateAllowsMutations verifies plain NewManager (which
+// installs NoopGate) does not gate mutations. This preserves the
+// pre-existing behaviour of the 21+ NewManager call sites.
+func TestManager_NoopGateAllowsMutations(t *testing.T) {
+	ctx := context.Background()
+	mgr, err := NewManager(ctx, t.TempDir())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	if err := mgr.UpdateProgress(ctx, "001/01/01_t.md", 25); err != nil {
+		t.Errorf("UpdateProgress with NoopGate should not error, got: %v", err)
+	}
+}

--- a/internal/progress/gate_manager_test.go
+++ b/internal/progress/gate_manager_test.go
@@ -50,15 +50,45 @@ func TestManager_GateBlocksMutations(t *testing.T) {
 
 // TestManager_NoopGateAllowsMutations verifies plain NewManager (which
 // installs NoopGate) does not gate mutations. This preserves the
-// pre-existing behaviour of the 21+ NewManager call sites.
+// pre-existing behaviour of the existing NewManager call sites.
 func TestManager_NoopGateAllowsMutations(t *testing.T) {
 	ctx := context.Background()
-	mgr, err := NewManager(ctx, t.TempDir())
-	if err != nil {
-		t.Fatalf("NewManager: %v", err)
+
+	cases := []struct {
+		name string
+		call func(*Manager) error
+	}{
+		{"UpdateProgress", func(m *Manager) error { return m.UpdateProgress(ctx, "001/01/01_t.md", 25) }},
+		{"MarkInProgress", func(m *Manager) error { return m.MarkInProgress(ctx, "001/01/02_t.md") }},
+		{"MarkComplete", func(m *Manager) error { return m.MarkComplete(ctx, "001/01/03_t.md") }},
+		{"ReportBlocker", func(m *Manager) error { return m.ReportBlocker(ctx, "001/01/04_t.md", "x") }},
+		{"ResetTask", func(m *Manager) error { return m.ResetTask(ctx, "001/01/05_t.md") }},
 	}
 
-	if err := mgr.UpdateProgress(ctx, "001/01/01_t.md", 25); err != nil {
-		t.Errorf("UpdateProgress with NoopGate should not error, got: %v", err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mgr, err := NewManager(ctx, t.TempDir())
+			if err != nil {
+				t.Fatalf("NewManager: %v", err)
+			}
+			if err := tc.call(mgr); err != nil {
+				t.Errorf("%s with NoopGate should not error, got: %v", tc.name, err)
+			}
+		})
 	}
+
+	// ClearBlocker has its own happy path: it requires a pre-existing task
+	// with a blocker, so seed via ReportBlocker first.
+	t.Run("ClearBlocker", func(t *testing.T) {
+		mgr, err := NewManager(ctx, t.TempDir())
+		if err != nil {
+			t.Fatalf("NewManager: %v", err)
+		}
+		if err := mgr.ReportBlocker(ctx, "001/01/06_t.md", "blocker"); err != nil {
+			t.Fatalf("seed ReportBlocker: %v", err)
+		}
+		if err := mgr.ClearBlocker(ctx, "001/01/06_t.md"); err != nil {
+			t.Errorf("ClearBlocker with NoopGate should not error, got: %v", err)
+		}
+	})
 }

--- a/internal/progress/manager.go
+++ b/internal/progress/manager.go
@@ -14,25 +14,43 @@ import (
 // Manager handles progress operations for a festival
 type Manager struct {
 	store *Store
+	gate  Gate
 }
 
-// NewManager creates a new progress manager
+// NewManager creates a new progress manager with no lifecycle gate.
+// Mutations are not gated. Suitable for read-heavy callers and tests.
+// CLI mutation entry points should use NewManagerWithGate instead.
 func NewManager(ctx context.Context, festivalPath string) (*Manager, error) {
+	return NewManagerWithGate(ctx, festivalPath, NoopGate{})
+}
+
+// NewManagerWithGate creates a new progress manager whose mutation
+// methods consult the supplied Gate. Pass a real gate at CLI mutation
+// sites; pass NoopGate{} for housekeeping paths that legitimately
+// bypass enforcement (e.g., promote internals, store fixups).
+func NewManagerWithGate(ctx context.Context, festivalPath string, gate Gate) (*Manager, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, errors.Wrap(err, "context cancelled")
+	}
+
+	if gate == nil {
+		gate = NoopGate{}
 	}
 
 	store := NewStore(festivalPath)
 	if err := store.Load(ctx); err != nil {
 		return nil, errors.Wrap(err, "loading progress data")
 	}
-	return &Manager{store: store}, nil
+	return &Manager{store: store, gate: gate}, nil
 }
 
 // UpdateProgress updates the progress percentage for a task
 func (m *Manager) UpdateProgress(ctx context.Context, taskID string, progress int) error {
 	if err := ctx.Err(); err != nil {
 		return errors.Wrap(err, "context cancelled")
+	}
+	if err := m.gate.EnforceForTask(ctx, taskID); err != nil {
+		return err
 	}
 
 	if progress < 0 || progress > 100 {
@@ -114,6 +132,9 @@ func (m *Manager) MarkComplete(ctx context.Context, taskID string) error {
 	if err := ctx.Err(); err != nil {
 		return errors.Wrap(err, "context cancelled")
 	}
+	if err := m.gate.EnforceForTask(ctx, taskID); err != nil {
+		return err
+	}
 
 	task, exists := m.store.GetTask(taskID)
 	if !exists {
@@ -163,6 +184,9 @@ func (m *Manager) MarkInProgress(ctx context.Context, taskID string) error {
 	if err := ctx.Err(); err != nil {
 		return errors.Wrap(err, "context cancelled")
 	}
+	if err := m.gate.EnforceForTask(ctx, taskID); err != nil {
+		return err
+	}
 
 	task, exists := m.store.GetTask(taskID)
 	if !exists {
@@ -200,6 +224,9 @@ func (m *Manager) MarkInProgress(ctx context.Context, taskID string) error {
 func (m *Manager) ReportBlocker(ctx context.Context, taskID, message string) error {
 	if err := ctx.Err(); err != nil {
 		return errors.Wrap(err, "context cancelled")
+	}
+	if err := m.gate.EnforceForTask(ctx, taskID); err != nil {
+		return err
 	}
 
 	if message == "" {
@@ -245,6 +272,9 @@ func (m *Manager) ResetTask(ctx context.Context, taskID string) error {
 	if err := ctx.Err(); err != nil {
 		return errors.Wrap(err, "context cancelled")
 	}
+	if err := m.gate.EnforceForTask(ctx, taskID); err != nil {
+		return err
+	}
 
 	task, exists := m.store.GetTask(taskID)
 	if !exists {
@@ -282,6 +312,9 @@ func (m *Manager) ResetTask(ctx context.Context, taskID string) error {
 func (m *Manager) ClearBlocker(ctx context.Context, taskID string) error {
 	if err := ctx.Err(); err != nil {
 		return errors.Wrap(err, "context cancelled")
+	}
+	if err := m.gate.EnforceForTask(ctx, taskID); err != nil {
+		return err
 	}
 
 	task, exists := m.store.GetTask(taskID)


### PR DESCRIPTION
## Summary

The pre-active lifecycle gate (`checkPreActiveStatus`) was enforced only inside `fest next`. Sibling commands that read or mutate task progress walked straight past it. An agent could fully execute an implementation phase while the festival sat in `planning` or `ready`, never tripping the gate and never seeing the human-approval prompt that `fest promote` represents.

This PR closes every known bypass surface and adds defense in depth at the `progress.Manager` layer.

## Design

Full design lives in `obey-campaign:workflow/design/fest-lifecycle-gate-bypass-2026-04-29/`:

- `01-current-state-and-bypass-vectors.md` — original investigation, file:line citations for every bypass.
- `02-fix-architecture.md` — shared `internal/lifecycle/` package, fail-closed semantics, error shape. Updated during review to record position evolution on `fest task show` and `fest workflow` gating.
- `03-command-surface-rationalization.md` — why `fest task` and `fest progress` overlap is kept (different audiences) and both are gated.
- `04-test-and-acceptance.md` — regression matrix and end-to-end repro.
- `05-implementation-plan.md` — file-by-file change list this PR follows.

## What Changed

1. **New package `internal/lifecycle/`**
   - `EnforcePreActive(ctx, festivalPath, EnforceOptions{PhasePath, TaskID, Reason})`. Resolves the phase from `PhasePath`, then `TaskID`, then `FindFirstIncompletePhase`.
   - `FindFirstIncompletePhase` and `HasIncompletePhaseGate` exported (used by both lifecycle and the existing phase-scan helpers in `commands/next/phase.go`).
   - **Fail-closed flips**: missing/unparseable `fest.yaml` and unscannable progress store now block with a `fest validate` hint instead of returning nil.
   - `lifecycle.NewGate(festivalPath)` / `NewGateWithReason(festivalPath, reason)` returning `progress.Gate`.

2. **`progress.Manager` defense in depth**
   - New `progress.Gate` interface and `progress.NoopGate{}`.
   - `NewManager` keeps its signature; defaults to `NoopGate` so existing read-heavy callers stay unchanged.
   - `NewManagerWithGate(ctx, path, gate)` for mutation entry points.
   - `UpdateProgress`, `MarkComplete`, `MarkInProgress`, `ReportBlocker`, `ResetTask`, `ClearBlocker` all consult the gate at the top of each method.
   - **Caveat (called out in review):** the NoopGate default is not airtight. Two existing call sites in `workflow/advance.go::showNextStep` (`PropagatePhaseCompletion`) and `workflow/reset.go` (`ResetPhaseStatus`) were switched to `NewManagerWithGate` so they inherit enforcement. The runX-level lifecycle gate is the load-bearing block; Manager-layer gating is defense in depth. A future change should require a `Gate` at construction time so the noop-default pitfall is eliminated. Tracked as a follow-up.

3. **CLI mutation entry points wired through both layers**
   - `fest task show` — both auto-resolve and explicit-arg are gated. Planning, research, and ingest task reads pass through the phase-type check in any status, so reviewing prep work before promotion stays open.
   - `fest task completed / blocked / reset / edit`
   - `fest progress --task <id> --complete | --in-progress | --update | --blocker | --clear` — one insertion in `handleTaskUpdate` covers all five mutation flags via a `progressReasonFor(opts)` helper.
   - `fest status set --task <id>` — every status target (`pending`, `in_progress`, `blocked`, `completed`).
   - `fest status set --phase <phase>` and `fest status set --sequence <seq>` — `UpdateGoalFrontmatter` for phase/sequence frontmatter mutations now consults the gate. Sequences gate on the parent phase via `filepath.Dir(seqPath)`.
   - `fest workflow advance | approve | reject | skip | reset` — the Navigator mutates `progress.Store` directly via `SaveEvents` (it never goes through `progress.Manager`), so the Manager-layer gate cannot help. Each `runX` calls `lifecycle.EnforcePreActive` immediately after `getWorkflowNavigator`, using the navigator's resolved festival/phase paths.

4. **`fest next` migrated**
   - Inline `checkPreActiveStatus` call swapped for `lifecycle.EnforcePreActive`. `next.go` behaviour unchanged.
   - Private duplicates (`findFirstIncompletePhase`, `hasIncompletePhaseGate`, `hasSequenceDirs`, `arePhaseTasksComplete`) deleted from `commands/next/phase.go` and `validation.go`.

## Tests

- `next/next_preactive_test.go` ported to `internal/lifecycle/gate_test.go`. All original cases retained, plus new coverage for:
  - `EnforceOptions{TaskID: ...}` resolution.
  - Fail-closed: missing `fest.yaml` (`TestEnforcePreActive_NoConfig_FailsClosed`).
  - Fail-closed: malformed YAML (`TestEnforcePreActive_MalformedConfig_FailsClosed`).
- `internal/progress/gate_manager_test.go` covers all six mutation methods on the blocking path AND on the NoopGate happy path.
- `internal/commands/task/lifecycle_gate_test.go::TestTaskShowGate` — 7-row matrix for explicit-arg `fest task show` across status × phase-type.
- `internal/commands/workflow/lifecycle_gate_test.go::TestWorkflowGate_BlocksImplPhaseInPlanningFestival` and `TestWorkflowGate_AllowsImplPhaseInActiveFestival`.
- `internal/commands/status/lifecycle_gate_test.go::TestPhaseStatusSetGate` — table over status × phase-type for `--phase` mutations.

`go test ./...` — all 87 packages pass. `golangci-lint run ./...` — 0 issues. `go vet ./...` — clean.

## What Is NOT Gated

- `fest show` (tree, roadmap, stats) — aggregate views; never surface a single task body.
- `fest progress` with no flags — festival summary.
- `fest validate` — needs to introspect arbitrary festivals.
- `fest promote` — the gate is what `promote` releases.

Reading planning, research, or ingest task content in a `planning`-status festival is still allowed; only impl/review work is gated.

## Test Plan

- [ ] On a `planning`-status festival, `fest task show` (no arg) auto-resolves to the next implementation task and blocks with the lifecycle message.
- [ ] `fest task show <impl-task>` (explicit arg) blocks in `planning`/`ready`; `fest task show <planning-task>` succeeds.
- [ ] `fest task completed <impl-task>` blocks before quality-gate evaluation.
- [ ] `fest progress --task <impl-task> --complete | --in-progress | --update 50% | --blocker x | --clear` all block.
- [ ] `fest status set --task <impl-task> in_progress` (and `completed`, `blocked`, `pending`) block.
- [ ] `fest status set --phase <impl-phase> completed` blocks; `fest status set --phase <ingest-phase> completed` succeeds.
- [ ] `fest status set --sequence <impl-seq>/01_seq completed` blocks; `--sequence <planning-seq>/01_seq completed` succeeds.
- [ ] `fest workflow advance | approve | reject | skip | reset` all block in a planning festival with an implementation phase.
- [ ] After `fest promote` (planning → ready) impl/review commands still block (ready+impl is also gated).
- [ ] After `fest promote` (ready → active) every command succeeds.
- [ ] Truncate the festival's `fest.yaml` and verify gated commands block with the new "could not read fest.yaml" hint; `fest show` and `fest progress` (no flags) still succeed.

## Deferred (follow-up)

- Require `Gate` at `progress.NewManager` construction time so the NoopGate default cannot mask future mutation paths.
- Gate at `progress.Store.SaveEvents` so future Navigator-style callers inherit enforcement without a per-command `runX` guard.
- Tests for unreadable progress store, cancelled context, and TaskID with leading slash / empty first segment.