### PR TITLE
Remove remaining docker module graph edges

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.25.6
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0
-	github.com/Obedience-Corp/camp v0.2.6-0.20260516214523-02acfc0f9d91
-	github.com/Obedience-Corp/obey-shared v0.4.3
+	github.com/Obedience-Corp/camp v0.2.6-0.20260518212052-2079884af0c0
+	github.com/Obedience-Corp/obey-shared v0.4.4-0.20260518211933-8a93452bf649
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v0.10.0
@@ -109,7 +109,6 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 // indirect
 	go.opentelemetry.io/otel v1.42.0 // indirect
 	go.opentelemetry.io/otel/metric v1.42.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.39.0 // indirect
 	go.opentelemetry.io/otel/trace v1.42.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.48.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,10 +14,10 @@ github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/Obedience-Corp/camp v0.2.6-0.20260516214523-02acfc0f9d91 h1:Ay2wFC1NGMs5QqkhV1oxW+3C3SeHHqYbsuODS7m9vtE=
-github.com/Obedience-Corp/camp v0.2.6-0.20260516214523-02acfc0f9d91/go.mod h1:QXq04a0fE+Ceeg+0Ttfs/xx0fNTxhbJM54t1KExdJHk=
-github.com/Obedience-Corp/obey-shared v0.4.3 h1:SnGNVXAb2Oqt+zhByTJWdR4lPZmp6DeNpJO5rg6KZr0=
-github.com/Obedience-Corp/obey-shared v0.4.3/go.mod h1:xHdUVdyQ1gA+jo4p0ZyFBVdPVhuV4BT7+YVPjx24JLI=
+github.com/Obedience-Corp/camp v0.2.6-0.20260518212052-2079884af0c0 h1:2r/flRPgbwxo7Nnieu13K11o8zL0gtnDBBLERRglPc8=
+github.com/Obedience-Corp/camp v0.2.6-0.20260518212052-2079884af0c0/go.mod h1:KURae9cnrMJrTAr9DyV70ciZ4lhl/IDw7fyWAiFSJGw=
+github.com/Obedience-Corp/obey-shared v0.4.4-0.20260518211933-8a93452bf649 h1:lZmH9TH7JpNBLUkTtvhqL/ONZ3G1ksP58THCgy2Db3s=
+github.com/Obedience-Corp/obey-shared v0.4.4-0.20260518211933-8a93452bf649/go.mod h1:X7xXZJ/S8Ek7s6dsihrnpFLnBykOkv2dQnHv+sRHx/Q=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/chroma/v2 v2.23.1 h1:nv2AVZdTyClGbVQkIzlDm/rnhk1E9bU9nXwmZ/Vk/iY=
@@ -247,8 +247,8 @@ go.opentelemetry.io/otel/metric v1.42.0 h1:2jXG+3oZLNXEPfNmnpxKDeZsFI5o4J+nz6xUl
 go.opentelemetry.io/otel/metric v1.42.0/go.mod h1:RlUN/7vTU7Ao/diDkEpQpnz3/92J9ko05BIwxYa2SSI=
 go.opentelemetry.io/otel/sdk v1.42.0 h1:LyC8+jqk6UJwdrI/8VydAq/hvkFKNHZVIWuslJXYsDo=
 go.opentelemetry.io/otel/sdk v1.42.0/go.mod h1:rGHCAxd9DAph0joO4W6OPwxjNTYWghRWmkHuGbayMts=
-go.opentelemetry.io/otel/sdk/metric v1.39.0 h1:cXMVVFVgsIf2YL6QkRF4Urbr/aMInf+2WKg+sEJTtB8=
-go.opentelemetry.io/otel/sdk/metric v1.39.0/go.mod h1:xq9HEVH7qeX69/JnwEfp6fVq5wosJsY1mt4lLfYdVew=
+go.opentelemetry.io/otel/sdk/metric v1.42.0 h1:D/1QR46Clz6ajyZ3G8SgNlTJKBdGp84q9RKCAZ3YGuA=
+go.opentelemetry.io/otel/sdk/metric v1.42.0/go.mod h1:Ua6AAlDKdZ7tdvaQKfSmnFTdHx37+J4ba8MwVCYM5hc=
 go.opentelemetry.io/otel/trace v1.42.0 h1:OUCgIPt+mzOnaUTpOQcBiM/PLQ/Op7oq6g4LenLmOYY=
 go.opentelemetry.io/otel/trace v1.42.0/go.mod h1:f3K9S+IFqnumBkKhRJMeaZeNk9epyhnCmQh/EysQCdc=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=


### PR DESCRIPTION
## Summary
- consume docker-free camp and obey-shared commits
- remove the remaining github.com/docker/docker transitive module graph edges from fest
- leave the direct Moby API/Testcontainers setup from PR #177 intact

## Why
After PR #177 merged, Dependabot still reported five github.com/docker/docker alerts because the old Docker module remained in the graph through camp and obey-shared module metadata. This follow-up points fest at cleaned dependency commits so the default branch graph can drop Docker entirely once the dependency chain lands.

## Dependencies
- depends on Obedience-Corp/obey-shared#15
- depends on lancekrogers/guild-scaffold#1
- depends on Obedience-Corp/camp#291

## Validation
- `just build quick`
- `go test -short ./...`
- `just build test-binary`
- `go test -run ^$ -tags=integration ./tests/integration/...`
- `go mod graph | rg github.com/docker/docker` returns no matches
- normal and integration package dependency lists contain no github.com/docker/docker
