### PR TITLE
chore(deps): bump obey-shared to v0.4.3 for honest test dashboard + 10m integration timeout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.6
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/Obedience-Corp/camp v0.2.2
-	github.com/Obedience-Corp/obey-shared v0.4.2
+	github.com/Obedience-Corp/obey-shared v0.4.3
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Obedience-Corp/camp v0.2.2 h1:JMo1tpEjmroHH77spOIjNgC6Ldt/OJn5NtUnrZfVDhA=
 github.com/Obedience-Corp/camp v0.2.2/go.mod h1:TQTVQ90emA8wj9I1kcwx+Uv3PNIkhcp2nQbdVI/4WC8=
-github.com/Obedience-Corp/obey-shared v0.4.2 h1:4g6NdnvMqB1Jj08stbGr9XrZyccP3ySH1S6bZhaMA1g=
-github.com/Obedience-Corp/obey-shared v0.4.2/go.mod h1:xHdUVdyQ1gA+jo4p0ZyFBVdPVhuV4BT7+YVPjx24JLI=
+github.com/Obedience-Corp/obey-shared v0.4.3 h1:SnGNVXAb2Oqt+zhByTJWdR4lPZmp6DeNpJO5rg6KZr0=
+github.com/Obedience-Corp/obey-shared v0.4.3/go.mod h1:xHdUVdyQ1gA+jo4p0ZyFBVdPVhuV4BT7+YVPjx24JLI=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/chroma/v2 v2.23.1 h1:nv2AVZdTyClGbVQkIzlDm/rnhk1E9bU9nXwmZ/Vk/iY=


### PR DESCRIPTION
## Summary
Stacked on #173. Bumps `github.com/Obedience-Corp/obey-shared` from v0.4.2 → v0.4.3 to pick up:

- `BuildConfig.IntegrationTimeout` (time.Duration), default **10m** — replaces the hardcoded 2m that was too tight for fest's growing container suite.
- Honest dashboard rendering when a suite exits non-zero with no per-test failure recorded — no more contradictory `✗ 0/N TESTS FAILED` plus exit 1 when every test actually passed.

See obey-shared#14 for the underlying fix.

## Why this is stacked into #173
On #173 head (1dc17b6) `just test all` would render:
```
║                             ✗ 0/54 TESTS FAILED                              ║
Error: 1 tasks failed
```
…even though every individual test passed. The root cause was the integration suite hitting the old 2m timeout in `obey-shared/buildutil/integration.go`. Fest can't merge #173 cleanly until the dashboard tells the truth, so the dep bump goes in as a stacked PR.

## Verification
- `just test all` exits 0 with `✓ BUILD SUCCESSFUL` summary card (was failing on identical code before this bump).
- 53 unit + 1 integration suite (54 tests) pass in ~230s — comfortably under the new 10m budget.
- `go mod tidy` clean; no other dep changes.

## Merge order
1. Merge this PR into `integration/WW0001`.
2. Then #173 can merge into `main` with a green dashboard.

## Test plan
- [x] `just test all` exits 0 with the success summary
- [x] No other dependency drift in go.sum