### PR TITLE
fix: include lifecycle events in promote autocommit

### DIFF
--- a/internal/commands/status/handlers_festival.go
+++ b/internal/commands/status/handlers_festival.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/frontmatter"
 	"github.com/Obedience-Corp/fest/internal/id"
 	"github.com/Obedience-Corp/fest/internal/navigation"
+	"github.com/Obedience-Corp/fest/internal/registry"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
 	"github.com/Obedience-Corp/fest/internal/ui/theme"
@@ -470,6 +471,13 @@ func AutoCommitStatusChange(ctx context.Context, festivalName, festivalID, oldSt
 		return "", errors.New("workspace not available in context")
 	}
 
+	if ws.FestivalsPath != "" {
+		eventsPath := registry.GetEventsPath(ws.FestivalsPath)
+		if _, err := os.Stat(eventsPath); err == nil {
+			changedPaths = statusChangeCommitPaths(changedPaths, eventsPath)
+		}
+	}
+
 	// Stage only the paths affected by the status change (lock-aware with retry).
 	if err := commitkit.StageFiles(ctx, ws.Root, changedPaths...); err != nil {
 		return "", errors.Wrap(err, "stage")
@@ -513,4 +521,28 @@ func AutoCommitStatusChange(ctx context.Context, festivalName, festivalID, oldSt
 	}
 
 	return hash, nil
+}
+
+func statusChangeCommitPaths(changedPaths []string, eventsPath string) []string {
+	paths := make([]string, 0, len(changedPaths)+1)
+	seen := make(map[string]struct{}, len(changedPaths)+1)
+
+	appendPath := func(path string) {
+		if path == "" {
+			return
+		}
+		key := filepath.Clean(path)
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		paths = append(paths, path)
+	}
+
+	for _, path := range changedPaths {
+		appendPath(path)
+	}
+	appendPath(eventsPath)
+
+	return paths
 }

--- a/internal/commands/status/handlers_festival_paths_test.go
+++ b/internal/commands/status/handlers_festival_paths_test.go
@@ -1,0 +1,55 @@
+package status
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestStatusChangeCommitPaths_AppendsLifecycleEventLog(t *testing.T) {
+	changedPaths := []string{
+		"/repo/festivals/planning/my-fest",
+		"/repo/festivals/ready/my-fest",
+	}
+	eventsPath := "/repo/festivals/.festival/.state/festival_events.jsonl"
+
+	got := statusChangeCommitPaths(changedPaths, eventsPath)
+	want := []string{
+		"/repo/festivals/planning/my-fest",
+		"/repo/festivals/ready/my-fest",
+		"/repo/festivals/.festival/.state/festival_events.jsonl",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("statusChangeCommitPaths() = %#v, want %#v", got, want)
+	}
+}
+
+func TestStatusChangeCommitPaths_DeduplicatesLifecycleEventLog(t *testing.T) {
+	eventsPath := "/repo/festivals/.festival/.state/festival_events.jsonl"
+	changedPaths := []string{
+		"/repo/festivals/planning/my-fest",
+		eventsPath,
+		"/repo/festivals/ready/my-fest",
+	}
+
+	got := statusChangeCommitPaths(changedPaths, eventsPath)
+	want := changedPaths
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("statusChangeCommitPaths() = %#v, want %#v", got, want)
+	}
+}
+
+func TestStatusChangeCommitPaths_EmptyEventPathLeavesScopeUnchanged(t *testing.T) {
+	changedPaths := []string{
+		"/repo/festivals/planning/my-fest",
+		"/repo/festivals/ready/my-fest",
+	}
+
+	got := statusChangeCommitPaths(changedPaths, "")
+	want := changedPaths
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("statusChangeCommitPaths() = %#v, want %#v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- include `festivals/.festival/.state/festival_events.jsonl` in the status-change autocommit scope when the lifecycle event log exists
- centralize the path augmentation in `AutoCommitStatusChange`, so `fest promote` and `fest status set` share the fix
- add pure path-list tests that verify the lifecycle event log is appended, deduplicated, and skipped when absent

## Verification
- `go test ./internal/commands/status -run 'TestStatusChangeCommitPaths'`
- `go test ./internal/commands/promote -run '^$'` (compile-only; no tests executed)
- `git diff --check`
- added-diff audit for filesystem-mutating test calls (`TempDir`, `MkdirAll`, `WriteFile`, `Chdir`, `Remove`, `RemoveAll`, `chmod`, `git init`, `CreateTemp`, `MkdirTemp`, `os.Rename`, `exec.Command`): no matches

Note: I did not run the broader host test suite because existing tests mutate the filesystem and must run through a containerized harness.