### PR TITLE
test(integration): repair 6 fixtures broken by pre-active lifecycle gate

### DIFF
--- a/tests/integration/guidance_implementation_test.go
+++ b/tests/integration/guidance_implementation_test.go
@@ -93,29 +93,11 @@ func TestImplementationMode_PhaseBoundaries(t *testing.T) {
 
 	festPath := findFestivalPath(t, container, festivalsPath+"/planning", "test-impl-phases")
 
-	// Write fest.yaml with quality gates enabled and auto-link disabled (no real project dirs in container)
-	festYaml := `version: "1.0"
-auto_link:
-  enabled: false
-quality_gates:
-  enabled: true
-  auto_append: true
-  implementation:
-    - id: testing
-      template: gates/implementation/QUALITY_GATE_TESTING
-      enabled: true
-    - id: review
-      template: gates/implementation/QUALITY_GATE_REVIEW
-      enabled: true
-    - id: iterate
-      template: gates/implementation/QUALITY_GATE_ITERATE
-      enabled: true
-    - id: fest-commit
-      template: gates/implementation/QUALITY_GATE_FEST_COMMIT
-      enabled: true
-`
-	err = writeFileInContainer(container, festPath+"/fest.yaml", festYaml)
-	require.NoError(t, err)
+	// Append quality_gates and disable auto_link without overwriting the
+	// metadata block that fest create festival wrote (status_history is
+	// required by the pre-active lifecycle gate and fest status set).
+	err = ensureQualityGatesInFestivalConfig(container, festPath)
+	require.NoError(t, err, "should ensure quality gates in fest.yaml")
 
 	// Create FESTIVAL_OVERVIEW.md (required by validator)
 	overviewContent := `---
@@ -163,6 +145,10 @@ fest_type: overview
 	err = replaceMarkersInContainer(container, festPath)
 	require.NoError(t, err, "should replace markers")
 
+	// Promote to active so the pre-active lifecycle gate allows
+	// progress mutations on implementation phases.
+	festPath = promoteToActive(t, container, festivalsPath, festPath)
+
 	// Run execute - should show phase 1 task
 	output := runExecuteMode(t, container, festPath)
 	verifyOutputContains(t, output, "phase1_task")
@@ -198,10 +184,11 @@ func TestImplementationMode_Completion(t *testing.T) {
 
 	festPath := findFestivalPath(t, container, festivalsPath+"/planning", "test-impl-done")
 
-	// Write fest.yaml with quality gates enabled and auto-link disabled (no real project dirs in container)
-	festYaml := "version: \"1.0\"\nauto_link:\n  enabled: false\nquality_gates:\n  enabled: true\n  auto_append: true\n  implementation:\n    - id: testing\n      template: gates/implementation/QUALITY_GATE_TESTING\n      enabled: true\n    - id: review\n      template: gates/implementation/QUALITY_GATE_REVIEW\n      enabled: true\n    - id: iterate\n      template: gates/implementation/QUALITY_GATE_ITERATE\n      enabled: true\n    - id: fest-commit\n      template: gates/implementation/QUALITY_GATE_FEST_COMMIT\n      enabled: true\n"
-	err = writeFileInContainer(container, festPath+"/fest.yaml", festYaml)
-	require.NoError(t, err)
+	// Append quality_gates and disable auto_link without overwriting the
+	// metadata block that fest create festival wrote (status_history is
+	// required by the pre-active lifecycle gate and fest status set).
+	err = ensureQualityGatesInFestivalConfig(container, festPath)
+	require.NoError(t, err, "should ensure quality gates in fest.yaml")
 
 	// Create FESTIVAL_OVERVIEW.md (required by validator)
 	overviewContent := "---\nfest_type: overview\n---\n\n# Test Festival Overview\n\n## Goals\n- Test completion behavior\n\n## Success Criteria\n- All tasks completed\n"
@@ -230,6 +217,10 @@ func TestImplementationMode_Completion(t *testing.T) {
 	// Replace markers across entire festival (simulates user/agent filling them in)
 	err = replaceMarkersInContainer(container, festPath)
 	require.NoError(t, err, "should replace markers")
+
+	// Promote to active so the pre-active lifecycle gate allows
+	// progress mutations on the implementation phase.
+	festPath = promoteToActive(t, container, festivalsPath, festPath)
 
 	// Run execute
 	_ = runExecuteMode(t, container, festPath)

--- a/tests/integration/template_validation_test.go
+++ b/tests/integration/template_validation_test.go
@@ -22,8 +22,10 @@ var forbiddenTemplateTokens = []string{
 }
 
 // setupTemplateFestival creates a festival with implementation phase for template testing.
-// Returns the festival path.
-func setupTemplateFestival(t *testing.T, tc *TestContainer, festName string) string {
+// Returns the festival path and the workspace's festivals/ root so callers can
+// promote the festival to active when they need to bypass the pre-active
+// lifecycle gate.
+func setupTemplateFestival(t *testing.T, tc *TestContainer, festName string) (string, string) {
 	t.Helper()
 
 	// Initialize workspace properly
@@ -36,29 +38,11 @@ func setupTemplateFestival(t *testing.T, tc *TestContainer, festName string) str
 	// Find the actual festival path (fest adds an ID suffix)
 	festPath := findFestivalPath(t, tc, festivalsPath+"/planning", festName)
 
-	// Write fest.yaml with quality gates enabled
-	festYaml := `version: "1.0"
-auto_link:
-  enabled: false
-quality_gates:
-  enabled: true
-  auto_append: true
-  implementation:
-    - id: testing
-      template: gates/implementation/QUALITY_GATE_TESTING
-      enabled: true
-    - id: review
-      template: gates/implementation/QUALITY_GATE_REVIEW
-      enabled: true
-    - id: iterate
-      template: gates/implementation/QUALITY_GATE_ITERATE
-      enabled: true
-    - id: fest-commit
-      template: gates/implementation/QUALITY_GATE_FEST_COMMIT
-      enabled: true
-`
-	err = writeFileInContainer(tc, festPath+"/fest.yaml", festYaml)
-	require.NoError(t, err, "should create fest.yaml")
+	// Append quality_gates and disable auto_link without overwriting the
+	// metadata block that fest create festival wrote (status_history is
+	// required by the pre-active lifecycle gate and fest status set).
+	err = ensureQualityGatesInFestivalConfig(tc, festPath)
+	require.NoError(t, err, "should ensure quality gates in fest.yaml")
 
 	// Create FESTIVAL_OVERVIEW.md (required by validator completeness check)
 	overviewContent := `---
@@ -81,7 +65,7 @@ fest_type: overview
 	err = writeFileInContainer(tc, festPath+"/FESTIVAL_RULES.md", rulesContent)
 	require.NoError(t, err, "should create FESTIVAL_RULES.md")
 
-	return festPath
+	return festPath, festivalsPath
 }
 
 // TestNextTemplateOutputIsValidBasic verifies that fest next produces
