### PR TITLE
feat(workflow): standalone WORKFLOW.md runtime (WW0001 phase 004 seq 1)

### DIFF
--- a/internal/commands/chain/complete.go
+++ b/internal/commands/chain/complete.go
@@ -9,8 +9,8 @@ import (
 	chainpkg "github.com/Obedience-Corp/fest/internal/chain"
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/ui"
-	"github.com/spf13/cobra"
 	"github.com/Obedience-Corp/fest/internal/yamlutil"
+	"github.com/spf13/cobra"
 )
 
 func newCompleteCmd() *cobra.Command {

--- a/internal/commands/gendocs.go
+++ b/internal/commands/gendocs.go
@@ -263,7 +263,6 @@ func looksLikeShellBlock(line string) bool {
 	return false
 }
 
-
 // stripSeeAlso removes the "### SEE ALSO" section from markdown content.
 // Used when combining individual command docs into a single reference page
 // where cross-links are redundant.

--- a/internal/commands/markers/scaffold.go
+++ b/internal/commands/markers/scaffold.go
@@ -12,8 +12,8 @@ import (
 	"github.com/Obedience-Corp/fest/internal/markers"
 	tpl "github.com/Obedience-Corp/fest/internal/template"
 	"github.com/Obedience-Corp/fest/internal/ui"
-	"github.com/spf13/cobra"
 	"github.com/Obedience-Corp/fest/internal/yamlutil"
+	"github.com/spf13/cobra"
 )
 
 // ScaffoldMeta contains metadata about the scaffold output

--- a/internal/commands/next/validation.go
+++ b/internal/commands/next/validation.go
@@ -129,4 +129,3 @@ func emitValidationBlock(festivalPath string, result *validator.Result) error {
 	fmt.Print(sb.String())
 	return errors.ErrAlreadyPrinted
 }
-

--- a/internal/commands/research/link.go
+++ b/internal/commands/research/link.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/ui"
-	"github.com/spf13/cobra"
 	"github.com/Obedience-Corp/fest/internal/yamlutil"
+	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
 

--- a/internal/commands/show/stats.go
+++ b/internal/commands/show/stats.go
@@ -16,11 +16,11 @@ import (
 
 // FestivalInfo holds information about a festival.
 type FestivalInfo struct {
-	ID           string    `json:"id"`                      // Directory-based ID (e.g., "my-project_GU0001")
-	MetadataID   string    `json:"metadata_id,omitempty"`   // ID from fest.yaml metadata (e.g., "GU0001")
-	Name         string    `json:"name"`                    // Directory name (used for linking)
-	MetadataName string    `json:"metadata_name,omitempty"` // Name from fest.yaml metadata (clean name without ID)
-	Status       string    `json:"status"`
+	ID           string `json:"id"`                      // Directory-based ID (e.g., "my-project_GU0001")
+	MetadataID   string `json:"metadata_id,omitempty"`   // ID from fest.yaml metadata (e.g., "GU0001")
+	Name         string `json:"name"`                    // Directory name (used for linking)
+	MetadataName string `json:"metadata_name,omitempty"` // Name from fest.yaml metadata (clean name without ID)
+	Status       string `json:"status"`
 	// StatusDate is the dated bucket a festival lives under when it is in a
 	// dungeon substatus. Format is the raw on-disk directory name
 	// (YYYY-MM-DD for new entries, or YYYY-MM for legacy entries).

--- a/internal/commands/status/lifecycle_gate_test.go
+++ b/internal/commands/status/lifecycle_gate_test.go
@@ -17,10 +17,10 @@ import (
 // the phase frontmatter without ever consulting the lifecycle gate.
 func TestPhaseStatusSetGate(t *testing.T) {
 	cases := []struct {
-		name         string
-		status       string
-		phaseType    string
-		expectBlock  bool
+		name        string
+		status      string
+		phaseType   string
+		expectBlock bool
 	}{
 		{name: "planning_blocks_impl_phase_completed", status: "planning", phaseType: "implementation", expectBlock: true},
 		{name: "ready_blocks_review_phase_completed", status: "ready", phaseType: "review", expectBlock: true},

--- a/internal/commands/tui/helpers.go
+++ b/internal/commands/tui/helpers.go
@@ -378,7 +378,6 @@ func nextTaskAfter(ctx context.Context, seqDir string) int {
 	return max
 }
 
-
 // PhaseInfo holds information about a discovered phase.
 type PhaseInfo struct {
 	Number    int

--- a/internal/commands/workflow/init.go
+++ b/internal/commands/workflow/init.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/workflow/localstore"
 	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -97,9 +98,43 @@ func runInit(ctx context.Context) error {
 	return nil
 }
 
+// minimalWorkitem is the typed struct yaml.Marshal serializes for a bootstrap
+// .workitem file. Using a struct + yaml.Marshal escapes special characters
+// (colons, quotes, leading dashes, hash signs, whitespace) in fields like
+// title that flow from arbitrary user directory names. String concatenation
+// would produce malformed YAML for any directory name containing those.
+type minimalWorkitem struct {
+	Version  int                `yaml:"version"`
+	Kind     string             `yaml:"kind"`
+	ID       string             `yaml:"id"`
+	Type     string             `yaml:"type"`
+	Title    string             `yaml:"title"`
+	Workflow minimalWorkitemWf  `yaml:"workflow"`
+}
+
+type minimalWorkitemWf struct {
+	DocPath    string `yaml:"doc_path"`
+	RuntimeDir string `yaml:"runtime_dir"`
+	WorkflowID string `yaml:"workflow_id"`
+}
+
 func writeMinimalWorkitem(path, id, basename, workflowID string) error {
-	body := "version: 1\nkind: workitem\nid: " + id + "\ntype: workflow\ntitle: " + basename + "\nworkflow:\n  doc_path: WORKFLOW.md\n  runtime_dir: .workflow\n  workflow_id: " + workflowID + "\n"
-	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+	body, err := yaml.Marshal(minimalWorkitem{
+		Version: 1,
+		Kind:    "workitem",
+		ID:      id,
+		Type:    "workflow",
+		Title:   basename,
+		Workflow: minimalWorkitemWf{
+			DocPath:    "WORKFLOW.md",
+			RuntimeDir: ".workflow",
+			WorkflowID: workflowID,
+		},
+	})
+	if err != nil {
+		return festerrors.Wrap(err, "marshal .workitem")
+	}
+	if err := os.WriteFile(path, body, 0o644); err != nil {
 		return festerrors.IO("writing .workitem", err)
 	}
 	return nil

--- a/internal/commands/workflow/init.go
+++ b/internal/commands/workflow/init.go
@@ -11,32 +11,32 @@ import (
 	"github.com/Obedience-Corp/fest/internal/workflow/localstore"
 	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
 var (
 	initForce      bool
 	initWorkflowID string
-	initWorkitemID string
 )
 
 func newInitCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Initialize standalone workflow runtime",
-		Long: `Create .workitem and .workflow/ next to an existing WORKFLOW.md.
+		Long: `Create .workflow/ next to an existing WORKFLOW.md.
 
 Run from the directory containing WORKFLOW.md. The command refuses to run
-inside a festival phase. Use --force to overwrite existing .workitem
-or .workflow/workflow.yaml.`,
+inside a festival phase. Use --force to overwrite an existing
+.workflow/workflow.yaml.
+
+This command does not create .workitem; that file is owned by camp
+(see 'camp workitem create' and 'camp workitem adopt').`,
 		Annotations: map[string]string{"scope": string(scope.Global)},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runInit(cmd.Context())
 		},
 	}
-	cmd.Flags().BoolVar(&initForce, "force", false, "overwrite existing .workitem and .workflow/")
+	cmd.Flags().BoolVar(&initForce, "force", false, "overwrite existing .workflow/workflow.yaml")
 	cmd.Flags().StringVar(&initWorkflowID, "workflow-id", "", "workflow_id to write into manifest (defaults to wf-<basename>)")
-	cmd.Flags().StringVar(&initWorkitemID, "workitem-id", "", "workitem_id to write into manifest (required)")
 	return cmd
 }
 
@@ -63,79 +63,20 @@ func runInit(ctx context.Context) error {
 			WithHint("Author a WORKFLOW.md before running init")
 	}
 
-	if initWorkitemID == "" {
-		return festerrors.Validation("--workitem-id is required")
-	}
-
 	workflowID := initWorkflowID
 	if workflowID == "" {
 		workflowID = "wf-" + filepath.Base(cwd)
 	}
 
-	// Refuse to overwrite an existing .workitem unless --force.
-	workitemPath := filepath.Join(cwd, ".workitem")
-	if _, statErr := os.Stat(workitemPath); statErr == nil && !initForce {
-		return festerrors.New(".workitem already exists; pass --force to overwrite").
-			WithField("path", workitemPath)
-	}
-
 	store := localstore.Open(filepath.Join(cwd, ".workflow"), doc)
 	if err := store.Init(ctx, localstore.InitOptions{
 		WorkflowID: workflowID,
-		WorkitemID: initWorkitemID,
 		Force:      initForce,
 	}); err != nil {
 		return err
 	}
 
-	if err := writeMinimalWorkitem(workitemPath, initWorkitemID, filepath.Base(cwd), workflowID); err != nil {
-		return err
-	}
-
 	fmt.Printf("Initialized standalone workflow runtime at %s\n", cwd)
-	fmt.Printf("  .workitem: workitem_id=%s\n", initWorkitemID)
 	fmt.Printf("  .workflow/workflow.yaml: workflow_id=%s\n", workflowID)
-	return nil
-}
-
-// minimalWorkitem is the typed struct yaml.Marshal serializes for a bootstrap
-// .workitem file. Using a struct + yaml.Marshal escapes special characters
-// (colons, quotes, leading dashes, hash signs, whitespace) in fields like
-// title that flow from arbitrary user directory names. String concatenation
-// would produce malformed YAML for any directory name containing those.
-type minimalWorkitem struct {
-	Version  int                `yaml:"version"`
-	Kind     string             `yaml:"kind"`
-	ID       string             `yaml:"id"`
-	Type     string             `yaml:"type"`
-	Title    string             `yaml:"title"`
-	Workflow minimalWorkitemWf  `yaml:"workflow"`
-}
-
-type minimalWorkitemWf struct {
-	DocPath    string `yaml:"doc_path"`
-	RuntimeDir string `yaml:"runtime_dir"`
-	WorkflowID string `yaml:"workflow_id"`
-}
-
-func writeMinimalWorkitem(path, id, basename, workflowID string) error {
-	body, err := yaml.Marshal(minimalWorkitem{
-		Version: 1,
-		Kind:    "workitem",
-		ID:      id,
-		Type:    "workflow",
-		Title:   basename,
-		Workflow: minimalWorkitemWf{
-			DocPath:    "WORKFLOW.md",
-			RuntimeDir: ".workflow",
-			WorkflowID: workflowID,
-		},
-	})
-	if err != nil {
-		return festerrors.Wrap(err, "marshal .workitem")
-	}
-	if err := os.WriteFile(path, body, 0o644); err != nil {
-		return festerrors.IO("writing .workitem", err)
-	}
 	return nil
 }

--- a/internal/commands/workflow/init.go
+++ b/internal/commands/workflow/init.go
@@ -1,0 +1,106 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/scope"
+	"github.com/Obedience-Corp/fest/internal/workflow/localstore"
+	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
+	"github.com/spf13/cobra"
+)
+
+var (
+	initForce      bool
+	initWorkflowID string
+	initWorkitemID string
+)
+
+func newInitCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Initialize standalone workflow runtime",
+		Long: `Create .workitem and .workflow/ next to an existing WORKFLOW.md.
+
+Run from the directory containing WORKFLOW.md. The command refuses to run
+inside a festival phase. Use --force to overwrite existing .workitem
+or .workflow/workflow.yaml.`,
+		Annotations: map[string]string{"scope": string(scope.Global)},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runInit(cmd.Context())
+		},
+	}
+	cmd.Flags().BoolVar(&initForce, "force", false, "overwrite existing .workitem and .workflow/")
+	cmd.Flags().StringVar(&initWorkflowID, "workflow-id", "", "workflow_id to write into manifest (defaults to wf-<basename>)")
+	cmd.Flags().StringVar(&initWorkitemID, "workitem-id", "", "workitem_id to write into manifest (required)")
+	return cmd
+}
+
+func runInit(ctx context.Context) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return festerrors.IO("getwd", err)
+	}
+
+	res, err := standalone.Resolve(ctx, cwd)
+	if err != nil {
+		return err
+	}
+	if res.Mode == standalone.ModeFestival {
+		return festerrors.New("fest workflow init cannot run inside a festival phase").
+			WithField("festival_path", res.FestivalPath).
+			WithHint("This command is for standalone WORKFLOW.md directories. Use festival workflow commands inside the festival.")
+	}
+
+	doc := filepath.Join(cwd, "WORKFLOW.md")
+	if _, statErr := os.Stat(doc); statErr != nil {
+		return festerrors.New("no WORKFLOW.md found").
+			WithField("dir", cwd).
+			WithHint("Author a WORKFLOW.md before running init")
+	}
+
+	if initWorkitemID == "" {
+		return festerrors.Validation("--workitem-id is required")
+	}
+
+	workflowID := initWorkflowID
+	if workflowID == "" {
+		workflowID = "wf-" + filepath.Base(cwd)
+	}
+
+	// Refuse to overwrite an existing .workitem unless --force.
+	workitemPath := filepath.Join(cwd, ".workitem")
+	if _, statErr := os.Stat(workitemPath); statErr == nil && !initForce {
+		return festerrors.New(".workitem already exists; pass --force to overwrite").
+			WithField("path", workitemPath)
+	}
+
+	store := localstore.Open(filepath.Join(cwd, ".workflow"), doc)
+	if err := store.Init(ctx, localstore.InitOptions{
+		WorkflowID: workflowID,
+		WorkitemID: initWorkitemID,
+		Force:      initForce,
+	}); err != nil {
+		return err
+	}
+
+	if err := writeMinimalWorkitem(workitemPath, initWorkitemID, filepath.Base(cwd), workflowID); err != nil {
+		return err
+	}
+
+	fmt.Printf("Initialized standalone workflow runtime at %s\n", cwd)
+	fmt.Printf("  .workitem: workitem_id=%s\n", initWorkitemID)
+	fmt.Printf("  .workflow/workflow.yaml: workflow_id=%s\n", workflowID)
+	return nil
+}
+
+func writeMinimalWorkitem(path, id, basename, workflowID string) error {
+	body := "version: 1\nkind: workitem\nid: " + id + "\ntype: workflow\ntitle: " + basename + "\nworkflow:\n  doc_path: WORKFLOW.md\n  runtime_dir: .workflow\n  workflow_id: " + workflowID + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		return festerrors.IO("writing .workitem", err)
+	}
+	return nil
+}

