### PR TITLE
fix: guard ritual templates from execution commands

### DIFF
--- a/embedded/templates/agent/contracts.go
+++ b/embedded/templates/agent/contracts.go
@@ -308,6 +308,15 @@ var Contracts = map[string]TemplateContract{
 		ForbiddenTokens:  DefaultForbiddenTokens,
 		MinimumLength:    50,
 	},
+
+	// Lifecycle templates
+	"lifecycle/ritual_template_block": {
+		Name:             "lifecycle/ritual_template_block",
+		RequiredFields:   []string{"RitualName", "Reason"},
+		ExpectedSections: []string{"RITUAL TEMPLATE IS NOT A RUN", "fest ritual run"},
+		ForbiddenTokens:  DefaultForbiddenTokens,
+		MinimumLength:    100,
+	},
 }
 
 // Validate checks if rendered output satisfies the contract.

--- a/embedded/templates/agent/embed.go
+++ b/embedded/templates/agent/embed.go
@@ -13,4 +13,5 @@ import "embed"
 //go:embed ingest/*.tmpl
 //go:embed validate/*.tmpl
 //go:embed workflow/*.tmpl
+//go:embed lifecycle/*.tmpl
 var Templates embed.FS

--- a/embedded/templates/agent/lifecycle/ritual_template_block.tmpl
+++ b/embedded/templates/agent/lifecycle/ritual_template_block.tmpl
@@ -1,0 +1,19 @@
+{{/*
+TEMPLATE: lifecycle/ritual_template_block.tmpl
+PURPOSE: Blocks execution commands from operating directly on ritual templates.
+
+Ritual templates under festivals/ritual/ are repeatable templates. Users must
+create a copied run under festivals/active/ before using execution commands.
+*/}}
+STOP - RITUAL TEMPLATE IS NOT A RUN
+-----------------------------------
+Ritual "{{.RitualName}}" lives in festivals/ritual/.
+That directory is the repeatable template, not an execution run.
+
+Create an active run first:
+  fest ritual run {{.RitualName}}
+
+Then work from the copied run under festivals/active/ with fest next,
+fest task, or fest workflow commands.
+{{if .Reason}}Action "{{.Reason}}" is blocked on the ritual template.
+{{end}}

--- a/embedded/templates/agent/registry_test.go
+++ b/embedded/templates/agent/registry_test.go
@@ -131,6 +131,8 @@ func minimalTestData(templateName string) any {
 		return validateData(templateName, commonFields)
 	case strings.HasPrefix(templateName, "workflow/"):
 		return workflowData(templateName, commonFields)
+	case strings.HasPrefix(templateName, "lifecycle/"):
+		return lifecycleData()
 	default:
 		// Fallback: return common fields for any unknown template
 		return commonFields
@@ -218,6 +220,13 @@ func ingestData(common map[string]any) map[string]any {
 		"PositionSection": common["PositionSection"],
 		"ContextSection":  common["ContextSection"],
 		"ProgressCmd":     common["ProgressCmd"],
+	}
+}
+
+func lifecycleData() map[string]any {
+	return map[string]any{
+		"RitualName": "daily-ritual-RI-DR0001",
+		"Reason":     "fest next",
 	}
 }
 

--- a/internal/commands/workflow/status.go
+++ b/internal/commands/workflow/status.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
 	"github.com/Obedience-Corp/fest/internal/guidance"
 	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+	"github.com/Obedience-Corp/fest/internal/lifecycle"
 	"github.com/Obedience-Corp/fest/internal/progress"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
@@ -137,6 +138,9 @@ func getWorkflowNavigator(ctx context.Context) (*wf.Navigator, error) {
 		if err != nil {
 			return nil, fmt.Errorf("not in a festival: %w", err)
 		}
+	}
+	if err := lifecycle.EnforceRitualRun(ctx, festivalPath, "fest workflow"); err != nil {
+		return nil, err
 	}
 
 	var phasePath string

--- a/internal/lifecycle/gate.go
+++ b/internal/lifecycle/gate.go
@@ -6,10 +6,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Obedience-Corp/fest/embedded/templates/agent"
 	"github.com/Obedience-Corp/fest/internal/config"
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/guidance"
 	"github.com/Obedience-Corp/fest/internal/progress"
