### PR TITLE
Add auto-write support to fest commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.6
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0
-	github.com/Obedience-Corp/camp v0.2.2
+	github.com/Obedience-Corp/camp v0.2.6-0.20260516214523-02acfc0f9d91
 	github.com/Obedience-Corp/obey-shared v0.4.2
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/Obedience-Corp/camp v0.2.2 h1:JMo1tpEjmroHH77spOIjNgC6Ldt/OJn5NtUnrZfVDhA=
-github.com/Obedience-Corp/camp v0.2.2/go.mod h1:TQTVQ90emA8wj9I1kcwx+Uv3PNIkhcp2nQbdVI/4WC8=
+github.com/Obedience-Corp/camp v0.2.6-0.20260516214523-02acfc0f9d91 h1:Ay2wFC1NGMs5QqkhV1oxW+3C3SeHHqYbsuODS7m9vtE=
+github.com/Obedience-Corp/camp v0.2.6-0.20260516214523-02acfc0f9d91/go.mod h1:QXq04a0fE+Ceeg+0Ttfs/xx0fNTxhbJM54t1KExdJHk=
 github.com/Obedience-Corp/obey-shared v0.4.2 h1:4g6NdnvMqB1Jj08stbGr9XrZyccP3ySH1S6bZhaMA1g=
 github.com/Obedience-Corp/obey-shared v0.4.2/go.mod h1:xHdUVdyQ1gA+jo4p0ZyFBVdPVhuV4BT7+YVPjx24JLI=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=

--- a/internal/commands/autowrite_alias.go
+++ b/internal/commands/autowrite_alias.go
@@ -1,0 +1,26 @@
+package commands
+
+// normalizeAutoWriteAlias rewrites the exact -aw token for fest commit before
+// cobra parses flags. Cobra/pflag only supports single-character shorthand
+// flags.
+func normalizeAutoWriteAlias(args []string) []string {
+	out := make([]string, len(args))
+	copy(out, args)
+	if !isAutoWriteCommitInvocation(out) {
+		return out
+	}
+	for i, arg := range out {
+		if arg == "--" {
+			break
+		}
+		if arg == "-aw" {
+			out[i] = "--auto-write"
+		}
+	}
+	return out
+}
+
+func isAutoWriteCommitInvocation(args []string) bool {
+	command, _ := findFirstPositionalArg(args)
+	return command == "commit"
+}

--- a/internal/commands/autowrite_alias_test.go
+++ b/internal/commands/autowrite_alias_test.go
@@ -1,0 +1,49 @@
+package commands
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNormalizeAutoWriteAlias(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "commit",
+			args: []string{"fest", "commit", "-aw", "-m", "msg", "-aw=false"},
+			want: []string{"fest", "commit", "--auto-write", "-m", "msg", "-aw=false"},
+		},
+		{
+			name: "commit with global flag",
+			args: []string{"fest", "--verbose", "commit", "-aw"},
+			want: []string{"fest", "--verbose", "commit", "--auto-write"},
+		},
+		{
+			name: "unrelated command",
+			args: []string{"fest", "status", "-aw"},
+			want: []string{"fest", "status", "-aw"},
+		},
+		{
+			name: "plugin style command",
+			args: []string{"fest", "external-tool", "-aw"},
+			want: []string{"fest", "external-tool", "-aw"},
+		},
+		{
+			name: "argument terminator",
+			args: []string{"fest", "commit", "--", "-aw"},
+			want: []string{"fest", "commit", "--", "-aw"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizeAutoWriteAlias(tc.args)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("normalizeAutoWriteAlias() = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/commands/commit/commit.go
+++ b/internal/commands/commit/commit.go
@@ -31,6 +31,7 @@ var (
 	noTag            bool
 	jsonOut          bool
 	autoStage        bool
+	autoWrite        bool
 	noRoot           bool
 	syncSubmoduleRef bool // deprecated: kept for backward compat
 )
@@ -88,21 +89,23 @@ Examples:
   # → No reference
 
   fest commit --stage=false -m "Only commit staged"
-  # Skip auto-staging, commit only what's already staged`,
+  # Skip auto-staging, commit only what's already staged
+
+  fest commit --auto-write
+  # Run the configured campaign commit-message hook from the target repo`,
 		RunE: runCommit,
 	}
 
-	cmd.Flags().StringVarP(&message, "message", "m", "", "commit message")
+	cmd.Flags().StringVarP(&message, "message", "m", "", "commit message (required unless --auto-write)")
 	cmd.Flags().StringVar(&taskRef, "task", "", "task reference ID to use (e.g., FEST-a3b2c1)")
 	cmd.Flags().StringVar(&festivalFlag, "festival", "", "festival name or ID (overrides auto-detection)")
 	cmd.Flags().BoolVar(&noTag, "no-tag", false, "don't prepend task reference")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "output result as JSON")
 	cmd.Flags().BoolVar(&autoStage, "stage", true, "auto-stage all changes before commit")
+	cmd.Flags().BoolVar(&autoWrite, "auto-write", false, "run configured commit message writer")
 	cmd.Flags().BoolVar(&noRoot, "no-root", false, "skip campaign root commit (project commit only)")
 	cmd.Flags().BoolVar(&syncSubmoduleRef, "sync-submodule-ref", false, "deprecated: campaign root commit is now automatic")
 	_ = cmd.Flags().MarkDeprecated("sync-submodule-ref", "campaign root commit is now automatic; use --no-root to skip")
-
-	_ = cmd.MarkFlagRequired("message")
 
 	return cmd
 }