--- a/internal/commands/workflow/init.go
+++ b/internal/commands/workflow/init.go
@@ -8,6 +8,7 @@ import (
 
 	festerrors "github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/scope"
+	"github.com/Obedience-Corp/fest/internal/workflow"
 	"github.com/Obedience-Corp/fest/internal/workflow/localstore"
 	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
 	"github.com/spf13/cobra"
@@ -65,7 +66,11 @@ func runInit(ctx context.Context) error {
 
 	workflowID := initWorkflowID
 	if workflowID == "" {
-		workflowID = "wf-" + filepath.Base(cwd)
+		slug := workflow.SanitizeBasenameAsSlug(filepath.Base(cwd))
+		workflowID = "wf-" + slug
+	}
+	if err := workflow.ValidateWorkflowID(workflowID); err != nil {
+		return err
 	}
 
 	store := localstore.Open(filepath.Join(cwd, ".workflow"), doc)

--- a/internal/commands/workflow/runs.go
+++ b/internal/commands/workflow/runs.go
@@ -1,0 +1,72 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/scope"
+	"github.com/Obedience-Corp/fest/internal/workflow/localstore"
+	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
+	"github.com/spf13/cobra"
+)
+
+var runsJSON bool
+
+func newRunsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "runs",
+		Short: "List runs of a standalone workflow",
+		Long: `List runs recorded in .workflow/workflow.yaml.
+
+Each row shows run id, status, started time, and completed time.`,
+		Annotations: map[string]string{"scope": string(scope.Global)},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRuns(cmd.Context())
+		},
+	}
+	cmd.Flags().BoolVar(&runsJSON, "json", false, "emit JSON")
+	return cmd
+}
+
+func runRuns(ctx context.Context) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return festerrors.IO("getwd", err)
+	}
+	res, err := standalone.Resolve(ctx, cwd)
+	if err != nil {
+		return err
+	}
+	if res.Mode != standalone.ModeTracked {
+		return festerrors.New("fest workflow runs requires a tracked standalone workflow").
+			WithField("mode", string(res.Mode))
+	}
+	store := localstore.Open(res.RuntimeDir, res.WorkflowDoc)
+	runs, err := store.ListRuns(ctx)
+	if err != nil {
+		return err
+	}
+	if runsJSON {
+		data, err := json.MarshalIndent(runs, "", "  ")
+		if err != nil {
+			return festerrors.Parse("encoding runs json", err)
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+	if len(runs) == 0 {
+		fmt.Println("No runs.")
+		return nil
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%-26s  %-10s  %-25s  %s\n", "RUN_ID", "STATUS", "STARTED", "COMPLETED")
+	for _, r := range runs {
+		fmt.Fprintf(&b, "%-26s  %-10s  %-25s  %s\n", r.RunID, r.Status, r.StartedAt, r.CompletedAt)
+	}
+	fmt.Print(b.String())
+	return nil
+}

--- a/internal/commands/workflow/show.go
+++ b/internal/commands/workflow/show.go
@@ -3,12 +3,15 @@ package workflow
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
 	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
+	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
 	"github.com/spf13/cobra"
 )
 
@@ -46,6 +49,24 @@ Shows:
 }
 
 func runShow(ctx context.Context, stepNum int) error {
+	// Narrow standalone-resolver integration (introduced in WW0001/004.01).
+	// Festival context always wins; tracked/anonymous standalone modes return
+	// a deferred-feature stub until the next sequence wires them in fully.
+	cwd, _ := os.Getwd()
+	if res, resErr := standalone.Resolve(ctx, cwd); resErr == nil {
+		switch res.Mode {
+		case standalone.ModeTracked:
+			return festerrors.New("standalone tracked workflow show not yet implemented").
+				WithField("workflow_doc", res.WorkflowDoc).
+				WithHint("Scheduled for sequence 004.02 of WW0001")
+		case standalone.ModeAnonymous:
+			return festerrors.New("anonymous WORKFLOW.md show not yet implemented").
+				WithField("workflow_doc", res.WorkflowDoc).
+				WithHint("Run 'fest workflow init' or wait for sequence 004.02")
+		}
+		// ModeFestival or ModeNone: fall through to existing behavior.
+	}
+
 	nav, err := getWorkflowNavigator(ctx)
 	if err != nil {
 		return err

--- a/internal/commands/workflow/show.go
+++ b/internal/commands/workflow/show.go
@@ -3,15 +3,12 @@ package workflow
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
-	festerrors "github.com/Obedience-Corp/fest/internal/errors"
 	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
-	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
 	"github.com/spf13/cobra"
 )
 
@@ -49,24 +46,6 @@ Shows:
 }
 
 func runShow(ctx context.Context, stepNum int) error {
-	// Narrow standalone-resolver integration (introduced in WW0001/004.01).
-	// Festival context always wins; tracked/anonymous standalone modes return
-	// a deferred-feature stub until the next sequence wires them in fully.
-	cwd, _ := os.Getwd()
-	if res, resErr := standalone.Resolve(ctx, cwd); resErr == nil {
-		switch res.Mode {
-		case standalone.ModeTracked:
-			return festerrors.New("standalone tracked workflow show not yet implemented").
-				WithField("workflow_doc", res.WorkflowDoc).
-				WithHint("Scheduled for sequence 004.02 of WW0001")
-		case standalone.ModeAnonymous:
-			return festerrors.New("anonymous WORKFLOW.md show not yet implemented").
-				WithField("workflow_doc", res.WorkflowDoc).
-				WithHint("Run 'fest workflow init' or wait for sequence 004.02")
-		}
-		// ModeFestival or ModeNone: fall through to existing behavior.
-	}
-
 	nav, err := getWorkflowNavigator(ctx)
 	if err != nil {
 		return err

--- a/internal/commands/workflow/start.go
+++ b/internal/commands/workflow/start.go
@@ -1,0 +1,51 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/scope"
+	"github.com/Obedience-Corp/fest/internal/workflow/localstore"
+	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
+	"github.com/spf13/cobra"
+)
+
+func newStartCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "start",
+		Short: "Start a new run for a standalone workflow",
+		Long: `Create a new .workflow/runs/<run-id>/ directory and mark it active.
+
+Requires .workflow/workflow.yaml to exist (run fest workflow init first).`,
+		Annotations: map[string]string{"scope": string(scope.Global)},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runStart(cmd.Context())
+		},
+	}
+}
+
+func runStart(ctx context.Context) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return festerrors.IO("getwd", err)
+	}
+	res, err := standalone.Resolve(ctx, cwd)
+	if err != nil {
+		return err
+	}
+	if res.Mode != standalone.ModeTracked {
+		return festerrors.New("fest workflow start requires a tracked standalone workflow").
+			WithField("mode", string(res.Mode)).
+			WithHint("Run 'fest workflow init' first to create .workflow/workflow.yaml")
+	}
+
+	store := localstore.Open(res.RuntimeDir, res.WorkflowDoc)
+	runID, err := store.StartRun(ctx, "")
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Started run %s\n", runID)
+	return nil
+}

--- a/internal/commands/workflow/workflow.go
+++ b/internal/commands/workflow/workflow.go
@@ -73,6 +73,10 @@ Examples:
 		newRejectCmd(),
 		newResetCmd(),
 		newShowCmd(),