@@ -90,7 +74,7 @@ func TestNextTemplateOutputIsValidBasic(t *testing.T) {
 	tc := GetSharedContainer(t)
 
 	// Create a minimal festival for testing
-	festPath := setupTemplateFestival(t, tc, "template-test")
+	festPath, festivalsPath := setupTemplateFestival(t, tc, "template-test")
 
 	// Create an implementation phase with a task
 	_, err := tc.RunFestInDir(festPath, "create", "phase", "--name", "PLANNING", "--type", "implementation")
@@ -113,6 +97,10 @@ func TestNextTemplateOutputIsValidBasic(t *testing.T) {
 	err = replaceMarkersInContainer(tc, festPath)
 	require.NoError(t, err, "failed to replace markers")
 
+	// Promote to active so the pre-active lifecycle gate allows
+	// fest next on an implementation phase.
+	festPath = promoteToActive(t, tc, festivalsPath, festPath)
+
 	// Run next command - this uses the implementation/instructions template
 	output, err := tc.RunFestInDir(festPath, "next")
 	require.NoError(t, err, "fest next failed")
@@ -129,7 +117,7 @@ func TestNextTemplateOutputIsValid(t *testing.T) {
 	tc := GetSharedContainer(t)
 
 	// Create a festival with tasks
-	festPath := setupTemplateFestival(t, tc, "next-test")
+	festPath, festivalsPath := setupTemplateFestival(t, tc, "next-test")
 
 	_, err := tc.RunFestInDir(festPath, "create", "phase", "--name", "IMPL", "--type", "implementation")
 	require.NoError(t, err)
@@ -164,6 +152,10 @@ func TestNextTemplateOutputIsValid(t *testing.T) {
 	err = replaceMarkersInContainer(tc, festPath)
 	require.NoError(t, err, "failed to replace markers")
 
+	// Promote to active so the pre-active lifecycle gate allows
+	// fest next on an implementation phase.
+	festPath = promoteToActive(t, tc, festivalsPath, festPath)
+
 	// Run next command
 	output, err := tc.RunFestInDir(festPath, "next")
 	require.NoError(t, err, "fest next failed")
@@ -180,7 +172,7 @@ func TestValidateTemplateOutputIsValid(t *testing.T) {
 	tc := GetSharedContainer(t)
 
 	// Create a festival
-	festPath := setupTemplateFestival(t, tc, "validate-test")
+	festPath, _ := setupTemplateFestival(t, tc, "validate-test")
 
 	// Run validate command
 	output, err := tc.RunFestInDir(festPath, "validate")
@@ -196,7 +188,7 @@ func TestStatusTemplateOutputIsValid(t *testing.T) {
 	tc := GetSharedContainer(t)
 
 	// Create a festival with content
-	festPath := setupTemplateFestival(t, tc, "status-test")
+	festPath, _ := setupTemplateFestival(t, tc, "status-test")
 
 	_, err := tc.RunFestInDir(festPath, "create", "phase", "--name", "PHASE", "--type", "implementation")
 	require.NoError(t, err)
@@ -217,7 +209,7 @@ func TestAllCommandsProduceValidOutput(t *testing.T) {
 	tc := GetSharedContainer(t)
 
 	// Create base festival
-	festPath := setupTemplateFestival(t, tc, "allcmds-test")
+	festPath, _ := setupTemplateFestival(t, tc, "allcmds-test")
 
 	_, err := tc.RunFestInDir(festPath, "create", "phase", "--name", "PHASE", "--type", "implementation")
 	require.NoError(t, err)
@@ -274,7 +266,7 @@ func TestCompleteFestivalTemplateOutput(t *testing.T) {
 	tc := GetSharedContainer(t)
 
 	// Create a minimal festival
-	festPath := setupTemplateFestival(t, tc, "complete-test")
+	festPath, festivalsPath := setupTemplateFestival(t, tc, "complete-test")
 
 	_, err := tc.RunFestInDir(festPath, "create", "phase", "--name", "PHASE", "--type", "implementation")
 	require.NoError(t, err)
@@ -303,6 +295,10 @@ Complete the only_task task.
 `
 	err = writeFileInContainer(tc, seqPath+"/01_only_task.md", taskContent)
 	require.NoError(t, err)
+
+	// Promote to active so the pre-active lifecycle gate allows
+	// progress mutations on the implementation phase.
+	festPath = promoteToActive(t, tc, festivalsPath, festPath)
 
 	// Mark the task as complete
 	_, err = tc.RunFestInDir(festPath, "progress", "--task", "001_PHASE/01_seq/01_only_task.md", "--complete")

--- a/tests/integration/workflow_skip_test.go
+++ b/tests/integration/workflow_skip_test.go
@@ -77,8 +77,14 @@ set -eu
 mkdir -p /festivals/.festival
 mkdir -p "` + phasePath + `"
 cat > "` + festPath + `/fest.yaml" <<'EOF'
+version: "1.0"
 name: workflow-skip-test
 id: WF-SKIP-001
+metadata:
+  id: WF-SKIP-001
+  status_history:
+    - status: active
+      timestamp: 2026-02-10T00:00:00Z
 EOF
 cat > "` + phasePath + `/PHASE_GOAL.md" <<'EOF'
 ---


### PR DESCRIPTION
## Summary

`just test all` was failing on `lr/develop` (main) with 6 integration tests broken. Investigation showed these are **stale test fixtures**, not product regressions.

PR #162's `lifecycle.EnforcePreActive` gate blocks implementation/review work on `planning`/`ready` festivals and fails closed when `fest.yaml` metadata is missing. The shared `setupImplementationFestival` helper got `promoteToActive` (`tests/integration/guidance_helpers_test.go:136`), and `internal/commands/workflow/workflow_test.go` got `metadata.status_history` (commit 14f5178), but six tests with inline setups were missed:

- `TestImplementationMode_PhaseBoundaries`
- `TestImplementationMode_Completion`
- `TestNextTemplateOutputIsValidBasic`
- `TestNextTemplateOutputIsValid`
- `TestCompleteFestivalTemplateOutput`
- `TestWorkflowSkip_HumanTTYExecution`

Two underlying issues in those setups:

1. They overwrote `fest.yaml` entirely, wiping the `metadata.status_history` that `fest create festival` writes and that both the gate and `fest status set` rely on.
2. They never promoted to active before running gated commands.

## Changes (test-only)

- `tests/integration/guidance_implementation_test.go`: replace inline `fest.yaml` overwrites with `ensureQualityGatesInFestivalConfig` (preserves CLI-written metadata) and add `promoteToActive` after marker replacement in `PhaseBoundaries` and `Completion`.
- `tests/integration/template_validation_test.go`: same fix in `setupTemplateFestival`; signature now returns `(festPath, festivalsPath)`; add `promoteToActive` in the three failing tests that reach gated commands.
- `tests/integration/workflow_skip_test.go`: add `metadata.status_history` with `status: active` to the inline `fest.yaml` heredoc, mirroring `workflow_test.go` from commit 14f5178.

No product code touched. The lifecycle gate is correct as designed.

## Test plan

- [x] `just test all` green: clean, build, 2011 unit tests passed, 48/48 integration tests passed (was 42/48)
- [x] All 6 previously-failing tests now pass
- [x] No regressions in the 42 previously-passing integration tests