### PR TITLE
chore(deps): bump google.golang.org/grpc to v1.80.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -116,5 +116,5 @@ require (
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
-	google.golang.org/grpc v1.79.2 // indirect
+	google.golang.org/grpc v1.80.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -292,8 +292,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260209200024-4cfbd4190f57 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260209200024-4cfbd4190f57/go.mod h1:kSJwQxqmFXeo79zOmbrALdflXQeAYcUbgS7PbpMknCY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260209200024-4cfbd4190f57 h1:mWPCjDEyshlQYzBpMNHaEof6UX1PmHcaUODUywQ0uac=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260209200024-4cfbd4190f57/go.mod h1:j9x/tPzZkyxcgEFkiKEEGxfvyumM01BEtsW8xzOahRQ=
-google.golang.org/grpc v1.79.2 h1:fRMD94s2tITpyJGtBBn7MkMseNpOZU8ZxgC3MMBaXRU=
-google.golang.org/grpc v1.79.2/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
+google.golang.org/grpc v1.80.0 h1:Xr6m2WmWZLETvUNvIUmeD5OAagMw3FiKmMlTdViWsHM=
+google.golang.org/grpc v1.80.0/go.mod h1:ho/dLnxwi3EDJA4Zghp7k2Ec1+c2jqup0bFkw07bwF4=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Summary

Closes the **critical** Dependabot alert: gRPC-Go authorization bypass via missing leading slash in `:path` (vulnerable: `< 1.79.3`). Bumping to v1.80.0 puts us safely past the patched version.

This is an indirect dependency only. No callsite changes; `go mod tidy` produced a 1-line bump in `go.mod` and matching `go.sum` updates.

### Other open Dependabot alerts (not addressed here)

The two `github.com/docker/docker` alerts (high and moderate, vulnerable `< 29.3.1`) cannot be fixed via `go.mod`. v29 isn't published as a Go module on the proxy, and we're already on the latest available `v28.5.2+incompatible`. The advisories cover the Docker daemon's authz plugin path; we only use the SDK as a Go client to talk to a daemon in integration tests (`tests/integration/helpers.go`, `pkg/stdcopy`). Right move is dismiss-with-rationale rather than a code change. Leaving that decision to a maintainer.

## Test plan

- [x] `just build` clean
- [x] `just test unit` green: 2011/2011 unit tests pass
- [ ] CI integration tests on this PR