+		// Standalone workflow lifecycle (introduced in WW0001/004.01).
+		newInitCmd(),
+		newStartCmd(),
+		newRunsCmd(),
 	)
 
 	return cmd

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,13 +48,13 @@ type Execute struct {
 
 // Repository contains repository information
 type Repository struct {
-	URL      string `json:"url"`
-	Branch   string `json:"branch"`               // Legacy, still honored
-	Path     string `json:"path"`
+	URL    string `json:"url"`
+	Branch string `json:"branch"` // Legacy, still honored
+	Path   string `json:"path"`
 	// TODO: consider using SyncMode type directly once config validation is added
 	SyncMode string `json:"sync_mode,omitempty"` // "channel" | "branch" | "tag"
 	Channel  string `json:"channel,omitempty"`   // "stable" | "dev" | ""
-	Ref      string `json:"ref,omitempty"`        // Exact ref for tag/branch mode
+	Ref      string `json:"ref,omitempty"`       // Exact ref for tag/branch mode
 }
 
 // Local contains local path configuration

--- a/internal/github/tags.go
+++ b/internal/github/tags.go
@@ -129,7 +129,7 @@ func ResolveLatestTag(repoURL, channel string) (string, error) {
 	}
 
 	if len(candidates) == 0 {
-		return "", errors.NotFound("tags matching channel " + channel).WithField("url", repoURL)
+		return "", errors.NotFound("tags matching channel "+channel).WithField("url", repoURL)
 	}
 
 	// Sort descending and return the first element.

--- a/internal/validator/gates.go
+++ b/internal/validator/gates.go
@@ -93,7 +93,7 @@ func ValidateQualityGates(ctx context.Context, festivalPath string) ([]Issue, er
 			}
 
 			sort.Strings(missing)
-		if len(missing) > 0 && len(tasks) > 0 {
+			if len(missing) > 0 && len(tasks) > 0 {
 				rel, _ := filepath.Rel(festivalPath, seq.Path)
 				// Phase-type-aware error message
 				phaseTypeTitle := titleCase(phaseType)

--- a/internal/workflow/id_safety.go
+++ b/internal/workflow/id_safety.go
@@ -1,0 +1,43 @@
+package workflow
+
+import (
+	"regexp"
+	"strings"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+)
+
+var workflowIDPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{0,79}$`)
+
+// ValidateWorkflowID returns a festerrors.Validation error if id does not
+// match the slug-safety pattern required for filesystem-derived workflow
+// identifiers. The pattern is lowercase ASCII alphanumeric plus underscore
+// and dash, must start with [a-z0-9], 1-80 chars.
+func ValidateWorkflowID(id string) error {
+	if id == "" {
+		return festerrors.Validation("workflow_id must not be empty").
+			WithHint("pass --workflow-id or run from a directory with a slug-safe basename")
+	}
+	if !workflowIDPattern.MatchString(id) {
+		return festerrors.Validation("invalid workflow_id").
+			WithField("workflow_id", id).
+			WithHint("use lowercase letters, digits, '-', '_'; start with [a-z0-9]; max 80 chars")
+	}
+	return nil
+}
+
+var slugInvalidPattern = regexp.MustCompile(`[^a-z0-9_-]+`)
+
+// SanitizeBasenameAsSlug lowercases name and replaces runs of invalid
+// characters with a single '-'. Leading dashes are stripped. Used when
+// auto-deriving a workflow_id from a directory basename so e.g.
+// "My Project!" becomes "my-project".
+func SanitizeBasenameAsSlug(name string) string {
+	if name == "" {
+		return ""
+	}
+	lower := strings.ToLower(name)
+	cleaned := slugInvalidPattern.ReplaceAllString(lower, "-")
+	cleaned = strings.Trim(cleaned, "-")
+	return cleaned
+}

--- a/internal/workflow/id_safety_test.go
+++ b/internal/workflow/id_safety_test.go
@@ -1,0 +1,72 @@
+package workflow
+
+import (
+	"strings"
+	"testing"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+)
+
+func TestValidateWorkflowID(t *testing.T) {
+	cases := []struct {
+		name    string
+		id      string
+		wantErr bool
+	}{
+		{"empty", "", true},
+		{"simple", "wf", false},
+		{"with-dash", "wf-foo", false},
+		{"with-date", "my-project-2026-05-13", false},
+		{"with-underscore", "wf_bar", false},
+		{"alnum", "abc123", false},
+		{"leading-dash", "-leading", true},
+		{"leading-underscore", "_leading", true},
+		{"uppercase", "WfFoo", true},
+		{"space", "Has Spaces", true},
+		{"path-separator", "wf/foo", true},
+		{"double-dot", "..", true},
+		{"single-char", "a", false},
+		{"max-length", "a" + strings.Repeat("b", 79), false},
+		{"too-long", "a" + strings.Repeat("b", 80), true},
+		{"non-ascii", "résumé", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := ValidateWorkflowID(c.id)
+			if (err != nil) != c.wantErr {
+				t.Fatalf("ValidateWorkflowID(%q): got err=%v, wantErr=%v", c.id, err, c.wantErr)
+			}
+			if c.wantErr && err != nil {
+				if !festerrors.Is(err, festerrors.ErrCodeValidation) {
+					t.Errorf("expected festerrors.Validation, got %T: %v", err, err)
+				}
+			}
+		})
+	}
+}
+
+func TestSanitizeBasenameAsSlug(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"foo", "foo"},
+		{"Foo", "foo"},
+		{"My Project", "my-project"},
+		{"My Project!", "my-project"},
+		{"my_thing", "my_thing"},
+		{"-leading-", "leading"},
+		{"  spaces  ", "spaces"},
+		{"foo//bar", "foo-bar"},
+		{"résumé", "r-sum"},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got := SanitizeBasenameAsSlug(c.in)
+			if got != c.want {
+				t.Errorf("SanitizeBasenameAsSlug(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/workflow/localstore/events.go
+++ b/internal/workflow/localstore/events.go
@@ -1,0 +1,32 @@
+package localstore
+
+import "time"
+
+// Event type names mirror LOCAL_RUN_STATE.md.
+const (
+	EventWorkflowRunCreated   = "workflow_run_created"
+	EventWorkflowRunStarted   = "workflow_run_started"
+	EventStepStart            = "wf_step_start"
+	EventStepDone             = "wf_step_done"
+	EventStepSkip             = "wf_step_skip"
+	EventStepBlock            = "wf_step_block"
+	EventCheckpointApproved   = "wf_checkpoint_approved"
+	EventCheckpointRejected   = "wf_checkpoint_rejected"
+	EventWorkflowRunCompleted = "workflow_run_completed"
+	EventWorkflowRunAbandoned = "workflow_run_abandoned"
+	EventWorkflowDocChanged   = "workflow_doc_changed"
+)
+
+// Event is one append-only entry in progress_events.jsonl.
+type Event struct {
+	Version    int       `json:"version"`
+	EventID    string    `json:"event_id"`
+	EventType  string    `json:"event_type"`
+	RunID      string    `json:"run_id"`
+	WorkflowID string    `json:"workflow_id,omitempty"`
+	WorkitemID string    `json:"workitem_id,omitempty"`
+	StepID     string    `json:"step_id,omitempty"`
+	StepIndex  int       `json:"step_index,omitempty"`
+	Feedback   string    `json:"feedback,omitempty"`
+	Timestamp  time.Time `json:"timestamp"`
+}

--- a/internal/workflow/localstore/events.go
+++ b/internal/workflow/localstore/events.go
@@ -24,7 +24,6 @@ type Event struct {
 	EventType  string    `json:"event_type"`
 	RunID      string    `json:"run_id"`
 	WorkflowID string    `json:"workflow_id,omitempty"`
-	WorkitemID string    `json:"workitem_id,omitempty"`
 	StepID     string    `json:"step_id,omitempty"`
 	StepIndex  int       `json:"step_index,omitempty"`
 	Feedback   string    `json:"feedback,omitempty"`

--- a/internal/workflow/localstore/hash.go
+++ b/internal/workflow/localstore/hash.go
@@ -1,0 +1,19 @@
+package localstore
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+)
+
+// HashWorkflowDoc returns "sha256:<hex>" for the file at path.
+func HashWorkflowDoc(path string) (string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", festerrors.Wrap(err, "hashing workflow doc")
+	}
+	sum := sha256.Sum256(raw)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}

--- a/internal/workflow/localstore/manifest.go
+++ b/internal/workflow/localstore/manifest.go
@@ -5,7 +5,6 @@ type Manifest struct {
 	Version     int         `yaml:"version"`
 	Kind        string      `yaml:"kind"`
 	WorkflowID  string      `yaml:"workflow_id"`
-	WorkitemID  string      `yaml:"workitem_id"`
 	DocPath     string      `yaml:"doc_path,omitempty"`
 	DocHash     string      `yaml:"doc_hash,omitempty"`
 	ActiveRunID string      `yaml:"active_run_id,omitempty"`

--- a/internal/workflow/localstore/manifest.go
+++ b/internal/workflow/localstore/manifest.go
@@ -1,0 +1,28 @@
+package localstore
+
+// Manifest is .workflow/workflow.yaml. Schema defined in LOCAL_RUN_STATE.md.
+type Manifest struct {
+	Version     int         `yaml:"version"`
+	Kind        string      `yaml:"kind"`
+	WorkflowID  string      `yaml:"workflow_id"`
+	WorkitemID  string      `yaml:"workitem_id"`
+	DocPath     string      `yaml:"doc_path,omitempty"`
+	DocHash     string      `yaml:"doc_hash,omitempty"`
+	ActiveRunID string      `yaml:"active_run_id,omitempty"`
+	Runs        []RunRecord `yaml:"runs,omitempty"`
+}
+
+// RunRecord is one entry in Manifest.Runs.
+type RunRecord struct {
+	RunID       string `yaml:"run_id"`
+	Status      string `yaml:"status"`
+	Path        string `yaml:"path"`
+	StartedAt   string `yaml:"started_at,omitempty"`
+	CompletedAt string `yaml:"completed_at,omitempty"`
+}
+
+// ManifestVersion is the only manifest schema version supported.
+const ManifestVersion = 1
+
+// ManifestKind is the expected kind value in workflow.yaml.
+const ManifestKind = "workflow-runtime"

--- a/internal/workflow/localstore/manifest.go
+++ b/internal/workflow/localstore/manifest.go
@@ -18,6 +18,7 @@ type RunRecord struct {
 	Path        string `yaml:"path"`
 	StartedAt   string `yaml:"started_at,omitempty"`
 	CompletedAt string `yaml:"completed_at,omitempty"`
+	EndedAt     string `yaml:"ended_at,omitempty"`
 }
 
 // ManifestVersion is the only manifest schema version supported.

--- a/internal/workflow/localstore/run.go
+++ b/internal/workflow/localstore/run.go
@@ -10,7 +10,6 @@ type RunManifest struct {
 	Kind        string     `yaml:"kind"`
 	RunID       string     `yaml:"run_id"`
 	WorkflowID  string     `yaml:"workflow_id"`
-	WorkitemID  string     `yaml:"workitem_id"`
 	Status      string     `yaml:"status"`
 	StartedAt   time.Time  `yaml:"started_at"`
 	CompletedAt time.Time  `yaml:"completed_at,omitempty"`

--- a/internal/workflow/localstore/run.go
+++ b/internal/workflow/localstore/run.go
@@ -1,0 +1,55 @@
+package localstore
+
+import (
+	"time"
+)
+
+// RunManifest is .workflow/runs/<run-id>/run.yaml.
+type RunManifest struct {
+	Version     int        `yaml:"version"`
+	Kind        string     `yaml:"kind"`
+	RunID       string     `yaml:"run_id"`
+	WorkflowID  string     `yaml:"workflow_id"`
+	WorkitemID  string     `yaml:"workitem_id"`
+	Status      string     `yaml:"status"`
+	StartedAt   time.Time  `yaml:"started_at"`
+	CompletedAt time.Time  `yaml:"completed_at,omitempty"`
+	StartedBy   string     `yaml:"started_by,omitempty"`
+	Executor    string     `yaml:"executor,omitempty"`
+	Source      RunSource  `yaml:"source"`
+	Summary     RunSummary `yaml:"summary"`
+}
+
+// RunSource captures pointers to the authored workflow document.
+type RunSource struct {
+	WorkflowPath string `yaml:"workflow_path"`
+	WorkflowHash string `yaml:"workflow_hash"`
+	WorkitemPath string `yaml:"workitem_path"`
+}
+
+// RunSummary is the cached current state. Event replay is authoritative;
+// summary is updated from replay on read.
+type RunSummary struct {
+	CurrentStep    int  `yaml:"current_step"`
+	TotalSteps     int  `yaml:"total_steps"`
+	CompletedSteps int  `yaml:"completed_steps"`
+	Blocked        bool `yaml:"blocked"`
+}
+
+// RunState is the replayed view of an active or completed run.
+type RunState struct {
+	RunID          string
+	Status         string // "active" | "completed" | "abandoned" | "blocked"
+	StartedAt      time.Time
+	CompletedAt    time.Time
+	CurrentStep    int
+	TotalSteps     int
+	CompletedSteps int
+	Blocked        bool
+	DocHashChanged bool
+}
+
+const (
+	RunVersion = 1
+	RunKind    = "workflow-run"
+)

--- a/internal/workflow/localstore/store.go
+++ b/internal/workflow/localstore/store.go
@@ -44,7 +44,6 @@ func Open(workflowDir, workflowDocPath string) *Store {
 // InitOptions controls Store.Init.
 type InitOptions struct {
 	WorkflowID string
-	WorkitemID string
 	Force      bool
 }
 
@@ -56,9 +55,6 @@ func (s *Store) Init(ctx context.Context, opts InitOptions) error {
 	}
 	if opts.WorkflowID == "" {
 		return festerrors.Validation("workflow_id is required")
-	}
-	if opts.WorkitemID == "" {
-		return festerrors.Validation("workitem_id is required")
 	}
 
 	if err := os.MkdirAll(s.root, 0o755); err != nil {
@@ -80,7 +76,6 @@ func (s *Store) Init(ctx context.Context, opts InitOptions) error {
 		Version:    ManifestVersion,
 		Kind:       ManifestKind,
 		WorkflowID: opts.WorkflowID,
-		WorkitemID: opts.WorkitemID,
 		DocPath:    filepath.Base(s.workflowDoc),
 		DocHash:    docHash,
 	}
@@ -150,7 +145,6 @@ func (s *Store) StartRun(ctx context.Context, startedBy string) (string, error) 
 		Kind:       RunKind,
 		RunID:      runID,
 		WorkflowID: m.WorkflowID,
-		WorkitemID: m.WorkitemID,
 		Status:     "active",
 		StartedAt:  now,
 		StartedBy:  startedBy,
@@ -171,7 +165,6 @@ func (s *Store) StartRun(ctx context.Context, startedBy string) (string, error) 
 		EventType:  EventWorkflowRunStarted,
 		RunID:      runID,
 		WorkflowID: m.WorkflowID,
-		WorkitemID: m.WorkitemID,
 		Timestamp:  now,
 	}); err != nil {
 		return "", err

--- a/internal/workflow/localstore/store.go
+++ b/internal/workflow/localstore/store.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -115,10 +116,27 @@ func (s *Store) StartRun(ctx context.Context, startedBy string) (string, error) 
 		return "", err
 	}
 
-	runID := newRunID(time.Now().UTC())
+	// Allocate a unique run ID. Base is a UTC second-granularity timestamp;
+	// if two starts land in the same second we append -2, -3, ... so older
+	// runs are never overwritten.
+	base := newRunID(time.Now().UTC())
+	runID := base
 	runDir := filepath.Join(s.root, runsDir, runID)
-	if err := os.MkdirAll(runDir, 0o755); err != nil {
-		return "", festerrors.IO("creating run directory", err)
+	for suffix := 2; ; suffix++ {
+		if err := os.Mkdir(runDir, 0o755); err == nil {
+			break
+		} else if !os.IsExist(err) {
+			// Parent .workflow/runs may not exist yet; create and retry.
+			if errors.Is(err, os.ErrNotExist) {
+				if mkErr := os.MkdirAll(filepath.Dir(runDir), 0o755); mkErr != nil {
+					return "", festerrors.IO("creating runs directory", mkErr)
+				}
+				continue
+			}
+			return "", festerrors.IO("creating run directory", err)
+		}
+		runID = base + "-" + strconv.Itoa(suffix)
+		runDir = filepath.Join(s.root, runsDir, runID)
 	}
 
 	docHash := ""

--- a/internal/workflow/localstore/store.go
+++ b/internal/workflow/localstore/store.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+	wfparser "github.com/Obedience-Corp/fest/internal/guidance/workflow"
 	"github.com/google/uuid"
 	"gopkg.in/yaml.v3"
 )
@@ -82,7 +83,8 @@ func (s *Store) Init(ctx context.Context, opts InitOptions) error {
 	return writeYAML(manifestPath, &m)
 }
 
-// LoadManifest reads workflow.yaml.
+// LoadManifest reads workflow.yaml. Validates version, kind, and required
+// IDs before returning so callers do not propagate corrupt state.
 func (s *Store) LoadManifest(ctx context.Context) (*Manifest, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -96,7 +98,38 @@ func (s *Store) LoadManifest(ctx context.Context) (*Manifest, error) {
 	if err := yaml.Unmarshal(raw, &m); err != nil {
 		return nil, festerrors.Parse("parsing workflow manifest", err)
 	}
+	if err := validateManifest(&m, path); err != nil {
+		return nil, err
+	}
 	return &m, nil
+}
+
+// validateManifest enforces version/kind/workflow_id presence. Rejecting
+// malformed manifests at the loader prevents compound corruption from
+// downstream writes (D030 finding #2).
+func validateManifest(m *Manifest, path string) error {
+	if m.Version == 0 {
+		return festerrors.Validation("workflow manifest missing version").
+			WithField("path", path).
+			WithHint("expected version: 1")
+	}
+	if m.Version != ManifestVersion {
+		return festerrors.Validation("unsupported workflow manifest version").
+			WithField("path", path).
+			WithField("got", m.Version).
+			WithField("supported", ManifestVersion)
+	}
+	if m.Kind != ManifestKind {
+		return festerrors.Validation("workflow manifest kind mismatch").
+			WithField("path", path).
+			WithField("got", m.Kind).
+			WithField("expected", ManifestKind)
+	}
+	if m.WorkflowID == "" {
+		return festerrors.Validation("workflow manifest missing workflow_id").
+			WithField("path", path)
+	}
+	return nil
 }
 
 // StartRun creates a new run directory, writes run.yaml, appends the
@@ -139,6 +172,16 @@ func (s *Store) StartRun(ctx context.Context, startedBy string) (string, error) 
 		docHash, _ = HashWorkflowDoc(s.workflowDoc)
 	}
 
+	// Count steps for Summary.TotalSteps so consumers (camp dashboard, fest
+	// next renderer) can display "Step N of M" without inventing a fallback.
+	// Closes D030 finding #4.
+	totalSteps := 0
+	if s.workflowDoc != "" {
+		if n, parseErr := wfparser.NewParser().StepCount(ctx, s.workflowDoc); parseErr == nil {
+			totalSteps = n
+		}
+	}
+
 	now := time.Now().UTC()
 	run := RunManifest{
 		Version:    RunVersion,
@@ -154,6 +197,7 @@ func (s *Store) StartRun(ctx context.Context, startedBy string) (string, error) 
 			WorkflowHash: docHash,
 			WorkitemPath: "../..",
 		},
+		Summary: RunSummary{TotalSteps: totalSteps},
 	}
 	if err := writeYAML(filepath.Join(runDir, runManifestName), &run); err != nil {
 		return "", err
@@ -208,7 +252,48 @@ func (s *Store) AppendEvent(ctx context.Context, evt Event) error {
 	if evt.Version == 0 {
 		evt.Version = 1
 	}
-	return s.appendEvent(ctx, runDir, evt)
+	if err := s.appendEvent(ctx, runDir, evt); err != nil {
+		return err
+	}
+	// Terminal events must also update the parent workflow.yaml so
+	// `fest workflow runs` and subsequent LoadActive calls see a consistent
+	// view. Without this, runs[i].Status stays "active" and ActiveRunID
+	// keeps pointing at a finished run (D030 finding #3).
+	if evt.EventType == EventWorkflowRunCompleted || evt.EventType == EventWorkflowRunAbandoned {
+		if err := s.finalizeRunInManifest(ctx, evt); err != nil {
+			return festerrors.Wrap(err, "finalize run in manifest")
+		}
+	}
+	return nil
+}
+
+// finalizeRunInManifest updates workflow.yaml after a terminal event.
+// Idempotent — re-finalizing an already-terminal run is a no-op.
+func (s *Store) finalizeRunInManifest(ctx context.Context, evt Event) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	m, err := s.LoadManifest(ctx)
+	if err != nil {
+		return err
+	}
+	terminalStatus := "completed"
+	if evt.EventType == EventWorkflowRunAbandoned {
+		terminalStatus = "abandoned"
+	}
+	for i := range m.Runs {
+		if m.Runs[i].RunID == evt.RunID {
+			m.Runs[i].Status = terminalStatus
+			if m.Runs[i].EndedAt == "" {
+				m.Runs[i].EndedAt = evt.Timestamp.Format(time.RFC3339)
+			}
+			break
+		}
+	}
+	if m.ActiveRunID == evt.RunID {
+		m.ActiveRunID = ""
+	}
+	return writeYAML(filepath.Join(s.root, manifestName), m)
 }
 
 func (s *Store) appendEvent(_ context.Context, runDir string, evt Event) error {
@@ -369,6 +454,13 @@ func replayEvents(eventsPath string, cache RunManifest) *RunState {
 		case EventStepStart:
 			state.CurrentStep++
 		case EventStepDone:
+			state.CompletedSteps++
+			state.Blocked = false
+		case EventStepSkip:
+			// Mirror camp's localrun.go skip handling: skipped steps count
+			// as forward progress and clear any prior block. Without this
+			// case, fest and camp would replay the same event stream into
+			// divergent state (D030 finding #1).
 			state.CompletedSteps++
 			state.Blocked = false
 		case EventStepBlock, EventCheckpointRejected:

--- a/internal/workflow/localstore/store.go
+++ b/internal/workflow/localstore/store.go
@@ -302,7 +302,7 @@ func (s *Store) appendEvent(_ context.Context, runDir string, evt Event) error {
 	if err != nil {
 		return festerrors.IO("opening events file", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	line, err := json.Marshal(evt)
 	if err != nil {
 		return festerrors.Parse("encoding event", err)
@@ -429,7 +429,7 @@ func replayEvents(eventsPath string, cache RunManifest) *RunState {
 	if err != nil {
 		return state
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	// Replay overrides cache when events exist.
 	state.CurrentStep = 0

--- a/internal/workflow/localstore/store.go
+++ b/internal/workflow/localstore/store.go
@@ -1,0 +1,401 @@
+// Package localstore manages a single .workflow/ runtime directory for
+// standalone workflow execution. See workflow/design/workitem-workflows/
+// LOCAL_RUN_STATE.md for the canonical contract.
+//
+// The store is filesystem-only: append-only event stream, derived state via
+// replay, cached summary fields repaired on read.
+package localstore
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/google/uuid"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	manifestName    = "workflow.yaml"
+	runsDir         = "runs"
+	runManifestName = "run.yaml"
+	eventsName      = "progress_events.jsonl"
+)
+
+// Store manages a single .workflow/ runtime directory.
+type Store struct {
+	root        string // absolute path to .workflow/
+	workflowDoc string // absolute path to WORKFLOW.md (sibling of .workflow/)
+}
+
+// Open returns a Store anchored at the given .workflow/ directory.
+// workflowDir may not yet exist (Init will create it).
+func Open(workflowDir, workflowDocPath string) *Store {
+	return &Store{root: workflowDir, workflowDoc: workflowDocPath}
+}
+
+// InitOptions controls Store.Init.
+type InitOptions struct {
+	WorkflowID string
+	WorkitemID string
+	Force      bool
+}
+
+// Init creates .workflow/ and writes workflow.yaml.
+// Refuses to overwrite an existing manifest unless Force is true.
+func (s *Store) Init(ctx context.Context, opts InitOptions) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if opts.WorkflowID == "" {
+		return festerrors.Validation("workflow_id is required")
+	}
+	if opts.WorkitemID == "" {
+		return festerrors.Validation("workitem_id is required")
+	}
+
+	if err := os.MkdirAll(s.root, 0o755); err != nil {
+		return festerrors.IO("creating .workflow", err)
+	}
+	manifestPath := filepath.Join(s.root, manifestName)
+	if _, err := os.Stat(manifestPath); err == nil && !opts.Force {
+		return festerrors.Validation("workflow.yaml already exists; pass Force to overwrite")
+	}
+
+	docHash := ""
+	if s.workflowDoc != "" {
+		if h, err := HashWorkflowDoc(s.workflowDoc); err == nil {
+			docHash = h
+		}
+	}
+
+	m := Manifest{
+		Version:    ManifestVersion,
+		Kind:       ManifestKind,
+		WorkflowID: opts.WorkflowID,
+		WorkitemID: opts.WorkitemID,
+		DocPath:    filepath.Base(s.workflowDoc),
+		DocHash:    docHash,
+	}
+	return writeYAML(manifestPath, &m)
+}
+
+// LoadManifest reads workflow.yaml.
+func (s *Store) LoadManifest(ctx context.Context) (*Manifest, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	path := filepath.Join(s.root, manifestName)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, festerrors.Wrap(err, "reading workflow manifest")
+	}
+	var m Manifest
+	if err := yaml.Unmarshal(raw, &m); err != nil {
+		return nil, festerrors.Parse("parsing workflow manifest", err)
+	}
+	return &m, nil
+}
+
+// StartRun creates a new run directory, writes run.yaml, appends the
+// workflow_run_started event, and updates the manifest's active_run_id.
+// Returns the new run id.
+func (s *Store) StartRun(ctx context.Context, startedBy string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	m, err := s.LoadManifest(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	runID := newRunID(time.Now().UTC())
+	runDir := filepath.Join(s.root, runsDir, runID)
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		return "", festerrors.IO("creating run directory", err)
+	}
+
+	docHash := ""
+	if s.workflowDoc != "" {
+		docHash, _ = HashWorkflowDoc(s.workflowDoc)
+	}
+
+	now := time.Now().UTC()
+	run := RunManifest{
+		Version:    RunVersion,
+		Kind:       RunKind,
+		RunID:      runID,
+		WorkflowID: m.WorkflowID,
+		WorkitemID: m.WorkitemID,
+		Status:     "active",
+		StartedAt:  now,
+		StartedBy:  startedBy,
+		Executor:   "fest",
+		Source: RunSource{
+			WorkflowPath: "../../" + filepath.Base(s.workflowDoc),
+			WorkflowHash: docHash,
+			WorkitemPath: "../..",
+		},
+	}
+	if err := writeYAML(filepath.Join(runDir, runManifestName), &run); err != nil {
+		return "", err
+	}
+
+	if err := s.appendEvent(ctx, runDir, Event{
+		Version:    1,
+		EventID:    "evt_" + uuid.NewString()[:8],
+		EventType:  EventWorkflowRunStarted,
+		RunID:      runID,
+		WorkflowID: m.WorkflowID,
+		WorkitemID: m.WorkitemID,
+		Timestamp:  now,
+	}); err != nil {
+		return "", err
+	}
+
+	m.ActiveRunID = runID
+	m.Runs = append(m.Runs, RunRecord{
+		RunID:     runID,
+		Status:    "active",
+		Path:      filepath.Join(runsDir, runID),
+		StartedAt: now.Format(time.RFC3339),
+	})
+	if err := writeYAML(filepath.Join(s.root, manifestName), m); err != nil {
+		return "", err
+	}
+	return runID, nil
+}
+
+// AppendEvent appends an event to the active run's event stream.
+func (s *Store) AppendEvent(ctx context.Context, evt Event) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	m, err := s.LoadManifest(ctx)
+	if err != nil {
+		return err
+	}
+	if m.ActiveRunID == "" {
+		return festerrors.Validation("no active run")
+	}
+	runDir := filepath.Join(s.root, runsDir, m.ActiveRunID)
+	if evt.RunID == "" {
+		evt.RunID = m.ActiveRunID
+	}
+	if evt.Timestamp.IsZero() {
+		evt.Timestamp = time.Now().UTC()
+	}
+	if evt.EventID == "" {
+		evt.EventID = "evt_" + uuid.NewString()[:8]
+	}
+	if evt.Version == 0 {
+		evt.Version = 1
+	}
+	return s.appendEvent(ctx, runDir, evt)
+}
+
+func (s *Store) appendEvent(_ context.Context, runDir string, evt Event) error {
+	path := filepath.Join(runDir, eventsName)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return festerrors.IO("opening events file", err)
+	}
+	defer f.Close()
+	line, err := json.Marshal(evt)
+	if err != nil {
+		return festerrors.Parse("encoding event", err)
+	}
+	if _, err := f.Write(append(line, '\n')); err != nil {
+		return festerrors.IO("writing event", err)
+	}
+	return nil
+}
+
+// LoadActive returns the active run's replayed state.
+// If summary cached in run.yaml disagrees with the event stream, the file
+// is rewritten with corrected values; events are never modified.
+func (s *Store) LoadActive(ctx context.Context) (*RunState, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	m, err := s.LoadManifest(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if m.ActiveRunID == "" {
+		return nil, nil
+	}
+	runDir := filepath.Join(s.root, runsDir, m.ActiveRunID)
+	runPath := filepath.Join(runDir, runManifestName)
+	raw, err := os.ReadFile(runPath)
+	if err != nil {
+		return nil, festerrors.Wrap(err, "reading run manifest")
+	}
+	var rm RunManifest
+	if err := yaml.Unmarshal(raw, &rm); err != nil {
+		return nil, festerrors.Parse("parsing run manifest", err)
+	}
+
+	state := replayEvents(filepath.Join(runDir, eventsName), rm)
+
+	// Repair stale summary on disk if it disagrees with replay.
+	if rm.Summary.CurrentStep != state.CurrentStep ||
+		rm.Summary.CompletedSteps != state.CompletedSteps ||
+		rm.Summary.Blocked != state.Blocked ||
+		(state.Status != "" && state.Status != "active" && state.Status != rm.Status) {
+		rm.Summary.CurrentStep = state.CurrentStep
+		rm.Summary.CompletedSteps = state.CompletedSteps
+		rm.Summary.Blocked = state.Blocked
+		if state.Status != "" {
+			rm.Status = state.Status
+		}
+		_ = writeYAML(runPath, &rm)
+	}
+
+	state.RunID = rm.RunID
+	state.StartedAt = rm.StartedAt
+	state.CompletedAt = rm.CompletedAt
+	state.TotalSteps = rm.Summary.TotalSteps
+	if state.TotalSteps == 0 {
+		state.TotalSteps = state.CurrentStep
+	}
+
+	// Detect doc-hash drift.
+	if s.workflowDoc != "" && m.DocHash != "" {
+		if cur, hashErr := HashWorkflowDoc(s.workflowDoc); hashErr == nil && cur != m.DocHash {
+			state.DocHashChanged = true
+		}
+	}
+	return state, nil
+}
+
+// CheckDocHash compares the stored workflow.yaml doc_hash against the
+// current WORKFLOW.md hash.
+func (s *Store) CheckDocHash(ctx context.Context) (changed bool, current, stored string, err error) {
+	if err := ctx.Err(); err != nil {
+		return false, "", "", err
+	}
+	m, mErr := s.LoadManifest(ctx)
+	if mErr != nil {
+		return false, "", "", mErr
+	}
+	cur, hErr := HashWorkflowDoc(s.workflowDoc)
+	if hErr != nil {
+		return false, "", m.DocHash, hErr
+	}
+	return cur != m.DocHash, cur, m.DocHash, nil
+}
+
+// RunSummaryView is the public view returned by ListRuns.
+type RunSummaryView struct {
+	RunID       string
+	Status      string
+	Path        string
+	StartedAt   string
+	CompletedAt string
+}
+
+// ListRuns enumerates runs from the manifest in their stored order.
+func (s *Store) ListRuns(ctx context.Context) ([]RunSummaryView, error) {
+	m, err := s.LoadManifest(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]RunSummaryView, 0, len(m.Runs))
+	for _, r := range m.Runs {
+		out = append(out, RunSummaryView{
+			RunID:       r.RunID,
+			Status:      r.Status,
+			Path:        r.Path,
+			StartedAt:   r.StartedAt,
+			CompletedAt: r.CompletedAt,
+		})
+	}
+	return out, nil
+}
+
+// replayEvents walks the event stream and derives current state.
+// Returns zero values for missing or unreadable events.
+func replayEvents(eventsPath string, cache RunManifest) *RunState {
+	state := &RunState{
+		Status:         "active",
+		CurrentStep:    cache.Summary.CurrentStep,
+		CompletedSteps: cache.Summary.CompletedSteps,
+		Blocked:        cache.Summary.Blocked,
+	}
+	f, err := os.Open(eventsPath)
+	if err != nil {
+		return state
+	}
+	defer f.Close()
+
+	// Replay overrides cache when events exist.
+	state.CurrentStep = 0
+	state.CompletedSteps = 0
+	state.Blocked = false
+	state.Status = "active"
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(strings.TrimSpace(string(line))) == 0 {
+			continue
+		}
+		var evt struct {
+			EventType string `json:"event_type"`
+		}
+		if err := json.Unmarshal(line, &evt); err != nil {
+			continue
+		}
+		switch evt.EventType {
+		case EventStepStart:
+			state.CurrentStep++
+		case EventStepDone:
+			state.CompletedSteps++
+			state.Blocked = false
+		case EventStepBlock, EventCheckpointRejected:
+			state.Blocked = true
+		case EventCheckpointApproved:
+			state.Blocked = false
+		case EventWorkflowRunCompleted:
+			state.Status = "completed"
+		case EventWorkflowRunAbandoned:
+			state.Status = "abandoned"
+		}
+	}
+	if state.Blocked && state.Status == "active" {
+		state.Status = "blocked"
+	}
+	return state
+}
+
+func writeYAML(path string, v any) error {
+	data, err := yaml.Marshal(v)
+	if err != nil {
+		return festerrors.Parse("marshal yaml", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return festerrors.IO("writing "+filepath.Base(path), err)
+	}
+	return nil
+}
+
+func newRunID(t time.Time) string {
+	return "run-" + t.Format("20060102T150405Z")
+}
+
+// ManifestPath is the on-disk path to workflow.yaml under this store.
+func (s *Store) ManifestPath() string { return filepath.Join(s.root, manifestName) }
+
+// IsInitialized reports whether workflow.yaml exists in this store.
+func (s *Store) IsInitialized() bool {
+	_, err := os.Stat(s.ManifestPath())
+	return !errors.Is(err, os.ErrNotExist)
+}

--- a/internal/workflow/localstore/store_test.go
+++ b/internal/workflow/localstore/store_test.go
@@ -144,6 +144,47 @@ func TestStore_SecondStartCoexistsWithFirst(t *testing.T) {
 	}
 }
 
+func TestStore_StartRunUniqueWithinSameSecond(t *testing.T) {
+	// Pre-create the .workflow/runs/<base-id>/ directory so the next
+	// StartRun in the same second must allocate a -2 suffix instead of
+	// overwriting it.
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+		t.Fatal(err)
+	}
+	first, err := s.StartRun(ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstRunYAMLBefore, err := os.ReadFile(filepath.Join(s.root, "runs", first, "run.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Second start within the same second.
+	second, err := s.StartRun(ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == second {
+		t.Fatalf("expected distinct run ids on same-second starts, got %q and %q", first, second)
+	}
+
+	// First run's directory and run.yaml must be untouched.
+	firstRunYAMLAfter, err := os.ReadFile(filepath.Join(s.root, "runs", first, "run.yaml"))
+	if err != nil {
+		t.Fatalf("first run.yaml missing after second start: %v", err)
+	}
+	if string(firstRunYAMLBefore) != string(firstRunYAMLAfter) {
+		t.Errorf("first run.yaml was modified by second start")
+	}
+	// Second run directory must exist.
+	if _, err := os.Stat(filepath.Join(s.root, "runs", second, "run.yaml")); err != nil {
+		t.Errorf("second run.yaml missing: %v", err)
+	}
+}
+
 func TestStore_AppendEventAndReplay(t *testing.T) {
 	s, _ := newTestStore(t)
 	ctx := context.Background()

--- a/internal/workflow/localstore/store_test.go
+++ b/internal/workflow/localstore/store_test.go
@@ -1,0 +1,276 @@
+package localstore
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const sampleWorkflow = `---
+workflow_version: 1
+workflow_id: wf-sample
+workitem_id: smoke-001
+---
+
+## Step 1: ALIGN PROBLEM
+
+**Goal:** Sample.
+
+**Actions:**
+1. Read step.
+
+**Output:** A read step.
+`
+
+func newTestStore(t *testing.T) (*Store, string) {
+	t.Helper()
+	dir := t.TempDir()
+	docPath := filepath.Join(dir, "WORKFLOW.md")
+	if err := os.WriteFile(docPath, []byte(sampleWorkflow), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return Open(filepath.Join(dir, ".workflow"), docPath), dir
+}
+
+func TestStore_InitCreatesManifest(t *testing.T) {
+	s, _ := newTestStore(t)
+	err := s.Init(context.Background(), InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := s.LoadManifest(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Version != ManifestVersion || m.Kind != ManifestKind || m.WorkflowID != "wf-x" {
+		t.Errorf("unexpected manifest: %+v", m)
+	}
+	if m.DocHash == "" {
+		t.Errorf("DocHash should be populated when workflow doc exists")
+	}
+}
+
+func TestStore_InitRefusesOverwrite(t *testing.T) {
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+		t.Fatal(err)
+	}
+	err := s.Init(ctx, InitOptions{WorkflowID: "wf-y", WorkitemID: "wi-y"})
+	if err == nil {
+		t.Fatal("expected refusal without Force")
+	}
+}
+
+func TestStore_InitForceOverwrites(t *testing.T) {
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-y", WorkitemID: "wi-y", Force: true}); err != nil {
+		t.Fatal(err)
+	}
+	m, _ := s.LoadManifest(ctx)
+	if m.WorkflowID != "wf-y" {
+		t.Errorf("expected overwrite to wf-y, got %q", m.WorkflowID)
+	}
+}
+
+func TestStore_StartRunCreatesRunDir(t *testing.T) {
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+		t.Fatal(err)
+	}
+	runID, err := s.StartRun(ctx, "tester")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(runID, "run-") {
+		t.Errorf("RunID = %q, want run- prefix", runID)
+	}
+
+	m, _ := s.LoadManifest(ctx)
+	if m.ActiveRunID != runID {
+		t.Errorf("active_run_id not updated, got %q", m.ActiveRunID)
+	}
+	if len(m.Runs) != 1 {
+		t.Errorf("expected 1 run record, got %d", len(m.Runs))
+	}
+
+	runDir := filepath.Join(s.root, "runs", runID)
+	if _, err := os.Stat(filepath.Join(runDir, "run.yaml")); err != nil {
+		t.Errorf("run.yaml missing: %v", err)
+	}
+
+	eventsPath := filepath.Join(runDir, "progress_events.jsonl")
+	raw, err := os.ReadFile(eventsPath)
+	if err != nil {
+		t.Fatalf("events file: %v", err)
+	}
+	if !strings.Contains(string(raw), EventWorkflowRunStarted) {
+		t.Errorf("missing workflow_run_started event: %s", raw)
+	}
+}
+
+func TestStore_SecondStartCoexistsWithFirst(t *testing.T) {
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+		t.Fatal(err)
+	}
+	first, _ := s.StartRun(ctx, "")
+	// Move clock forward slightly so the run-id timestamp differs.
+	time.Sleep(1100 * time.Millisecond)
+	second, err := s.StartRun(ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == second {
+		t.Fatalf("expected distinct run ids, got %q and %q", first, second)
+	}
+	if _, err := os.Stat(filepath.Join(s.root, "runs", first, "run.yaml")); err != nil {
+		t.Errorf("first run dir missing after second start: %v", err)
+	}
+	runs, _ := s.ListRuns(ctx)
+	if len(runs) != 2 {
+		t.Errorf("expected 2 runs, got %d", len(runs))
+	}
+}
+
+func TestStore_AppendEventAndReplay(t *testing.T) {
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.StartRun(ctx, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AppendEvent(ctx, Event{EventType: EventStepStart}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AppendEvent(ctx, Event{EventType: EventStepDone}); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := s.LoadActive(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state == nil {
+		t.Fatal("expected state, got nil")
+	}
+	if state.CurrentStep != 1 || state.CompletedSteps != 1 {
+		t.Errorf("CurrentStep=%d CompletedSteps=%d", state.CurrentStep, state.CompletedSteps)
+	}
+}
+
+func TestStore_ReplayOverridesStaleSummary(t *testing.T) {
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+		t.Fatal(err)
+	}
+	runID, _ := s.StartRun(ctx, "")
+	if err := s.AppendEvent(ctx, Event{EventType: EventStepStart}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AppendEvent(ctx, Event{EventType: EventStepStart}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AppendEvent(ctx, Event{EventType: EventStepDone}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Corrupt the summary on disk.
+	runPath := filepath.Join(s.root, "runs", runID, "run.yaml")
+	raw, _ := os.ReadFile(runPath)
+	bad := strings.Replace(string(raw), "current_step: 0", "current_step: 999", 1)
+	_ = os.WriteFile(runPath, []byte(bad), 0o644)
+
+	state, _ := s.LoadActive(ctx)
+	if state.CurrentStep != 2 || state.CompletedSteps != 1 {
+		t.Errorf("replay should override stale summary, got CurrentStep=%d CompletedSteps=%d", state.CurrentStep, state.CompletedSteps)
+	}
+
+	// Repair should have rewritten the summary.
+	raw2, _ := os.ReadFile(runPath)
+	if strings.Contains(string(raw2), "current_step: 999") {
+		t.Errorf("stale summary not repaired")
+	}
+}
+
+func TestStore_DocHashChange(t *testing.T) {
+	s, root := newTestStore(t)
+	ctx := context.Background()
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(root, "WORKFLOW.md"), []byte("mutated"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	changed, cur, stored, err := s.CheckDocHash(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Errorf("expected changed=true, cur=%s stored=%s", cur, stored)
+	}
+}
+
+func TestStore_EventsAreAppendOnly(t *testing.T) {
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.StartRun(ctx, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AppendEvent(ctx, Event{EventType: "A"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AppendEvent(ctx, Event{EventType: "B"}); err != nil {
+		t.Fatal(err)
+	}
+
+	m, _ := s.LoadManifest(ctx)
+	eventsPath := filepath.Join(s.root, "runs", m.ActiveRunID, "progress_events.jsonl")
+	raw, _ := os.ReadFile(eventsPath)
+	lines := strings.Split(strings.TrimRight(string(raw), "\n"), "\n")
+	// expect 3 lines: workflow_run_started, A, B
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 event lines, got %d: %s", len(lines), raw)
+	}
+
+	var first, second, third struct {
+		EventType string `json:"event_type"`
+	}
+	_ = json.Unmarshal([]byte(lines[0]), &first)
+	_ = json.Unmarshal([]byte(lines[1]), &second)
+	_ = json.Unmarshal([]byte(lines[2]), &third)
+	if first.EventType != EventWorkflowRunStarted {
+		t.Errorf("line 1 = %q", first.EventType)
+	}
+	if second.EventType != "A" || third.EventType != "B" {
+		t.Errorf("append order broken: A=%q B=%q", second.EventType, third.EventType)
+	}
+}
+
+func TestStore_ContextCancel(t *testing.T) {
+	s, _ := newTestStore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}

--- a/internal/workflow/localstore/store_test.go
+++ b/internal/workflow/localstore/store_test.go
@@ -213,6 +213,150 @@ func TestStore_AppendEventAndReplay(t *testing.T) {
 	}
 }
 
+// TestStore_TerminalEventFinalizesManifest locks in D030 finding #3:
+// completing/abandoning a run clears active_run_id and stamps the runs[]
+// entry. Without this, `fest workflow runs` reports terminated runs as
+// active.
+func TestStore_TerminalEventFinalizesManifest(t *testing.T) {
+	for _, ev := range []string{EventWorkflowRunCompleted, EventWorkflowRunAbandoned} {
+		t.Run(ev, func(t *testing.T) {
+			s, _ := newTestStore(t)
+			ctx := context.Background()
+			if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
+				t.Fatal(err)
+			}
+			runID, err := s.StartRun(ctx, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if err := s.AppendEvent(ctx, Event{EventType: ev}); err != nil {
+				t.Fatal(err)
+			}
+
+			m, err := s.LoadManifest(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if m.ActiveRunID != "" {
+				t.Errorf("ActiveRunID = %q, want empty after terminal event", m.ActiveRunID)
+			}
+			if len(m.Runs) != 1 {
+				t.Fatalf("Runs = %d, want 1", len(m.Runs))
+			}
+			wantStatus := "completed"
+			if ev == EventWorkflowRunAbandoned {
+				wantStatus = "abandoned"
+			}
+			if m.Runs[0].Status != wantStatus {
+				t.Errorf("Runs[0].Status = %q, want %q", m.Runs[0].Status, wantStatus)
+			}
+			if m.Runs[0].RunID != runID {
+				t.Errorf("Runs[0].RunID = %q, want %q", m.Runs[0].RunID, runID)
+			}
+			if m.Runs[0].EndedAt == "" {
+				t.Error("Runs[0].EndedAt empty, want a timestamp")
+			}
+
+			// Idempotent at the finalize layer: calling finalize again for an
+			// already-terminal run does not corrupt state. AppendEvent itself
+			// refuses with "no active run" once ActiveRunID is cleared, which
+			// is the expected guard for callers.
+			if err := s.finalizeRunInManifest(ctx, Event{EventType: ev, RunID: runID, Timestamp: time.Now().UTC()}); err != nil {
+				t.Fatalf("re-finalize should be idempotent, got %v", err)
+			}
+			m2, _ := s.LoadManifest(ctx)
+			if m2.Runs[0].Status != wantStatus {
+				t.Errorf("after re-finalize Runs[0].Status = %q, want %q", m2.Runs[0].Status, wantStatus)
+			}
+		})
+	}
+}
+
+// TestLoadManifest_RejectsMalformed locks in D030 finding #2: LoadManifest
+// must validate version/kind/workflow_id before returning so callers do not
+// silently propagate corrupt state.
+func TestLoadManifest_RejectsMalformed(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			name: "missing version",
+			yaml: "kind: workflow-runtime\nworkflow_id: wf-x\n",
+			want: "missing version",
+		},
+		{
+			name: "unsupported version",
+			yaml: "version: 99\nkind: workflow-runtime\nworkflow_id: wf-x\n",
+			want: "unsupported workflow manifest version",
+		},
+		{
+			name: "wrong kind",
+			yaml: "version: 1\nkind: not-workflow\nworkflow_id: wf-x\n",
+			want: "kind mismatch",
+		},
+		{
+			name: "missing workflow_id",
+			yaml: "version: 1\nkind: workflow-runtime\n",
+			want: "missing workflow_id",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, manifestName), []byte(c.yaml), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			s := &Store{root: dir}
+			_, err := s.LoadManifest(context.Background())
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", c.want)
+			}
+			if !strings.Contains(err.Error(), c.want) {
+				t.Errorf("error %q does not contain %q", err.Error(), c.want)
+			}
+		})
+	}
+}
+
+// TestStore_ReplayHandlesStepSkip locks in D030 finding #1: skip clears
+// Blocked and counts as forward progress, matching camp's localrun.go
+// semantics so the same event stream produces the same state in both repos.
+func TestStore_ReplayHandlesStepSkip(t *testing.T) {
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.StartRun(ctx, ""); err != nil {
+		t.Fatal(err)
+	}
+	for _, ev := range []string{EventStepStart, EventStepBlock, EventStepSkip} {
+		if err := s.AppendEvent(ctx, Event{EventType: ev}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	state, err := s.LoadActive(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state == nil {
+		t.Fatal("expected state, got nil")
+	}
+	if state.Blocked {
+		t.Errorf("Blocked = true after skip, want false")
+	}
+	if state.CompletedSteps != 1 {
+		t.Errorf("CompletedSteps = %d, want 1 (skip counts as progress)", state.CompletedSteps)
+	}
+	if state.Status != "active" {
+		t.Errorf("Status = %q, want active (skip clears blocked status)", state.Status)
+	}
+}
+
 func TestStore_ReplayOverridesStaleSummary(t *testing.T) {
 	s, _ := newTestStore(t)
 	ctx := context.Background()

--- a/internal/workflow/localstore/store_test.go
+++ b/internal/workflow/localstore/store_test.go
@@ -39,7 +39,7 @@ func newTestStore(t *testing.T) (*Store, string) {
 
 func TestStore_InitCreatesManifest(t *testing.T) {
 	s, _ := newTestStore(t)
-	err := s.Init(context.Background(), InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"})
+	err := s.Init(context.Background(), InitOptions{WorkflowID: "wf-x"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,10 +58,10 @@ func TestStore_InitCreatesManifest(t *testing.T) {
 func TestStore_InitRefusesOverwrite(t *testing.T) {
 	s, _ := newTestStore(t)
 	ctx := context.Background()
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
 		t.Fatal(err)
 	}
-	err := s.Init(ctx, InitOptions{WorkflowID: "wf-y", WorkitemID: "wi-y"})
+	err := s.Init(ctx, InitOptions{WorkflowID: "wf-y"})
 	if err == nil {
 		t.Fatal("expected refusal without Force")
 	}
@@ -70,10 +70,10 @@ func TestStore_InitRefusesOverwrite(t *testing.T) {
 func TestStore_InitForceOverwrites(t *testing.T) {
 	s, _ := newTestStore(t)
 	ctx := context.Background()
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-y", WorkitemID: "wi-y", Force: true}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-y", Force: true}); err != nil {
 		t.Fatal(err)
 	}
 	m, _ := s.LoadManifest(ctx)
@@ -85,7 +85,7 @@ func TestStore_InitForceOverwrites(t *testing.T) {
 func TestStore_StartRunCreatesRunDir(t *testing.T) {
 	s, _ := newTestStore(t)
 	ctx := context.Background()
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
 		t.Fatal(err)
 	}
 	runID, err := s.StartRun(ctx, "tester")
@@ -122,7 +122,7 @@ func TestStore_StartRunCreatesRunDir(t *testing.T) {
 func TestStore_SecondStartCoexistsWithFirst(t *testing.T) {
 	s, _ := newTestStore(t)
 	ctx := context.Background()
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
 		t.Fatal(err)
 	}
 	first, _ := s.StartRun(ctx, "")
@@ -150,7 +150,7 @@ func TestStore_StartRunUniqueWithinSameSecond(t *testing.T) {
 	// overwriting it.
 	s, _ := newTestStore(t)
 	ctx := context.Background()
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
 		t.Fatal(err)
 	}
 	first, err := s.StartRun(ctx, "")
@@ -188,7 +188,7 @@ func TestStore_StartRunUniqueWithinSameSecond(t *testing.T) {
 func TestStore_AppendEventAndReplay(t *testing.T) {
 	s, _ := newTestStore(t)
 	ctx := context.Background()
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := s.StartRun(ctx, ""); err != nil {
@@ -216,7 +216,7 @@ func TestStore_AppendEventAndReplay(t *testing.T) {
 func TestStore_ReplayOverridesStaleSummary(t *testing.T) {
 	s, _ := newTestStore(t)
 	ctx := context.Background()
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
 		t.Fatal(err)
 	}
 	runID, _ := s.StartRun(ctx, "")
@@ -251,7 +251,7 @@ func TestStore_ReplayOverridesStaleSummary(t *testing.T) {
 func TestStore_DocHashChange(t *testing.T) {
 	s, root := newTestStore(t)
 	ctx := context.Background()
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -270,7 +270,7 @@ func TestStore_DocHashChange(t *testing.T) {
 func TestStore_EventsAreAppendOnly(t *testing.T) {
 	s, _ := newTestStore(t)
 	ctx := context.Background()
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := s.StartRun(ctx, ""); err != nil {
@@ -310,7 +310,7 @@ func TestStore_ContextCancel(t *testing.T) {
 	s, _ := newTestStore(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"})
+	err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"})
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("expected context.Canceled, got %v", err)
 	}

--- a/internal/workflow/standalone/resolver.go
+++ b/internal/workflow/standalone/resolver.go
@@ -32,6 +32,12 @@ const (
 	ModeAnonymous Mode = "anonymous"
 )
 
+// resolveFestivalPath is a package-level indirection over
+// shared.ResolveFestivalPath so tests can inject failures (permission
+// denied, I/O) without mutating the host filesystem. Production code
+// always uses the real implementation.
+var resolveFestivalPath = shared.ResolveFestivalPath
+
 // Result is the typed output of resolution. All paths are absolute.
 type Result struct {
 	Mode         Mode
@@ -56,7 +62,7 @@ func Resolve(ctx context.Context, startDir string) (*Result, error) {
 	}
 
 	// Priority 1: festival context.
-	festPath, festErr := shared.ResolveFestivalPath(absStart, "")
+	festPath, festErr := resolveFestivalPath(absStart, "")
 	if festErr == nil && festPath != "" {
 		phasePath := shared.ResolvePhasePath(absStart, festPath)
 		workflowDoc := ""

--- a/internal/workflow/standalone/resolver.go
+++ b/internal/workflow/standalone/resolver.go
@@ -1,11 +1,11 @@
 // Package standalone resolves workflow context outside of a festival.
 //
 // Resolution priority:
-//  1. Festival context (delegates to shared.ResolveFestivalPath) — always wins
-//     when both festival and standalone signals exist.
-//  2. Tracked standalone workflow — a directory with .workflow/workflow.yaml.
-//  3. Anonymous standalone workflow — a directory with WORKFLOW.md only.
-//  4. None — neither signal found.
+//  1. Festival context (delegates to shared.ResolveFestivalPath). Wins
+//     unconditionally when both festival and standalone signals exist.
+//  2. Tracked standalone workflow: a directory with .workflow/workflow.yaml.
+//  3. Anonymous standalone workflow: a directory with WORKFLOW.md only.
+//  4. None: neither signal found.
 package standalone
 
 import (

--- a/internal/workflow/standalone/resolver.go
+++ b/internal/workflow/standalone/resolver.go
@@ -3,8 +3,11 @@
 // Resolution priority:
 //  1. Festival context (delegates to shared.ResolveFestivalPath). Wins
 //     unconditionally when both festival and standalone signals exist.
+//     Festival detection walks up parent directories.
 //  2. Tracked standalone workflow: a directory with .workflow/workflow.yaml.
+//     Detected at cwd only (D013) — does not walk up.
 //  3. Anonymous standalone workflow: a directory with WORKFLOW.md only.
+//     Detected at cwd only (D013).
 //  4. None: neither signal found.
 package standalone
 
@@ -88,44 +91,40 @@ func Resolve(ctx context.Context, startDir string) (*Result, error) {
 		return nil, festerrors.Wrap(festErr, "resolving festival path")
 	}
 
-	// Priority 2 + 3: standalone walk upward.
-	return walkForStandalone(ctx, absStart)
+	// Priority 2 + 3: standalone cwd-only check (D013). Unlike festival
+	// detection, standalone WORKFLOW.md detection does not walk up parent
+	// directories — `fest next` from a child directory of a workflow does
+	// not pick it up.
+	return checkCwdForStandalone(ctx, absStart)
 }
 
-func walkForStandalone(ctx context.Context, startDir string) (*Result, error) {
-	dir := startDir
-	for {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-
-		manifest := filepath.Join(dir, ".workflow", "workflow.yaml")
-		if _, err := os.Stat(manifest); err == nil {
-			return &Result{
-				Mode:        ModeTracked,
-				StartDir:    startDir,
-				WorkflowDoc: filepath.Join(dir, "WORKFLOW.md"),
-				RuntimeDir:  filepath.Join(dir, ".workflow"),
-			}, nil
-		} else if !errors.Is(err, os.ErrNotExist) {
-			return nil, festerrors.Wrap(err, "stat workflow manifest")
-		}
-
-		doc := filepath.Join(dir, "WORKFLOW.md")
-		if _, err := os.Stat(doc); err == nil {
-			return &Result{
-				Mode:        ModeAnonymous,
-				StartDir:    startDir,
-				WorkflowDoc: doc,
-			}, nil
-		} else if !errors.Is(err, os.ErrNotExist) {
-			return nil, festerrors.Wrap(err, "stat workflow doc")
-		}
-
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return &Result{Mode: ModeNone, StartDir: startDir}, nil
-		}
-		dir = parent
+func checkCwdForStandalone(ctx context.Context, startDir string) (*Result, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
+
+	manifest := filepath.Join(startDir, ".workflow", "workflow.yaml")
+	if _, err := os.Stat(manifest); err == nil {
+		return &Result{
+			Mode:        ModeTracked,
+			StartDir:    startDir,
+			WorkflowDoc: filepath.Join(startDir, "WORKFLOW.md"),
+			RuntimeDir:  filepath.Join(startDir, ".workflow"),
+		}, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, festerrors.Wrap(err, "stat workflow manifest")
+	}
+
+	doc := filepath.Join(startDir, "WORKFLOW.md")
+	if _, err := os.Stat(doc); err == nil {
+		return &Result{
+			Mode:        ModeAnonymous,
+			StartDir:    startDir,
+			WorkflowDoc: doc,
+		}, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, festerrors.Wrap(err, "stat workflow doc")
+	}
+
+	return &Result{Mode: ModeNone, StartDir: startDir}, nil
 }

--- a/internal/workflow/standalone/resolver.go
+++ b/internal/workflow/standalone/resolver.go
@@ -1,0 +1,117 @@
+// Package standalone resolves workflow context outside of a festival.
+//
+// Resolution priority:
+//  1. Festival context (delegates to shared.ResolveFestivalPath) — always wins
+//     when both festival and standalone signals exist.
+//  2. Tracked standalone workflow — a directory with .workflow/workflow.yaml.
+//  3. Anonymous standalone workflow — a directory with WORKFLOW.md only.
+//  4. None — neither signal found.
+package standalone
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/Obedience-Corp/fest/internal/commands/shared"
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+)
+
+// Mode identifies which workflow context was resolved.
+type Mode string
+
+const (
+	// ModeNone means no workflow context was found.
+	ModeNone Mode = "none"
+	// ModeFestival means resolution found a fest festival workflow.
+	ModeFestival Mode = "festival"
+	// ModeTracked means a standalone .workflow/ runtime is present.
+	ModeTracked Mode = "tracked"
+	// ModeAnonymous means a WORKFLOW.md exists with no .workflow/ runtime.
+	ModeAnonymous Mode = "anonymous"
+)
+
+// Result is the typed output of resolution. All paths are absolute.
+type Result struct {
+	Mode         Mode
+	StartDir     string
+	FestivalPath string // set when Mode == ModeFestival
+	PhasePath    string // set when Mode == ModeFestival and inside a phase
+	WorkflowDoc  string // absolute path to WORKFLOW.md, set for tracked/anonymous/festival-phase
+	RuntimeDir   string // absolute path to .workflow/, set when Mode == ModeTracked
+}
+
+// Resolve walks from startDir to find the nearest workflow context.
+// Festival context wins when both festival and standalone signals exist for
+// the same path.
+func Resolve(ctx context.Context, startDir string) (*Result, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	absStart, err := filepath.Abs(startDir)
+	if err != nil {
+		return nil, festerrors.Wrap(err, "resolving start dir")
+	}
+
+	// Priority 1: festival context.
+	if festPath, festErr := shared.ResolveFestivalPath(absStart, ""); festErr == nil && festPath != "" {
+		phasePath := shared.ResolvePhasePath(absStart, festPath)
+		workflowDoc := ""
+		if phasePath != "" {
+			candidate := filepath.Join(phasePath, "WORKFLOW.md")
+			if _, statErr := os.Stat(candidate); statErr == nil {
+				workflowDoc = candidate
+			}
+		}
+		return &Result{
+			Mode:         ModeFestival,
+			StartDir:     absStart,
+			FestivalPath: festPath,
+			PhasePath:    phasePath,
+			WorkflowDoc:  workflowDoc,
+		}, nil
+	}
+
+	// Priority 2 + 3: standalone walk upward.
+	return walkForStandalone(ctx, absStart)
+}
+
+func walkForStandalone(ctx context.Context, startDir string) (*Result, error) {
+	dir := startDir
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		manifest := filepath.Join(dir, ".workflow", "workflow.yaml")
+		if _, err := os.Stat(manifest); err == nil {
+			return &Result{
+				Mode:        ModeTracked,
+				StartDir:    startDir,
+				WorkflowDoc: filepath.Join(dir, "WORKFLOW.md"),
+				RuntimeDir:  filepath.Join(dir, ".workflow"),
+			}, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, festerrors.Wrap(err, "stat workflow manifest")
+		}
+
+		doc := filepath.Join(dir, "WORKFLOW.md")
+		if _, err := os.Stat(doc); err == nil {
+			return &Result{
+				Mode:        ModeAnonymous,
+				StartDir:    startDir,
+				WorkflowDoc: doc,
+			}, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, festerrors.Wrap(err, "stat workflow doc")
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return &Result{Mode: ModeNone, StartDir: startDir}, nil
+		}
+		dir = parent
+	}
+}

--- a/internal/workflow/standalone/resolver.go
+++ b/internal/workflow/standalone/resolver.go
@@ -56,7 +56,8 @@ func Resolve(ctx context.Context, startDir string) (*Result, error) {
 	}
 
 	// Priority 1: festival context.
-	if festPath, festErr := shared.ResolveFestivalPath(absStart, ""); festErr == nil && festPath != "" {
+	festPath, festErr := shared.ResolveFestivalPath(absStart, "")
+	if festErr == nil && festPath != "" {
 		phasePath := shared.ResolvePhasePath(absStart, festPath)
 		workflowDoc := ""
 		if phasePath != "" {
@@ -72,6 +73,13 @@ func Resolve(ctx context.Context, startDir string) (*Result, error) {
 			PhasePath:    phasePath,
 			WorkflowDoc:  workflowDoc,
 		}, nil
+	}
+	// A NotFound error means "not inside a festival" — fall through to
+	// standalone resolution. Any other error (permission denied, I/O failure
+	// while walking) is real and must propagate so the caller does not
+	// silently degrade to ModeAnonymous/ModeNone.
+	if festErr != nil && !festerrors.Is(festErr, festerrors.ErrCodeNotFound) {
+		return nil, festerrors.Wrap(festErr, "resolving festival path")
 	}
 
 	// Priority 2 + 3: standalone walk upward.

--- a/internal/workflow/standalone/resolver_test.go
+++ b/internal/workflow/standalone/resolver_test.go
@@ -2,10 +2,35 @@ package standalone
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
 )
+
+func TestResolve_PropagatesNonNotFoundFestivalError(t *testing.T) {
+	prev := resolveFestivalPath
+	t.Cleanup(func() { resolveFestivalPath = prev })
+
+	want := festerrors.IO("walking festivals dir", errors.New("permission denied"))
+	resolveFestivalPath = func(_, _ string) (string, error) {
+		return "", want
+	}
+
+	dir := t.TempDir()
+	res, err := Resolve(context.Background(), dir)
+	if err == nil {
+		t.Fatalf("expected error, got nil (res=%+v)", res)
+	}
+	if res != nil {
+		t.Errorf("expected nil result on propagated error, got %+v", res)
+	}
+	if !errors.Is(err, want) {
+		t.Errorf("expected wrapped festErr, got %T: %v", err, err)
+	}
+}
 
 func writeF(t *testing.T, path, body string) {
 	t.Helper()

--- a/internal/workflow/standalone/resolver_test.go
+++ b/internal/workflow/standalone/resolver_test.go
@@ -137,7 +137,10 @@ func TestResolve_Anonymous(t *testing.T) {
 	}
 }
 
-func TestResolve_NestedAnonymous(t *testing.T) {
+// TestResolve_CwdOnly_NoWalkUp asserts D013: standalone detection checks
+// cwd only, not parent directories. A WORKFLOW.md in a parent dir must not
+// surface as ModeAnonymous when invoked from a child.
+func TestResolve_CwdOnly_NoWalkUp(t *testing.T) {
 	root := t.TempDir()
 	parent := filepath.Join(root, "wf-parent")
 	subdir := filepath.Join(parent, "deeper", "nested")
@@ -150,8 +153,8 @@ func TestResolve_NestedAnonymous(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r.Mode != ModeAnonymous {
-		t.Errorf("Mode = %q, want anonymous (walk up to parent)", r.Mode)
+	if r.Mode != ModeNone {
+		t.Errorf("Mode = %q from child dir, want ModeNone (cwd-only detection)", r.Mode)
 	}
 }
 

--- a/internal/workflow/standalone/resolver_test.go
+++ b/internal/workflow/standalone/resolver_test.go
@@ -1,0 +1,141 @@
+package standalone
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeF(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestResolve_None(t *testing.T) {
+	dir := t.TempDir()
+	r, err := Resolve(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Mode != ModeNone {
+		t.Errorf("Mode = %q, want %q", r.Mode, ModeNone)
+	}
+}
+
+func TestResolve_Festival(t *testing.T) {
+	root := t.TempDir()
+	festDir := filepath.Join(root, "festivals", "active", "test-TF0001")
+	writeF(t, filepath.Join(festDir, "fest.yaml"), `version: "1.0"
+metadata:
+  id: TF0001
+  name: test
+`)
+
+	r, err := Resolve(context.Background(), festDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Mode != ModeFestival {
+		t.Errorf("Mode = %q, want %q", r.Mode, ModeFestival)
+	}
+}
+
+func TestResolve_FestivalPhaseWithWorkflowDoc(t *testing.T) {
+	root := t.TempDir()
+	festDir := filepath.Join(root, "festivals", "active", "test-TF0002")
+	writeF(t, filepath.Join(festDir, "fest.yaml"), `version: "1.0"
+metadata:
+  id: TF0002
+  name: test
+`)
+	phaseDir := filepath.Join(festDir, "001_INGEST")
+	writeF(t, filepath.Join(phaseDir, "PHASE_GOAL.md"), "# phase")
+	writeF(t, filepath.Join(phaseDir, "WORKFLOW.md"), "## Step 1: X\n")
+
+	r, err := Resolve(context.Background(), phaseDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Mode != ModeFestival {
+		t.Errorf("Mode = %q, want festival", r.Mode)
+	}
+	if r.PhasePath == "" {
+		t.Errorf("PhasePath should be set inside a phase")
+	}
+	if r.WorkflowDoc == "" || filepath.Base(r.WorkflowDoc) != "WORKFLOW.md" {
+		t.Errorf("WorkflowDoc = %q", r.WorkflowDoc)
+	}
+}
+
+func TestResolve_Tracked(t *testing.T) {
+	dir := t.TempDir()
+	writeF(t, filepath.Join(dir, "WORKFLOW.md"), "## Step 1: X\n")
+	writeF(t, filepath.Join(dir, ".workflow", "workflow.yaml"), `version: 1
+kind: workflow-runtime
+workflow_id: wf-x
+`)
+
+	r, err := Resolve(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Mode != ModeTracked {
+		t.Errorf("Mode = %q, want tracked", r.Mode)
+	}
+	if r.RuntimeDir == "" {
+		t.Errorf("RuntimeDir should be set")
+	}
+}
+
+func TestResolve_Anonymous(t *testing.T) {
+	dir := t.TempDir()
+	writeF(t, filepath.Join(dir, "WORKFLOW.md"), "## Step 1: X\n")
+
+	r, err := Resolve(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Mode != ModeAnonymous {
+		t.Errorf("Mode = %q, want anonymous", r.Mode)
+	}
+	if r.RuntimeDir != "" {
+		t.Errorf("RuntimeDir should be empty for anonymous, got %q", r.RuntimeDir)
+	}
+	if filepath.Base(r.WorkflowDoc) != "WORKFLOW.md" {
+		t.Errorf("WorkflowDoc = %q", r.WorkflowDoc)
+	}
+}
+
+func TestResolve_NestedAnonymous(t *testing.T) {
+	root := t.TempDir()
+	parent := filepath.Join(root, "wf-parent")
+	subdir := filepath.Join(parent, "deeper", "nested")
+	writeF(t, filepath.Join(parent, "WORKFLOW.md"), "## Step 1: X\n")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Resolve(context.Background(), subdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Mode != ModeAnonymous {
+		t.Errorf("Mode = %q, want anonymous (walk up to parent)", r.Mode)
+	}
+}
+
+func TestResolve_ContextCancelled(t *testing.T) {
+	dir := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := Resolve(ctx, dir)
+	if err == nil {
+		t.Fatal("expected context.Canceled error")
+	}
+}

--- a/tests/integration/helpers.go
+++ b/tests/integration/helpers.go
@@ -222,6 +222,35 @@ func (tc *TestContainer) RunFestInDirTTY(dir string, args ...string) (string, er
  return output, nil
 }
 
+// Exec runs an arbitrary shell command inside the container via `sh -c`.
+// Returns combined stdout+stderr and any execution error. Non-zero exit
+// codes are surfaced via the error so tests can assert on them.
+func (tc *TestContainer) Exec(cmd ...string) (string, error) {
+	out, err := tc.runCommand(cmd)
+	return out, err
+}
+
+// WriteFile writes content into a path inside the container, creating
+// any missing parent directories.
+func (tc *TestContainer) WriteFile(path, content string) error {
+	parent := filepath.Dir(path)
+	if _, _, err := tc.container.Exec(tc.ctx, []string{"mkdir", "-p", parent}); err != nil {
+		return fmt.Errorf("mkdir -p %s: %w", parent, err)
+	}
+	// Use a temp host file and CopyToContainer to avoid shell-escaping content.
+	f, err := os.CreateTemp("", "fest-helper-write-*")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.WriteString(content); err != nil {
+		f.Close()
+		return err
+	}
+	f.Close()
+	return tc.CopyToContainer(f.Name(), path)
+}
+
 // runCommand executes a command in the container
 // Returns output even on non-zero exit for test debugging
 func (tc *TestContainer) runCommand(cmd []string) (string, error) {

--- a/tests/integration/standalone_workflow_test.go
+++ b/tests/integration/standalone_workflow_test.go
@@ -1,0 +1,90 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestStandaloneWorkflow_InitStart exercises the standalone WORKFLOW.md
+// init/start lifecycle inside a container, validating real filesystem effects
+// (atomic writes, directory creation, manifest YAML shape) without mutating
+// the host. Closes a slice of WW0001 task 008.01.10's container-harness
+// requirement; the in-package store_test.go tests remain as pure unit tests
+// for internal APIs the CLI surface can't drive directly.
+func TestStandaloneWorkflow_InitStart(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	container := GetSharedContainer(t)
+
+	const dir = "/tmp/standalone-wf"
+	_, err := container.Exec("rm", "-rf", dir)
+	require.NoError(t, err)
+
+	workflowMD := `# Test Workflow
+
+## Step 1: First
+
+Do the first thing.
+
+## Step 2: Second
+
+Do the second thing.
+`
+	require.NoError(t, container.WriteFile(dir+"/WORKFLOW.md", workflowMD))
+
+	t.Run("Init", func(t *testing.T) {
+		out, err := container.RunFestInDir(dir, "workflow", "init")
+		require.NoError(t, err, "fest workflow init: %s", out)
+		require.Contains(t, out, "Initialized standalone workflow runtime")
+		require.Contains(t, out, "workflow_id=wf-standalone-wf")
+
+		manifest, err := container.ReadFile(dir + "/.workflow/workflow.yaml")
+		require.NoError(t, err)
+		require.Contains(t, manifest, "workflow_id: wf-standalone-wf")
+		require.NotContains(t, manifest, "workitem_id", "manifest must not contain workitem_id post-D024")
+
+		exists, _ := container.CheckFileExists(dir + "/.workitem")
+		require.False(t, exists, "fest workflow init must not write .workitem (D007)")
+	})
+
+	t.Run("Start", func(t *testing.T) {
+		out, err := container.RunFestInDir(dir, "workflow", "start")
+		require.NoError(t, err, "fest workflow start: %s", out)
+
+		runs, err := container.ListDirectory(dir + "/.workflow/runs")
+		require.NoError(t, err)
+		require.NotEmpty(t, runs, "expected at least one run file under runs/")
+
+		// Find a run.yaml among the listed files.
+		var runYAMLPath string
+		for _, f := range runs {
+			if strings.HasSuffix(f, "/run.yaml") {
+				runYAMLPath = f
+				break
+			}
+		}
+		require.NotEmpty(t, runYAMLPath, "run.yaml not found under runs/")
+
+		runYAML, err := container.ReadFile(runYAMLPath)
+		require.NoError(t, err)
+		require.Contains(t, runYAML, "status: active")
+		require.NotContains(t, runYAML, "workitem_id", "run.yaml must not contain workitem_id post-D024")
+	})
+
+	t.Run("InitRejectsInvalidWorkflowID", func(t *testing.T) {
+		badDir := "/tmp/standalone-bad"
+		_, _ = container.Exec("rm", "-rf", badDir)
+		require.NoError(t, container.WriteFile(badDir+"/WORKFLOW.md", "## Step 1: X\n"))
+
+		out, err := container.RunFestInDir(badDir, "workflow", "init", "--workflow-id", "Bad Name!")
+		require.Error(t, err, "expected non-zero exit for invalid workflow_id")
+		require.Contains(t, out, "invalid workflow_id")
+	})
+}


### PR DESCRIPTION
## Summary

Sequence 1 of phase 004 in festival WW0001 (workitem-workflows). Adds the
foundation for standalone `WORKFLOW.md` execution outside of festivals:

- `internal/workflow/standalone/` resolver returns a typed `Result` with
  `Mode` of `festival` / `tracked` / `anonymous` / `none`. Festival context
  wins unconditionally when both signals exist.
- `internal/workflow/localstore/` filesystem-only store implementing the
  contract in `workflow/design/workitem-workflows/LOCAL_RUN_STATE.md`:
  `workflow.yaml`, `runs/<id>/run.yaml`, append-only
  `progress_events.jsonl`. Replay derives state; cached summary repaired
  on read; event lines are never rewritten.
- `fest workflow init/start/runs` subcommands wired via the resolver.

`fest workflow show` is the first consumer of the resolver (narrow
integration). Festival mode is unchanged; tracked and anonymous modes
return a deferred-feature stub that points at sequence 004.02 for full
integration.

## Test plan

- [x] `go test -race -count=1 ./internal/workflow/... ./internal/commands/workflow/...` green
- [x] `just build quick` successful
- [x] E2E smoke: `fest workflow init` creates `.workitem` + `.workflow/`,
      `fest workflow start` writes a new `run-...` directory and event,
      `fest workflow runs` lists it. Real output:
      ```
      Initialized standalone workflow runtime at /tmp/wf
      Started run run-20260513T041814Z
      RUN_ID                STATUS    STARTED                 COMPLETED
      run-20260513T041814Z  active    2026-05-13T04:18:14Z
      ```

## Codex review fixes (commit 7b41b3f)

Codex review (acting as user-proxy reviewer per the festival loop)
flagged two issues that landed as follow-up commits:

- Emdashes in resolver.go doc comment. Replaced with colons.
- Same-second `StartRun` calls would overwrite earlier `run.yaml` via
  `MkdirAll`. Now uses `os.Mkdir` with `-2`, `-3` suffix on collision;
  older runs are byte-identical before and after. New test
  `TestStore_StartRunUniqueWithinSameSecond` proves this.

## Festival traceability

Festival: workitem-workflows-WW0001
Phase: 004_IMPLEMENT_FEST_WORKFLOWS
Sequence: 01_standalone_runtime (all 8 tasks complete)