### PR TITLE
feat(workflow): fest next + workflow standalone routing (WW0001 phase 004 seq 2)

### DIFF
--- a/internal/commands/chain/complete.go
+++ b/internal/commands/chain/complete.go
@@ -9,8 +9,8 @@ import (
 	chainpkg "github.com/Obedience-Corp/fest/internal/chain"
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/ui"
-	"github.com/spf13/cobra"
 	"github.com/Obedience-Corp/fest/internal/yamlutil"
+	"github.com/spf13/cobra"
 )
 
 func newCompleteCmd() *cobra.Command {

--- a/internal/commands/gendocs.go
+++ b/internal/commands/gendocs.go
@@ -263,7 +263,6 @@ func looksLikeShellBlock(line string) bool {
 	return false
 }
 
-
 // stripSeeAlso removes the "### SEE ALSO" section from markdown content.
 // Used when combining individual command docs into a single reference page
 // where cross-links are redundant.

--- a/internal/commands/markers/scaffold.go
+++ b/internal/commands/markers/scaffold.go
@@ -12,8 +12,8 @@ import (
 	"github.com/Obedience-Corp/fest/internal/markers"
 	tpl "github.com/Obedience-Corp/fest/internal/template"
 	"github.com/Obedience-Corp/fest/internal/ui"
-	"github.com/spf13/cobra"
 	"github.com/Obedience-Corp/fest/internal/yamlutil"
+	"github.com/spf13/cobra"
 )
 
 // ScaffoldMeta contains metadata about the scaffold output

--- a/internal/commands/next/next.go
+++ b/internal/commands/next/next.go
@@ -3,6 +3,7 @@ package next
 
 import (
 	"context"
+	jsonpkg "encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -16,12 +17,15 @@ import (
 	"github.com/Obedience-Corp/fest/internal/frontmatter"
 	"github.com/Obedience-Corp/fest/internal/guidance"
 	"github.com/Obedience-Corp/fest/internal/guidance/selection"
+	wfparser "github.com/Obedience-Corp/fest/internal/guidance/workflow"
 	"github.com/Obedience-Corp/fest/internal/id"
 	"github.com/Obedience-Corp/fest/internal/lifecycle"
 	"github.com/Obedience-Corp/fest/internal/pathutil"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	tpl "github.com/Obedience-Corp/fest/internal/template"
 	"github.com/Obedience-Corp/fest/internal/validator"
+	"github.com/Obedience-Corp/fest/internal/workflow/localstore"
+	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
 	"github.com/Obedience-Corp/fest/internal/workspace"
 	"github.com/spf13/cobra"
 
@@ -54,7 +58,9 @@ func NewNextCommand() *cobra.Command {
 		Use:   "next",
 		Short: "Find the next task to work on",
 		Annotations: map[string]string{
-			"scope": string(scope.Festival),
+			// scope.Global so the cobra middleware does not pre-require a
+			// festival; runNext does its own festival vs standalone resolution.
+			"scope": string(scope.Global),
 		},
 		Long: `Determine the next task to work on based on dependencies and progress.
 
@@ -121,6 +127,17 @@ func runNext(cmd *cobra.Command, args []string) error {
 	// Resolve festival path (supports linked festivals via fest link)
 	festivalPath, err := shared.ResolveFestivalPath(cwd, "")
 	if err != nil {
+		// No festival context. Try standalone workflow resolution (WW0001/004.02).
+		if res, resErr := standalone.Resolve(ctx, cwd); resErr == nil {
+			switch res.Mode {
+			case standalone.ModeTracked:
+				return runStandaloneNext(ctx, res, showInlineContext)
+			case standalone.ModeAnonymous:
+				return errors.New("anonymous WORKFLOW.md routing not yet implemented").
+					WithField("workflow_doc", res.WorkflowDoc).
+					WithHint("Scheduled for sequence 004.02 task 03; run 'fest workflow init' to track this workflow first")
+			}
+		}
 		return errors.Wrap(err, "not inside a festival")
 	}
 
@@ -464,4 +481,125 @@ func mapChainFestivalStatus(s string) chainpkg.FestivalStatus {
 	default:
 		return chainpkg.FestivalPlanning
 	}
+}
+
+// StandaloneView is the JSON-friendly view of a standalone tracked workflow.
+type StandaloneView struct {
+	Mode           string   `json:"mode"`
+	WorkflowDoc    string   `json:"workflow_doc"`
+	RuntimeDir     string   `json:"runtime_dir,omitempty"`
+	RunID          string   `json:"run_id,omitempty"`
+	RunStatus      string   `json:"run_status,omitempty"`
+	CurrentStep    int      `json:"current_step,omitempty"`
+	TotalSteps     int      `json:"total_steps,omitempty"`
+	StepName       string   `json:"step_name,omitempty"`
+	StepGoal       string   `json:"step_goal,omitempty"`
+	StepActions    []string `json:"step_actions,omitempty"`
+	StepCheckpoint string   `json:"step_checkpoint,omitempty"`
+	Blocked        bool     `json:"blocked,omitempty"`
+	DocHashChanged bool     `json:"doc_hash_changed,omitempty"`
+	Completion     string   `json:"completion_command,omitempty"`
+}
+
+// runStandaloneNext renders the next step for a tracked standalone workflow.
+func runStandaloneNext(ctx context.Context, res *standalone.Result, showInlineContext bool) error {
+	store := localstore.Open(res.RuntimeDir, res.WorkflowDoc)
+	state, err := store.LoadActive(ctx)
+	if err != nil {
+		return err
+	}
+	if state == nil {
+		return errors.NotFound("no active run").
+			WithHint("Run 'fest workflow start' to begin")
+	}
+
+	steps, parseErr := wfparser.NewParser().Parse(ctx, res.WorkflowDoc)
+	if parseErr != nil {
+		return errors.Wrap(parseErr, "parsing WORKFLOW.md")
+	}
+
+	view := StandaloneView{
+		Mode:           "standalone-tracked",
+		WorkflowDoc:    res.WorkflowDoc,
+		RuntimeDir:     res.RuntimeDir,
+		RunID:          state.RunID,
+		RunStatus:      state.Status,
+		CurrentStep:    state.CurrentStep,
+		TotalSteps:     len(steps),
+		Blocked:        state.Blocked,
+		DocHashChanged: state.DocHashChanged,
+		Completion:     "fest workflow advance",
+	}
+	if state.CurrentStep > 0 && state.CurrentStep <= len(steps) {
+		s := steps[state.CurrentStep-1]
+		view.StepName = s.Name
+		view.StepGoal = s.Goal
+		view.StepActions = s.Actions
+		view.StepCheckpoint = string(s.Checkpoint)
+	} else if len(steps) > 0 {
+		// No step started yet; preview step 1.
+		s := steps[0]
+		view.StepName = s.Name
+		view.StepGoal = s.Goal
+		view.StepActions = s.Actions
+		view.StepCheckpoint = string(s.Checkpoint)
+		view.CurrentStep = 1
+	}
+
+	if projectDirFlag {
+		fmt.Println(filepath.Dir(res.WorkflowDoc))
+		return nil
+	}
+	if pathFlag {
+		rel, _ := filepath.Rel(res.StartDir, res.WorkflowDoc)
+		fmt.Println(rel)
+		return nil
+	}
+	if cdOutput {
+		fmt.Println(filepath.Dir(res.WorkflowDoc))
+		return nil
+	}
+	if shortOutput {
+		fmt.Printf("%s step %d/%d (%s)\n", view.WorkflowDoc, view.CurrentStep, view.TotalSteps, view.RunStatus)
+		return nil
+	}
+	if jsonOutput {
+		data, jerr := jsonMarshalView(view)
+		if jerr != nil {
+			return errors.Parse("formatting JSON", jerr)
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+
+	fmt.Println("STANDALONE WORKFLOW")
+	fmt.Println("───────────────────")
+	fmt.Printf("Workflow doc: %s\n", view.WorkflowDoc)
+	fmt.Printf("Run: %s (%s)\n", view.RunID, view.RunStatus)
+	fmt.Printf("Step %d of %d", view.CurrentStep, view.TotalSteps)
+	if view.Blocked {
+		fmt.Print(" (blocked)")
+	}
+	fmt.Println()
+	if view.StepName != "" {
+		fmt.Printf("\n%s\n", view.StepName)
+		if showInlineContext && view.StepGoal != "" {
+			fmt.Printf("Goal: %s\n", view.StepGoal)
+		}
+		if showInlineContext && len(view.StepActions) > 0 {
+			fmt.Println("Actions:")
+			for i, a := range view.StepActions {
+				fmt.Printf("  %d. %s\n", i+1, a)
+			}
+		}
+	}
+	if view.DocHashChanged {
+		fmt.Println("\n⚠ WORKFLOW.md has changed since this run started")
+	}
+	fmt.Printf("\nWhen step complete: %s\n", view.Completion)
+	return nil
+}
+
+func jsonMarshalView(v StandaloneView) ([]byte, error) {
+	return jsonpkg.MarshalIndent(v, "", "  ")
 }

--- a/internal/commands/next/next.go
+++ b/internal/commands/next/next.go
@@ -133,9 +133,7 @@ func runNext(cmd *cobra.Command, args []string) error {
 			case standalone.ModeTracked:
 				return runStandaloneNext(ctx, res, showInlineContext)
 			case standalone.ModeAnonymous:
-				return errors.New("anonymous WORKFLOW.md routing not yet implemented").
-					WithField("workflow_doc", res.WorkflowDoc).
-					WithHint("Scheduled for sequence 004.02 task 03; run 'fest workflow init' to track this workflow first")
+				return runAnonymousNext(ctx, res, showInlineContext)
 			}
 		}
 		return errors.Wrap(err, "not inside a festival")
@@ -602,4 +600,73 @@ func runStandaloneNext(ctx context.Context, res *standalone.Result, showInlineCo
 
 func jsonMarshalView(v StandaloneView) ([]byte, error) {
 	return jsonpkg.MarshalIndent(v, "", "  ")
+}
+
+// runAnonymousNext renders step 1 of a WORKFLOW.md that has no .workflow/
+// runtime yet. Pure read; creates no files. First mutation (fest workflow
+// advance) will bootstrap to tracked mode.
+func runAnonymousNext(ctx context.Context, res *standalone.Result, showInlineContext bool) error {
+	steps, parseErr := wfparser.NewParser().Parse(ctx, res.WorkflowDoc)
+	if parseErr != nil {
+		return errors.Wrap(parseErr, "parsing WORKFLOW.md")
+	}
+	if len(steps) == 0 {
+		return errors.New("WORKFLOW.md has no parseable steps").
+			WithField("workflow_doc", res.WorkflowDoc).
+			WithHint("Add at least one '## Step 1: NAME' header")
+	}
+
+	view := StandaloneView{
+		Mode:        "standalone-anonymous",
+		WorkflowDoc: res.WorkflowDoc,
+		RunStatus:   "not-started",
+		CurrentStep: 1,
+		TotalSteps:  len(steps),
+		Completion:  "fest workflow advance",
+	}
+	s := steps[0]
+	view.StepName = s.Name
+	view.StepGoal = s.Goal
+	view.StepActions = s.Actions
+	view.StepCheckpoint = string(s.Checkpoint)
+
+	if projectDirFlag || cdOutput {
+		fmt.Println(filepath.Dir(res.WorkflowDoc))
+		return nil
+	}
+	if pathFlag {
+		rel, _ := filepath.Rel(res.StartDir, res.WorkflowDoc)
+		fmt.Println(rel)
+		return nil
+	}
+	if shortOutput {
+		fmt.Printf("%s anonymous step 1/%d\n", res.WorkflowDoc, len(steps))
+		return nil
+	}
+	if jsonOutput {
+		data, jerr := jsonMarshalView(view)
+		if jerr != nil {
+			return errors.Parse("formatting JSON", jerr)
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+
+	fmt.Println("STANDALONE WORKFLOW (anonymous)")
+	fmt.Println("───────────────────────────────")
+	fmt.Printf("Workflow doc: %s\n", res.WorkflowDoc)
+	fmt.Printf("Status: not-started\n")
+	fmt.Printf("Step 1 of %d\n", len(steps))
+	fmt.Printf("\n%s\n", view.StepName)
+	if showInlineContext && view.StepGoal != "" {
+		fmt.Printf("Goal: %s\n", view.StepGoal)
+	}
+	if showInlineContext && len(view.StepActions) > 0 {
+		fmt.Println("Actions:")
+		for i, a := range view.StepActions {
+			fmt.Printf("  %d. %s\n", i+1, a)
+		}
+	}
+	fmt.Printf("\nFirst mutating command (fest workflow advance) will bootstrap a tracked run.\n")
+	return nil
 }

--- a/internal/commands/next/next.go
+++ b/internal/commands/next/next.go
@@ -124,6 +124,20 @@ func runNext(cmd *cobra.Command, args []string) error {
 	// Context is shown by default, --no-context disables it
 	showInlineContext := !noInlineContext
 
+	// Snapshot cobra flag globals into a RenderOptions struct so render
+	// functions receive their configuration by parameter rather than reading
+	// package-level state. Without this, tests that toggle the flags inside
+	// goroutines (or under t.Parallel) race.
+	opts := RenderOptions{
+		JSON:       jsonOutput,
+		Short:      shortOutput,
+		CD:         cdOutput,
+		Path:       pathFlag,
+		ProjectDir: projectDirFlag,
+		Verbose:    verboseOutput,
+		NoContext:  noInlineContext,
+	}
+
 	// Resolve festival path (supports linked festivals via fest link)
 	festivalPath, err := shared.ResolveFestivalPath(cwd, "")
 	if err != nil {
@@ -131,9 +145,9 @@ func runNext(cmd *cobra.Command, args []string) error {
 		if res, resErr := standalone.Resolve(ctx, cwd); resErr == nil {
 			switch res.Mode {
 			case standalone.ModeTracked:
-				return runStandaloneNext(ctx, res, showInlineContext)
+				return runStandaloneNext(ctx, res, opts)
 			case standalone.ModeAnonymous:
-				return runAnonymousNext(ctx, res, showInlineContext)
+				return runAnonymousNext(ctx, res, opts)
 			}
 		}
 		return errors.Wrap(err, "not inside a festival")
@@ -497,10 +511,51 @@ type StandaloneView struct {
 	Blocked        bool     `json:"blocked,omitempty"`
 	DocHashChanged bool     `json:"doc_hash_changed,omitempty"`
 	Completion     string   `json:"completion_command,omitempty"`
+	RenderMode     string   `json:"render_mode,omitempty"` // "in_progress" | "next_up" | "complete"
 }
 
+// pickRenderStep selects which step runStandaloneNext should display. Returns
+// the 1-indexed step number plus a mode describing what the user is looking
+// at. The localstore replay distinguishes "started but not done" (CurrentStep
+// > CompletedSteps) from "last done, next not yet started" (equal). Without
+// this, post-bootstrap rendering shows the just-completed step (D030 #6).
+func pickRenderStep(state *localstore.RunState, totalSteps int) (int, string) {
+	if totalSteps == 0 {
+		return 0, "no_run"
+	}
+	if state.Status == "completed" || state.CompletedSteps >= totalSteps {
+		return totalSteps, "complete"
+	}
+	if state.CurrentStep > state.CompletedSteps {
+		return state.CurrentStep, "in_progress"
+	}
+	next := state.CompletedSteps + 1
+	if next > totalSteps {
+		return totalSteps, "complete"
+	}
+	if next < 1 {
+		return 1, "next_up"
+	}
+	return next, "next_up"
+}
+
+// RenderOptions configures rendering for standalone / anonymous next output.
+// Snapshotted from cobra flag globals once at runNext entry; render functions
+// only read this struct, not package state.
+type RenderOptions struct {
+	JSON       bool
+	Short      bool
+	CD         bool
+	Path       bool
+	ProjectDir bool
+	Verbose    bool
+	NoContext  bool
+}
+
+func (o RenderOptions) showInlineContext() bool { return !o.NoContext }
+
 // runStandaloneNext renders the next step for a tracked standalone workflow.
-func runStandaloneNext(ctx context.Context, res *standalone.Result, showInlineContext bool) error {
+func runStandaloneNext(ctx context.Context, res *standalone.Result, opts RenderOptions) error {
 	store := localstore.Open(res.RuntimeDir, res.WorkflowDoc)
 	state, err := store.LoadActive(ctx)
 	if err != nil {
@@ -516,52 +571,51 @@ func runStandaloneNext(ctx context.Context, res *standalone.Result, showInlineCo
 		return errors.Wrap(parseErr, "parsing WORKFLOW.md")
 	}
 
+	// Pick the step to render. Distinguishes "in progress" (start without
+	// matching done) from "next up" (last step completed, next not started)
+	// so post-bootstrap views don't show the just-completed step. Closes
+	// D030 finding #6.
+	renderIdx, renderMode := pickRenderStep(state, len(steps))
+
 	view := StandaloneView{
 		Mode:           "standalone-tracked",
 		WorkflowDoc:    res.WorkflowDoc,
 		RuntimeDir:     res.RuntimeDir,
 		RunID:          state.RunID,
 		RunStatus:      state.Status,
-		CurrentStep:    state.CurrentStep,
+		CurrentStep:    renderIdx,
 		TotalSteps:     len(steps),
 		Blocked:        state.Blocked,
 		DocHashChanged: state.DocHashChanged,
 		Completion:     "fest workflow advance",
+		RenderMode:     renderMode,
 	}
-	if state.CurrentStep > 0 && state.CurrentStep <= len(steps) {
-		s := steps[state.CurrentStep-1]
+	if renderIdx >= 1 && renderIdx <= len(steps) {
+		s := steps[renderIdx-1]
 		view.StepName = s.Name
 		view.StepGoal = s.Goal
 		view.StepActions = s.Actions
 		view.StepCheckpoint = string(s.Checkpoint)
-	} else if len(steps) > 0 {
-		// No step started yet; preview step 1.
-		s := steps[0]
-		view.StepName = s.Name
-		view.StepGoal = s.Goal
-		view.StepActions = s.Actions
-		view.StepCheckpoint = string(s.Checkpoint)
-		view.CurrentStep = 1
 	}
 
-	if projectDirFlag {
+	if opts.ProjectDir {
 		fmt.Println(filepath.Dir(res.WorkflowDoc))
 		return nil
 	}
-	if pathFlag {
+	if opts.Path {
 		rel, _ := filepath.Rel(res.StartDir, res.WorkflowDoc)
 		fmt.Println(rel)
 		return nil
 	}
-	if cdOutput {
+	if opts.CD {
 		fmt.Println(filepath.Dir(res.WorkflowDoc))
 		return nil
 	}
-	if shortOutput {
+	if opts.Short {
 		fmt.Printf("%s step %d/%d (%s)\n", view.WorkflowDoc, view.CurrentStep, view.TotalSteps, view.RunStatus)
 		return nil
 	}
-	if jsonOutput {
+	if opts.JSON {
 		data, jerr := jsonMarshalView(view)
 		if jerr != nil {
 			return errors.Parse("formatting JSON", jerr)
@@ -581,10 +635,10 @@ func runStandaloneNext(ctx context.Context, res *standalone.Result, showInlineCo
 	fmt.Println()
 	if view.StepName != "" {
 		fmt.Printf("\n%s\n", view.StepName)
-		if showInlineContext && view.StepGoal != "" {
+		if opts.showInlineContext() && view.StepGoal != "" {
 			fmt.Printf("Goal: %s\n", view.StepGoal)
 		}
-		if showInlineContext && len(view.StepActions) > 0 {
+		if opts.showInlineContext() && len(view.StepActions) > 0 {
 			fmt.Println("Actions:")
 			for i, a := range view.StepActions {
 				fmt.Printf("  %d. %s\n", i+1, a)
@@ -605,7 +659,7 @@ func jsonMarshalView(v StandaloneView) ([]byte, error) {
 // runAnonymousNext renders step 1 of a WORKFLOW.md that has no .workflow/
 // runtime yet. Pure read; creates no files. First mutation (fest workflow
 // advance) will bootstrap to tracked mode.
-func runAnonymousNext(ctx context.Context, res *standalone.Result, showInlineContext bool) error {
+func runAnonymousNext(ctx context.Context, res *standalone.Result, opts RenderOptions) error {
 	steps, parseErr := wfparser.NewParser().Parse(ctx, res.WorkflowDoc)
 	if parseErr != nil {
 		return errors.Wrap(parseErr, "parsing WORKFLOW.md")
@@ -630,20 +684,20 @@ func runAnonymousNext(ctx context.Context, res *standalone.Result, showInlineCon
 	view.StepActions = s.Actions
 	view.StepCheckpoint = string(s.Checkpoint)
 
-	if projectDirFlag || cdOutput {
+	if opts.ProjectDir || opts.CD {
 		fmt.Println(filepath.Dir(res.WorkflowDoc))
 		return nil
 	}
-	if pathFlag {
+	if opts.Path {
 		rel, _ := filepath.Rel(res.StartDir, res.WorkflowDoc)
 		fmt.Println(rel)
 		return nil
 	}
-	if shortOutput {
+	if opts.Short {
 		fmt.Printf("%s anonymous step 1/%d\n", res.WorkflowDoc, len(steps))
 		return nil
 	}
-	if jsonOutput {
+	if opts.JSON {
 		data, jerr := jsonMarshalView(view)
 		if jerr != nil {
 			return errors.Parse("formatting JSON", jerr)
@@ -658,10 +712,10 @@ func runAnonymousNext(ctx context.Context, res *standalone.Result, showInlineCon
 	fmt.Printf("Status: not-started\n")
 	fmt.Printf("Step 1 of %d\n", len(steps))
 	fmt.Printf("\n%s\n", view.StepName)
-	if showInlineContext && view.StepGoal != "" {
+	if opts.showInlineContext() && view.StepGoal != "" {
 		fmt.Printf("Goal: %s\n", view.StepGoal)
 	}
-	if showInlineContext && len(view.StepActions) > 0 {
+	if opts.showInlineContext() && len(view.StepActions) > 0 {
 		fmt.Println("Actions:")
 		for i, a := range view.StepActions {
 			fmt.Printf("  %d. %s\n", i+1, a)

--- a/internal/commands/next/standalone_test.go
+++ b/internal/commands/next/standalone_test.go
@@ -65,7 +65,7 @@ func TestRunStandaloneNext_Tracked(t *testing.T) {
 	doc := writeWFDoc(t, dir)
 	store := localstore.Open(filepath.Join(dir, ".workflow"), doc)
 	if err := store.Init(context.Background(), localstore.InitOptions{
-		WorkflowID: "wf-test", WorkitemID: "test-001",
+		WorkflowID: "wf-test",
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +81,7 @@ func TestRunStandaloneNext_Tracked(t *testing.T) {
 	}
 
 	out, err := captureStdoutErr(t, func() error {
-		return runStandaloneNext(context.Background(), res, true)
+		return runStandaloneNext(context.Background(), res, RenderOptions{})
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -99,7 +99,7 @@ func TestRunStandaloneNext_TrackedJSON(t *testing.T) {
 	doc := writeWFDoc(t, dir)
 	store := localstore.Open(filepath.Join(dir, ".workflow"), doc)
 	_ = store.Init(context.Background(), localstore.InitOptions{
-		WorkflowID: "wf-test", WorkitemID: "test-001",
+		WorkflowID: "wf-test",
 	})
 	_, _ = store.StartRun(context.Background(), "")
 
@@ -110,13 +110,8 @@ func TestRunStandaloneNext_TrackedJSON(t *testing.T) {
 		RuntimeDir:  filepath.Join(dir, ".workflow"),
 	}
 
-	// Set the JSON flag for this test.
-	prev := jsonOutput
-	jsonOutput = true
-	defer func() { jsonOutput = prev }()
-
 	out, err := captureStdoutErr(t, func() error {
-		return runStandaloneNext(context.Background(), res, true)
+		return runStandaloneNext(context.Background(), res, RenderOptions{JSON: true})
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -140,7 +135,7 @@ func TestRunAnonymousNext_NoFilesCreated(t *testing.T) {
 	}
 
 	out, err := captureStdoutErr(t, func() error {
-		return runAnonymousNext(context.Background(), res, true)
+		return runAnonymousNext(context.Background(), res, RenderOptions{})
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -167,12 +162,8 @@ func TestRunAnonymousNext_JSONMode(t *testing.T) {
 		WorkflowDoc: doc,
 	}
 
-	prev := jsonOutput
-	jsonOutput = true
-	defer func() { jsonOutput = prev }()
-
 	out, err := captureStdoutErr(t, func() error {
-		return runAnonymousNext(context.Background(), res, true)
+		return runAnonymousNext(context.Background(), res, RenderOptions{JSON: true})
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/commands/next/standalone_test.go
+++ b/internal/commands/next/standalone_test.go
@@ -1,0 +1,186 @@
+package next
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/workflow/localstore"
+	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
+)
+
+func writeWFDoc(t *testing.T, dir string) string {
+	t.Helper()
+	doc := filepath.Join(dir, "WORKFLOW.md")
+	body := `---
+workflow_version: 1
+workflow_id: wf-test
+workitem_id: test-001
+---
+
+## Step 1: ALIGN
+
+**Goal:** prove routing.
+
+**Actions:**
+1. Step one.
+
+**Output:** done
+`
+	if err := os.WriteFile(doc, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return doc
+}
+
+func captureStdoutErr(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+
+	done := make(chan struct{})
+	var buf bytes.Buffer
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(done)
+	}()
+
+	err = fn()
+	_ = w.Close()
+	<-done
+	return buf.String(), err
+}
+
+func TestRunStandaloneNext_Tracked(t *testing.T) {
+	dir := t.TempDir()
+	doc := writeWFDoc(t, dir)
+	store := localstore.Open(filepath.Join(dir, ".workflow"), doc)
+	if err := store.Init(context.Background(), localstore.InitOptions{
+		WorkflowID: "wf-test", WorkitemID: "test-001",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.StartRun(context.Background(), ""); err != nil {
+		t.Fatal(err)
+	}
+
+	res := &standalone.Result{
+		Mode:        standalone.ModeTracked,
+		StartDir:    dir,
+		WorkflowDoc: doc,
+		RuntimeDir:  filepath.Join(dir, ".workflow"),
+	}
+
+	out, err := captureStdoutErr(t, func() error {
+		return runStandaloneNext(context.Background(), res, true)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "STANDALONE WORKFLOW") {
+		t.Errorf("output missing header: %s", out)
+	}
+	if !strings.Contains(out, "ALIGN") {
+		t.Errorf("output missing step name: %s", out)
+	}
+}
+
+func TestRunStandaloneNext_TrackedJSON(t *testing.T) {
+	dir := t.TempDir()
+	doc := writeWFDoc(t, dir)
+	store := localstore.Open(filepath.Join(dir, ".workflow"), doc)
+	_ = store.Init(context.Background(), localstore.InitOptions{
+		WorkflowID: "wf-test", WorkitemID: "test-001",
+	})
+	_, _ = store.StartRun(context.Background(), "")
+
+	res := &standalone.Result{
+		Mode:        standalone.ModeTracked,
+		StartDir:    dir,
+		WorkflowDoc: doc,
+		RuntimeDir:  filepath.Join(dir, ".workflow"),
+	}
+
+	// Set the JSON flag for this test.
+	prev := jsonOutput
+	jsonOutput = true
+	defer func() { jsonOutput = prev }()
+
+	out, err := captureStdoutErr(t, func() error {
+		return runStandaloneNext(context.Background(), res, true)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, `"mode": "standalone-tracked"`) {
+		t.Errorf("JSON mode field missing: %s", out)
+	}
+	if !strings.Contains(out, `"current_step": 1`) && !strings.Contains(out, `"current_step":1`) {
+		t.Errorf("JSON current_step missing: %s", out)
+	}
+}
+
+func TestRunAnonymousNext_NoFilesCreated(t *testing.T) {
+	dir := t.TempDir()
+	doc := writeWFDoc(t, dir)
+
+	res := &standalone.Result{
+		Mode:        standalone.ModeAnonymous,
+		StartDir:    dir,
+		WorkflowDoc: doc,
+	}
+
+	out, err := captureStdoutErr(t, func() error {
+		return runAnonymousNext(context.Background(), res, true)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "anonymous") {
+		t.Errorf("output should identify anonymous mode: %s", out)
+	}
+
+	// Critical: no files created.
+	if _, err := os.Stat(filepath.Join(dir, ".workitem")); err == nil {
+		t.Errorf(".workitem should not exist after read-only fest next")
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".workflow")); err == nil {
+		t.Errorf(".workflow/ should not exist after read-only fest next")
+	}
+}
+
+func TestRunAnonymousNext_JSONMode(t *testing.T) {
+	dir := t.TempDir()
+	doc := writeWFDoc(t, dir)
+	res := &standalone.Result{
+		Mode:        standalone.ModeAnonymous,
+		StartDir:    dir,
+		WorkflowDoc: doc,
+	}
+
+	prev := jsonOutput
+	jsonOutput = true
+	defer func() { jsonOutput = prev }()
+
+	out, err := captureStdoutErr(t, func() error {
+		return runAnonymousNext(context.Background(), res, true)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, `"mode": "standalone-anonymous"`) {
+		t.Errorf("JSON mode field missing: %s", out)
+	}
+	if !strings.Contains(out, `"run_status": "not-started"`) {
+		t.Errorf("JSON run_status missing: %s", out)
+	}
+}

--- a/internal/commands/next/validation.go
+++ b/internal/commands/next/validation.go
@@ -129,4 +129,3 @@ func emitValidationBlock(festivalPath string, result *validator.Result) error {
 	fmt.Print(sb.String())
 	return errors.ErrAlreadyPrinted
 }
-

--- a/internal/commands/research/link.go
+++ b/internal/commands/research/link.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/ui"
-	"github.com/spf13/cobra"
 	"github.com/Obedience-Corp/fest/internal/yamlutil"
+	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
 

--- a/internal/commands/show/stats.go
+++ b/internal/commands/show/stats.go
@@ -16,11 +16,11 @@ import (
 
 // FestivalInfo holds information about a festival.
 type FestivalInfo struct {
-	ID           string    `json:"id"`                      // Directory-based ID (e.g., "my-project_GU0001")
-	MetadataID   string    `json:"metadata_id,omitempty"`   // ID from fest.yaml metadata (e.g., "GU0001")
-	Name         string    `json:"name"`                    // Directory name (used for linking)
-	MetadataName string    `json:"metadata_name,omitempty"` // Name from fest.yaml metadata (clean name without ID)
-	Status       string    `json:"status"`
+	ID           string `json:"id"`                      // Directory-based ID (e.g., "my-project_GU0001")
+	MetadataID   string `json:"metadata_id,omitempty"`   // ID from fest.yaml metadata (e.g., "GU0001")
+	Name         string `json:"name"`                    // Directory name (used for linking)
+	MetadataName string `json:"metadata_name,omitempty"` // Name from fest.yaml metadata (clean name without ID)
+	Status       string `json:"status"`
 	// StatusDate is the dated bucket a festival lives under when it is in a
 	// dungeon substatus. Format is the raw on-disk directory name
 	// (YYYY-MM-DD for new entries, or YYYY-MM for legacy entries).

--- a/internal/commands/status/lifecycle_gate_test.go
+++ b/internal/commands/status/lifecycle_gate_test.go
@@ -17,10 +17,10 @@ import (
 // the phase frontmatter without ever consulting the lifecycle gate.
 func TestPhaseStatusSetGate(t *testing.T) {
 	cases := []struct {
-		name         string
-		status       string
-		phaseType    string
-		expectBlock  bool
+		name        string
+		status      string
+		phaseType   string
+		expectBlock bool
 	}{
 		{name: "planning_blocks_impl_phase_completed", status: "planning", phaseType: "implementation", expectBlock: true},
 		{name: "ready_blocks_review_phase_completed", status: "ready", phaseType: "review", expectBlock: true},

--- a/internal/commands/tui/helpers.go
+++ b/internal/commands/tui/helpers.go
@@ -378,7 +378,6 @@ func nextTaskAfter(ctx context.Context, seqDir string) int {
 	return max
 }
 
-
 // PhaseInfo holds information about a discovered phase.
 type PhaseInfo struct {
 	Number    int

--- a/internal/commands/workflow/advance.go
+++ b/internal/commands/workflow/advance.go
@@ -41,6 +41,13 @@ func runAdvanceBootstrap(ctx context.Context, res *standalone.Result) error {
 // honors blocked state and blocking checkpoints with the same semantics as
 // the festival navigator. Closes D030 finding #5 — previously this code path
 // fell through to getWorkflowNavigator and failed.
+//
+// Step selection mirrors pickRenderStep so `fest workflow advance` operates
+// on the same step `fest next` shows. After bootstrap (start+done for step 1)
+// state.CurrentStep == state.CompletedSteps == 1, and the actionable step is
+// state.CompletedSteps + 1. When a step is in flight (CurrentStep > CompletedSteps)
+// only a Done event is appended; otherwise a Start+Done pair is appended for
+// the next unstarted step.
 func runAdvanceTracked(ctx context.Context, res *standalone.Result) error {
 	store := localstore.Open(res.RuntimeDir, res.WorkflowDoc)
 	state, err := store.LoadActive(ctx)
@@ -61,26 +68,51 @@ func runAdvanceTracked(ctx context.Context, res *standalone.Result) error {
 	if parseErr != nil {
 		return festerrors.Wrap(parseErr, "parsing WORKFLOW.md")
 	}
-	if state.CurrentStep < 1 || state.CurrentStep > len(steps) {
+
+	actionable := state.CurrentStep
+	needStart := false
+	if state.CurrentStep <= state.CompletedSteps {
+		actionable = state.CompletedSteps + 1
+		needStart = true
+	}
+
+	if actionable > len(steps) {
+		if err := store.AppendEvent(ctx, localstore.Event{EventType: localstore.EventWorkflowRunCompleted}); err != nil {
+			return err
+		}
+		fmt.Println(ui.Success("🎉 Workflow complete!"))
+		return nil
+	}
+	if actionable < 1 {
 		return festerrors.New("invalid step index").
-			WithField("current_step", state.CurrentStep).
+			WithField("actionable_step", actionable).
 			WithField("total_steps", len(steps))
 	}
-	step := steps[state.CurrentStep-1]
+	step := steps[actionable-1]
 
 	if step.Checkpoint.IsBlocking() {
-		fmt.Printf("%s Step %d: %s — work complete\n", ui.Success("✓"), state.CurrentStep, step.Name)
+		if needStart {
+			if err := store.AppendEvent(ctx, localstore.Event{EventType: localstore.EventStepStart}); err != nil {
+				return err
+			}
+		}
+		fmt.Printf("%s Step %d: %s — work complete\n", ui.Success("✓"), actionable, step.Name)
 		fmt.Printf("%s CHECKPOINT: awaiting approval\n", ui.Warning("⚠"))
 		fmt.Println("approve: " + ui.Accent("fest workflow approve"))
 		return nil
 	}
 
+	if needStart {
+		if err := store.AppendEvent(ctx, localstore.Event{EventType: localstore.EventStepStart}); err != nil {
+			return err
+		}
+	}
 	if err := store.AppendEvent(ctx, localstore.Event{EventType: localstore.EventStepDone}); err != nil {
 		return err
 	}
-	fmt.Printf("%s Step %d: %s completed\n", ui.Success("✓"), state.CurrentStep, step.Name)
+	fmt.Printf("%s Step %d: %s completed\n", ui.Success("✓"), actionable, step.Name)
 
-	if state.CurrentStep >= len(steps) {
+	if actionable >= len(steps) {
 		if err := store.AppendEvent(ctx, localstore.Event{EventType: localstore.EventWorkflowRunCompleted}); err != nil {
 			return err
 		}
@@ -88,9 +120,6 @@ func runAdvanceTracked(ctx context.Context, res *standalone.Result) error {
 		return nil
 	}
 
-	if err := store.AppendEvent(ctx, localstore.Event{EventType: localstore.EventStepStart}); err != nil {
-		return err
-	}
 	fmt.Println("next: " + ui.Accent("fest next"))
 	return nil
 }

--- a/internal/commands/workflow/advance.go
+++ b/internal/commands/workflow/advance.go
@@ -3,6 +3,8 @@ package workflow
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/Obedience-Corp/fest/internal/chaining"
 	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
@@ -10,6 +12,8 @@ import (
 	"github.com/Obedience-Corp/fest/internal/progress"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
+	"github.com/Obedience-Corp/fest/internal/workflow/localstore"
+	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
 	"github.com/spf13/cobra"
 )
 
@@ -26,7 +30,9 @@ This command:
 
 Note: If the current step has a blocking checkpoint, use 'fest workflow approve' instead.`,
 		Annotations: map[string]string{
-			"scope": string(scope.Festival),
+			// scope.Global so runAdvance can route to anonymous-bootstrap
+			// or tracked standalone runtimes outside a festival.
+			"scope": string(scope.Global),
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runAdvance(cmd.Context())
@@ -37,6 +43,26 @@ Note: If the current step has a blocking checkpoint, use 'fest workflow approve'
 }
 
 func runAdvance(ctx context.Context) error {
+	// Anonymous standalone bootstrap (WW0001/004.02/03): first mutation
+	// converts a hand-written WORKFLOW.md into tracked mode.
+	cwd, _ := os.Getwd()
+	if res, resErr := standalone.Resolve(ctx, cwd); resErr == nil && res.Mode == standalone.ModeAnonymous {
+		if _, err := EnsureTracked(ctx, res, BootstrapOptions{}); err != nil {
+			return err
+		}
+		// After bootstrap, advance the new run by appending a wf_step_start +
+		// wf_step_done event so step 1 is marked complete on the same call.
+		store := localstore.Open(filepath.Join(filepath.Dir(res.WorkflowDoc), ".workflow"), res.WorkflowDoc)
+		if err := store.AppendEvent(ctx, localstore.Event{EventType: localstore.EventStepStart}); err != nil {
+			return err
+		}
+		if err := store.AppendEvent(ctx, localstore.Event{EventType: localstore.EventStepDone}); err != nil {
+			return err
+		}
+		fmt.Println(ui.Success("✓ Bootstrapped tracked workflow and advanced step 1"))
+		return nil
+	}
+
 	nav, err := getWorkflowNavigator(ctx)
 	if err != nil {
 		return err

--- a/internal/commands/workflow/advance.go
+++ b/internal/commands/workflow/advance.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/Obedience-Corp/fest/internal/chaining"
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
 	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
 	"github.com/Obedience-Corp/fest/internal/lifecycle"
 	"github.com/Obedience-Corp/fest/internal/progress"
@@ -16,6 +17,83 @@ import (
 	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
 	"github.com/spf13/cobra"
 )
+
+// runAdvanceBootstrap converts an anonymous WORKFLOW.md into tracked mode
+// (D007 — fest writes only .workflow/, never .workitem). After bootstrap it
+// appends a start+done pair so step 1 reads as completed.
+func runAdvanceBootstrap(ctx context.Context, res *standalone.Result) error {
+	if _, err := EnsureTracked(ctx, res, BootstrapOptions{}); err != nil {
+		return err
+	}
+	store := localstore.Open(filepath.Join(filepath.Dir(res.WorkflowDoc), ".workflow"), res.WorkflowDoc)
+	if err := store.AppendEvent(ctx, localstore.Event{EventType: localstore.EventStepStart}); err != nil {
+		return err
+	}
+	if err := store.AppendEvent(ctx, localstore.Event{EventType: localstore.EventStepDone}); err != nil {
+		return err
+	}
+	fmt.Println(ui.Success("✓ Bootstrapped tracked workflow and advanced step 1"))
+	fmt.Println("next: " + ui.Accent("fest next"))
+	return nil
+}
+
+// runAdvanceTracked advances a standalone tracked workflow by one step. It
+// honors blocked state and blocking checkpoints with the same semantics as
+// the festival navigator. Closes D030 finding #5 — previously this code path
+// fell through to getWorkflowNavigator and failed.
+func runAdvanceTracked(ctx context.Context, res *standalone.Result) error {
+	store := localstore.Open(res.RuntimeDir, res.WorkflowDoc)
+	state, err := store.LoadActive(ctx)
+	if err != nil {
+		return err
+	}
+	if state == nil {
+		return festerrors.NotFound("no active run").
+			WithHint("run 'fest workflow start' first")
+	}
+	if state.Blocked {
+		return festerrors.New("step is blocked").
+			WithField("step", state.CurrentStep).
+			WithHint("use 'fest workflow approve' or 'fest workflow reset'")
+	}
+
+	steps, parseErr := wf.NewParser().Parse(ctx, res.WorkflowDoc)
+	if parseErr != nil {
+		return festerrors.Wrap(parseErr, "parsing WORKFLOW.md")
+	}
+	if state.CurrentStep < 1 || state.CurrentStep > len(steps) {
+		return festerrors.New("invalid step index").
+			WithField("current_step", state.CurrentStep).
+			WithField("total_steps", len(steps))
+	}
+	step := steps[state.CurrentStep-1]
+
+	if step.Checkpoint.IsBlocking() {
+		fmt.Printf("%s Step %d: %s — work complete\n", ui.Success("✓"), state.CurrentStep, step.Name)
+		fmt.Printf("%s CHECKPOINT: awaiting approval\n", ui.Warning("⚠"))
+		fmt.Println("approve: " + ui.Accent("fest workflow approve"))
+		return nil
+	}
+
+	if err := store.AppendEvent(ctx, localstore.Event{EventType: localstore.EventStepDone}); err != nil {
+		return err
+	}
+	fmt.Printf("%s Step %d: %s completed\n", ui.Success("✓"), state.CurrentStep, step.Name)
+
+	if state.CurrentStep >= len(steps) {
+		if err := store.AppendEvent(ctx, localstore.Event{EventType: localstore.EventWorkflowRunCompleted}); err != nil {
+			return err
+		}
+		fmt.Println(ui.Success("🎉 Workflow complete!"))
+		return nil
+	}
+
+	if err := store.AppendEvent(ctx, localstore.Event{EventType: localstore.EventStepStart}); err != nil {
+		return err
+	}
+	fmt.Println("next: " + ui.Accent("fest next"))
+	return nil
+}
 
 func newAdvanceCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -43,24 +121,15 @@ Note: If the current step has a blocking checkpoint, use 'fest workflow approve'
 }
 
 func runAdvance(ctx context.Context) error {
-	// Anonymous standalone bootstrap (WW0001/004.02/03): first mutation
-	// converts a hand-written WORKFLOW.md into tracked mode.
 	cwd, _ := os.Getwd()
-	if res, resErr := standalone.Resolve(ctx, cwd); resErr == nil && res.Mode == standalone.ModeAnonymous {
-		if _, err := EnsureTracked(ctx, res, BootstrapOptions{}); err != nil {
-			return err
+	if res, resErr := standalone.Resolve(ctx, cwd); resErr == nil {
+		switch res.Mode {
+		case standalone.ModeAnonymous:
+			return runAdvanceBootstrap(ctx, res)
+		case standalone.ModeTracked:
+			return runAdvanceTracked(ctx, res)
 		}
-		// After bootstrap, advance the new run by appending a wf_step_start +
-		// wf_step_done event so step 1 is marked complete on the same call.
-		store := localstore.Open(filepath.Join(filepath.Dir(res.WorkflowDoc), ".workflow"), res.WorkflowDoc)
-		if err := store.AppendEvent(ctx, localstore.Event{EventType: localstore.EventStepStart}); err != nil {
-			return err
-		}
-		if err := store.AppendEvent(ctx, localstore.Event{EventType: localstore.EventStepDone}); err != nil {
-			return err
-		}
-		fmt.Println(ui.Success("✓ Bootstrapped tracked workflow and advanced step 1"))
-		return nil
+		// ModeFestival or ModeNone: fall through to festival navigator.
 	}
 
 	nav, err := getWorkflowNavigator(ctx)

--- a/internal/commands/workflow/bootstrap.go
+++ b/internal/commands/workflow/bootstrap.go
@@ -4,29 +4,32 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"strconv"
-	"time"
 
 	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/workflow"
 	"github.com/Obedience-Corp/fest/internal/workflow/localstore"
 	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
 )
 
 // BootstrapOptions controls anonymous-to-tracked conversion.
 type BootstrapOptions struct {
-	WorkitemID  string // optional override for the generated workitem id
-	NoBootstrap bool   // refuse to create files
+	NoBootstrap bool // refuse to create files
 }
 
 // EnsureTracked converts an anonymous standalone workflow into tracked mode by
-// writing .workitem, .workflow/workflow.yaml, and starting the first run.
-// Returns a standalone.Result reflecting the new tracked state.
+// initializing .workflow/ and starting the first run. Fest does NOT write
+// .workitem (D007: .workitem is owned by camp). Returns a standalone.Result
+// reflecting the new tracked state.
 //
 // Behavior:
 //   - if res.Mode is not ModeAnonymous, returns res unchanged
 //   - if opts.NoBootstrap is true, returns an error
-//   - if .workitem or .workflow/ already exists, refuses to overwrite
-//   - otherwise creates both files and starts run 1
+//   - if .workflow/ already exists, refuses to overwrite
+//   - validates that WORKFLOW.md has at least one parseable step BEFORE
+//     creating any state (D030 finding #7)
+//   - otherwise initializes .workflow/ and starts run 1
+//   - if StartRun fails after Init, removes the .workflow/ dir to avoid
+//     leaving the user in a half-initialized state
 func EnsureTracked(ctx context.Context, res *standalone.Result, opts BootstrapOptions) (*standalone.Result, error) {
 	if res == nil || res.Mode != standalone.ModeAnonymous {
 		return res, nil
@@ -39,39 +42,40 @@ func EnsureTracked(ctx context.Context, res *standalone.Result, opts BootstrapOp
 
 	dir := filepath.Dir(res.WorkflowDoc)
 
-	if _, err := os.Stat(filepath.Join(dir, ".workitem")); err == nil {
-		return nil, festerrors.New("refusing to bootstrap: .workitem already exists").
-			WithField("path", filepath.Join(dir, ".workitem"))
-	}
-	if _, err := os.Stat(filepath.Join(dir, ".workflow")); err == nil {
+	workflowDir := filepath.Join(dir, ".workflow")
+	if _, err := os.Stat(workflowDir); err == nil {
 		return nil, festerrors.New("refusing to bootstrap: .workflow/ already exists").
-			WithField("path", filepath.Join(dir, ".workflow"))
+			WithField("path", workflowDir)
 	}
 
-	workitemID := opts.WorkitemID
-	if workitemID == "" {
-		workitemID = "wf-" + filepath.Base(dir) + "-" + strconv.FormatInt(time.Now().UTC().Unix(), 10)
+	// Validate WORKFLOW.md has parseable steps before any state is created
+	// (D030 finding #7). Avoids leaving the user with a broken .workflow/
+	// after a malformed WORKFLOW.md.
+	if err := standalone.ValidateWorkflowDoc(ctx, res.WorkflowDoc); err != nil {
+		return nil, err
 	}
-	workflowID := "wf-" + filepath.Base(dir)
 
-	store := localstore.Open(filepath.Join(dir, ".workflow"), res.WorkflowDoc)
+	workflowID := "wf-" + workflow.SanitizeBasenameAsSlug(filepath.Base(dir))
+	if err := workflow.ValidateWorkflowID(workflowID); err != nil {
+		return nil, err
+	}
+
+	store := localstore.Open(workflowDir, res.WorkflowDoc)
 	if err := store.Init(ctx, localstore.InitOptions{
 		WorkflowID: workflowID,
-		WorkitemID: workitemID,
 	}); err != nil {
 		return nil, festerrors.Wrap(err, "bootstrap init")
 	}
 	if _, err := store.StartRun(ctx, ""); err != nil {
+		// Rollback: remove .workflow/ so the user can retry cleanly.
+		_ = os.RemoveAll(workflowDir)
 		return nil, festerrors.Wrap(err, "bootstrap start")
-	}
-	if err := writeMinimalWorkitem(filepath.Join(dir, ".workitem"), workitemID, filepath.Base(dir), workflowID); err != nil {
-		return nil, festerrors.Wrap(err, "bootstrap .workitem")
 	}
 
 	return &standalone.Result{
 		Mode:        standalone.ModeTracked,
 		StartDir:    res.StartDir,
 		WorkflowDoc: res.WorkflowDoc,
-		RuntimeDir:  filepath.Join(dir, ".workflow"),
+		RuntimeDir:  workflowDir,
 	}, nil
 }

--- a/internal/commands/workflow/bootstrap.go
+++ b/internal/commands/workflow/bootstrap.go
@@ -1,0 +1,77 @@
+package workflow
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/workflow/localstore"
+	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
+)
+
+// BootstrapOptions controls anonymous-to-tracked conversion.
+type BootstrapOptions struct {
+	WorkitemID  string // optional override for the generated workitem id
+	NoBootstrap bool   // refuse to create files
+}
+
+// EnsureTracked converts an anonymous standalone workflow into tracked mode by
+// writing .workitem, .workflow/workflow.yaml, and starting the first run.
+// Returns a standalone.Result reflecting the new tracked state.
+//
+// Behavior:
+//   - if res.Mode is not ModeAnonymous, returns res unchanged
+//   - if opts.NoBootstrap is true, returns an error
+//   - if .workitem or .workflow/ already exists, refuses to overwrite
+//   - otherwise creates both files and starts run 1
+func EnsureTracked(ctx context.Context, res *standalone.Result, opts BootstrapOptions) (*standalone.Result, error) {
+	if res == nil || res.Mode != standalone.ModeAnonymous {
+		return res, nil
+	}
+	if opts.NoBootstrap {
+		return nil, festerrors.New("anonymous workflow detected and --no-bootstrap is set").
+			WithField("workflow_doc", res.WorkflowDoc).
+			WithHint("Run 'fest workflow init' first or omit --no-bootstrap")
+	}
+
+	dir := filepath.Dir(res.WorkflowDoc)
+
+	if _, err := os.Stat(filepath.Join(dir, ".workitem")); err == nil {
+		return nil, festerrors.New("refusing to bootstrap: .workitem already exists").
+			WithField("path", filepath.Join(dir, ".workitem"))
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".workflow")); err == nil {
+		return nil, festerrors.New("refusing to bootstrap: .workflow/ already exists").
+			WithField("path", filepath.Join(dir, ".workflow"))
+	}
+
+	workitemID := opts.WorkitemID
+	if workitemID == "" {
+		workitemID = "wf-" + filepath.Base(dir) + "-" + strconv.FormatInt(time.Now().UTC().Unix(), 10)
+	}
+	workflowID := "wf-" + filepath.Base(dir)
+
+	store := localstore.Open(filepath.Join(dir, ".workflow"), res.WorkflowDoc)
+	if err := store.Init(ctx, localstore.InitOptions{
+		WorkflowID: workflowID,
+		WorkitemID: workitemID,
+	}); err != nil {
+		return nil, festerrors.Wrap(err, "bootstrap init")
+	}
+	if _, err := store.StartRun(ctx, ""); err != nil {
+		return nil, festerrors.Wrap(err, "bootstrap start")
+	}
+	if err := writeMinimalWorkitem(filepath.Join(dir, ".workitem"), workitemID, filepath.Base(dir), workflowID); err != nil {
+		return nil, festerrors.Wrap(err, "bootstrap .workitem")
+	}
+
+	return &standalone.Result{
+		Mode:        standalone.ModeTracked,
+		StartDir:    res.StartDir,
+		WorkflowDoc: res.WorkflowDoc,
+		RuntimeDir:  filepath.Join(dir, ".workflow"),
+	}, nil
+}

--- a/internal/commands/workflow/bootstrap_test.go
+++ b/internal/commands/workflow/bootstrap_test.go
@@ -1,0 +1,130 @@
+package workflow
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/workflow/localstore"
+	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
+)
+
+func setupAnonymousFixture(t *testing.T) (*standalone.Result, string) {
+	t.Helper()
+	dir := t.TempDir()
+	doc := filepath.Join(dir, "WORKFLOW.md")
+	if err := os.WriteFile(doc, []byte(`---
+workflow_version: 1
+workflow_id: wf-test
+workitem_id: test-001
+---
+
+## Step 1: PLAN
+
+**Goal:** test.
+
+**Actions:**
+1. Do it.
+
+**Output:** done
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return &standalone.Result{
+		Mode:        standalone.ModeAnonymous,
+		StartDir:    dir,
+		WorkflowDoc: doc,
+	}, dir
+}
+
+func TestEnsureTracked_HappyPath(t *testing.T) {
+	res, dir := setupAnonymousFixture(t)
+	out, err := EnsureTracked(context.Background(), res, BootstrapOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Mode != standalone.ModeTracked {
+		t.Errorf("Mode = %q, want tracked", out.Mode)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, ".workitem")); err != nil {
+		t.Errorf(".workitem missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".workflow", "workflow.yaml")); err != nil {
+		t.Errorf("workflow.yaml missing: %v", err)
+	}
+
+	// Run should be active.
+	store := localstore.Open(filepath.Join(dir, ".workflow"), filepath.Join(dir, "WORKFLOW.md"))
+	state, err := store.LoadActive(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state == nil || state.RunID == "" {
+		t.Errorf("no active run after bootstrap: %+v", state)
+	}
+}
+
+func TestEnsureTracked_NoBootstrap(t *testing.T) {
+	res, _ := setupAnonymousFixture(t)
+	_, err := EnsureTracked(context.Background(), res, BootstrapOptions{NoBootstrap: true})
+	if err == nil {
+		t.Fatal("expected error with NoBootstrap=true")
+	}
+	if !strings.Contains(err.Error(), "no-bootstrap") {
+		t.Errorf("error should mention no-bootstrap: %v", err)
+	}
+}
+
+func TestEnsureTracked_RefusesExistingWorkitem(t *testing.T) {
+	res, dir := setupAnonymousFixture(t)
+	if err := os.WriteFile(filepath.Join(dir, ".workitem"), []byte("existing"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := EnsureTracked(context.Background(), res, BootstrapOptions{})
+	if err == nil {
+		t.Fatal("expected refusal when .workitem exists")
+	}
+	if !strings.Contains(err.Error(), ".workitem") {
+		t.Errorf("error should mention .workitem: %v", err)
+	}
+}
+
+func TestEnsureTracked_RefusesExistingWorkflow(t *testing.T) {
+	res, dir := setupAnonymousFixture(t)
+	if err := os.MkdirAll(filepath.Join(dir, ".workflow"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, err := EnsureTracked(context.Background(), res, BootstrapOptions{})
+	if err == nil {
+		t.Fatal("expected refusal when .workflow/ exists")
+	}
+	if !strings.Contains(err.Error(), ".workflow") {
+		t.Errorf("error should mention .workflow: %v", err)
+	}
+}
+
+func TestEnsureTracked_NonAnonymousIsNoop(t *testing.T) {
+	res := &standalone.Result{Mode: standalone.ModeTracked, WorkflowDoc: "/tmp/x"}
+	out, err := EnsureTracked(context.Background(), res, BootstrapOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != res {
+		t.Errorf("non-anonymous Result should pass through unchanged")
+	}
+}
+
+func TestEnsureTracked_CustomWorkitemID(t *testing.T) {
+	res, dir := setupAnonymousFixture(t)
+	_, err := EnsureTracked(context.Background(), res, BootstrapOptions{WorkitemID: "custom-id-123"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := os.ReadFile(filepath.Join(dir, ".workitem"))
+	if !strings.Contains(string(raw), "id: custom-id-123") {
+		t.Errorf(".workitem missing custom id: %s", raw)
+	}
+}

--- a/internal/commands/workflow/bootstrap_test.go
+++ b/internal/commands/workflow/bootstrap_test.go
@@ -18,7 +18,6 @@ func setupAnonymousFixture(t *testing.T) (*standalone.Result, string) {
 	if err := os.WriteFile(doc, []byte(`---
 workflow_version: 1
 workflow_id: wf-test
-workitem_id: test-001
 ---
 
 ## Step 1: PLAN
@@ -49,8 +48,9 @@ func TestEnsureTracked_HappyPath(t *testing.T) {
 		t.Errorf("Mode = %q, want tracked", out.Mode)
 	}
 
-	if _, err := os.Stat(filepath.Join(dir, ".workitem")); err != nil {
-		t.Errorf(".workitem missing: %v", err)
+	// D007: fest must NOT write .workitem.
+	if _, err := os.Stat(filepath.Join(dir, ".workitem")); err == nil {
+		t.Errorf(".workitem should not exist after bootstrap (D007: fest never writes .workitem)")
 	}
 	if _, err := os.Stat(filepath.Join(dir, ".workflow", "workflow.yaml")); err != nil {
 		t.Errorf("workflow.yaml missing: %v", err)
@@ -75,20 +75,6 @@ func TestEnsureTracked_NoBootstrap(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no-bootstrap") {
 		t.Errorf("error should mention no-bootstrap: %v", err)
-	}
-}
-
-func TestEnsureTracked_RefusesExistingWorkitem(t *testing.T) {
-	res, dir := setupAnonymousFixture(t)
-	if err := os.WriteFile(filepath.Join(dir, ".workitem"), []byte("existing"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	_, err := EnsureTracked(context.Background(), res, BootstrapOptions{})
-	if err == nil {
-		t.Fatal("expected refusal when .workitem exists")
-	}
-	if !strings.Contains(err.Error(), ".workitem") {
-		t.Errorf("error should mention .workitem: %v", err)
 	}
 }
 
@@ -117,14 +103,20 @@ func TestEnsureTracked_NonAnonymousIsNoop(t *testing.T) {
 	}
 }
 
-func TestEnsureTracked_CustomWorkitemID(t *testing.T) {
-	res, dir := setupAnonymousFixture(t)
-	_, err := EnsureTracked(context.Background(), res, BootstrapOptions{WorkitemID: "custom-id-123"})
-	if err != nil {
+// TestEnsureTracked_RejectsEmptyWorkflowDoc locks in D030 finding #7:
+// bootstrap must validate WORKFLOW.md before creating .workflow/.
+func TestEnsureTracked_RejectsEmptyWorkflowDoc(t *testing.T) {
+	dir := t.TempDir()
+	doc := filepath.Join(dir, "WORKFLOW.md")
+	if err := os.WriteFile(doc, []byte("# No steps here\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	raw, _ := os.ReadFile(filepath.Join(dir, ".workitem"))
-	if !strings.Contains(string(raw), "id: custom-id-123") {
-		t.Errorf(".workitem missing custom id: %s", raw)
+	res := &standalone.Result{Mode: standalone.ModeAnonymous, StartDir: dir, WorkflowDoc: doc}
+	_, err := EnsureTracked(context.Background(), res, BootstrapOptions{})
+	if err == nil {
+		t.Fatal("expected validation error for WORKFLOW.md with no steps")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, ".workflow")); statErr == nil {
+		t.Errorf(".workflow/ should not exist after validation failure")
 	}
 }

--- a/internal/commands/workflow/init.go
+++ b/internal/commands/workflow/init.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/workflow/localstore"
 	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -97,9 +98,43 @@ func runInit(ctx context.Context) error {
 	return nil
 }
 
+// minimalWorkitem is the typed struct yaml.Marshal serializes for a bootstrap
+// .workitem file. Using a struct + yaml.Marshal escapes special characters
+// (colons, quotes, leading dashes, hash signs, whitespace) in fields like
+// title that flow from arbitrary user directory names. String concatenation
+// would produce malformed YAML for any directory name containing those.
+type minimalWorkitem struct {
+	Version  int                `yaml:"version"`
+	Kind     string             `yaml:"kind"`
+	ID       string             `yaml:"id"`
+	Type     string             `yaml:"type"`
+	Title    string             `yaml:"title"`
+	Workflow minimalWorkitemWf  `yaml:"workflow"`
+}
+
+type minimalWorkitemWf struct {
+	DocPath    string `yaml:"doc_path"`
+	RuntimeDir string `yaml:"runtime_dir"`
+	WorkflowID string `yaml:"workflow_id"`
+}
+
 func writeMinimalWorkitem(path, id, basename, workflowID string) error {
-	body := "version: 1\nkind: workitem\nid: " + id + "\ntype: workflow\ntitle: " + basename + "\nworkflow:\n  doc_path: WORKFLOW.md\n  runtime_dir: .workflow\n  workflow_id: " + workflowID + "\n"
-	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+	body, err := yaml.Marshal(minimalWorkitem{
+		Version: 1,
+		Kind:    "workitem",
+		ID:      id,
+		Type:    "workflow",
+		Title:   basename,
+		Workflow: minimalWorkitemWf{
+			DocPath:    "WORKFLOW.md",
+			RuntimeDir: ".workflow",
+			WorkflowID: workflowID,
+		},
+	})
+	if err != nil {
+		return festerrors.Wrap(err, "marshal .workitem")
+	}
+	if err := os.WriteFile(path, body, 0o644); err != nil {
 		return festerrors.IO("writing .workitem", err)
 	}
 	return nil

--- a/internal/commands/workflow/init.go
+++ b/internal/commands/workflow/init.go
@@ -8,6 +8,7 @@ import (
 
 	festerrors "github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/scope"
+	"github.com/Obedience-Corp/fest/internal/workflow"
 	"github.com/Obedience-Corp/fest/internal/workflow/localstore"
 	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
 	"github.com/spf13/cobra"
@@ -16,26 +17,27 @@ import (
 var (
 	initForce      bool
 	initWorkflowID string
-	initWorkitemID string
 )
 
 func newInitCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Initialize standalone workflow runtime",
-		Long: `Create .workitem and .workflow/ next to an existing WORKFLOW.md.
+		Long: `Create .workflow/ next to an existing WORKFLOW.md.
 
 Run from the directory containing WORKFLOW.md. The command refuses to run
-inside a festival phase. Use --force to overwrite existing .workitem
-or .workflow/workflow.yaml.`,
+inside a festival phase. Use --force to overwrite an existing
+.workflow/workflow.yaml.
+
+This command does not create .workitem; that file is owned by camp
+(see 'camp workitem create' and 'camp workitem adopt').`,
 		Annotations: map[string]string{"scope": string(scope.Global)},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runInit(cmd.Context())
 		},
 	}
-	cmd.Flags().BoolVar(&initForce, "force", false, "overwrite existing .workitem and .workflow/")
+	cmd.Flags().BoolVar(&initForce, "force", false, "overwrite existing .workflow/workflow.yaml")
 	cmd.Flags().StringVar(&initWorkflowID, "workflow-id", "", "workflow_id to write into manifest (defaults to wf-<basename>)")
-	cmd.Flags().StringVar(&initWorkitemID, "workitem-id", "", "workitem_id to write into manifest (required)")
 	return cmd
 }
 
@@ -62,45 +64,24 @@ func runInit(ctx context.Context) error {
 			WithHint("Author a WORKFLOW.md before running init")
 	}
 
-	if initWorkitemID == "" {
-		return festerrors.Validation("--workitem-id is required")
-	}
-
 	workflowID := initWorkflowID
 	if workflowID == "" {
-		workflowID = "wf-" + filepath.Base(cwd)
+		slug := workflow.SanitizeBasenameAsSlug(filepath.Base(cwd))
+		workflowID = "wf-" + slug
 	}
-
-	// Refuse to overwrite an existing .workitem unless --force.
-	workitemPath := filepath.Join(cwd, ".workitem")
-	if _, statErr := os.Stat(workitemPath); statErr == nil && !initForce {
-		return festerrors.New(".workitem already exists; pass --force to overwrite").
-			WithField("path", workitemPath)
+	if err := workflow.ValidateWorkflowID(workflowID); err != nil {
+		return err
 	}
 
 	store := localstore.Open(filepath.Join(cwd, ".workflow"), doc)
 	if err := store.Init(ctx, localstore.InitOptions{
 		WorkflowID: workflowID,
-		WorkitemID: initWorkitemID,
 		Force:      initForce,
 	}); err != nil {
 		return err
 	}
 
-	if err := writeMinimalWorkitem(workitemPath, initWorkitemID, filepath.Base(cwd), workflowID); err != nil {
-		return err
-	}
-
 	fmt.Printf("Initialized standalone workflow runtime at %s\n", cwd)
-	fmt.Printf("  .workitem: workitem_id=%s\n", initWorkitemID)
 	fmt.Printf("  .workflow/workflow.yaml: workflow_id=%s\n", workflowID)
-	return nil
-}
-
-func writeMinimalWorkitem(path, id, basename, workflowID string) error {
-	body := "version: 1\nkind: workitem\nid: " + id + "\ntype: workflow\ntitle: " + basename + "\nworkflow:\n  doc_path: WORKFLOW.md\n  runtime_dir: .workflow\n  workflow_id: " + workflowID + "\n"
-	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
-		return festerrors.IO("writing .workitem", err)
-	}
 	return nil
 }

--- a/internal/commands/workflow/init.go
+++ b/internal/commands/workflow/init.go
@@ -11,32 +11,32 @@ import (
 	"github.com/Obedience-Corp/fest/internal/workflow/localstore"
 	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
 var (
 	initForce      bool
 	initWorkflowID string
-	initWorkitemID string
 )
 
 func newInitCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Initialize standalone workflow runtime",
-		Long: `Create .workitem and .workflow/ next to an existing WORKFLOW.md.
+		Long: `Create .workflow/ next to an existing WORKFLOW.md.
 
 Run from the directory containing WORKFLOW.md. The command refuses to run
-inside a festival phase. Use --force to overwrite existing .workitem
-or .workflow/workflow.yaml.`,
+inside a festival phase. Use --force to overwrite an existing
+.workflow/workflow.yaml.
+
+This command does not create .workitem; that file is owned by camp
+(see 'camp workitem create' and 'camp workitem adopt').`,
 		Annotations: map[string]string{"scope": string(scope.Global)},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runInit(cmd.Context())
 		},
 	}
-	cmd.Flags().BoolVar(&initForce, "force", false, "overwrite existing .workitem and .workflow/")
+	cmd.Flags().BoolVar(&initForce, "force", false, "overwrite existing .workflow/workflow.yaml")
 	cmd.Flags().StringVar(&initWorkflowID, "workflow-id", "", "workflow_id to write into manifest (defaults to wf-<basename>)")
-	cmd.Flags().StringVar(&initWorkitemID, "workitem-id", "", "workitem_id to write into manifest (required)")
 	return cmd
 }
 
@@ -63,79 +63,20 @@ func runInit(ctx context.Context) error {
 			WithHint("Author a WORKFLOW.md before running init")
 	}
 
-	if initWorkitemID == "" {
-		return festerrors.Validation("--workitem-id is required")
-	}
-
 	workflowID := initWorkflowID
 	if workflowID == "" {
 		workflowID = "wf-" + filepath.Base(cwd)
 	}
 
-	// Refuse to overwrite an existing .workitem unless --force.
-	workitemPath := filepath.Join(cwd, ".workitem")
-	if _, statErr := os.Stat(workitemPath); statErr == nil && !initForce {
-		return festerrors.New(".workitem already exists; pass --force to overwrite").
-			WithField("path", workitemPath)
-	}
-
 	store := localstore.Open(filepath.Join(cwd, ".workflow"), doc)
 	if err := store.Init(ctx, localstore.InitOptions{
 		WorkflowID: workflowID,
-		WorkitemID: initWorkitemID,
 		Force:      initForce,
 	}); err != nil {
 		return err
 	}
 
-	if err := writeMinimalWorkitem(workitemPath, initWorkitemID, filepath.Base(cwd), workflowID); err != nil {
-		return err
-	}
-
 	fmt.Printf("Initialized standalone workflow runtime at %s\n", cwd)
-	fmt.Printf("  .workitem: workitem_id=%s\n", initWorkitemID)
 	fmt.Printf("  .workflow/workflow.yaml: workflow_id=%s\n", workflowID)
-	return nil
-}
-
-// minimalWorkitem is the typed struct yaml.Marshal serializes for a bootstrap
-// .workitem file. Using a struct + yaml.Marshal escapes special characters
-// (colons, quotes, leading dashes, hash signs, whitespace) in fields like
-// title that flow from arbitrary user directory names. String concatenation
-// would produce malformed YAML for any directory name containing those.
-type minimalWorkitem struct {
-	Version  int                `yaml:"version"`
-	Kind     string             `yaml:"kind"`
-	ID       string             `yaml:"id"`
-	Type     string             `yaml:"type"`
-	Title    string             `yaml:"title"`
-	Workflow minimalWorkitemWf  `yaml:"workflow"`
-}
-
-type minimalWorkitemWf struct {
-	DocPath    string `yaml:"doc_path"`
-	RuntimeDir string `yaml:"runtime_dir"`
-	WorkflowID string `yaml:"workflow_id"`
-}
-
-func writeMinimalWorkitem(path, id, basename, workflowID string) error {
-	body, err := yaml.Marshal(minimalWorkitem{
-		Version: 1,
-		Kind:    "workitem",
-		ID:      id,
-		Type:    "workflow",
-		Title:   basename,
-		Workflow: minimalWorkitemWf{
-			DocPath:    "WORKFLOW.md",
-			RuntimeDir: ".workflow",
-			WorkflowID: workflowID,
-		},
-	})
-	if err != nil {
-		return festerrors.Wrap(err, "marshal .workitem")
-	}
-	if err := os.WriteFile(path, body, 0o644); err != nil {
-		return festerrors.IO("writing .workitem", err)
-	}
 	return nil
 }

--- a/internal/commands/workflow/init.go
+++ b/internal/commands/workflow/init.go
@@ -1,0 +1,106 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/scope"
+	"github.com/Obedience-Corp/fest/internal/workflow/localstore"
+	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
+	"github.com/spf13/cobra"
+)
+
+var (
+	initForce      bool
+	initWorkflowID string
+	initWorkitemID string
+)
+
+func newInitCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Initialize standalone workflow runtime",
+		Long: `Create .workitem and .workflow/ next to an existing WORKFLOW.md.
+
+Run from the directory containing WORKFLOW.md. The command refuses to run
+inside a festival phase. Use --force to overwrite existing .workitem
+or .workflow/workflow.yaml.`,
+		Annotations: map[string]string{"scope": string(scope.Global)},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runInit(cmd.Context())
+		},
+	}
+	cmd.Flags().BoolVar(&initForce, "force", false, "overwrite existing .workitem and .workflow/")
+	cmd.Flags().StringVar(&initWorkflowID, "workflow-id", "", "workflow_id to write into manifest (defaults to wf-<basename>)")
+	cmd.Flags().StringVar(&initWorkitemID, "workitem-id", "", "workitem_id to write into manifest (required)")
+	return cmd
+}
+
+func runInit(ctx context.Context) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return festerrors.IO("getwd", err)
+	}
+
+	res, err := standalone.Resolve(ctx, cwd)
+	if err != nil {
+		return err
+	}
+	if res.Mode == standalone.ModeFestival {
+		return festerrors.New("fest workflow init cannot run inside a festival phase").
+			WithField("festival_path", res.FestivalPath).
+			WithHint("This command is for standalone WORKFLOW.md directories. Use festival workflow commands inside the festival.")
+	}
+
+	doc := filepath.Join(cwd, "WORKFLOW.md")
+	if _, statErr := os.Stat(doc); statErr != nil {
+		return festerrors.New("no WORKFLOW.md found").
+			WithField("dir", cwd).
+			WithHint("Author a WORKFLOW.md before running init")
+	}
+
+	if initWorkitemID == "" {
+		return festerrors.Validation("--workitem-id is required")
+	}
+
+	workflowID := initWorkflowID
+	if workflowID == "" {
+		workflowID = "wf-" + filepath.Base(cwd)
+	}
+
+	// Refuse to overwrite an existing .workitem unless --force.
+	workitemPath := filepath.Join(cwd, ".workitem")
+	if _, statErr := os.Stat(workitemPath); statErr == nil && !initForce {
+		return festerrors.New(".workitem already exists; pass --force to overwrite").
+			WithField("path", workitemPath)
+	}
+
+	store := localstore.Open(filepath.Join(cwd, ".workflow"), doc)
+	if err := store.Init(ctx, localstore.InitOptions{
+		WorkflowID: workflowID,
+		WorkitemID: initWorkitemID,
+		Force:      initForce,
+	}); err != nil {
+		return err
+	}
+
+	if err := writeMinimalWorkitem(workitemPath, initWorkitemID, filepath.Base(cwd), workflowID); err != nil {
+		return err
+	}
+
+	fmt.Printf("Initialized standalone workflow runtime at %s\n", cwd)
+	fmt.Printf("  .workitem: workitem_id=%s\n", initWorkitemID)
+	fmt.Printf("  .workflow/workflow.yaml: workflow_id=%s\n", workflowID)
+	return nil
+}
+
+func writeMinimalWorkitem(path, id, basename, workflowID string) error {
+	body := "version: 1\nkind: workitem\nid: " + id + "\ntype: workflow\ntitle: " + basename + "\nworkflow:\n  doc_path: WORKFLOW.md\n  runtime_dir: .workflow\n  workflow_id: " + workflowID + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		return festerrors.IO("writing .workitem", err)
+	}
+	return nil
+}

--- a/internal/commands/workflow/init.go
+++ b/internal/commands/workflow/init.go
@@ -8,6 +8,7 @@ import (
 
 	festerrors "github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/scope"
+	"github.com/Obedience-Corp/fest/internal/workflow"
 	"github.com/Obedience-Corp/fest/internal/workflow/localstore"
 	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
 	"github.com/spf13/cobra"
@@ -65,7 +66,11 @@ func runInit(ctx context.Context) error {
 
 	workflowID := initWorkflowID
 	if workflowID == "" {
-		workflowID = "wf-" + filepath.Base(cwd)
+		slug := workflow.SanitizeBasenameAsSlug(filepath.Base(cwd))
+		workflowID = "wf-" + slug
+	}
+	if err := workflow.ValidateWorkflowID(workflowID); err != nil {
+		return err
 	}
 
 	store := localstore.Open(filepath.Join(cwd, ".workflow"), doc)

--- a/internal/commands/workflow/runs.go
+++ b/internal/commands/workflow/runs.go
@@ -1,0 +1,72 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/scope"
+	"github.com/Obedience-Corp/fest/internal/workflow/localstore"
+	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
+	"github.com/spf13/cobra"
+)
+
+var runsJSON bool
+
+func newRunsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "runs",
+		Short: "List runs of a standalone workflow",
+		Long: `List runs recorded in .workflow/workflow.yaml.
+
+Each row shows run id, status, started time, and completed time.`,
+		Annotations: map[string]string{"scope": string(scope.Global)},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRuns(cmd.Context())
+		},
+	}
+	cmd.Flags().BoolVar(&runsJSON, "json", false, "emit JSON")
+	return cmd
+}
+
+func runRuns(ctx context.Context) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return festerrors.IO("getwd", err)
+	}
+	res, err := standalone.Resolve(ctx, cwd)
+	if err != nil {
+		return err
+	}
+	if res.Mode != standalone.ModeTracked {
+		return festerrors.New("fest workflow runs requires a tracked standalone workflow").
+			WithField("mode", string(res.Mode))
+	}
+	store := localstore.Open(res.RuntimeDir, res.WorkflowDoc)
+	runs, err := store.ListRuns(ctx)
+	if err != nil {
+		return err
+	}
+	if runsJSON {
+		data, err := json.MarshalIndent(runs, "", "  ")
+		if err != nil {
+			return festerrors.Parse("encoding runs json", err)
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+	if len(runs) == 0 {
+		fmt.Println("No runs.")
+		return nil
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%-26s  %-10s  %-25s  %s\n", "RUN_ID", "STATUS", "STARTED", "COMPLETED")
+	for _, r := range runs {
+		fmt.Fprintf(&b, "%-26s  %-10s  %-25s  %s\n", r.RunID, r.Status, r.StartedAt, r.CompletedAt)
+	}
+	fmt.Print(b.String())
+	return nil
+}

--- a/internal/commands/workflow/show.go
+++ b/internal/commands/workflow/show.go
@@ -32,7 +32,9 @@ Shows:
   - Expected output
   - Checkpoint type if applicable`,
 		Annotations: map[string]string{
-			"scope": string(scope.Festival),
+			// scope.Global so runShow can route to standalone tracked or
+			// anonymous workflows before middleware demands a festival.
+			"scope": string(scope.Global),
 		},
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/commands/workflow/show.go
+++ b/internal/commands/workflow/show.go
@@ -11,6 +11,7 @@ import (
 	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
+	"github.com/Obedience-Corp/fest/internal/workflow/localstore"
 	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
 	"github.com/spf13/cobra"
 )
@@ -55,14 +56,8 @@ func runShow(ctx context.Context, stepNum int) error {
 	cwd, _ := os.Getwd()
 	if res, resErr := standalone.Resolve(ctx, cwd); resErr == nil {
 		switch res.Mode {
-		case standalone.ModeTracked:
-			return festerrors.New("standalone tracked workflow show not yet implemented").
-				WithField("workflow_doc", res.WorkflowDoc).
-				WithHint("Scheduled for sequence 004.02 of WW0001")
-		case standalone.ModeAnonymous:
-			return festerrors.New("anonymous WORKFLOW.md show not yet implemented").
-				WithField("workflow_doc", res.WorkflowDoc).
-				WithHint("Run 'fest workflow init' or wait for sequence 004.02")
+		case standalone.ModeTracked, standalone.ModeAnonymous:
+			return runStandaloneShow(ctx, res, stepNum)
 		}
 		// ModeFestival or ModeNone: fall through to existing behavior.
 	}
@@ -196,4 +191,56 @@ func formatStepStatus(status wf.StepStatus) string {
 	default:
 		return string(status)
 	}
+}
+
+// runStandaloneShow renders the current step of a standalone workflow without
+// requiring a festival context. Anonymous mode renders step 1.
+func runStandaloneShow(ctx context.Context, res *standalone.Result, stepNum int) error {
+	parser := wf.NewParser()
+	steps, err := parser.Parse(ctx, res.WorkflowDoc)
+	if err != nil {
+		return festerrors.Wrap(err, "parsing WORKFLOW.md")
+	}
+	if len(steps) == 0 {
+		return festerrors.New("WORKFLOW.md has no parseable steps")
+	}
+
+	current := stepNum
+	if current == 0 {
+		if res.Mode == standalone.ModeTracked {
+			store := localstore.Open(res.RuntimeDir, res.WorkflowDoc)
+			state, lerr := store.LoadActive(ctx)
+			if lerr == nil && state != nil && state.CurrentStep > 0 {
+				current = state.CurrentStep
+			}
+		}
+		if current == 0 {
+			current = 1
+		}
+	}
+	if current < 1 || current > len(steps) {
+		return festerrors.New("step out of range").WithField("step", current).WithField("total", len(steps))
+	}
+
+	s := steps[current-1]
+	fmt.Printf("Step %d of %d: %s\n", current, len(steps), s.Name)
+	if s.Goal != "" {
+		fmt.Printf("Goal: %s\n", s.Goal)
+	}
+	if len(s.Actions) > 0 {
+		fmt.Println("Actions:")
+		for i, a := range s.Actions {
+			fmt.Printf("  %d. %s\n", i+1, a)
+		}
+	}
+	if s.Output != "" {
+		fmt.Printf("Output: %s\n", s.Output)
+	}
+	if s.Checkpoint != "" {
+		fmt.Printf("Checkpoint: %s\n", s.Checkpoint)
+	}
+	if res.Mode == standalone.ModeAnonymous {
+		fmt.Println("(anonymous; first mutation will bootstrap to tracked mode)")
+	}
+	return nil
 }

--- a/internal/commands/workflow/show.go
+++ b/internal/commands/workflow/show.go
@@ -52,16 +52,15 @@ Shows:
 }
 
 func runShow(ctx context.Context, stepNum int) error {
-	// Narrow standalone-resolver integration (introduced in WW0001/004.01).
-	// Festival context always wins; tracked/anonymous standalone modes return
-	// a deferred-feature stub until the next sequence wires them in fully.
+	// Standalone-resolver integration. Festival context always wins; tracked
+	// and anonymous standalone modes route to runStandaloneShow.
 	cwd, _ := os.Getwd()
 	if res, resErr := standalone.Resolve(ctx, cwd); resErr == nil {
 		switch res.Mode {
 		case standalone.ModeTracked, standalone.ModeAnonymous:
 			return runStandaloneShow(ctx, res, stepNum)
 		}
-		// ModeFestival or ModeNone: fall through to existing behavior.
+		// ModeFestival or ModeNone: fall through to existing festival flow.
 	}
 
 	nav, err := getWorkflowNavigator(ctx)

--- a/internal/commands/workflow/show.go
+++ b/internal/commands/workflow/show.go
@@ -3,12 +3,15 @@ package workflow
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
 	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
+	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
 	"github.com/spf13/cobra"
 )
 
@@ -46,6 +49,24 @@ Shows:
 }
 
 func runShow(ctx context.Context, stepNum int) error {
+	// Narrow standalone-resolver integration (introduced in WW0001/004.01).
+	// Festival context always wins; tracked/anonymous standalone modes return
+	// a deferred-feature stub until the next sequence wires them in fully.
+	cwd, _ := os.Getwd()
+	if res, resErr := standalone.Resolve(ctx, cwd); resErr == nil {
+		switch res.Mode {
+		case standalone.ModeTracked:
+			return festerrors.New("standalone tracked workflow show not yet implemented").
+				WithField("workflow_doc", res.WorkflowDoc).
+				WithHint("Scheduled for sequence 004.02 of WW0001")
+		case standalone.ModeAnonymous:
+			return festerrors.New("anonymous WORKFLOW.md show not yet implemented").
+				WithField("workflow_doc", res.WorkflowDoc).
+				WithHint("Run 'fest workflow init' or wait for sequence 004.02")
+		}
+		// ModeFestival or ModeNone: fall through to existing behavior.
+	}
+
 	nav, err := getWorkflowNavigator(ctx)
 	if err != nil {
 		return err

--- a/internal/commands/workflow/show.go
+++ b/internal/commands/workflow/show.go
@@ -3,15 +3,12 @@ package workflow
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
-	festerrors "github.com/Obedience-Corp/fest/internal/errors"
 	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
-	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
 	"github.com/spf13/cobra"
 )
 
@@ -49,24 +46,6 @@ Shows:
 }
 
 func runShow(ctx context.Context, stepNum int) error {
-	// Narrow standalone-resolver integration (introduced in WW0001/004.01).
-	// Festival context always wins; tracked/anonymous standalone modes return
-	// a deferred-feature stub until the next sequence wires them in fully.
-	cwd, _ := os.Getwd()
-	if res, resErr := standalone.Resolve(ctx, cwd); resErr == nil {
-		switch res.Mode {
-		case standalone.ModeTracked:
-			return festerrors.New("standalone tracked workflow show not yet implemented").
-				WithField("workflow_doc", res.WorkflowDoc).
-				WithHint("Scheduled for sequence 004.02 of WW0001")
-		case standalone.ModeAnonymous:
-			return festerrors.New("anonymous WORKFLOW.md show not yet implemented").
-				WithField("workflow_doc", res.WorkflowDoc).
-				WithHint("Run 'fest workflow init' or wait for sequence 004.02")
-		}
-		// ModeFestival or ModeNone: fall through to existing behavior.
-	}
-
 	nav, err := getWorkflowNavigator(ctx)
 	if err != nil {
 		return err

--- a/internal/commands/workflow/start.go
+++ b/internal/commands/workflow/start.go
@@ -1,0 +1,51 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/scope"
+	"github.com/Obedience-Corp/fest/internal/workflow/localstore"
+	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
+	"github.com/spf13/cobra"
+)
+
+func newStartCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "start",
+		Short: "Start a new run for a standalone workflow",
+		Long: `Create a new .workflow/runs/<run-id>/ directory and mark it active.
+
+Requires .workflow/workflow.yaml to exist (run fest workflow init first).`,
+		Annotations: map[string]string{"scope": string(scope.Global)},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runStart(cmd.Context())
+		},
+	}
+}
+
+func runStart(ctx context.Context) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return festerrors.IO("getwd", err)
+	}
+	res, err := standalone.Resolve(ctx, cwd)
+	if err != nil {
+		return err
+	}
+	if res.Mode != standalone.ModeTracked {
+		return festerrors.New("fest workflow start requires a tracked standalone workflow").
+			WithField("mode", string(res.Mode)).
+			WithHint("Run 'fest workflow init' first to create .workflow/workflow.yaml")
+	}
+
+	store := localstore.Open(res.RuntimeDir, res.WorkflowDoc)
+	runID, err := store.StartRun(ctx, "")
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Started run %s\n", runID)
+	return nil
+}

--- a/internal/commands/workflow/workflow.go
+++ b/internal/commands/workflow/workflow.go
@@ -73,6 +73,10 @@ Examples:
 		newRejectCmd(),
 		newResetCmd(),
 		newShowCmd(),
+		// Standalone workflow lifecycle (introduced in WW0001/004.01).
+		newInitCmd(),
+		newStartCmd(),
+		newRunsCmd(),
 	)
 
 	return cmd

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,13 +48,13 @@ type Execute struct {
 
 // Repository contains repository information
 type Repository struct {
-	URL      string `json:"url"`
-	Branch   string `json:"branch"`               // Legacy, still honored
-	Path     string `json:"path"`
+	URL    string `json:"url"`
+	Branch string `json:"branch"` // Legacy, still honored
+	Path   string `json:"path"`
 	// TODO: consider using SyncMode type directly once config validation is added
 	SyncMode string `json:"sync_mode,omitempty"` // "channel" | "branch" | "tag"
 	Channel  string `json:"channel,omitempty"`   // "stable" | "dev" | ""
-	Ref      string `json:"ref,omitempty"`        // Exact ref for tag/branch mode
+	Ref      string `json:"ref,omitempty"`       // Exact ref for tag/branch mode
 }
 
 // Local contains local path configuration

--- a/internal/github/tags.go
+++ b/internal/github/tags.go
@@ -129,7 +129,7 @@ func ResolveLatestTag(repoURL, channel string) (string, error) {
 	}
 
 	if len(candidates) == 0 {
-		return "", errors.NotFound("tags matching channel " + channel).WithField("url", repoURL)
+		return "", errors.NotFound("tags matching channel "+channel).WithField("url", repoURL)
 	}
 
 	// Sort descending and return the first element.

--- a/internal/validator/gates.go
+++ b/internal/validator/gates.go
@@ -93,7 +93,7 @@ func ValidateQualityGates(ctx context.Context, festivalPath string) ([]Issue, er
 			}
 
 			sort.Strings(missing)
-		if len(missing) > 0 && len(tasks) > 0 {
+			if len(missing) > 0 && len(tasks) > 0 {
 				rel, _ := filepath.Rel(festivalPath, seq.Path)
 				// Phase-type-aware error message
 				phaseTypeTitle := titleCase(phaseType)

--- a/internal/workflow/id_safety.go
+++ b/internal/workflow/id_safety.go
@@ -1,0 +1,43 @@
+package workflow
+
+import (
+	"regexp"
+	"strings"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+)
+
+var workflowIDPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{0,79}$`)
+
+// ValidateWorkflowID returns a festerrors.Validation error if id does not
+// match the slug-safety pattern required for filesystem-derived workflow
+// identifiers. The pattern is lowercase ASCII alphanumeric plus underscore
+// and dash, must start with [a-z0-9], 1-80 chars.
+func ValidateWorkflowID(id string) error {
+	if id == "" {
+		return festerrors.Validation("workflow_id must not be empty").
+			WithHint("pass --workflow-id or run from a directory with a slug-safe basename")
+	}
+	if !workflowIDPattern.MatchString(id) {
+		return festerrors.Validation("invalid workflow_id").
+			WithField("workflow_id", id).
+			WithHint("use lowercase letters, digits, '-', '_'; start with [a-z0-9]; max 80 chars")
+	}
+	return nil
+}
+
+var slugInvalidPattern = regexp.MustCompile(`[^a-z0-9_-]+`)
+
+// SanitizeBasenameAsSlug lowercases name and replaces runs of invalid
+// characters with a single '-'. Leading dashes are stripped. Used when
+// auto-deriving a workflow_id from a directory basename so e.g.
+// "My Project!" becomes "my-project".
+func SanitizeBasenameAsSlug(name string) string {
+	if name == "" {
+		return ""
+	}
+	lower := strings.ToLower(name)
+	cleaned := slugInvalidPattern.ReplaceAllString(lower, "-")
+	cleaned = strings.Trim(cleaned, "-")
+	return cleaned
+}

--- a/internal/workflow/id_safety_test.go
+++ b/internal/workflow/id_safety_test.go
@@ -1,0 +1,72 @@
+package workflow
+
+import (
+	"strings"
+	"testing"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+)
+
+func TestValidateWorkflowID(t *testing.T) {
+	cases := []struct {
+		name    string
+		id      string
+		wantErr bool
+	}{
+		{"empty", "", true},
+		{"simple", "wf", false},
+		{"with-dash", "wf-foo", false},
+		{"with-date", "my-project-2026-05-13", false},
+		{"with-underscore", "wf_bar", false},
+		{"alnum", "abc123", false},
+		{"leading-dash", "-leading", true},
+		{"leading-underscore", "_leading", true},
+		{"uppercase", "WfFoo", true},
+		{"space", "Has Spaces", true},
+		{"path-separator", "wf/foo", true},
+		{"double-dot", "..", true},
+		{"single-char", "a", false},
+		{"max-length", "a" + strings.Repeat("b", 79), false},
+		{"too-long", "a" + strings.Repeat("b", 80), true},
+		{"non-ascii", "résumé", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := ValidateWorkflowID(c.id)
+			if (err != nil) != c.wantErr {
+				t.Fatalf("ValidateWorkflowID(%q): got err=%v, wantErr=%v", c.id, err, c.wantErr)
+			}
+			if c.wantErr && err != nil {
+				if !festerrors.Is(err, festerrors.ErrCodeValidation) {
+					t.Errorf("expected festerrors.Validation, got %T: %v", err, err)
+				}
+			}
+		})
+	}
+}
+
+func TestSanitizeBasenameAsSlug(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"foo", "foo"},
+		{"Foo", "foo"},
+		{"My Project", "my-project"},
+		{"My Project!", "my-project"},
+		{"my_thing", "my_thing"},
+		{"-leading-", "leading"},
+		{"  spaces  ", "spaces"},
+		{"foo//bar", "foo-bar"},
+		{"résumé", "r-sum"},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got := SanitizeBasenameAsSlug(c.in)
+			if got != c.want {
+				t.Errorf("SanitizeBasenameAsSlug(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/workflow/localstore/events.go
+++ b/internal/workflow/localstore/events.go
@@ -1,0 +1,32 @@
+package localstore
+
+import "time"
+
+// Event type names mirror LOCAL_RUN_STATE.md.
+const (
+	EventWorkflowRunCreated   = "workflow_run_created"
+	EventWorkflowRunStarted   = "workflow_run_started"
+	EventStepStart            = "wf_step_start"
+	EventStepDone             = "wf_step_done"
+	EventStepSkip             = "wf_step_skip"
+	EventStepBlock            = "wf_step_block"
+	EventCheckpointApproved   = "wf_checkpoint_approved"
+	EventCheckpointRejected   = "wf_checkpoint_rejected"
+	EventWorkflowRunCompleted = "workflow_run_completed"
+	EventWorkflowRunAbandoned = "workflow_run_abandoned"
+	EventWorkflowDocChanged   = "workflow_doc_changed"
+)
+
+// Event is one append-only entry in progress_events.jsonl.
+type Event struct {
+	Version    int       `json:"version"`
+	EventID    string    `json:"event_id"`
+	EventType  string    `json:"event_type"`
+	RunID      string    `json:"run_id"`
+	WorkflowID string    `json:"workflow_id,omitempty"`
+	WorkitemID string    `json:"workitem_id,omitempty"`
+	StepID     string    `json:"step_id,omitempty"`
+	StepIndex  int       `json:"step_index,omitempty"`
+	Feedback   string    `json:"feedback,omitempty"`
+	Timestamp  time.Time `json:"timestamp"`
+}

--- a/internal/workflow/localstore/events.go
+++ b/internal/workflow/localstore/events.go
@@ -24,7 +24,6 @@ type Event struct {
 	EventType  string    `json:"event_type"`
 	RunID      string    `json:"run_id"`
 	WorkflowID string    `json:"workflow_id,omitempty"`
-	WorkitemID string    `json:"workitem_id,omitempty"`
 	StepID     string    `json:"step_id,omitempty"`
 	StepIndex  int       `json:"step_index,omitempty"`
 	Feedback   string    `json:"feedback,omitempty"`

--- a/internal/workflow/localstore/hash.go
+++ b/internal/workflow/localstore/hash.go
@@ -1,0 +1,19 @@
+package localstore
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+)
+
+// HashWorkflowDoc returns "sha256:<hex>" for the file at path.
+func HashWorkflowDoc(path string) (string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", festerrors.Wrap(err, "hashing workflow doc")
+	}
+	sum := sha256.Sum256(raw)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}

--- a/internal/workflow/localstore/manifest.go
+++ b/internal/workflow/localstore/manifest.go
@@ -5,7 +5,6 @@ type Manifest struct {
 	Version     int         `yaml:"version"`
 	Kind        string      `yaml:"kind"`
 	WorkflowID  string      `yaml:"workflow_id"`
-	WorkitemID  string      `yaml:"workitem_id"`
 	DocPath     string      `yaml:"doc_path,omitempty"`
 	DocHash     string      `yaml:"doc_hash,omitempty"`
 	ActiveRunID string      `yaml:"active_run_id,omitempty"`

--- a/internal/workflow/localstore/manifest.go
+++ b/internal/workflow/localstore/manifest.go
@@ -1,0 +1,28 @@
+package localstore
+
+// Manifest is .workflow/workflow.yaml. Schema defined in LOCAL_RUN_STATE.md.
+type Manifest struct {
+	Version     int         `yaml:"version"`
+	Kind        string      `yaml:"kind"`
+	WorkflowID  string      `yaml:"workflow_id"`
+	WorkitemID  string      `yaml:"workitem_id"`
+	DocPath     string      `yaml:"doc_path,omitempty"`
+	DocHash     string      `yaml:"doc_hash,omitempty"`
+	ActiveRunID string      `yaml:"active_run_id,omitempty"`
+	Runs        []RunRecord `yaml:"runs,omitempty"`
+}
+
+// RunRecord is one entry in Manifest.Runs.
+type RunRecord struct {
+	RunID       string `yaml:"run_id"`
+	Status      string `yaml:"status"`
+	Path        string `yaml:"path"`
+	StartedAt   string `yaml:"started_at,omitempty"`
+	CompletedAt string `yaml:"completed_at,omitempty"`
+}
+
+// ManifestVersion is the only manifest schema version supported.
+const ManifestVersion = 1
+
+// ManifestKind is the expected kind value in workflow.yaml.
+const ManifestKind = "workflow-runtime"

--- a/internal/workflow/localstore/manifest.go
+++ b/internal/workflow/localstore/manifest.go
@@ -5,7 +5,6 @@ type Manifest struct {
 	Version     int         `yaml:"version"`
 	Kind        string      `yaml:"kind"`
 	WorkflowID  string      `yaml:"workflow_id"`
-	WorkitemID  string      `yaml:"workitem_id"`
 	DocPath     string      `yaml:"doc_path,omitempty"`
 	DocHash     string      `yaml:"doc_hash,omitempty"`
 	ActiveRunID string      `yaml:"active_run_id,omitempty"`
@@ -19,6 +18,7 @@ type RunRecord struct {
 	Path        string `yaml:"path"`
 	StartedAt   string `yaml:"started_at,omitempty"`
 	CompletedAt string `yaml:"completed_at,omitempty"`
+	EndedAt     string `yaml:"ended_at,omitempty"`
 }
 
 // ManifestVersion is the only manifest schema version supported.

--- a/internal/workflow/localstore/manifest.go
+++ b/internal/workflow/localstore/manifest.go
@@ -18,6 +18,7 @@ type RunRecord struct {
 	Path        string `yaml:"path"`
 	StartedAt   string `yaml:"started_at,omitempty"`
 	CompletedAt string `yaml:"completed_at,omitempty"`
+	EndedAt     string `yaml:"ended_at,omitempty"`
 }
 
 // ManifestVersion is the only manifest schema version supported.

--- a/internal/workflow/localstore/run.go
+++ b/internal/workflow/localstore/run.go
@@ -10,7 +10,6 @@ type RunManifest struct {
 	Kind        string     `yaml:"kind"`
 	RunID       string     `yaml:"run_id"`
 	WorkflowID  string     `yaml:"workflow_id"`
-	WorkitemID  string     `yaml:"workitem_id"`
 	Status      string     `yaml:"status"`
 	StartedAt   time.Time  `yaml:"started_at"`
 	CompletedAt time.Time  `yaml:"completed_at,omitempty"`

--- a/internal/workflow/localstore/run.go
+++ b/internal/workflow/localstore/run.go
@@ -1,0 +1,55 @@
+package localstore
+
+import (
+	"time"
+)
+
+// RunManifest is .workflow/runs/<run-id>/run.yaml.
+type RunManifest struct {
+	Version     int        `yaml:"version"`
+	Kind        string     `yaml:"kind"`
+	RunID       string     `yaml:"run_id"`
+	WorkflowID  string     `yaml:"workflow_id"`
+	WorkitemID  string     `yaml:"workitem_id"`
+	Status      string     `yaml:"status"`
+	StartedAt   time.Time  `yaml:"started_at"`
+	CompletedAt time.Time  `yaml:"completed_at,omitempty"`
+	StartedBy   string     `yaml:"started_by,omitempty"`
+	Executor    string     `yaml:"executor,omitempty"`
+	Source      RunSource  `yaml:"source"`
+	Summary     RunSummary `yaml:"summary"`
+}
+
+// RunSource captures pointers to the authored workflow document.
+type RunSource struct {
+	WorkflowPath string `yaml:"workflow_path"`
+	WorkflowHash string `yaml:"workflow_hash"`
+	WorkitemPath string `yaml:"workitem_path"`
+}
+
+// RunSummary is the cached current state. Event replay is authoritative;
+// summary is updated from replay on read.
+type RunSummary struct {
+	CurrentStep    int  `yaml:"current_step"`
+	TotalSteps     int  `yaml:"total_steps"`
+	CompletedSteps int  `yaml:"completed_steps"`
+	Blocked        bool `yaml:"blocked"`
+}
+
+// RunState is the replayed view of an active or completed run.
+type RunState struct {
+	RunID          string
+	Status         string // "active" | "completed" | "abandoned" | "blocked"
+	StartedAt      time.Time
+	CompletedAt    time.Time
+	CurrentStep    int
+	TotalSteps     int
+	CompletedSteps int
+	Blocked        bool
+	DocHashChanged bool
+}
+
+const (
+	RunVersion = 1
+	RunKind    = "workflow-run"
+)

--- a/internal/workflow/localstore/store.go
+++ b/internal/workflow/localstore/store.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+	wfparser "github.com/Obedience-Corp/fest/internal/guidance/workflow"
 	"github.com/google/uuid"
 	"gopkg.in/yaml.v3"
 )
@@ -44,7 +45,6 @@ func Open(workflowDir, workflowDocPath string) *Store {
 // InitOptions controls Store.Init.
 type InitOptions struct {
 	WorkflowID string
-	WorkitemID string
 	Force      bool
 }
 
@@ -56,9 +56,6 @@ func (s *Store) Init(ctx context.Context, opts InitOptions) error {
 	}
 	if opts.WorkflowID == "" {
 		return festerrors.Validation("workflow_id is required")
-	}
-	if opts.WorkitemID == "" {
-		return festerrors.Validation("workitem_id is required")
 	}
 
 	if err := os.MkdirAll(s.root, 0o755); err != nil {
@@ -80,14 +77,14 @@ func (s *Store) Init(ctx context.Context, opts InitOptions) error {
 		Version:    ManifestVersion,
 		Kind:       ManifestKind,
 		WorkflowID: opts.WorkflowID,
-		WorkitemID: opts.WorkitemID,
 		DocPath:    filepath.Base(s.workflowDoc),
 		DocHash:    docHash,
 	}
 	return writeYAML(manifestPath, &m)
 }
 
-// LoadManifest reads workflow.yaml.
+// LoadManifest reads workflow.yaml. Validates version, kind, and required
+// IDs before returning so callers do not propagate corrupt state.
 func (s *Store) LoadManifest(ctx context.Context) (*Manifest, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -101,7 +98,38 @@ func (s *Store) LoadManifest(ctx context.Context) (*Manifest, error) {
 	if err := yaml.Unmarshal(raw, &m); err != nil {
 		return nil, festerrors.Parse("parsing workflow manifest", err)
 	}
+	if err := validateManifest(&m, path); err != nil {
+		return nil, err
+	}
 	return &m, nil
+}
+
+// validateManifest enforces version/kind/workflow_id presence. Rejecting
+// malformed manifests at the loader prevents compound corruption from
+// downstream writes (D030 finding #2).
+func validateManifest(m *Manifest, path string) error {
+	if m.Version == 0 {
+		return festerrors.Validation("workflow manifest missing version").
+			WithField("path", path).
+			WithHint("expected version: 1")
+	}
+	if m.Version != ManifestVersion {
+		return festerrors.Validation("unsupported workflow manifest version").
+			WithField("path", path).
+			WithField("got", m.Version).
+			WithField("supported", ManifestVersion)
+	}
+	if m.Kind != ManifestKind {
+		return festerrors.Validation("workflow manifest kind mismatch").
+			WithField("path", path).
+			WithField("got", m.Kind).
+			WithField("expected", ManifestKind)
+	}
+	if m.WorkflowID == "" {
+		return festerrors.Validation("workflow manifest missing workflow_id").
+			WithField("path", path)
+	}
+	return nil
 }
 
 // StartRun creates a new run directory, writes run.yaml, appends the
@@ -144,13 +172,22 @@ func (s *Store) StartRun(ctx context.Context, startedBy string) (string, error) 
 		docHash, _ = HashWorkflowDoc(s.workflowDoc)
 	}
 
+	// Count steps for Summary.TotalSteps so consumers (camp dashboard, fest
+	// next renderer) can display "Step N of M" without inventing a fallback.
+	// Closes D030 finding #4.
+	totalSteps := 0
+	if s.workflowDoc != "" {
+		if n, parseErr := wfparser.NewParser().StepCount(ctx, s.workflowDoc); parseErr == nil {
+			totalSteps = n
+		}
+	}
+
 	now := time.Now().UTC()
 	run := RunManifest{
 		Version:    RunVersion,
 		Kind:       RunKind,
 		RunID:      runID,
 		WorkflowID: m.WorkflowID,
-		WorkitemID: m.WorkitemID,
 		Status:     "active",
 		StartedAt:  now,
 		StartedBy:  startedBy,
@@ -160,6 +197,7 @@ func (s *Store) StartRun(ctx context.Context, startedBy string) (string, error) 
 			WorkflowHash: docHash,
 			WorkitemPath: "../..",
 		},
+		Summary: RunSummary{TotalSteps: totalSteps},
 	}
 	if err := writeYAML(filepath.Join(runDir, runManifestName), &run); err != nil {
 		return "", err
@@ -171,7 +209,6 @@ func (s *Store) StartRun(ctx context.Context, startedBy string) (string, error) 
 		EventType:  EventWorkflowRunStarted,
 		RunID:      runID,
 		WorkflowID: m.WorkflowID,
-		WorkitemID: m.WorkitemID,
 		Timestamp:  now,
 	}); err != nil {
 		return "", err
@@ -215,7 +252,48 @@ func (s *Store) AppendEvent(ctx context.Context, evt Event) error {
 	if evt.Version == 0 {
 		evt.Version = 1
 	}
-	return s.appendEvent(ctx, runDir, evt)
+	if err := s.appendEvent(ctx, runDir, evt); err != nil {
+		return err
+	}
+	// Terminal events must also update the parent workflow.yaml so
+	// `fest workflow runs` and subsequent LoadActive calls see a consistent
+	// view. Without this, runs[i].Status stays "active" and ActiveRunID
+	// keeps pointing at a finished run (D030 finding #3).
+	if evt.EventType == EventWorkflowRunCompleted || evt.EventType == EventWorkflowRunAbandoned {
+		if err := s.finalizeRunInManifest(ctx, evt); err != nil {
+			return festerrors.Wrap(err, "finalize run in manifest")
+		}
+	}
+	return nil
+}
+
+// finalizeRunInManifest updates workflow.yaml after a terminal event.
+// Idempotent — re-finalizing an already-terminal run is a no-op.
+func (s *Store) finalizeRunInManifest(ctx context.Context, evt Event) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	m, err := s.LoadManifest(ctx)
+	if err != nil {
+		return err
+	}
+	terminalStatus := "completed"
+	if evt.EventType == EventWorkflowRunAbandoned {
+		terminalStatus = "abandoned"
+	}
+	for i := range m.Runs {
+		if m.Runs[i].RunID == evt.RunID {
+			m.Runs[i].Status = terminalStatus
+			if m.Runs[i].EndedAt == "" {
+				m.Runs[i].EndedAt = evt.Timestamp.Format(time.RFC3339)
+			}
+			break
+		}
+	}
+	if m.ActiveRunID == evt.RunID {
+		m.ActiveRunID = ""
+	}
+	return writeYAML(filepath.Join(s.root, manifestName), m)
 }
 
 func (s *Store) appendEvent(_ context.Context, runDir string, evt Event) error {
@@ -376,6 +454,13 @@ func replayEvents(eventsPath string, cache RunManifest) *RunState {
 		case EventStepStart:
 			state.CurrentStep++
 		case EventStepDone:
+			state.CompletedSteps++
+			state.Blocked = false
+		case EventStepSkip:
+			// Mirror camp's localrun.go skip handling: skipped steps count
+			// as forward progress and clear any prior block. Without this
+			// case, fest and camp would replay the same event stream into
+			// divergent state (D030 finding #1).
 			state.CompletedSteps++
 			state.Blocked = false
 		case EventStepBlock, EventCheckpointRejected:

--- a/internal/workflow/localstore/store.go
+++ b/internal/workflow/localstore/store.go
@@ -44,7 +44,6 @@ func Open(workflowDir, workflowDocPath string) *Store {
 // InitOptions controls Store.Init.
 type InitOptions struct {
 	WorkflowID string
-	WorkitemID string
 	Force      bool
 }
 
@@ -56,9 +55,6 @@ func (s *Store) Init(ctx context.Context, opts InitOptions) error {
 	}
 	if opts.WorkflowID == "" {
 		return festerrors.Validation("workflow_id is required")
-	}
-	if opts.WorkitemID == "" {
-		return festerrors.Validation("workitem_id is required")
 	}
 
 	if err := os.MkdirAll(s.root, 0o755); err != nil {
@@ -80,7 +76,6 @@ func (s *Store) Init(ctx context.Context, opts InitOptions) error {
 		Version:    ManifestVersion,
 		Kind:       ManifestKind,
 		WorkflowID: opts.WorkflowID,
-		WorkitemID: opts.WorkitemID,
 		DocPath:    filepath.Base(s.workflowDoc),
 		DocHash:    docHash,
 	}
@@ -150,7 +145,6 @@ func (s *Store) StartRun(ctx context.Context, startedBy string) (string, error) 
 		Kind:       RunKind,
 		RunID:      runID,
 		WorkflowID: m.WorkflowID,
-		WorkitemID: m.WorkitemID,
 		Status:     "active",
 		StartedAt:  now,
 		StartedBy:  startedBy,
@@ -171,7 +165,6 @@ func (s *Store) StartRun(ctx context.Context, startedBy string) (string, error) 
 		EventType:  EventWorkflowRunStarted,
 		RunID:      runID,
 		WorkflowID: m.WorkflowID,
-		WorkitemID: m.WorkitemID,
 		Timestamp:  now,
 	}); err != nil {
 		return "", err

--- a/internal/workflow/localstore/store.go
+++ b/internal/workflow/localstore/store.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -115,10 +116,27 @@ func (s *Store) StartRun(ctx context.Context, startedBy string) (string, error) 
 		return "", err
 	}
 
-	runID := newRunID(time.Now().UTC())
+	// Allocate a unique run ID. Base is a UTC second-granularity timestamp;
+	// if two starts land in the same second we append -2, -3, ... so older
+	// runs are never overwritten.
+	base := newRunID(time.Now().UTC())
+	runID := base
 	runDir := filepath.Join(s.root, runsDir, runID)
-	if err := os.MkdirAll(runDir, 0o755); err != nil {
-		return "", festerrors.IO("creating run directory", err)
+	for suffix := 2; ; suffix++ {
+		if err := os.Mkdir(runDir, 0o755); err == nil {
+			break
+		} else if !os.IsExist(err) {
+			// Parent .workflow/runs may not exist yet; create and retry.
+			if errors.Is(err, os.ErrNotExist) {
+				if mkErr := os.MkdirAll(filepath.Dir(runDir), 0o755); mkErr != nil {
+					return "", festerrors.IO("creating runs directory", mkErr)
+				}
+				continue
+			}
+			return "", festerrors.IO("creating run directory", err)
+		}
+		runID = base + "-" + strconv.Itoa(suffix)
+		runDir = filepath.Join(s.root, runsDir, runID)
 	}
 
 	docHash := ""

--- a/internal/workflow/localstore/store.go
+++ b/internal/workflow/localstore/store.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+	wfparser "github.com/Obedience-Corp/fest/internal/guidance/workflow"
 	"github.com/google/uuid"
 	"gopkg.in/yaml.v3"
 )
@@ -82,7 +83,8 @@ func (s *Store) Init(ctx context.Context, opts InitOptions) error {
 	return writeYAML(manifestPath, &m)
 }
 
-// LoadManifest reads workflow.yaml.
+// LoadManifest reads workflow.yaml. Validates version, kind, and required
+// IDs before returning so callers do not propagate corrupt state.
 func (s *Store) LoadManifest(ctx context.Context) (*Manifest, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -96,7 +98,38 @@ func (s *Store) LoadManifest(ctx context.Context) (*Manifest, error) {
 	if err := yaml.Unmarshal(raw, &m); err != nil {
 		return nil, festerrors.Parse("parsing workflow manifest", err)
 	}
+	if err := validateManifest(&m, path); err != nil {
+		return nil, err
+	}
 	return &m, nil
+}
+
+// validateManifest enforces version/kind/workflow_id presence. Rejecting
+// malformed manifests at the loader prevents compound corruption from
+// downstream writes (D030 finding #2).
+func validateManifest(m *Manifest, path string) error {
+	if m.Version == 0 {
+		return festerrors.Validation("workflow manifest missing version").
+			WithField("path", path).
+			WithHint("expected version: 1")
+	}
+	if m.Version != ManifestVersion {
+		return festerrors.Validation("unsupported workflow manifest version").
+			WithField("path", path).
+			WithField("got", m.Version).
+			WithField("supported", ManifestVersion)
+	}
+	if m.Kind != ManifestKind {
+		return festerrors.Validation("workflow manifest kind mismatch").
+			WithField("path", path).
+			WithField("got", m.Kind).
+			WithField("expected", ManifestKind)
+	}
+	if m.WorkflowID == "" {
+		return festerrors.Validation("workflow manifest missing workflow_id").
+			WithField("path", path)
+	}
+	return nil
 }
 
 // StartRun creates a new run directory, writes run.yaml, appends the
@@ -139,6 +172,16 @@ func (s *Store) StartRun(ctx context.Context, startedBy string) (string, error) 
 		docHash, _ = HashWorkflowDoc(s.workflowDoc)
 	}
 
+	// Count steps for Summary.TotalSteps so consumers (camp dashboard, fest
+	// next renderer) can display "Step N of M" without inventing a fallback.
+	// Closes D030 finding #4.
+	totalSteps := 0
+	if s.workflowDoc != "" {
+		if n, parseErr := wfparser.NewParser().StepCount(ctx, s.workflowDoc); parseErr == nil {
+			totalSteps = n
+		}
+	}
+
 	now := time.Now().UTC()
 	run := RunManifest{
 		Version:    RunVersion,
@@ -154,6 +197,7 @@ func (s *Store) StartRun(ctx context.Context, startedBy string) (string, error) 
 			WorkflowHash: docHash,
 			WorkitemPath: "../..",
 		},
+		Summary: RunSummary{TotalSteps: totalSteps},
 	}
 	if err := writeYAML(filepath.Join(runDir, runManifestName), &run); err != nil {
 		return "", err
@@ -208,7 +252,48 @@ func (s *Store) AppendEvent(ctx context.Context, evt Event) error {
 	if evt.Version == 0 {
 		evt.Version = 1
 	}
-	return s.appendEvent(ctx, runDir, evt)
+	if err := s.appendEvent(ctx, runDir, evt); err != nil {
+		return err
+	}
+	// Terminal events must also update the parent workflow.yaml so
+	// `fest workflow runs` and subsequent LoadActive calls see a consistent
+	// view. Without this, runs[i].Status stays "active" and ActiveRunID
+	// keeps pointing at a finished run (D030 finding #3).
+	if evt.EventType == EventWorkflowRunCompleted || evt.EventType == EventWorkflowRunAbandoned {
+		if err := s.finalizeRunInManifest(ctx, evt); err != nil {
+			return festerrors.Wrap(err, "finalize run in manifest")
+		}
+	}
+	return nil
+}
+
+// finalizeRunInManifest updates workflow.yaml after a terminal event.
+// Idempotent — re-finalizing an already-terminal run is a no-op.
+func (s *Store) finalizeRunInManifest(ctx context.Context, evt Event) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	m, err := s.LoadManifest(ctx)
+	if err != nil {
+		return err
+	}
+	terminalStatus := "completed"
+	if evt.EventType == EventWorkflowRunAbandoned {
+		terminalStatus = "abandoned"
+	}
+	for i := range m.Runs {
+		if m.Runs[i].RunID == evt.RunID {
+			m.Runs[i].Status = terminalStatus
+			if m.Runs[i].EndedAt == "" {
+				m.Runs[i].EndedAt = evt.Timestamp.Format(time.RFC3339)
+			}
+			break
+		}
+	}
+	if m.ActiveRunID == evt.RunID {
+		m.ActiveRunID = ""
+	}
+	return writeYAML(filepath.Join(s.root, manifestName), m)
 }
 
 func (s *Store) appendEvent(_ context.Context, runDir string, evt Event) error {
@@ -369,6 +454,13 @@ func replayEvents(eventsPath string, cache RunManifest) *RunState {
 		case EventStepStart:
 			state.CurrentStep++
 		case EventStepDone:
+			state.CompletedSteps++
+			state.Blocked = false
+		case EventStepSkip:
+			// Mirror camp's localrun.go skip handling: skipped steps count
+			// as forward progress and clear any prior block. Without this
+			// case, fest and camp would replay the same event stream into
+			// divergent state (D030 finding #1).
 			state.CompletedSteps++
 			state.Blocked = false
 		case EventStepBlock, EventCheckpointRejected:

--- a/internal/workflow/localstore/store.go
+++ b/internal/workflow/localstore/store.go
@@ -302,7 +302,7 @@ func (s *Store) appendEvent(_ context.Context, runDir string, evt Event) error {
 	if err != nil {
 		return festerrors.IO("opening events file", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	line, err := json.Marshal(evt)
 	if err != nil {
 		return festerrors.Parse("encoding event", err)
@@ -429,7 +429,7 @@ func replayEvents(eventsPath string, cache RunManifest) *RunState {
 	if err != nil {
 		return state
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	// Replay overrides cache when events exist.
 	state.CurrentStep = 0

--- a/internal/workflow/localstore/store.go
+++ b/internal/workflow/localstore/store.go
@@ -1,0 +1,401 @@
+// Package localstore manages a single .workflow/ runtime directory for
+// standalone workflow execution. See workflow/design/workitem-workflows/
+// LOCAL_RUN_STATE.md for the canonical contract.
+//
+// The store is filesystem-only: append-only event stream, derived state via
+// replay, cached summary fields repaired on read.
+package localstore
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/google/uuid"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	manifestName    = "workflow.yaml"
+	runsDir         = "runs"
+	runManifestName = "run.yaml"
+	eventsName      = "progress_events.jsonl"
+)
+
+// Store manages a single .workflow/ runtime directory.
+type Store struct {
+	root        string // absolute path to .workflow/
+	workflowDoc string // absolute path to WORKFLOW.md (sibling of .workflow/)
+}
+
+// Open returns a Store anchored at the given .workflow/ directory.
+// workflowDir may not yet exist (Init will create it).
+func Open(workflowDir, workflowDocPath string) *Store {
+	return &Store{root: workflowDir, workflowDoc: workflowDocPath}
+}
+
+// InitOptions controls Store.Init.
+type InitOptions struct {
+	WorkflowID string
+	WorkitemID string
+	Force      bool
+}
+
+// Init creates .workflow/ and writes workflow.yaml.
+// Refuses to overwrite an existing manifest unless Force is true.
+func (s *Store) Init(ctx context.Context, opts InitOptions) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if opts.WorkflowID == "" {
+		return festerrors.Validation("workflow_id is required")
+	}
+	if opts.WorkitemID == "" {
+		return festerrors.Validation("workitem_id is required")
+	}
+
+	if err := os.MkdirAll(s.root, 0o755); err != nil {
+		return festerrors.IO("creating .workflow", err)
+	}
+	manifestPath := filepath.Join(s.root, manifestName)
+	if _, err := os.Stat(manifestPath); err == nil && !opts.Force {
+		return festerrors.Validation("workflow.yaml already exists; pass Force to overwrite")
+	}
+
+	docHash := ""
+	if s.workflowDoc != "" {
+		if h, err := HashWorkflowDoc(s.workflowDoc); err == nil {
+			docHash = h
+		}
+	}
+
+	m := Manifest{
+		Version:    ManifestVersion,
+		Kind:       ManifestKind,
+		WorkflowID: opts.WorkflowID,
+		WorkitemID: opts.WorkitemID,
+		DocPath:    filepath.Base(s.workflowDoc),
+		DocHash:    docHash,
+	}
+	return writeYAML(manifestPath, &m)
+}
+
+// LoadManifest reads workflow.yaml.
+func (s *Store) LoadManifest(ctx context.Context) (*Manifest, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	path := filepath.Join(s.root, manifestName)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, festerrors.Wrap(err, "reading workflow manifest")
+	}
+	var m Manifest
+	if err := yaml.Unmarshal(raw, &m); err != nil {
+		return nil, festerrors.Parse("parsing workflow manifest", err)
+	}
+	return &m, nil
+}
+
+// StartRun creates a new run directory, writes run.yaml, appends the
+// workflow_run_started event, and updates the manifest's active_run_id.
+// Returns the new run id.
+func (s *Store) StartRun(ctx context.Context, startedBy string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	m, err := s.LoadManifest(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	runID := newRunID(time.Now().UTC())
+	runDir := filepath.Join(s.root, runsDir, runID)
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		return "", festerrors.IO("creating run directory", err)
+	}
+
+	docHash := ""
+	if s.workflowDoc != "" {
+		docHash, _ = HashWorkflowDoc(s.workflowDoc)
+	}
+
+	now := time.Now().UTC()
+	run := RunManifest{
+		Version:    RunVersion,
+		Kind:       RunKind,
+		RunID:      runID,
+		WorkflowID: m.WorkflowID,
+		WorkitemID: m.WorkitemID,
+		Status:     "active",
+		StartedAt:  now,
+		StartedBy:  startedBy,
+		Executor:   "fest",
+		Source: RunSource{
+			WorkflowPath: "../../" + filepath.Base(s.workflowDoc),
+			WorkflowHash: docHash,
+			WorkitemPath: "../..",
+		},
+	}
+	if err := writeYAML(filepath.Join(runDir, runManifestName), &run); err != nil {
+		return "", err
+	}
+
+	if err := s.appendEvent(ctx, runDir, Event{
+		Version:    1,
+		EventID:    "evt_" + uuid.NewString()[:8],
+		EventType:  EventWorkflowRunStarted,
+		RunID:      runID,
+		WorkflowID: m.WorkflowID,
+		WorkitemID: m.WorkitemID,
+		Timestamp:  now,
+	}); err != nil {
+		return "", err
+	}
+
+	m.ActiveRunID = runID
+	m.Runs = append(m.Runs, RunRecord{
+		RunID:     runID,
+		Status:    "active",
+		Path:      filepath.Join(runsDir, runID),
+		StartedAt: now.Format(time.RFC3339),
+	})
+	if err := writeYAML(filepath.Join(s.root, manifestName), m); err != nil {
+		return "", err
+	}
+	return runID, nil
+}
+
+// AppendEvent appends an event to the active run's event stream.
+func (s *Store) AppendEvent(ctx context.Context, evt Event) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	m, err := s.LoadManifest(ctx)
+	if err != nil {
+		return err
+	}
+	if m.ActiveRunID == "" {
+		return festerrors.Validation("no active run")
+	}
+	runDir := filepath.Join(s.root, runsDir, m.ActiveRunID)
+	if evt.RunID == "" {
+		evt.RunID = m.ActiveRunID
+	}
+	if evt.Timestamp.IsZero() {
+		evt.Timestamp = time.Now().UTC()
+	}
+	if evt.EventID == "" {
+		evt.EventID = "evt_" + uuid.NewString()[:8]
+	}
+	if evt.Version == 0 {
+		evt.Version = 1
+	}
+	return s.appendEvent(ctx, runDir, evt)
+}
+
+func (s *Store) appendEvent(_ context.Context, runDir string, evt Event) error {
+	path := filepath.Join(runDir, eventsName)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return festerrors.IO("opening events file", err)
+	}
+	defer f.Close()
+	line, err := json.Marshal(evt)
+	if err != nil {
+		return festerrors.Parse("encoding event", err)
+	}
+	if _, err := f.Write(append(line, '\n')); err != nil {
+		return festerrors.IO("writing event", err)
+	}
+	return nil
+}
+
+// LoadActive returns the active run's replayed state.
+// If summary cached in run.yaml disagrees with the event stream, the file
+// is rewritten with corrected values; events are never modified.
+func (s *Store) LoadActive(ctx context.Context) (*RunState, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	m, err := s.LoadManifest(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if m.ActiveRunID == "" {
+		return nil, nil
+	}
+	runDir := filepath.Join(s.root, runsDir, m.ActiveRunID)
+	runPath := filepath.Join(runDir, runManifestName)
+	raw, err := os.ReadFile(runPath)
+	if err != nil {
+		return nil, festerrors.Wrap(err, "reading run manifest")
+	}
+	var rm RunManifest
+	if err := yaml.Unmarshal(raw, &rm); err != nil {
+		return nil, festerrors.Parse("parsing run manifest", err)
+	}
+
+	state := replayEvents(filepath.Join(runDir, eventsName), rm)
+
+	// Repair stale summary on disk if it disagrees with replay.
+	if rm.Summary.CurrentStep != state.CurrentStep ||
+		rm.Summary.CompletedSteps != state.CompletedSteps ||
+		rm.Summary.Blocked != state.Blocked ||
+		(state.Status != "" && state.Status != "active" && state.Status != rm.Status) {
+		rm.Summary.CurrentStep = state.CurrentStep
+		rm.Summary.CompletedSteps = state.CompletedSteps
+		rm.Summary.Blocked = state.Blocked
+		if state.Status != "" {
+			rm.Status = state.Status
+		}
+		_ = writeYAML(runPath, &rm)
+	}
+
+	state.RunID = rm.RunID
+	state.StartedAt = rm.StartedAt
+	state.CompletedAt = rm.CompletedAt
+	state.TotalSteps = rm.Summary.TotalSteps
+	if state.TotalSteps == 0 {
+		state.TotalSteps = state.CurrentStep
+	}
+
+	// Detect doc-hash drift.
+	if s.workflowDoc != "" && m.DocHash != "" {
+		if cur, hashErr := HashWorkflowDoc(s.workflowDoc); hashErr == nil && cur != m.DocHash {
+			state.DocHashChanged = true
+		}
+	}
+	return state, nil
+}
+
+// CheckDocHash compares the stored workflow.yaml doc_hash against the
+// current WORKFLOW.md hash.
+func (s *Store) CheckDocHash(ctx context.Context) (changed bool, current, stored string, err error) {
+	if err := ctx.Err(); err != nil {
+		return false, "", "", err
+	}
+	m, mErr := s.LoadManifest(ctx)
+	if mErr != nil {
+		return false, "", "", mErr
+	}
+	cur, hErr := HashWorkflowDoc(s.workflowDoc)
+	if hErr != nil {
+		return false, "", m.DocHash, hErr
+	}
+	return cur != m.DocHash, cur, m.DocHash, nil
+}
+
+// RunSummaryView is the public view returned by ListRuns.
+type RunSummaryView struct {
+	RunID       string
+	Status      string
+	Path        string
+	StartedAt   string
+	CompletedAt string
+}
+
+// ListRuns enumerates runs from the manifest in their stored order.
+func (s *Store) ListRuns(ctx context.Context) ([]RunSummaryView, error) {
+	m, err := s.LoadManifest(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]RunSummaryView, 0, len(m.Runs))
+	for _, r := range m.Runs {
+		out = append(out, RunSummaryView{
+			RunID:       r.RunID,
+			Status:      r.Status,
+			Path:        r.Path,
+			StartedAt:   r.StartedAt,
+			CompletedAt: r.CompletedAt,
+		})
+	}
+	return out, nil
+}
+
+// replayEvents walks the event stream and derives current state.
+// Returns zero values for missing or unreadable events.
+func replayEvents(eventsPath string, cache RunManifest) *RunState {
+	state := &RunState{
+		Status:         "active",
+		CurrentStep:    cache.Summary.CurrentStep,
+		CompletedSteps: cache.Summary.CompletedSteps,
+		Blocked:        cache.Summary.Blocked,
+	}
+	f, err := os.Open(eventsPath)
+	if err != nil {
+		return state
+	}
+	defer f.Close()
+
+	// Replay overrides cache when events exist.
+	state.CurrentStep = 0
+	state.CompletedSteps = 0
+	state.Blocked = false
+	state.Status = "active"
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(strings.TrimSpace(string(line))) == 0 {
+			continue
+		}
+		var evt struct {
+			EventType string `json:"event_type"`
+		}
+		if err := json.Unmarshal(line, &evt); err != nil {
+			continue
+		}
+		switch evt.EventType {
+		case EventStepStart:
+			state.CurrentStep++
+		case EventStepDone:
+			state.CompletedSteps++
+			state.Blocked = false
+		case EventStepBlock, EventCheckpointRejected:
+			state.Blocked = true
+		case EventCheckpointApproved:
+			state.Blocked = false
+		case EventWorkflowRunCompleted:
+			state.Status = "completed"
+		case EventWorkflowRunAbandoned:
+			state.Status = "abandoned"
+		}
+	}
+	if state.Blocked && state.Status == "active" {
+		state.Status = "blocked"
+	}
+	return state
+}
+
+func writeYAML(path string, v any) error {
+	data, err := yaml.Marshal(v)
+	if err != nil {
+		return festerrors.Parse("marshal yaml", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return festerrors.IO("writing "+filepath.Base(path), err)
+	}
+	return nil
+}
+
+func newRunID(t time.Time) string {
+	return "run-" + t.Format("20060102T150405Z")
+}
+
+// ManifestPath is the on-disk path to workflow.yaml under this store.
+func (s *Store) ManifestPath() string { return filepath.Join(s.root, manifestName) }
+
+// IsInitialized reports whether workflow.yaml exists in this store.
+func (s *Store) IsInitialized() bool {
+	_, err := os.Stat(s.ManifestPath())
+	return !errors.Is(err, os.ErrNotExist)
+}

--- a/internal/workflow/localstore/store_test.go
+++ b/internal/workflow/localstore/store_test.go
@@ -144,6 +144,47 @@ func TestStore_SecondStartCoexistsWithFirst(t *testing.T) {
 	}
 }
 
+func TestStore_StartRunUniqueWithinSameSecond(t *testing.T) {
+	// Pre-create the .workflow/runs/<base-id>/ directory so the next
+	// StartRun in the same second must allocate a -2 suffix instead of
+	// overwriting it.
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+		t.Fatal(err)
+	}
+	first, err := s.StartRun(ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstRunYAMLBefore, err := os.ReadFile(filepath.Join(s.root, "runs", first, "run.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Second start within the same second.
+	second, err := s.StartRun(ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == second {
+		t.Fatalf("expected distinct run ids on same-second starts, got %q and %q", first, second)
+	}
+
+	// First run's directory and run.yaml must be untouched.
+	firstRunYAMLAfter, err := os.ReadFile(filepath.Join(s.root, "runs", first, "run.yaml"))
+	if err != nil {
+		t.Fatalf("first run.yaml missing after second start: %v", err)
+	}
+	if string(firstRunYAMLBefore) != string(firstRunYAMLAfter) {
+		t.Errorf("first run.yaml was modified by second start")
+	}
+	// Second run directory must exist.
+	if _, err := os.Stat(filepath.Join(s.root, "runs", second, "run.yaml")); err != nil {
+		t.Errorf("second run.yaml missing: %v", err)
+	}
+}
+
 func TestStore_AppendEventAndReplay(t *testing.T) {
 	s, _ := newTestStore(t)
 	ctx := context.Background()

--- a/internal/workflow/localstore/store_test.go
+++ b/internal/workflow/localstore/store_test.go
@@ -1,0 +1,276 @@
+package localstore
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const sampleWorkflow = `---
+workflow_version: 1
+workflow_id: wf-sample
+workitem_id: smoke-001
+---
+
+## Step 1: ALIGN PROBLEM
+
+**Goal:** Sample.
+
+**Actions:**
+1. Read step.
+
+**Output:** A read step.
+`
+
+func newTestStore(t *testing.T) (*Store, string) {
+	t.Helper()
+	dir := t.TempDir()
+	docPath := filepath.Join(dir, "WORKFLOW.md")
+	if err := os.WriteFile(docPath, []byte(sampleWorkflow), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return Open(filepath.Join(dir, ".workflow"), docPath), dir
+}
+
+func TestStore_InitCreatesManifest(t *testing.T) {
+	s, _ := newTestStore(t)
+	err := s.Init(context.Background(), InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := s.LoadManifest(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Version != ManifestVersion || m.Kind != ManifestKind || m.WorkflowID != "wf-x" {
+		t.Errorf("unexpected manifest: %+v", m)
+	}
+	if m.DocHash == "" {
+		t.Errorf("DocHash should be populated when workflow doc exists")
+	}
+}
+
+func TestStore_InitRefusesOverwrite(t *testing.T) {
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+		t.Fatal(err)
+	}
+	err := s.Init(ctx, InitOptions{WorkflowID: "wf-y", WorkitemID: "wi-y"})
+	if err == nil {
+		t.Fatal("expected refusal without Force")
+	}
+}
+
+func TestStore_InitForceOverwrites(t *testing.T) {
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-y", WorkitemID: "wi-y", Force: true}); err != nil {
+		t.Fatal(err)
+	}
+	m, _ := s.LoadManifest(ctx)
+	if m.WorkflowID != "wf-y" {
+		t.Errorf("expected overwrite to wf-y, got %q", m.WorkflowID)
+	}
+}
+
+func TestStore_StartRunCreatesRunDir(t *testing.T) {
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+		t.Fatal(err)
+	}
+	runID, err := s.StartRun(ctx, "tester")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(runID, "run-") {
+		t.Errorf("RunID = %q, want run- prefix", runID)
+	}
+
+	m, _ := s.LoadManifest(ctx)
+	if m.ActiveRunID != runID {
+		t.Errorf("active_run_id not updated, got %q", m.ActiveRunID)
+	}
+	if len(m.Runs) != 1 {
+		t.Errorf("expected 1 run record, got %d", len(m.Runs))
+	}
+
+	runDir := filepath.Join(s.root, "runs", runID)
+	if _, err := os.Stat(filepath.Join(runDir, "run.yaml")); err != nil {
+		t.Errorf("run.yaml missing: %v", err)
+	}
+
+	eventsPath := filepath.Join(runDir, "progress_events.jsonl")
+	raw, err := os.ReadFile(eventsPath)
+	if err != nil {
+		t.Fatalf("events file: %v", err)
+	}
+	if !strings.Contains(string(raw), EventWorkflowRunStarted) {
+		t.Errorf("missing workflow_run_started event: %s", raw)
+	}
+}
+
+func TestStore_SecondStartCoexistsWithFirst(t *testing.T) {
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+		t.Fatal(err)
+	}
+	first, _ := s.StartRun(ctx, "")
+	// Move clock forward slightly so the run-id timestamp differs.
+	time.Sleep(1100 * time.Millisecond)
+	second, err := s.StartRun(ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == second {
+		t.Fatalf("expected distinct run ids, got %q and %q", first, second)
+	}
+	if _, err := os.Stat(filepath.Join(s.root, "runs", first, "run.yaml")); err != nil {
+		t.Errorf("first run dir missing after second start: %v", err)
+	}
+	runs, _ := s.ListRuns(ctx)
+	if len(runs) != 2 {
+		t.Errorf("expected 2 runs, got %d", len(runs))
+	}
+}
+
+func TestStore_AppendEventAndReplay(t *testing.T) {
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.StartRun(ctx, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AppendEvent(ctx, Event{EventType: EventStepStart}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AppendEvent(ctx, Event{EventType: EventStepDone}); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := s.LoadActive(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state == nil {
+		t.Fatal("expected state, got nil")
+	}
+	if state.CurrentStep != 1 || state.CompletedSteps != 1 {
+		t.Errorf("CurrentStep=%d CompletedSteps=%d", state.CurrentStep, state.CompletedSteps)
+	}
+}
+
+func TestStore_ReplayOverridesStaleSummary(t *testing.T) {
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+		t.Fatal(err)
+	}
+	runID, _ := s.StartRun(ctx, "")
+	if err := s.AppendEvent(ctx, Event{EventType: EventStepStart}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AppendEvent(ctx, Event{EventType: EventStepStart}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AppendEvent(ctx, Event{EventType: EventStepDone}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Corrupt the summary on disk.
+	runPath := filepath.Join(s.root, "runs", runID, "run.yaml")
+	raw, _ := os.ReadFile(runPath)
+	bad := strings.Replace(string(raw), "current_step: 0", "current_step: 999", 1)
+	_ = os.WriteFile(runPath, []byte(bad), 0o644)
+
+	state, _ := s.LoadActive(ctx)
+	if state.CurrentStep != 2 || state.CompletedSteps != 1 {
+		t.Errorf("replay should override stale summary, got CurrentStep=%d CompletedSteps=%d", state.CurrentStep, state.CompletedSteps)
+	}
+
+	// Repair should have rewritten the summary.
+	raw2, _ := os.ReadFile(runPath)
+	if strings.Contains(string(raw2), "current_step: 999") {
+		t.Errorf("stale summary not repaired")
+	}
+}
+
+func TestStore_DocHashChange(t *testing.T) {
+	s, root := newTestStore(t)
+	ctx := context.Background()
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(root, "WORKFLOW.md"), []byte("mutated"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	changed, cur, stored, err := s.CheckDocHash(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Errorf("expected changed=true, cur=%s stored=%s", cur, stored)
+	}
+}
+
+func TestStore_EventsAreAppendOnly(t *testing.T) {
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.StartRun(ctx, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AppendEvent(ctx, Event{EventType: "A"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AppendEvent(ctx, Event{EventType: "B"}); err != nil {
+		t.Fatal(err)
+	}
+
+	m, _ := s.LoadManifest(ctx)
+	eventsPath := filepath.Join(s.root, "runs", m.ActiveRunID, "progress_events.jsonl")
+	raw, _ := os.ReadFile(eventsPath)
+	lines := strings.Split(strings.TrimRight(string(raw), "\n"), "\n")
+	// expect 3 lines: workflow_run_started, A, B
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 event lines, got %d: %s", len(lines), raw)
+	}
+
+	var first, second, third struct {
+		EventType string `json:"event_type"`
+	}
+	_ = json.Unmarshal([]byte(lines[0]), &first)
+	_ = json.Unmarshal([]byte(lines[1]), &second)
+	_ = json.Unmarshal([]byte(lines[2]), &third)
+	if first.EventType != EventWorkflowRunStarted {
+		t.Errorf("line 1 = %q", first.EventType)
+	}
+	if second.EventType != "A" || third.EventType != "B" {
+		t.Errorf("append order broken: A=%q B=%q", second.EventType, third.EventType)
+	}
+}
+
+func TestStore_ContextCancel(t *testing.T) {
+	s, _ := newTestStore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}

--- a/internal/workflow/localstore/store_test.go
+++ b/internal/workflow/localstore/store_test.go
@@ -213,6 +213,150 @@ func TestStore_AppendEventAndReplay(t *testing.T) {
 	}
 }
 
+// TestStore_TerminalEventFinalizesManifest locks in D030 finding #3:
+// completing/abandoning a run clears active_run_id and stamps the runs[]
+// entry. Without this, `fest workflow runs` reports terminated runs as
+// active.
+func TestStore_TerminalEventFinalizesManifest(t *testing.T) {
+	for _, ev := range []string{EventWorkflowRunCompleted, EventWorkflowRunAbandoned} {
+		t.Run(ev, func(t *testing.T) {
+			s, _ := newTestStore(t)
+			ctx := context.Background()
+			if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
+				t.Fatal(err)
+			}
+			runID, err := s.StartRun(ctx, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if err := s.AppendEvent(ctx, Event{EventType: ev}); err != nil {
+				t.Fatal(err)
+			}
+
+			m, err := s.LoadManifest(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if m.ActiveRunID != "" {
+				t.Errorf("ActiveRunID = %q, want empty after terminal event", m.ActiveRunID)
+			}
+			if len(m.Runs) != 1 {
+				t.Fatalf("Runs = %d, want 1", len(m.Runs))
+			}
+			wantStatus := "completed"
+			if ev == EventWorkflowRunAbandoned {
+				wantStatus = "abandoned"
+			}
+			if m.Runs[0].Status != wantStatus {
+				t.Errorf("Runs[0].Status = %q, want %q", m.Runs[0].Status, wantStatus)
+			}
+			if m.Runs[0].RunID != runID {
+				t.Errorf("Runs[0].RunID = %q, want %q", m.Runs[0].RunID, runID)
+			}
+			if m.Runs[0].EndedAt == "" {
+				t.Error("Runs[0].EndedAt empty, want a timestamp")
+			}
+
+			// Idempotent at the finalize layer: calling finalize again for an
+			// already-terminal run does not corrupt state. AppendEvent itself
+			// refuses with "no active run" once ActiveRunID is cleared, which
+			// is the expected guard for callers.
+			if err := s.finalizeRunInManifest(ctx, Event{EventType: ev, RunID: runID, Timestamp: time.Now().UTC()}); err != nil {
+				t.Fatalf("re-finalize should be idempotent, got %v", err)
+			}
+			m2, _ := s.LoadManifest(ctx)
+			if m2.Runs[0].Status != wantStatus {
+				t.Errorf("after re-finalize Runs[0].Status = %q, want %q", m2.Runs[0].Status, wantStatus)
+			}
+		})
+	}
+}
+
+// TestLoadManifest_RejectsMalformed locks in D030 finding #2: LoadManifest
+// must validate version/kind/workflow_id before returning so callers do not
+// silently propagate corrupt state.
+func TestLoadManifest_RejectsMalformed(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			name: "missing version",
+			yaml: "kind: workflow-runtime\nworkflow_id: wf-x\n",
+			want: "missing version",
+		},
+		{
+			name: "unsupported version",
+			yaml: "version: 99\nkind: workflow-runtime\nworkflow_id: wf-x\n",
+			want: "unsupported workflow manifest version",
+		},
+		{
+			name: "wrong kind",
+			yaml: "version: 1\nkind: not-workflow\nworkflow_id: wf-x\n",
+			want: "kind mismatch",
+		},
+		{
+			name: "missing workflow_id",
+			yaml: "version: 1\nkind: workflow-runtime\n",
+			want: "missing workflow_id",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, manifestName), []byte(c.yaml), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			s := &Store{root: dir}
+			_, err := s.LoadManifest(context.Background())
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", c.want)
+			}
+			if !strings.Contains(err.Error(), c.want) {
+				t.Errorf("error %q does not contain %q", err.Error(), c.want)
+			}
+		})
+	}
+}
+
+// TestStore_ReplayHandlesStepSkip locks in D030 finding #1: skip clears
+// Blocked and counts as forward progress, matching camp's localrun.go
+// semantics so the same event stream produces the same state in both repos.
+func TestStore_ReplayHandlesStepSkip(t *testing.T) {
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.StartRun(ctx, ""); err != nil {
+		t.Fatal(err)
+	}
+	for _, ev := range []string{EventStepStart, EventStepBlock, EventStepSkip} {
+		if err := s.AppendEvent(ctx, Event{EventType: ev}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	state, err := s.LoadActive(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state == nil {
+		t.Fatal("expected state, got nil")
+	}
+	if state.Blocked {
+		t.Errorf("Blocked = true after skip, want false")
+	}
+	if state.CompletedSteps != 1 {
+		t.Errorf("CompletedSteps = %d, want 1 (skip counts as progress)", state.CompletedSteps)
+	}
+	if state.Status != "active" {
+		t.Errorf("Status = %q, want active (skip clears blocked status)", state.Status)
+	}
+}
+
 func TestStore_ReplayOverridesStaleSummary(t *testing.T) {
 	s, _ := newTestStore(t)
 	ctx := context.Background()

--- a/internal/workflow/localstore/store_test.go
+++ b/internal/workflow/localstore/store_test.go
@@ -39,7 +39,7 @@ func newTestStore(t *testing.T) (*Store, string) {
 
 func TestStore_InitCreatesManifest(t *testing.T) {
 	s, _ := newTestStore(t)
-	err := s.Init(context.Background(), InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"})
+	err := s.Init(context.Background(), InitOptions{WorkflowID: "wf-x"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,10 +58,10 @@ func TestStore_InitCreatesManifest(t *testing.T) {
 func TestStore_InitRefusesOverwrite(t *testing.T) {
 	s, _ := newTestStore(t)
 	ctx := context.Background()
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
 		t.Fatal(err)
 	}
-	err := s.Init(ctx, InitOptions{WorkflowID: "wf-y", WorkitemID: "wi-y"})
+	err := s.Init(ctx, InitOptions{WorkflowID: "wf-y"})
 	if err == nil {
 		t.Fatal("expected refusal without Force")
 	}
@@ -70,10 +70,10 @@ func TestStore_InitRefusesOverwrite(t *testing.T) {
 func TestStore_InitForceOverwrites(t *testing.T) {
 	s, _ := newTestStore(t)
 	ctx := context.Background()
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-y", WorkitemID: "wi-y", Force: true}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-y", Force: true}); err != nil {
 		t.Fatal(err)
 	}
 	m, _ := s.LoadManifest(ctx)
@@ -85,7 +85,7 @@ func TestStore_InitForceOverwrites(t *testing.T) {
 func TestStore_StartRunCreatesRunDir(t *testing.T) {
 	s, _ := newTestStore(t)
 	ctx := context.Background()
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
 		t.Fatal(err)
 	}
 	runID, err := s.StartRun(ctx, "tester")
@@ -122,7 +122,7 @@ func TestStore_StartRunCreatesRunDir(t *testing.T) {
 func TestStore_SecondStartCoexistsWithFirst(t *testing.T) {
 	s, _ := newTestStore(t)
 	ctx := context.Background()
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
 		t.Fatal(err)
 	}
 	first, _ := s.StartRun(ctx, "")
@@ -150,7 +150,7 @@ func TestStore_StartRunUniqueWithinSameSecond(t *testing.T) {
 	// overwriting it.
 	s, _ := newTestStore(t)
 	ctx := context.Background()
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
 		t.Fatal(err)
 	}
 	first, err := s.StartRun(ctx, "")
@@ -188,7 +188,7 @@ func TestStore_StartRunUniqueWithinSameSecond(t *testing.T) {
 func TestStore_AppendEventAndReplay(t *testing.T) {
 	s, _ := newTestStore(t)
 	ctx := context.Background()
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := s.StartRun(ctx, ""); err != nil {
@@ -213,10 +213,154 @@ func TestStore_AppendEventAndReplay(t *testing.T) {
 	}
 }
 
+// TestStore_TerminalEventFinalizesManifest locks in D030 finding #3:
+// completing/abandoning a run clears active_run_id and stamps the runs[]
+// entry. Without this, `fest workflow runs` reports terminated runs as
+// active.
+func TestStore_TerminalEventFinalizesManifest(t *testing.T) {
+	for _, ev := range []string{EventWorkflowRunCompleted, EventWorkflowRunAbandoned} {
+		t.Run(ev, func(t *testing.T) {
+			s, _ := newTestStore(t)
+			ctx := context.Background()
+			if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
+				t.Fatal(err)
+			}
+			runID, err := s.StartRun(ctx, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if err := s.AppendEvent(ctx, Event{EventType: ev}); err != nil {
+				t.Fatal(err)
+			}
+
+			m, err := s.LoadManifest(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if m.ActiveRunID != "" {
+				t.Errorf("ActiveRunID = %q, want empty after terminal event", m.ActiveRunID)
+			}
+			if len(m.Runs) != 1 {
+				t.Fatalf("Runs = %d, want 1", len(m.Runs))
+			}
+			wantStatus := "completed"
+			if ev == EventWorkflowRunAbandoned {
+				wantStatus = "abandoned"
+			}
+			if m.Runs[0].Status != wantStatus {
+				t.Errorf("Runs[0].Status = %q, want %q", m.Runs[0].Status, wantStatus)
+			}
+			if m.Runs[0].RunID != runID {
+				t.Errorf("Runs[0].RunID = %q, want %q", m.Runs[0].RunID, runID)
+			}
+			if m.Runs[0].EndedAt == "" {
+				t.Error("Runs[0].EndedAt empty, want a timestamp")
+			}
+
+			// Idempotent at the finalize layer: calling finalize again for an
+			// already-terminal run does not corrupt state. AppendEvent itself
+			// refuses with "no active run" once ActiveRunID is cleared, which
+			// is the expected guard for callers.
+			if err := s.finalizeRunInManifest(ctx, Event{EventType: ev, RunID: runID, Timestamp: time.Now().UTC()}); err != nil {
+				t.Fatalf("re-finalize should be idempotent, got %v", err)
+			}
+			m2, _ := s.LoadManifest(ctx)
+			if m2.Runs[0].Status != wantStatus {
+				t.Errorf("after re-finalize Runs[0].Status = %q, want %q", m2.Runs[0].Status, wantStatus)
+			}
+		})
+	}
+}
+
+// TestLoadManifest_RejectsMalformed locks in D030 finding #2: LoadManifest
+// must validate version/kind/workflow_id before returning so callers do not
+// silently propagate corrupt state.
+func TestLoadManifest_RejectsMalformed(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			name: "missing version",
+			yaml: "kind: workflow-runtime\nworkflow_id: wf-x\n",
+			want: "missing version",
+		},
+		{
+			name: "unsupported version",
+			yaml: "version: 99\nkind: workflow-runtime\nworkflow_id: wf-x\n",
+			want: "unsupported workflow manifest version",
+		},
+		{
+			name: "wrong kind",
+			yaml: "version: 1\nkind: not-workflow\nworkflow_id: wf-x\n",
+			want: "kind mismatch",
+		},
+		{
+			name: "missing workflow_id",
+			yaml: "version: 1\nkind: workflow-runtime\n",
+			want: "missing workflow_id",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, manifestName), []byte(c.yaml), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			s := &Store{root: dir}
+			_, err := s.LoadManifest(context.Background())
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", c.want)
+			}
+			if !strings.Contains(err.Error(), c.want) {
+				t.Errorf("error %q does not contain %q", err.Error(), c.want)
+			}
+		})
+	}
+}
+
+// TestStore_ReplayHandlesStepSkip locks in D030 finding #1: skip clears
+// Blocked and counts as forward progress, matching camp's localrun.go
+// semantics so the same event stream produces the same state in both repos.
+func TestStore_ReplayHandlesStepSkip(t *testing.T) {
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.StartRun(ctx, ""); err != nil {
+		t.Fatal(err)
+	}
+	for _, ev := range []string{EventStepStart, EventStepBlock, EventStepSkip} {
+		if err := s.AppendEvent(ctx, Event{EventType: ev}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	state, err := s.LoadActive(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state == nil {
+		t.Fatal("expected state, got nil")
+	}
+	if state.Blocked {
+		t.Errorf("Blocked = true after skip, want false")
+	}
+	if state.CompletedSteps != 1 {
+		t.Errorf("CompletedSteps = %d, want 1 (skip counts as progress)", state.CompletedSteps)
+	}
+	if state.Status != "active" {
+		t.Errorf("Status = %q, want active (skip clears blocked status)", state.Status)
+	}
+}
+
 func TestStore_ReplayOverridesStaleSummary(t *testing.T) {
 	s, _ := newTestStore(t)
 	ctx := context.Background()
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
 		t.Fatal(err)
 	}
 	runID, _ := s.StartRun(ctx, "")
@@ -251,7 +395,7 @@ func TestStore_ReplayOverridesStaleSummary(t *testing.T) {
 func TestStore_DocHashChange(t *testing.T) {
 	s, root := newTestStore(t)
 	ctx := context.Background()
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -270,7 +414,7 @@ func TestStore_DocHashChange(t *testing.T) {
 func TestStore_EventsAreAppendOnly(t *testing.T) {
 	s, _ := newTestStore(t)
 	ctx := context.Background()
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := s.StartRun(ctx, ""); err != nil {
@@ -310,7 +454,7 @@ func TestStore_ContextCancel(t *testing.T) {
 	s, _ := newTestStore(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"})
+	err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"})
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("expected context.Canceled, got %v", err)
 	}

--- a/internal/workflow/localstore/store_test.go
+++ b/internal/workflow/localstore/store_test.go
@@ -39,7 +39,7 @@ func newTestStore(t *testing.T) (*Store, string) {
 
 func TestStore_InitCreatesManifest(t *testing.T) {
 	s, _ := newTestStore(t)
-	err := s.Init(context.Background(), InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"})
+	err := s.Init(context.Background(), InitOptions{WorkflowID: "wf-x"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,10 +58,10 @@ func TestStore_InitCreatesManifest(t *testing.T) {
 func TestStore_InitRefusesOverwrite(t *testing.T) {
 	s, _ := newTestStore(t)
 	ctx := context.Background()
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
 		t.Fatal(err)
 	}
-	err := s.Init(ctx, InitOptions{WorkflowID: "wf-y", WorkitemID: "wi-y"})
+	err := s.Init(ctx, InitOptions{WorkflowID: "wf-y"})
 	if err == nil {
 		t.Fatal("expected refusal without Force")
 	}
@@ -70,10 +70,10 @@ func TestStore_InitRefusesOverwrite(t *testing.T) {
 func TestStore_InitForceOverwrites(t *testing.T) {
 	s, _ := newTestStore(t)
 	ctx := context.Background()
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-y", WorkitemID: "wi-y", Force: true}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-y", Force: true}); err != nil {
 		t.Fatal(err)
 	}
 	m, _ := s.LoadManifest(ctx)
@@ -85,7 +85,7 @@ func TestStore_InitForceOverwrites(t *testing.T) {
 func TestStore_StartRunCreatesRunDir(t *testing.T) {
 	s, _ := newTestStore(t)
 	ctx := context.Background()
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
 		t.Fatal(err)
 	}
 	runID, err := s.StartRun(ctx, "tester")
@@ -122,7 +122,7 @@ func TestStore_StartRunCreatesRunDir(t *testing.T) {
 func TestStore_SecondStartCoexistsWithFirst(t *testing.T) {
 	s, _ := newTestStore(t)
 	ctx := context.Background()
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
 		t.Fatal(err)
 	}
 	first, _ := s.StartRun(ctx, "")
@@ -150,7 +150,7 @@ func TestStore_StartRunUniqueWithinSameSecond(t *testing.T) {
 	// overwriting it.
 	s, _ := newTestStore(t)
 	ctx := context.Background()
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
 		t.Fatal(err)
 	}
 	first, err := s.StartRun(ctx, "")
@@ -188,7 +188,7 @@ func TestStore_StartRunUniqueWithinSameSecond(t *testing.T) {
 func TestStore_AppendEventAndReplay(t *testing.T) {
 	s, _ := newTestStore(t)
 	ctx := context.Background()
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := s.StartRun(ctx, ""); err != nil {
@@ -216,7 +216,7 @@ func TestStore_AppendEventAndReplay(t *testing.T) {
 func TestStore_ReplayOverridesStaleSummary(t *testing.T) {
 	s, _ := newTestStore(t)
 	ctx := context.Background()
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
 		t.Fatal(err)
 	}
 	runID, _ := s.StartRun(ctx, "")
@@ -251,7 +251,7 @@ func TestStore_ReplayOverridesStaleSummary(t *testing.T) {
 func TestStore_DocHashChange(t *testing.T) {
 	s, root := newTestStore(t)
 	ctx := context.Background()
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -270,7 +270,7 @@ func TestStore_DocHashChange(t *testing.T) {
 func TestStore_EventsAreAppendOnly(t *testing.T) {
 	s, _ := newTestStore(t)
 	ctx := context.Background()
-	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"}); err != nil {
+	if err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"}); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := s.StartRun(ctx, ""); err != nil {
@@ -310,7 +310,7 @@ func TestStore_ContextCancel(t *testing.T) {
 	s, _ := newTestStore(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	err := s.Init(ctx, InitOptions{WorkflowID: "wf-x", WorkitemID: "wi-x"})
+	err := s.Init(ctx, InitOptions{WorkflowID: "wf-x"})
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("expected context.Canceled, got %v", err)
 	}

--- a/internal/workflow/standalone/resolver.go
+++ b/internal/workflow/standalone/resolver.go
@@ -32,6 +32,12 @@ const (
 	ModeAnonymous Mode = "anonymous"
 )
 
+// resolveFestivalPath is a package-level indirection over
+// shared.ResolveFestivalPath so tests can inject failures (permission
+// denied, I/O) without mutating the host filesystem. Production code
+// always uses the real implementation.
+var resolveFestivalPath = shared.ResolveFestivalPath
+
 // Result is the typed output of resolution. All paths are absolute.
 type Result struct {
 	Mode         Mode
@@ -56,7 +62,7 @@ func Resolve(ctx context.Context, startDir string) (*Result, error) {
 	}
 
 	// Priority 1: festival context.
-	festPath, festErr := shared.ResolveFestivalPath(absStart, "")
+	festPath, festErr := resolveFestivalPath(absStart, "")
 	if festErr == nil && festPath != "" {
 		phasePath := shared.ResolvePhasePath(absStart, festPath)
 		workflowDoc := ""

--- a/internal/workflow/standalone/resolver.go
+++ b/internal/workflow/standalone/resolver.go
@@ -1,11 +1,11 @@
 // Package standalone resolves workflow context outside of a festival.
 //
 // Resolution priority:
-//  1. Festival context (delegates to shared.ResolveFestivalPath) — always wins
-//     when both festival and standalone signals exist.
-//  2. Tracked standalone workflow — a directory with .workflow/workflow.yaml.
-//  3. Anonymous standalone workflow — a directory with WORKFLOW.md only.
-//  4. None — neither signal found.
+//  1. Festival context (delegates to shared.ResolveFestivalPath). Wins
+//     unconditionally when both festival and standalone signals exist.
+//  2. Tracked standalone workflow: a directory with .workflow/workflow.yaml.
+//  3. Anonymous standalone workflow: a directory with WORKFLOW.md only.
+//  4. None: neither signal found.
 package standalone
 
 import (

--- a/internal/workflow/standalone/resolver.go
+++ b/internal/workflow/standalone/resolver.go
@@ -3,8 +3,11 @@
 // Resolution priority:
 //  1. Festival context (delegates to shared.ResolveFestivalPath). Wins
 //     unconditionally when both festival and standalone signals exist.
+//     Festival detection walks up parent directories.
 //  2. Tracked standalone workflow: a directory with .workflow/workflow.yaml.
+//     Detected at cwd only (D013) — does not walk up.
 //  3. Anonymous standalone workflow: a directory with WORKFLOW.md only.
+//     Detected at cwd only (D013).
 //  4. None: neither signal found.
 package standalone
 
@@ -88,44 +91,40 @@ func Resolve(ctx context.Context, startDir string) (*Result, error) {
 		return nil, festerrors.Wrap(festErr, "resolving festival path")
 	}
 
-	// Priority 2 + 3: standalone walk upward.
-	return walkForStandalone(ctx, absStart)
+	// Priority 2 + 3: standalone cwd-only check (D013). Unlike festival
+	// detection, standalone WORKFLOW.md detection does not walk up parent
+	// directories — `fest next` from a child directory of a workflow does
+	// not pick it up.
+	return checkCwdForStandalone(ctx, absStart)
 }
 
-func walkForStandalone(ctx context.Context, startDir string) (*Result, error) {
-	dir := startDir
-	for {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-
-		manifest := filepath.Join(dir, ".workflow", "workflow.yaml")
-		if _, err := os.Stat(manifest); err == nil {
-			return &Result{
-				Mode:        ModeTracked,
-				StartDir:    startDir,
-				WorkflowDoc: filepath.Join(dir, "WORKFLOW.md"),
-				RuntimeDir:  filepath.Join(dir, ".workflow"),
-			}, nil
-		} else if !errors.Is(err, os.ErrNotExist) {
-			return nil, festerrors.Wrap(err, "stat workflow manifest")
-		}
-
-		doc := filepath.Join(dir, "WORKFLOW.md")
-		if _, err := os.Stat(doc); err == nil {
-			return &Result{
-				Mode:        ModeAnonymous,
-				StartDir:    startDir,
-				WorkflowDoc: doc,
-			}, nil
-		} else if !errors.Is(err, os.ErrNotExist) {
-			return nil, festerrors.Wrap(err, "stat workflow doc")
-		}
-
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return &Result{Mode: ModeNone, StartDir: startDir}, nil
-		}
-		dir = parent
+func checkCwdForStandalone(ctx context.Context, startDir string) (*Result, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
+
+	manifest := filepath.Join(startDir, ".workflow", "workflow.yaml")
+	if _, err := os.Stat(manifest); err == nil {
+		return &Result{
+			Mode:        ModeTracked,
+			StartDir:    startDir,
+			WorkflowDoc: filepath.Join(startDir, "WORKFLOW.md"),
+			RuntimeDir:  filepath.Join(startDir, ".workflow"),
+		}, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, festerrors.Wrap(err, "stat workflow manifest")
+	}
+
+	doc := filepath.Join(startDir, "WORKFLOW.md")
+	if _, err := os.Stat(doc); err == nil {
+		return &Result{
+			Mode:        ModeAnonymous,
+			StartDir:    startDir,
+			WorkflowDoc: doc,
+		}, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, festerrors.Wrap(err, "stat workflow doc")
+	}
+
+	return &Result{Mode: ModeNone, StartDir: startDir}, nil
 }

--- a/internal/workflow/standalone/resolver.go
+++ b/internal/workflow/standalone/resolver.go
@@ -1,0 +1,117 @@
+// Package standalone resolves workflow context outside of a festival.
+//
+// Resolution priority:
+//  1. Festival context (delegates to shared.ResolveFestivalPath) — always wins
+//     when both festival and standalone signals exist.
+//  2. Tracked standalone workflow — a directory with .workflow/workflow.yaml.
+//  3. Anonymous standalone workflow — a directory with WORKFLOW.md only.
+//  4. None — neither signal found.
+package standalone
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/Obedience-Corp/fest/internal/commands/shared"
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+)
+
+// Mode identifies which workflow context was resolved.
+type Mode string
+
+const (
+	// ModeNone means no workflow context was found.
+	ModeNone Mode = "none"
+	// ModeFestival means resolution found a fest festival workflow.
+	ModeFestival Mode = "festival"
+	// ModeTracked means a standalone .workflow/ runtime is present.
+	ModeTracked Mode = "tracked"
+	// ModeAnonymous means a WORKFLOW.md exists with no .workflow/ runtime.
+	ModeAnonymous Mode = "anonymous"
+)
+
+// Result is the typed output of resolution. All paths are absolute.
+type Result struct {
+	Mode         Mode
+	StartDir     string
+	FestivalPath string // set when Mode == ModeFestival
+	PhasePath    string // set when Mode == ModeFestival and inside a phase
+	WorkflowDoc  string // absolute path to WORKFLOW.md, set for tracked/anonymous/festival-phase
+	RuntimeDir   string // absolute path to .workflow/, set when Mode == ModeTracked
+}
+
+// Resolve walks from startDir to find the nearest workflow context.
+// Festival context wins when both festival and standalone signals exist for
+// the same path.
+func Resolve(ctx context.Context, startDir string) (*Result, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	absStart, err := filepath.Abs(startDir)
+	if err != nil {
+		return nil, festerrors.Wrap(err, "resolving start dir")
+	}
+
+	// Priority 1: festival context.
+	if festPath, festErr := shared.ResolveFestivalPath(absStart, ""); festErr == nil && festPath != "" {
+		phasePath := shared.ResolvePhasePath(absStart, festPath)
+		workflowDoc := ""
+		if phasePath != "" {
+			candidate := filepath.Join(phasePath, "WORKFLOW.md")
+			if _, statErr := os.Stat(candidate); statErr == nil {
+				workflowDoc = candidate
+			}
+		}
+		return &Result{
+			Mode:         ModeFestival,
+			StartDir:     absStart,
+			FestivalPath: festPath,
+			PhasePath:    phasePath,
+			WorkflowDoc:  workflowDoc,
+		}, nil
+	}
+
+	// Priority 2 + 3: standalone walk upward.
+	return walkForStandalone(ctx, absStart)
+}
+
+func walkForStandalone(ctx context.Context, startDir string) (*Result, error) {
+	dir := startDir
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		manifest := filepath.Join(dir, ".workflow", "workflow.yaml")
+		if _, err := os.Stat(manifest); err == nil {
+			return &Result{
+				Mode:        ModeTracked,
+				StartDir:    startDir,
+				WorkflowDoc: filepath.Join(dir, "WORKFLOW.md"),
+				RuntimeDir:  filepath.Join(dir, ".workflow"),
+			}, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, festerrors.Wrap(err, "stat workflow manifest")
+		}
+
+		doc := filepath.Join(dir, "WORKFLOW.md")
+		if _, err := os.Stat(doc); err == nil {
+			return &Result{
+				Mode:        ModeAnonymous,
+				StartDir:    startDir,
+				WorkflowDoc: doc,
+			}, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, festerrors.Wrap(err, "stat workflow doc")
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return &Result{Mode: ModeNone, StartDir: startDir}, nil
+		}
+		dir = parent
+	}
+}

--- a/internal/workflow/standalone/resolver.go
+++ b/internal/workflow/standalone/resolver.go
@@ -56,7 +56,8 @@ func Resolve(ctx context.Context, startDir string) (*Result, error) {
 	}
 
 	// Priority 1: festival context.
-	if festPath, festErr := shared.ResolveFestivalPath(absStart, ""); festErr == nil && festPath != "" {
+	festPath, festErr := shared.ResolveFestivalPath(absStart, "")
+	if festErr == nil && festPath != "" {
 		phasePath := shared.ResolvePhasePath(absStart, festPath)
 		workflowDoc := ""
 		if phasePath != "" {
@@ -72,6 +73,13 @@ func Resolve(ctx context.Context, startDir string) (*Result, error) {
 			PhasePath:    phasePath,
 			WorkflowDoc:  workflowDoc,
 		}, nil
+	}
+	// A NotFound error means "not inside a festival" — fall through to
+	// standalone resolution. Any other error (permission denied, I/O failure
+	// while walking) is real and must propagate so the caller does not
+	// silently degrade to ModeAnonymous/ModeNone.
+	if festErr != nil && !festerrors.Is(festErr, festerrors.ErrCodeNotFound) {
+		return nil, festerrors.Wrap(festErr, "resolving festival path")
 	}
 
 	// Priority 2 + 3: standalone walk upward.

--- a/internal/workflow/standalone/resolver.go
+++ b/internal/workflow/standalone/resolver.go
@@ -3,8 +3,11 @@
 // Resolution priority:
 //  1. Festival context (delegates to shared.ResolveFestivalPath). Wins
 //     unconditionally when both festival and standalone signals exist.
+//     Festival detection walks up parent directories.
 //  2. Tracked standalone workflow: a directory with .workflow/workflow.yaml.
+//     Detected at cwd only (D013) — does not walk up.
 //  3. Anonymous standalone workflow: a directory with WORKFLOW.md only.
+//     Detected at cwd only (D013).
 //  4. None: neither signal found.
 package standalone
 
@@ -32,6 +35,12 @@ const (
 	ModeAnonymous Mode = "anonymous"
 )
 
+// resolveFestivalPath is a package-level indirection over
+// shared.ResolveFestivalPath so tests can inject failures (permission
+// denied, I/O) without mutating the host filesystem. Production code
+// always uses the real implementation.
+var resolveFestivalPath = shared.ResolveFestivalPath
+
 // Result is the typed output of resolution. All paths are absolute.
 type Result struct {
 	Mode         Mode
@@ -56,7 +65,8 @@ func Resolve(ctx context.Context, startDir string) (*Result, error) {
 	}
 
 	// Priority 1: festival context.
-	if festPath, festErr := shared.ResolveFestivalPath(absStart, ""); festErr == nil && festPath != "" {
+	festPath, festErr := resolveFestivalPath(absStart, "")
+	if festErr == nil && festPath != "" {
 		phasePath := shared.ResolvePhasePath(absStart, festPath)
 		workflowDoc := ""
 		if phasePath != "" {
@@ -73,45 +83,48 @@ func Resolve(ctx context.Context, startDir string) (*Result, error) {
 			WorkflowDoc:  workflowDoc,
 		}, nil
 	}
+	// A NotFound error means "not inside a festival" — fall through to
+	// standalone resolution. Any other error (permission denied, I/O failure
+	// while walking) is real and must propagate so the caller does not
+	// silently degrade to ModeAnonymous/ModeNone.
+	if festErr != nil && !festerrors.Is(festErr, festerrors.ErrCodeNotFound) {
+		return nil, festerrors.Wrap(festErr, "resolving festival path")
+	}
 
-	// Priority 2 + 3: standalone walk upward.
-	return walkForStandalone(ctx, absStart)
+	// Priority 2 + 3: standalone cwd-only check (D013). Unlike festival
+	// detection, standalone WORKFLOW.md detection does not walk up parent
+	// directories — `fest next` from a child directory of a workflow does
+	// not pick it up.
+	return checkCwdForStandalone(ctx, absStart)
 }
 
-func walkForStandalone(ctx context.Context, startDir string) (*Result, error) {
-	dir := startDir
-	for {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-
-		manifest := filepath.Join(dir, ".workflow", "workflow.yaml")
-		if _, err := os.Stat(manifest); err == nil {
-			return &Result{
-				Mode:        ModeTracked,
-				StartDir:    startDir,
-				WorkflowDoc: filepath.Join(dir, "WORKFLOW.md"),
-				RuntimeDir:  filepath.Join(dir, ".workflow"),
-			}, nil
-		} else if !errors.Is(err, os.ErrNotExist) {
-			return nil, festerrors.Wrap(err, "stat workflow manifest")
-		}
-
-		doc := filepath.Join(dir, "WORKFLOW.md")
-		if _, err := os.Stat(doc); err == nil {
-			return &Result{
-				Mode:        ModeAnonymous,
-				StartDir:    startDir,
-				WorkflowDoc: doc,
-			}, nil
-		} else if !errors.Is(err, os.ErrNotExist) {
-			return nil, festerrors.Wrap(err, "stat workflow doc")
-		}
-
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return &Result{Mode: ModeNone, StartDir: startDir}, nil
-		}
-		dir = parent
+func checkCwdForStandalone(ctx context.Context, startDir string) (*Result, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
+
+	manifest := filepath.Join(startDir, ".workflow", "workflow.yaml")
+	if _, err := os.Stat(manifest); err == nil {
+		return &Result{
+			Mode:        ModeTracked,
+			StartDir:    startDir,
+			WorkflowDoc: filepath.Join(startDir, "WORKFLOW.md"),
+			RuntimeDir:  filepath.Join(startDir, ".workflow"),
+		}, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, festerrors.Wrap(err, "stat workflow manifest")
+	}
+
+	doc := filepath.Join(startDir, "WORKFLOW.md")
+	if _, err := os.Stat(doc); err == nil {
+		return &Result{
+			Mode:        ModeAnonymous,
+			StartDir:    startDir,
+			WorkflowDoc: doc,
+		}, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, festerrors.Wrap(err, "stat workflow doc")
+	}
+
+	return &Result{Mode: ModeNone, StartDir: startDir}, nil
 }

--- a/internal/workflow/standalone/resolver_test.go
+++ b/internal/workflow/standalone/resolver_test.go
@@ -2,10 +2,35 @@ package standalone
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
 )
+
+func TestResolve_PropagatesNonNotFoundFestivalError(t *testing.T) {
+	prev := resolveFestivalPath
+	t.Cleanup(func() { resolveFestivalPath = prev })
+
+	want := festerrors.IO("walking festivals dir", errors.New("permission denied"))
+	resolveFestivalPath = func(_, _ string) (string, error) {
+		return "", want
+	}
+
+	dir := t.TempDir()
+	res, err := Resolve(context.Background(), dir)
+	if err == nil {
+		t.Fatalf("expected error, got nil (res=%+v)", res)
+	}
+	if res != nil {
+		t.Errorf("expected nil result on propagated error, got %+v", res)
+	}
+	if !errors.Is(err, want) {
+		t.Errorf("expected wrapped festErr, got %T: %v", err, err)
+	}
+}
 
 func writeF(t *testing.T, path, body string) {
 	t.Helper()

--- a/internal/workflow/standalone/resolver_test.go
+++ b/internal/workflow/standalone/resolver_test.go
@@ -137,7 +137,10 @@ func TestResolve_Anonymous(t *testing.T) {
 	}
 }
 
-func TestResolve_NestedAnonymous(t *testing.T) {
+// TestResolve_CwdOnly_NoWalkUp asserts D013: standalone detection checks
+// cwd only, not parent directories. A WORKFLOW.md in a parent dir must not
+// surface as ModeAnonymous when invoked from a child.
+func TestResolve_CwdOnly_NoWalkUp(t *testing.T) {
 	root := t.TempDir()
 	parent := filepath.Join(root, "wf-parent")
 	subdir := filepath.Join(parent, "deeper", "nested")
@@ -150,8 +153,8 @@ func TestResolve_NestedAnonymous(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r.Mode != ModeAnonymous {
-		t.Errorf("Mode = %q, want anonymous (walk up to parent)", r.Mode)
+	if r.Mode != ModeNone {
+		t.Errorf("Mode = %q from child dir, want ModeNone (cwd-only detection)", r.Mode)
 	}
 }
 

--- a/internal/workflow/standalone/resolver_test.go
+++ b/internal/workflow/standalone/resolver_test.go
@@ -1,0 +1,141 @@
+package standalone
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeF(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestResolve_None(t *testing.T) {
+	dir := t.TempDir()
+	r, err := Resolve(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Mode != ModeNone {
+		t.Errorf("Mode = %q, want %q", r.Mode, ModeNone)
+	}
+}
+
+func TestResolve_Festival(t *testing.T) {
+	root := t.TempDir()
+	festDir := filepath.Join(root, "festivals", "active", "test-TF0001")
+	writeF(t, filepath.Join(festDir, "fest.yaml"), `version: "1.0"
+metadata:
+  id: TF0001
+  name: test
+`)
+
+	r, err := Resolve(context.Background(), festDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Mode != ModeFestival {
+		t.Errorf("Mode = %q, want %q", r.Mode, ModeFestival)
+	}
+}
+
+func TestResolve_FestivalPhaseWithWorkflowDoc(t *testing.T) {
+	root := t.TempDir()
+	festDir := filepath.Join(root, "festivals", "active", "test-TF0002")
+	writeF(t, filepath.Join(festDir, "fest.yaml"), `version: "1.0"
+metadata:
+  id: TF0002
+  name: test
+`)
+	phaseDir := filepath.Join(festDir, "001_INGEST")
+	writeF(t, filepath.Join(phaseDir, "PHASE_GOAL.md"), "# phase")
+	writeF(t, filepath.Join(phaseDir, "WORKFLOW.md"), "## Step 1: X\n")
+
+	r, err := Resolve(context.Background(), phaseDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Mode != ModeFestival {
+		t.Errorf("Mode = %q, want festival", r.Mode)
+	}
+	if r.PhasePath == "" {
+		t.Errorf("PhasePath should be set inside a phase")
+	}
+	if r.WorkflowDoc == "" || filepath.Base(r.WorkflowDoc) != "WORKFLOW.md" {
+		t.Errorf("WorkflowDoc = %q", r.WorkflowDoc)
+	}
+}
+
+func TestResolve_Tracked(t *testing.T) {
+	dir := t.TempDir()
+	writeF(t, filepath.Join(dir, "WORKFLOW.md"), "## Step 1: X\n")
+	writeF(t, filepath.Join(dir, ".workflow", "workflow.yaml"), `version: 1
+kind: workflow-runtime
+workflow_id: wf-x
+`)
+
+	r, err := Resolve(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Mode != ModeTracked {
+		t.Errorf("Mode = %q, want tracked", r.Mode)
+	}
+	if r.RuntimeDir == "" {
+		t.Errorf("RuntimeDir should be set")
+	}
+}
+
+func TestResolve_Anonymous(t *testing.T) {
+	dir := t.TempDir()
+	writeF(t, filepath.Join(dir, "WORKFLOW.md"), "## Step 1: X\n")
+
+	r, err := Resolve(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Mode != ModeAnonymous {
+		t.Errorf("Mode = %q, want anonymous", r.Mode)
+	}
+	if r.RuntimeDir != "" {
+		t.Errorf("RuntimeDir should be empty for anonymous, got %q", r.RuntimeDir)
+	}
+	if filepath.Base(r.WorkflowDoc) != "WORKFLOW.md" {
+		t.Errorf("WorkflowDoc = %q", r.WorkflowDoc)
+	}
+}
+
+func TestResolve_NestedAnonymous(t *testing.T) {
+	root := t.TempDir()
+	parent := filepath.Join(root, "wf-parent")
+	subdir := filepath.Join(parent, "deeper", "nested")
+	writeF(t, filepath.Join(parent, "WORKFLOW.md"), "## Step 1: X\n")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Resolve(context.Background(), subdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Mode != ModeAnonymous {
+		t.Errorf("Mode = %q, want anonymous (walk up to parent)", r.Mode)
+	}
+}
+
+func TestResolve_ContextCancelled(t *testing.T) {
+	dir := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := Resolve(ctx, dir)
+	if err == nil {
+		t.Fatal("expected context.Canceled error")
+	}
+}

--- a/internal/workflow/standalone/resolver_test.go
+++ b/internal/workflow/standalone/resolver_test.go
@@ -2,10 +2,35 @@ package standalone
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
 )
+
+func TestResolve_PropagatesNonNotFoundFestivalError(t *testing.T) {
+	prev := resolveFestivalPath
+	t.Cleanup(func() { resolveFestivalPath = prev })
+
+	want := festerrors.IO("walking festivals dir", errors.New("permission denied"))
+	resolveFestivalPath = func(_, _ string) (string, error) {
+		return "", want
+	}
+
+	dir := t.TempDir()
+	res, err := Resolve(context.Background(), dir)
+	if err == nil {
+		t.Fatalf("expected error, got nil (res=%+v)", res)
+	}
+	if res != nil {
+		t.Errorf("expected nil result on propagated error, got %+v", res)
+	}
+	if !errors.Is(err, want) {
+		t.Errorf("expected wrapped festErr, got %T: %v", err, err)
+	}
+}
 
 func writeF(t *testing.T, path, body string) {
 	t.Helper()
@@ -112,7 +137,10 @@ func TestResolve_Anonymous(t *testing.T) {
 	}
 }
 
-func TestResolve_NestedAnonymous(t *testing.T) {
+// TestResolve_CwdOnly_NoWalkUp asserts D013: standalone detection checks
+// cwd only, not parent directories. A WORKFLOW.md in a parent dir must not
+// surface as ModeAnonymous when invoked from a child.
+func TestResolve_CwdOnly_NoWalkUp(t *testing.T) {
 	root := t.TempDir()
 	parent := filepath.Join(root, "wf-parent")
 	subdir := filepath.Join(parent, "deeper", "nested")
@@ -125,8 +153,8 @@ func TestResolve_NestedAnonymous(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r.Mode != ModeAnonymous {
-		t.Errorf("Mode = %q, want anonymous (walk up to parent)", r.Mode)
+	if r.Mode != ModeNone {
+		t.Errorf("Mode = %q from child dir, want ModeNone (cwd-only detection)", r.Mode)
 	}
 }
 

--- a/internal/workflow/standalone/validate.go
+++ b/internal/workflow/standalone/validate.go
@@ -1,0 +1,25 @@
+package standalone
+
+import (
+	"context"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+	wfparser "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+)
+
+// ValidateWorkflowDoc ensures WORKFLOW.md is parseable and has at least one
+// step. Callers use this BEFORE creating any localstore state so a malformed
+// or empty WORKFLOW.md cannot leave the user with a half-initialized
+// .workflow/ directory (D030 finding #7).
+func ValidateWorkflowDoc(ctx context.Context, path string) error {
+	n, err := wfparser.NewParser().StepCount(ctx, path)
+	if err != nil {
+		return festerrors.Wrap(err, "parsing WORKFLOW.md").WithField("path", path)
+	}
+	if n == 0 {
+		return festerrors.Validation("WORKFLOW.md has no parseable steps").
+			WithField("path", path).
+			WithHint("add at least one '## Step 1:' heading")
+	}
+	return nil
+}

--- a/tests/integration/helpers.go
+++ b/tests/integration/helpers.go
@@ -222,6 +222,35 @@ func (tc *TestContainer) RunFestInDirTTY(dir string, args ...string) (string, er
  return output, nil
 }
 
+// Exec runs an arbitrary shell command inside the container via `sh -c`.
+// Returns combined stdout+stderr and any execution error. Non-zero exit
+// codes are surfaced via the error so tests can assert on them.
+func (tc *TestContainer) Exec(cmd ...string) (string, error) {
+	out, err := tc.runCommand(cmd)
+	return out, err
+}
+
+// WriteFile writes content into a path inside the container, creating
+// any missing parent directories.
+func (tc *TestContainer) WriteFile(path, content string) error {
+	parent := filepath.Dir(path)
+	if _, _, err := tc.container.Exec(tc.ctx, []string{"mkdir", "-p", parent}); err != nil {
+		return fmt.Errorf("mkdir -p %s: %w", parent, err)
+	}
+	// Use a temp host file and CopyToContainer to avoid shell-escaping content.
+	f, err := os.CreateTemp("", "fest-helper-write-*")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.WriteString(content); err != nil {
+		f.Close()
+		return err
+	}
+	f.Close()
+	return tc.CopyToContainer(f.Name(), path)
+}
+
 // runCommand executes a command in the container
 // Returns output even on non-zero exit for test debugging
 func (tc *TestContainer) runCommand(cmd []string) (string, error) {

--- a/tests/integration/standalone_next_test.go
+++ b/tests/integration/standalone_next_test.go
@@ -1,0 +1,130 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestStandaloneNext_AnonymousReadOnly verifies fest next on a WORKFLOW.md
+// without .workflow/ is a pure read: it renders step 1 but creates no files
+// (D013 cwd-only detection + anonymous render contract from 008.02).
+func TestStandaloneNext_AnonymousReadOnly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	container := GetSharedContainer(t)
+	const dir = "/tmp/standalone-anon"
+	_, err := container.Exec("rm", "-rf", dir)
+	require.NoError(t, err)
+
+	workflowMD := `# Test Workflow
+
+## Step 1: First
+
+Do the first thing.
+
+## Step 2: Second
+
+Do the second thing.
+`
+	require.NoError(t, container.WriteFile(dir+"/WORKFLOW.md", workflowMD))
+
+	out, err := container.RunFestInDir(dir, "next")
+	require.NoError(t, err, "fest next should succeed in anonymous mode: %s", out)
+	require.Contains(t, out, "Step 1")
+
+	exists, _ := container.CheckDirExists(dir + "/.workflow")
+	require.False(t, exists, "anonymous fest next must not create .workflow/")
+	exists, _ = container.CheckFileExists(dir + "/.workitem")
+	require.False(t, exists, "anonymous fest next must not create .workitem")
+}
+
+// TestStandaloneNext_BootstrapAndAdvance covers the full PR 170 flow:
+// anonymous -> bootstrap via fest workflow advance -> tracked -> fest next
+// shows the next step (not the just-completed one, D030 #6) -> advance again.
+// Asserts .workitem is never created (D007).
+func TestStandaloneNext_BootstrapAndAdvance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	container := GetSharedContainer(t)
+	const dir = "/tmp/standalone-bootstrap"
+	_, err := container.Exec("rm", "-rf", dir)
+	require.NoError(t, err)
+
+	workflowMD := `# Bootstrap Workflow
+
+## Step 1: Plan
+
+Plan the work.
+
+## Step 2: Execute
+
+Do the work.
+
+## Step 3: Verify
+
+Verify the work.
+`
+	require.NoError(t, container.WriteFile(dir+"/WORKFLOW.md", workflowMD))
+
+	t.Run("AdvanceBootstrapsAndCompletesStep1", func(t *testing.T) {
+		out, err := container.RunFestInDir(dir, "workflow", "advance")
+		require.NoError(t, err, "advance should bootstrap anonymous workflow: %s", out)
+		require.Contains(t, out, "Bootstrapped")
+
+		exists, _ := container.CheckDirExists(dir + "/.workflow")
+		require.True(t, exists, "advance should create .workflow/")
+		exists, _ = container.CheckFileExists(dir + "/.workitem")
+		require.False(t, exists, "fest must not write .workitem (D007)")
+	})
+
+	t.Run("NextShowsStep2NotJustCompleted", func(t *testing.T) {
+		out, err := container.RunFestInDir(dir, "next")
+		require.NoError(t, err, "fest next after bootstrap: %s", out)
+		// D030 #6: post-bootstrap should show step 2, not the just-completed step 1.
+		require.Contains(t, out, "Step 2", "should advance render past completed step 1")
+		require.Contains(t, out, "Execute")
+	})
+
+	t.Run("AdvanceTrackedMovesToNextStep", func(t *testing.T) {
+		// D030 #5: after bootstrap, advance must handle tracked mode without
+		// falling through to the festival navigator.
+		out, err := container.RunFestInDir(dir, "workflow", "advance")
+		require.NoError(t, err, "tracked advance should succeed: %s", out)
+		require.Contains(t, out, "Step 2")
+		require.Contains(t, out, "completed")
+	})
+}
+
+// TestStandaloneAdvance_RejectsEmptyWorkflow locks in D030 #7: bootstrap
+// must validate WORKFLOW.md has parseable steps before creating .workflow/.
+func TestStandaloneAdvance_RejectsEmptyWorkflow(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	container := GetSharedContainer(t)
+	const dir = "/tmp/standalone-empty"
+	_, err := container.Exec("rm", "-rf", dir)
+	require.NoError(t, err)
+
+	require.NoError(t, container.WriteFile(dir+"/WORKFLOW.md", "# No steps here\n"))
+
+	out, err := container.RunFestInDir(dir, "workflow", "advance")
+	require.Error(t, err, "advance must reject WORKFLOW.md with no steps")
+	require.True(t,
+		strings.Contains(out, "no parseable steps") || strings.Contains(out, "no steps"),
+		"error should mention missing steps, got: %s", out,
+	)
+
+	exists, _ := container.CheckDirExists(dir + "/.workflow")
+	require.False(t, exists, ".workflow/ must not be created on validation failure (D030 #7)")
+}

--- a/tests/integration/standalone_workflow_test.go
+++ b/tests/integration/standalone_workflow_test.go
@@ -1,0 +1,90 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestStandaloneWorkflow_InitStart exercises the standalone WORKFLOW.md
+// init/start lifecycle inside a container, validating real filesystem effects
+// (atomic writes, directory creation, manifest YAML shape) without mutating
+// the host. Closes a slice of WW0001 task 008.01.10's container-harness
+// requirement; the in-package store_test.go tests remain as pure unit tests
+// for internal APIs the CLI surface can't drive directly.
+func TestStandaloneWorkflow_InitStart(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	container := GetSharedContainer(t)
+
+	const dir = "/tmp/standalone-wf"
+	_, err := container.Exec("rm", "-rf", dir)
+	require.NoError(t, err)
+
+	workflowMD := `# Test Workflow
+
+## Step 1: First
+
+Do the first thing.
+
+## Step 2: Second
+
+Do the second thing.
+`
+	require.NoError(t, container.WriteFile(dir+"/WORKFLOW.md", workflowMD))
+
+	t.Run("Init", func(t *testing.T) {
+		out, err := container.RunFestInDir(dir, "workflow", "init")
+		require.NoError(t, err, "fest workflow init: %s", out)
+		require.Contains(t, out, "Initialized standalone workflow runtime")
+		require.Contains(t, out, "workflow_id=wf-standalone-wf")
+
+		manifest, err := container.ReadFile(dir + "/.workflow/workflow.yaml")
+		require.NoError(t, err)
+		require.Contains(t, manifest, "workflow_id: wf-standalone-wf")
+		require.NotContains(t, manifest, "workitem_id", "manifest must not contain workitem_id post-D024")
+
+		exists, _ := container.CheckFileExists(dir + "/.workitem")
+		require.False(t, exists, "fest workflow init must not write .workitem (D007)")
+	})
+
+	t.Run("Start", func(t *testing.T) {
+		out, err := container.RunFestInDir(dir, "workflow", "start")
+		require.NoError(t, err, "fest workflow start: %s", out)
+
+		runs, err := container.ListDirectory(dir + "/.workflow/runs")
+		require.NoError(t, err)
+		require.NotEmpty(t, runs, "expected at least one run file under runs/")
+
+		// Find a run.yaml among the listed files.
+		var runYAMLPath string
+		for _, f := range runs {
+			if strings.HasSuffix(f, "/run.yaml") {
+				runYAMLPath = f
+				break
+			}
+		}
+		require.NotEmpty(t, runYAMLPath, "run.yaml not found under runs/")
+
+		runYAML, err := container.ReadFile(runYAMLPath)
+		require.NoError(t, err)
+		require.Contains(t, runYAML, "status: active")
+		require.NotContains(t, runYAML, "workitem_id", "run.yaml must not contain workitem_id post-D024")
+	})
+
+	t.Run("InitRejectsInvalidWorkflowID", func(t *testing.T) {
+		badDir := "/tmp/standalone-bad"
+		_, _ = container.Exec("rm", "-rf", badDir)
+		require.NoError(t, container.WriteFile(badDir+"/WORKFLOW.md", "## Step 1: X\n"))
+
+		out, err := container.RunFestInDir(badDir, "workflow", "init", "--workflow-id", "Bad Name!")
+		require.Error(t, err, "expected non-zero exit for invalid workflow_id")
+		require.Contains(t, out, "invalid workflow_id")
+	})
+}


### PR DESCRIPTION
## Summary

Sequence 2 of phase 004 in festival WW0001 (workitem-workflows). Builds on
#169 (sequence 1 — standalone runtime + localstore) to wire the new
contexts into `fest next` and `fest workflow`.

- `fest next` routes through `standalone.Resolve` when not in a festival.
  Tracked mode renders the active run step (text + `--json`). Anonymous
  mode parses `WORKFLOW.md` and renders step 1 without creating files.
  Mode emitted as `standalone-tracked` or `standalone-anonymous` so
  consumers can distinguish.
- `fest workflow show` handles tracked and anonymous modes with a
  dedicated renderer; scope relaxed to `Global`.
- `fest workflow advance` detects anonymous mode and runs `EnsureTracked`
  (new `bootstrap.go` helper): creates `.workitem` and
  `.workflow/workflow.yaml`, starts the first run, appends
  `wf_step_start` + `wf_step_done` so step 1 completes atomically.
  Refuses to overwrite existing `.workitem` or `.workflow/`. Scope
  relaxed to `Global`.
- `fest next` scope relaxed to `Global` so the cobra middleware does not
  pre-require a festival; `runNext` does its own resolution.

## Codex review fix in this PR (commit `e748de3`)

Codex's review of 004.02 caught that `fest workflow show` still had
`scope.Festival`, so the cobra middleware short-circuited before
`runShow` could dispatch. Fixed in `e748de3`.

## Test plan

- [x] `go test -race -count=1 ./...` green (no FAILs)
- [x] `just build quick` successful
- [x] `bootstrap_test.go` (6 cases): happy path, no-bootstrap, refuses
      existing `.workitem`, refuses existing `.workflow/`, non-anonymous
      no-op, custom workitem-id
- [x] `standalone_test.go` (4 cases): tracked text, tracked JSON,
      anonymous no-files-created, anonymous JSON
- [x] E2E:
      - Anonymous `fest next`: renders step 1, asserts zero files via
        `ls -la` showing only `WORKFLOW.md`
      - Anonymous `fest workflow advance`: prints
        `✓ Bootstrapped tracked workflow and advanced step 1`, then
        `.workitem` + `.workflow/runs/run-*/progress_events.jsonl`
        contains `workflow_run_started` + `wf_step_start` + `wf_step_done`
      - Festival `fest next` from WW0001 directory unchanged

## Deferred for v1

- `fest workflow approve`/`reject`/`reset` for anonymous mode — `advance`
  is the supported bootstrap path; the other three fall through to the
  existing festival navigator.
- `--no-bootstrap` CLI flag — `BootstrapOptions.NoBootstrap` is wired in
  the helper but not yet exposed at the command surface.

## Festival traceability

Festival: workitem-workflows-WW0001
Phase: 004_IMPLEMENT_FEST_WORKFLOWS (both sequences complete, 4 phase
  gate checkpoints approved)
Sequence: 02_next_routing