+	"github.com/Obedience-Corp/fest/internal/workspace"
 )
 
 // EnforceOptions controls which festival phase the gate evaluates.
@@ -35,6 +37,10 @@ type EnforceOptions struct {
 // Fail-closed: if the festival config or phase scan cannot be determined,
 // the gate blocks rather than silently allowing the operation.
 func EnforcePreActive(ctx context.Context, festivalPath string, opts EnforceOptions) error {
+	if err := EnforceRitualRun(ctx, festivalPath, opts.Reason); err != nil {
+		return err
+	}
+
 	festCfg, err := config.LoadFestivalConfig(festivalPath, "")
 	if err != nil {
 		return emitFailClosed(festivalPath, opts.Reason,
@@ -76,6 +82,32 @@ func EnforcePreActive(ctx context.Context, festivalPath string, opts EnforceOpti
 	return emitBlock(festivalPath, status, opts.Reason)
 }
 
+// EnforceRitualRun blocks execution-oriented commands from operating directly
+// on a ritual template under festivals/ritual/. Ritual templates must be copied
+// into active/ with `fest ritual run` before users work through them.
+func EnforceRitualRun(ctx context.Context, festivalPath, reason string) error {
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+	if !IsRitualTemplatePath(festivalPath) {
+		return nil
+	}
+	return emitRitualTemplateBlock(ctx, festivalPath, reason)
+}
+
+// IsRitualTemplatePath reports whether festivalPath is a direct child of a
+// festivals/ritual/ directory. Active ritual runs are copied under active/ and
+// must remain executable even if their fest.yaml still records ritual metadata.
+func IsRitualTemplatePath(festivalPath string) bool {
+	clean := filepath.Clean(festivalPath)
+	if filepath.Base(filepath.Dir(clean)) != workspace.RitualDir {
+		return false
+	}
+	return filepath.Base(filepath.Dir(filepath.Dir(clean))) == workspace.FestivalsDir
+}
+
 func phasePathFromTaskID(festivalPath, taskID string) string {
 	parts := strings.SplitN(taskID, "/", 2)
 	if parts[0] == "" {
@@ -109,6 +141,27 @@ func emitBlock(festivalPath, status, reason string) error {
 	sb.WriteString("Promote first: fest promote\n")
 
 	fmt.Print(sb.String())
+	return errors.ErrAlreadyPrinted
+}
+
+func emitRitualTemplateBlock(ctx context.Context, festivalPath, reason string) error {
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+
+	ritualName := filepath.Base(festivalPath)
+
+	output, err := agent.Render("lifecycle/ritual_template_block", map[string]string{
+		"RitualName": ritualName,
+		"Reason":     reason,
+	})
+	if err != nil {
+		return errors.Wrap(err, "rendering ritual template block").WithCode(errors.ErrCodeTemplate)
+	}
+
+	fmt.Print(output)
 	return errors.ErrAlreadyPrinted
 }
 

--- a/internal/lifecycle/gate_test.go
+++ b/internal/lifecycle/gate_test.go
@@ -157,6 +157,89 @@ func TestEnforcePreActive_MalformedConfig_FailsClosed(t *testing.T) {
 	}
 }
 
+func TestIsRitualTemplatePath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{
+			name: "ritual template",
+			path: filepath.Join("workspace", "festivals", "ritual", "daily-ritual-RI-DR0001"),
+			want: true,
+		},
+		{
+			name: "active ritual run",
+			path: filepath.Join("workspace", "festivals", "active", "daily-ritual-RI-DR0001-0001"),
+			want: false,
+		},
+		{
+			name: "nested child inside ritual template is not festival root",
+			path: filepath.Join("workspace", "festivals", "ritual", "daily-ritual-RI-DR0001", "001_MONITOR"),
+			want: false,
+		},
+		{
+			name: "non festival ritual path",
+			path: filepath.Join("workspace", "ritual", "daily-ritual-RI-DR0001"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsRitualTemplatePath(tt.path); got != tt.want {
+				t.Fatalf("IsRitualTemplatePath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnforceRitualRun_BlocksRitualTemplate(t *testing.T) {
+	festDir := filepath.Join("workspace", "festivals", "ritual", "daily-ritual-RI-DR0001")
+
+	var err error
+	output := captureStdout(t, func() {
+		err = EnforceRitualRun(context.Background(), festDir, "fest next")
+	})
+
+	if err == nil {
+		t.Fatal("expected ritual template block, got nil")
+	}
+	if !stderrors.Is(err, errors.ErrAlreadyPrinted) {
+		t.Errorf("expected ErrAlreadyPrinted, got: %v", err)
+	}
+	if !strings.Contains(output, "RITUAL TEMPLATE IS NOT A RUN") {
+		t.Errorf("expected ritual block header, got: %s", output)
+	}
+	if !strings.Contains(output, "fest ritual run daily-ritual-RI-DR0001") {
+		t.Errorf("expected ritual run instruction, got: %s", output)
+	}
+	if !strings.Contains(output, "festivals/active") {
+		t.Errorf("expected active run instruction, got: %s", output)
+	}
+	if !strings.Contains(output, "fest next") {
+		t.Errorf("expected reason in output, got: %s", output)
+	}
+}
+
+func TestEnforceRitualRun_AllowsActiveRitualRunPath(t *testing.T) {
+	festDir := filepath.Join("workspace", "festivals", "active", "daily-ritual-RI-DR0001-0001")
+	if err := EnforceRitualRun(context.Background(), festDir, "fest next"); err != nil {
+		t.Errorf("expected active ritual run path to be allowed, got: %v", err)
+	}
+}
+
+func TestEnforceRitualRun_RespectsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	festDir := filepath.Join("workspace", "festivals", "ritual", "daily-ritual-RI-DR0001")
+	err := EnforceRitualRun(ctx, festDir, "fest next")
+	if !stderrors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got: %v", err)
+	}
+}
+
 func TestEnforcePreActive_NoConfig_FailsClosed(t *testing.T) {
 	festDir := t.TempDir()
 

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -23,6 +23,8 @@ const (
 	MarkerFile = ".workspace"
 	// FestivalsDir is the expected name of the festivals directory
 	FestivalsDir = "festivals"
+	// RitualDir is the expected name of the repeatable ritual template directory
+	RitualDir = "ritual"
 	// DotFestival is the hidden directory inside festivals/
 	DotFestival = ".festival"
 	// StateDir is the subdirectory for local state files (never synced)


### PR DESCRIPTION
## Summary
- block `fest next` when run directly inside `festivals/ritual/<ritual>` templates
- block `fest task ...` and `fest workflow ...` commands on ritual templates with an instruction to use `fest ritual run` first
- keep copied ritual runs under `festivals/active/` executable even if their metadata still records ritual status
- render the ritual-template block from an embedded agent template instead of hardcoded string-builder output
- address review feedback: keep `EnforcePreActive` as the canonical task/next gate path, pass `context.Context` into `EnforceRitualRun`, and use workspace constants for festival/ritual path components

## Verification
- `go test ./embedded/templates/agent -run 'Test(AllTemplatesRender|ContractValidation)'`
- `go test ./internal/lifecycle -run 'Test(IsRitualTemplatePath|EnforceRitualRun)'` selected only the pure ritual tests: `TestIsRitualTemplatePath`, `TestEnforceRitualRun_BlocksRitualTemplate`, `TestEnforceRitualRun_AllowsActiveRitualRunPath`, and `TestEnforceRitualRun_RespectsCanceledContext`
- `go test ./internal/commands/next ./internal/commands/task ./internal/commands/workflow -run '^$'` (compile-only; no tests executed)
- `git diff --check main...HEAD`
- audited the added diff for filesystem-mutating calls (`TempDir`, `MkdirAll`, `WriteFile`, `Chdir`, `Remove`, `RemoveAll`, `chmod`, `git init`, `CreateTemp`, `MkdirTemp`): no matches

Note: I did not run the full `./internal/lifecycle` package or broader host test suite because existing tests in that package mutate the filesystem and must run through a containerized harness.