@@ -123,6 +126,17 @@ func runCommit(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 
 	result := &CommitResult{}
+
+	if autoWrite && message != "" {
+		result.Success = false
+		result.Error = "--auto-write cannot be used with --message"
+		return outputResult(result)
+	}
+	if !autoWrite && message == "" {
+		result.Success = false
+		result.Error = "required flag(s) \"message\" not set"
+		return outputResult(result)
+	}
 
 	// Resolve workspace for campaign integration (nil-safe: ok if absent).
 	ws, _ := scope.WorkspaceFrom(ctx)
@@ -146,6 +160,13 @@ func runCommit(cmd *cobra.Command, args []string) error {
 	if !inRepo {
 		result.Success = false
 		result.Error = "not in a git repository"
+		return outputResult(result)
+	}
+
+	primaryRepoPath, err := currentGitRoot(ctx)
+	if err != nil {
+		result.Success = false
+		result.Error = err.Error()
 		return outputResult(result)
 	}
 
@@ -182,6 +203,22 @@ func runCommit(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	rawMsg := message
+	if autoWrite {
+		if ws == nil || ws.Type != scope.WorkspaceTypeCampaign {
+			result.Success = false
+			result.Error = "auto-write requires campaign context"
+			return outputResult(result)
+		}
+		fmt.Fprintln(os.Stderr, ui.Info("Writing commit message..."))
+		rawMsg, err = commitkit.AutoWriteCommitMessage(ctx, ws.Root, primaryRepoPath)
+		if err != nil {
+			result.Success = false
+			result.Error = err.Error()
+			return outputResult(result)
+		}
+	}
+
 	// Get task reference via cascading detection strategies.
 	var ref string
 	if !noTag {
@@ -210,13 +247,13 @@ func runCommit(cmd *cobra.Command, args []string) error {
 	}
 
 	// Build commit message with consolidated tag.
-	festMessage := message
+	festMessage := rawMsg
 	if ref != "" {
-		festMessage = fmt.Sprintf("[%s] %s", ref, message)
+		festMessage = fmt.Sprintf("[%s] %s", ref, rawMsg)
 	}
 
 	// Execute commit with campaign tag support.
-	if err := commitWithCampaignSupport(ctx, ws, ref, message, festMessage, result); err != nil {
+	if err := commitWithCampaignSupport(ctx, ws, primaryRepoPath, ref, rawMsg, festMessage, result); err != nil {
 		result.Success = false
 		result.Error = err.Error()
 		return outputResult(result)
@@ -229,7 +266,7 @@ func runCommit(cmd *cobra.Command, args []string) error {
 	// Only when we're in a submodule (the campaign root commit is a second commit).
 	// When at the campaign root, the primary commit above already handled festival files.
 	if !noRoot && inSubmodule && ws != nil && ws.Type == scope.WorkspaceTypeCampaign && hasFestival {
-		rootHash, rootErr := commitFestivalAtRoot(ctx, ws, festivalPath, submoduleRelPath, result.CampaignTag, ref, message)
+		rootHash, rootErr := commitFestivalAtRoot(ctx, ws, festivalPath, submoduleRelPath, result.CampaignTag, ref, rawMsg)
 		if rootErr != nil {
 			fmt.Fprintf(os.Stderr, "%s %s\n", ui.Warning("campaign root commit skipped:"), rootErr.Error())
 		} else if rootHash != "" {
@@ -283,11 +320,11 @@ func isGitRepo(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-func executeGitCommit(ctx context.Context, message string) (string, error) {
+func executeGitCommit(ctx context.Context, repoPath, message string) (string, error) {
 	if err := ctx.Err(); err != nil {
 		return "", errors.Wrap(err, "context cancelled")
 	}
-	cmd := exec.CommandContext(ctx, "git", "commit", "-m", message)
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "commit", "-m", message)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
@@ -296,7 +333,7 @@ func executeGitCommit(ctx context.Context, message string) (string, error) {
 	}
 
 	// Get the commit hash
-	hashCmd := exec.CommandContext(ctx, "git", "rev-parse", "--short", "HEAD")
+	hashCmd := exec.CommandContext(ctx, "git", "-C", repoPath, "rev-parse", "--short", "HEAD")
 	var out bytes.Buffer
 	hashCmd.Stdout = &out
 	if err := hashCmd.Run(); err != nil {
@@ -304,6 +341,18 @@ func executeGitCommit(ctx context.Context, message string) (string, error) {
 	}
 
 	return strings.TrimSpace(out.String()), nil
+}
+
+func currentGitRoot(ctx context.Context) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", errors.Wrap(err, "context cancelled")
+	}
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--show-toplevel")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", errors.Wrap(err, "finding git root")
+	}
+	return strings.TrimSpace(string(out)), nil
 }
 
 // stageAllChanges runs git add -A to stage all changes
@@ -402,7 +451,7 @@ func loadFestivalID(festivalPath, campaignRoot string) (string, error) {
 // integration. If the workspace is a campaign, it consolidates campaign and
 // festival refs into a single tag: [OBEY-CAMPAIGN-{cid}-FE-{fid}].
 // Campaign detection or sync failures degrade gracefully — the commit still proceeds.
-func commitWithCampaignSupport(ctx context.Context, ws *scope.WorkspaceInfo, festRef, rawMsg, festMessage string, result *CommitResult) error {
+func commitWithCampaignSupport(ctx context.Context, ws *scope.WorkspaceInfo, repoPath, festRef, rawMsg, festMessage string, result *CommitResult) error {
 	commitMessage := festMessage
 
 	var campaignID string
@@ -431,7 +480,7 @@ func commitWithCampaignSupport(ctx context.Context, ws *scope.WorkspaceInfo, fes
 		}
 	}
 
-	hash, err := executeGitCommit(ctx, commitMessage)
+	hash, err := executeGitCommit(ctx, repoPath, commitMessage)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/commit/commit_test.go
+++ b/internal/commands/commit/commit_test.go
@@ -32,6 +32,18 @@ func TestNewCommitCommand_SyncSubmoduleRefDeprecated(t *testing.T) {
 	}
 }
 
+func TestNewCommitCommand_AutoWriteFlag(t *testing.T) {
+	cmd := NewCommitCommand()
+
+	flag := cmd.Flags().Lookup("auto-write")
+	if flag == nil {
+		t.Fatal("--auto-write flag not registered")
+	}
+	if flag.DefValue != "false" {
+		t.Errorf("--auto-write default = %q, want %q", flag.DefValue, "false")
+	}
+}
+
 func TestNewCommitCommand_CampaignTaggingIndependentOfSync(t *testing.T) {
 	cmd := NewCommitCommand()
 

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	chaincmd "github.com/Obedience-Corp/fest/internal/commands/chain"
 	commitcmd "github.com/Obedience-Corp/fest/internal/commands/commit"
@@ -73,6 +74,8 @@ var rootCmd = &cobra.Command{
 
 // Execute runs the root command
 func Execute() error {
+	os.Args = normalizeAutoWriteAlias(os.Args)
+
 	// Try git-style plugin dispatch for unknown subcommands.
 	// A fest-<name> binary on PATH becomes "fest <name> [args...]".
 	if err := dispatchPlugin(); err != nil {


### PR DESCRIPTION
Summary
- Add --auto-write and -aw support to fest commit.
- Reuse camp commit hook handling so the configured command runs from the commit target context.
- Keep normal -m commit behavior unchanged and reject mixed --message/--auto-write usage.

Dependency
- Depends on Obedience-Corp/camp#290.
- Uses the camp branch pseudo-version until that PR is merged and tagged/released.

Validation
- git diff --check
- go test ./internal/commands ./internal/commands/commit
- just lint vet
- just test unit-raw