### PR TITLE
Include fest watch in stable profile

### DIFF
--- a/internal/commands/command_surface_dev_test.go
+++ b/internal/commands/command_surface_dev_test.go
@@ -11,6 +11,6 @@ func TestCollectVisibleCommandPathsDevIncludesDevOnlyCommands(t *testing.T) {
 		t.Fatal("dev command surface should include fest explore")
 	}
 	if !containsCommandPath(paths, "fest watch") {
-		t.Fatal("dev command surface should include fest watch")
+		t.Fatal("dev command surface should include stable fest watch")
 	}
 }

--- a/internal/commands/command_surface_stable_test.go
+++ b/internal/commands/command_surface_stable_test.go
@@ -14,7 +14,7 @@ func TestCollectVisibleCommandPathsStableOmitsDevOnlyCommands(t *testing.T) {
 	if containsCommandPath(paths, "fest explore") {
 		t.Fatal("stable command surface should not include fest explore")
 	}
-	if containsCommandPath(paths, "fest watch") {
-		t.Fatal("stable command surface should not include fest watch")
+	if !containsCommandPath(paths, "fest watch") {
+		t.Fatal("stable command surface should include fest watch")
 	}
 }

--- a/internal/commands/release/register_dev.go
+++ b/internal/commands/release/register_dev.go
@@ -4,7 +4,6 @@ package release
 
 import (
 	explorecmd "github.com/Obedience-Corp/fest/internal/commands/explore"
-	watchcmd "github.com/Obedience-Corp/fest/internal/commands/watch"
 	"github.com/spf13/cobra"
 )
 
@@ -13,9 +12,4 @@ func registerDev(root *cobra.Command) {
 	exploreCmd.GroupID = "navigation"
 	MarkDevOnly(exploreCmd)
 	root.AddCommand(exploreCmd)
-
-	watchCmd := watchcmd.NewWatchCommand()
-	watchCmd.GroupID = "query"
-	MarkDevOnly(watchCmd)
-	root.AddCommand(watchCmd)
 }

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -40,6 +40,7 @@ import (
 	typescmd "github.com/Obedience-Corp/fest/internal/commands/types"
 	understandcmd "github.com/Obedience-Corp/fest/internal/commands/understand"
 	"github.com/Obedience-Corp/fest/internal/commands/validation"
+	watchcmd "github.com/Obedience-Corp/fest/internal/commands/watch"
 	"github.com/Obedience-Corp/fest/internal/commands/wizard"
 	workflowcmd "github.com/Obedience-Corp/fest/internal/commands/workflow"
 	"github.com/Obedience-Corp/fest/internal/scope"
@@ -291,6 +292,10 @@ func init() {
 	idCmd := idcmd.NewIDCommand()
 	idCmd.GroupID = "query"
 	rootCmd.AddCommand(idCmd)
+
+	watchCmd := watchcmd.NewWatchCommand()
+	watchCmd.GroupID = "query"
+	rootCmd.AddCommand(watchCmd)
 
 	release.Register(rootCmd)
 

--- a/internal/commands/watch/command.go
+++ b/internal/commands/watch/command.go
@@ -1,4 +1,4 @@
-// Package watch implements the dev-gated fest watch command.
+// Package watch implements the fest watch command.
 package watch
 
 import (


### PR DESCRIPTION
## Summary

- Move `fest watch` from the dev-only release registrar into the normal stable command surface.
- Leave `fest explore` as the remaining dev-only command family.
- Update command-surface tests for both stable and dev profiles.

## Verification

- `comm -13 <(just build profile-commands stable | sed '1d' | sort) <(just build profile-commands dev | sed '1d' | sort)` now reports only `fest explore*` commands.\n- `just build profile-commands stable | rg '^fest watch$|^== stable'`\n- `go test -count=1 ./internal/commands ./internal/commands/release ./internal/commands/watch`\n- `go test -count=1 -tags dev ./internal/commands ./internal/commands/release ./internal/commands/watch`\n- `git diff --check`