### PR TITLE
fix(gates): show all phase buckets and preserve template on skip

### DIFF
--- a/internal/commands/gates/commands.go
+++ b/internal/commands/gates/commands.go
@@ -245,17 +245,16 @@ func printGatesShowMergedTable(cmd *cobra.Command, merged *gatescore.MergedPolic
 
 // Apply command in apply.go
 
-// extractPhaseFromTemplate extracts the phase type from a template path.
-// e.g., "gates/implementation/QUALITY_GATE_TESTING" -> "implementation"
+// extractPhaseFromTemplate extracts the phase type bucket for a configured
+// gate template path. Delegates to the gates package parser so that built-in
+// "agent/gates/..." templates and user-configured "gates/..." templates bucket
+// consistently. Returns "other" when the path cannot be parsed.
 func extractPhaseFromTemplate(template string) string {
-	// Expected format: gates/<phase_type>/<gate_name>
-	if strings.HasPrefix(template, "gates/") {
-		parts := strings.Split(template, "/")
-		if len(parts) >= 2 {
-			return parts[1]
-		}
+	phaseType, _ := gatescore.ExtractPhaseAndGate(template)
+	if phaseType == "" {
+		return "other"
 	}
-	return "other"
+	return phaseType
 }
 
 // canonicalPhaseBuckets lists known phase types in display order. Custom

--- a/internal/commands/gates/commands.go
+++ b/internal/commands/gates/commands.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/Obedience-Corp/fest/internal/errors"
@@ -192,17 +193,13 @@ func printGatesShowMergedTable(cmd *cobra.Command, merged *gatescore.MergedPolic
 	if len(activeGates) == 0 {
 		_, _ = fmt.Fprintln(out, ui.Dim("No active gates."))
 	} else {
-		// Group gates by phase type from template path (e.g., gates/implementation/...)
 		phaseGates := make(map[string][]gatescore.GateTask)
-		phaseOrder := []string{"implementation"}
-
 		for _, gate := range activeGates {
 			phaseType := extractPhaseFromTemplate(gate.Template)
 			phaseGates[phaseType] = append(phaseGates[phaseType], gate)
 		}
 
-		// Display gates grouped by phase type
-		for _, phaseType := range phaseOrder {
+		for _, phaseType := range orderedPhaseBuckets(phaseGates) {
 			gates := phaseGates[phaseType]
 			if len(gates) == 0 {
 				continue
@@ -259,4 +256,43 @@ func extractPhaseFromTemplate(template string) string {
 		}
 	}
 	return "other"
+}
+
+// canonicalPhaseBuckets lists known phase types in display order. Custom
+// template paths produce additional buckets, which are appended (sorted)
+// after these.
+var canonicalPhaseBuckets = []string{
+	"implementation",
+	"research",
+	"planning",
+	"review",
+	"non_coding_action",
+}
+
+// orderedPhaseBuckets returns bucket names in display order: canonical
+// buckets first (in canonicalPhaseBuckets order), then any other buckets
+// present in phaseGates sorted alphabetically. "other" sorts with the rest.
+func orderedPhaseBuckets(phaseGates map[string][]gatescore.GateTask) []string {
+	canonical := make(map[string]struct{}, len(canonicalPhaseBuckets))
+	for _, name := range canonicalPhaseBuckets {
+		canonical[name] = struct{}{}
+	}
+
+	var ordered []string
+	for _, name := range canonicalPhaseBuckets {
+		if _, ok := phaseGates[name]; ok {
+			ordered = append(ordered, name)
+		}
+	}
+
+	var extras []string
+	for name := range phaseGates {
+		if _, isCanonical := canonical[name]; isCanonical {
+			continue
+		}
+		extras = append(extras, name)
+	}
+	sort.Strings(extras)
+
+	return append(ordered, extras...)
 }

--- a/internal/commands/gates/commands_test.go
+++ b/internal/commands/gates/commands_test.go
@@ -1,0 +1,94 @@
+package gates
+
+import (
+	"reflect"
+	"testing"
+
+	gatescore "github.com/Obedience-Corp/fest/internal/gates"
+)
+
+func TestOrderedPhaseBuckets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   map[string][]gatescore.GateTask
+		want []string
+	}{
+		{
+			name: "only implementation",
+			in: map[string][]gatescore.GateTask{
+				"implementation": {{ID: "testing"}},
+			},
+			want: []string{"implementation"},
+		},
+		{
+			name: "custom bucket appears after canonical",
+			in: map[string][]gatescore.GateTask{
+				"implementation": {{ID: "testing"}},
+				"problem-mining": {{ID: "artifact-check"}},
+			},
+			want: []string{"implementation", "problem-mining"},
+		},
+		{
+			name: "multiple custom buckets sorted alphabetically",
+			in: map[string][]gatescore.GateTask{
+				"zeta":           {{ID: "z"}},
+				"problem-mining": {{ID: "artifact-check"}},
+				"alpha":          {{ID: "a"}},
+			},
+			want: []string{"alpha", "problem-mining", "zeta"},
+		},
+		{
+			name: "canonical buckets render in declared order",
+			in: map[string][]gatescore.GateTask{
+				"review":         {{ID: "r"}},
+				"implementation": {{ID: "i"}},
+				"research":       {{ID: "rs"}},
+			},
+			want: []string{"implementation", "research", "review"},
+		},
+		{
+			name: "other bucket is treated as custom",
+			in: map[string][]gatescore.GateTask{
+				"implementation": {{ID: "testing"}},
+				"other":          {{ID: "custom"}},
+			},
+			want: []string{"implementation", "other"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := orderedPhaseBuckets(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("orderedPhaseBuckets() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractPhaseFromTemplate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		template string
+		want     string
+	}{
+		{"gates/implementation/QUALITY_GATE_TESTING", "implementation"},
+		{"gates/problem-mining/QUALITY_GATE_ARTIFACT_CHECK", "problem-mining"},
+		{"gates/research/QUALITY_GATE_FOO", "research"},
+		{"agent/gates/implementation/testing", "other"},
+		{"", "other"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.template, func(t *testing.T) {
+			t.Parallel()
+			if got := extractPhaseFromTemplate(tc.template); got != tc.want {
+				t.Fatalf("extractPhaseFromTemplate(%q) = %q, want %q", tc.template, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/commands/gates/commands_test.go
+++ b/internal/commands/gates/commands_test.go
@@ -78,8 +78,9 @@ func TestExtractPhaseFromTemplate(t *testing.T) {
 	}{
 		{"gates/implementation/QUALITY_GATE_TESTING", "implementation"},
 		{"gates/problem-mining/QUALITY_GATE_ARTIFACT_CHECK", "problem-mining"},
+		{"gates/problem-mining/QUALITY_GATE_ARTIFACT_CHECK.md", "problem-mining"},
 		{"gates/research/QUALITY_GATE_FOO", "research"},
-		{"agent/gates/implementation/testing", "other"},
+		{"agent/gates/implementation/testing", "implementation"},
 		{"", "other"},
 	}
 

--- a/internal/gates/task_generator.go
+++ b/internal/gates/task_generator.go
@@ -123,10 +123,11 @@ func (g *TaskGenerator) GenerateForSequence(
 			}
 			if !opts.Force {
 				results = append(results, GenerateResult{
-					Type:   "skip",
-					Path:   existingPath,
-					TaskID: gate.ID,
-					Reason: "gate_exists",
+					Type:     "skip",
+					Path:     existingPath,
+					Template: gate.Template,
+					TaskID:   gate.ID,
+					Reason:   "gate_exists",
 				})
 				continue
 			}

--- a/internal/gates/task_generator.go
+++ b/internal/gates/task_generator.go
@@ -272,7 +272,7 @@ func (g *TaskGenerator) renderGateContent(ctx context.Context, gate GateTask, ta
 	}
 
 	// Extract phase type and gate name from template path
-	phaseType, gateName := extractPhaseAndGate(gate.Template)
+	phaseType, gateName := ExtractPhaseAndGate(gate.Template)
 	if phaseType == "" || gateName == "" {
 		return "", errors.Validation("invalid gate template path").
 			WithField("template", gate.Template).
@@ -297,22 +297,23 @@ func (g *TaskGenerator) renderGateContent(ctx context.Context, gate GateTask, ta
 	return content, nil
 }
 
-// extractPhaseAndGate extracts phase type and gate name from a template path.
-// Handles formats: "gates/{phaseType}/{gateName}", "{phaseType}/{gateName}"
-func extractPhaseAndGate(templatePath string) (phaseType, gateName string) {
-	// Strip common prefixes
+// ExtractPhaseAndGate extracts phase type and gate name from a template path.
+// Accepts "gates/{phaseType}/{gateName}", "agent/gates/{phaseType}/{gateName}",
+// or a bare "{phaseType}/{gateName}". A trailing ".md" on the gate name is
+// stripped so callers can append the extension exactly once when resolving
+// to a file.
+func ExtractPhaseAndGate(templatePath string) (phaseType, gateName string) {
 	path := templatePath
-	for _, prefix := range []string{"gates/", "agent/gates/"} {
-		if strings.HasPrefix(path, prefix) {
-			path = strings.TrimPrefix(path, prefix)
+	for _, prefix := range []string{"agent/gates/", "gates/"} {
+		if rest, ok := strings.CutPrefix(path, prefix); ok {
+			path = rest
 			break
 		}
 	}
 
-	// Split into parts: should be {phaseType}/{gateName}
 	parts := strings.Split(path, "/")
 	if len(parts) >= 2 {
-		return parts[0], parts[len(parts)-1]
+		return parts[0], strings.TrimSuffix(parts[len(parts)-1], ".md")
 	}
 
 	return "", ""

--- a/internal/gates/task_generator_test.go
+++ b/internal/gates/task_generator_test.go
@@ -86,6 +86,95 @@ fest_status: pending
 	}
 }
 
+func TestGenerateForSequence_ResolvesTemplateWithMdSuffix(t *testing.T) {
+	t.Parallel()
+
+	festivalPath := t.TempDir()
+	sequencePath := filepath.Join(festivalPath, "001_IMPLEMENTATION", "01_core")
+	templateDir := filepath.Join(festivalPath, "gates", "problem-mining")
+	if err := os.MkdirAll(sequencePath, 0755); err != nil {
+		t.Fatalf("mkdir sequence: %v", err)
+	}
+	if err := os.MkdirAll(templateDir, 0755); err != nil {
+		t.Fatalf("mkdir template dir: %v", err)
+	}
+
+	templatePath := filepath.Join(templateDir, "QUALITY_GATE_ARTIFACT_CHECK.md")
+	templateContent := `---
+fest_type: gate
+fest_status: pending
+---
+# Gate: Artifact Check
+`
+	if err := os.WriteFile(templatePath, []byte(templateContent), 0644); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+
+	generator, err := NewTaskGenerator(context.Background(), festivalPath)
+	if err != nil {
+		t.Fatalf("NewTaskGenerator() error = %v", err)
+	}
+
+	results, warnings, err := generator.GenerateForSequence(
+		context.Background(),
+		sequencePath,
+		[]GateTask{{
+			ID:       "artifact-check",
+			Name:     "Artifact Check",
+			Template: "gates/problem-mining/QUALITY_GATE_ARTIFACT_CHECK.md",
+			Enabled:  true,
+		}},
+		GenerateOptions{DryRun: false},
+		festivalPath,
+	)
+	if err != nil {
+		t.Fatalf("GenerateForSequence() error = %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("GenerateForSequence() warnings = %v, want none", warnings)
+	}
+	if len(results) != 1 || results[0].Type != "create" {
+		t.Fatalf("GenerateForSequence() results = %+v, want 1 create", results)
+	}
+
+	if _, err := os.Stat(filepath.Join(sequencePath, "01_artifact_check.md")); err != nil {
+		t.Fatalf("expected generated gate file: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(sequencePath, "01_artifact_check.md.md")); err == nil {
+		t.Fatalf("double .md suffix file should not be created")
+	}
+}
+
+func TestExtractPhaseAndGate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		template string
+		phase    string
+		gate     string
+	}{
+		{"gates/implementation/QUALITY_GATE_TESTING", "implementation", "QUALITY_GATE_TESTING"},
+		{"gates/implementation/QUALITY_GATE_TESTING.md", "implementation", "QUALITY_GATE_TESTING"},
+		{"gates/problem-mining/QUALITY_GATE_ARTIFACT_CHECK.md", "problem-mining", "QUALITY_GATE_ARTIFACT_CHECK"},
+		{"agent/gates/implementation/testing", "implementation", "testing"},
+		{"agent/gates/implementation/testing.md", "implementation", "testing"},
+		{"implementation/testing", "implementation", "testing"},
+		{"", "", ""},
+		{"gates/", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.template, func(t *testing.T) {
+			t.Parallel()
+			phase, gate := ExtractPhaseAndGate(tc.template)
+			if phase != tc.phase || gate != tc.gate {
+				t.Fatalf("ExtractPhaseAndGate(%q) = (%q, %q), want (%q, %q)",
+					tc.template, phase, gate, tc.phase, tc.gate)
+			}
+		})
+	}
+}
+
 func TestGenerateForSequence_SkipResultPreservesTemplate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gates/task_generator_test.go
+++ b/internal/gates/task_generator_test.go
@@ -86,6 +86,45 @@ fest_status: pending
 	}
 }
 
+func TestGenerateForSequence_SkipResultPreservesTemplate(t *testing.T) {
+	t.Parallel()
+
+	sequencePath := t.TempDir()
+
+	existing := `---
+fest_type: gate
+fest_gate_id: testing
+fest_status: pending
+---
+# Gate: Testing
+`
+	if err := os.WriteFile(filepath.Join(sequencePath, "01_quality_gate_testing.md"), []byte(existing), 0644); err != nil {
+		t.Fatalf("write existing gate: %v", err)
+	}
+
+	generator := &TaskGenerator{}
+	gateTemplate := "gates/problem-mining/QUALITY_GATE_ARTIFACT_CHECK"
+	results, _, err := generator.GenerateForSequence(
+		context.Background(),
+		sequencePath,
+		[]GateTask{{ID: "testing", Template: gateTemplate, Enabled: true}},
+		GenerateOptions{DryRun: true},
+	)
+	if err != nil {
+		t.Fatalf("GenerateForSequence() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("GenerateForSequence() returned %d results, want 1", len(results))
+	}
+	r := results[0]
+	if r.Type != "skip" || r.Reason != "gate_exists" {
+		t.Fatalf("GenerateForSequence() = %+v, want skip/gate_exists", r)
+	}
+	if r.Template != gateTemplate {
+		t.Fatalf("skip result Template = %q, want %q", r.Template, gateTemplate)
+	}
+}
+
 func TestGenerateForSequence_BackfillsLegacyGateIDFromFilename(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Fixes #168.

Two related bugs in `fest gates` that combined to make custom quality gate template paths appear broken when they actually worked.

### Bug 1: `fest gates show` silently dropped non-canonical buckets

`printGatesShowMergedTable` hardcoded `phaseOrder := []string{"implementation"}`, so gates whose template path bucketed under anything other than `implementation` (e.g. `gates/problem-mining/...`) were grouped correctly but never rendered. The table showed an empty "Active Gates" section even though the merger had loaded the gates.

JSON output (`--json`) was unaffected because it emits `merged.Gates` directly without grouping.

Fix: render canonical buckets first in declared order (`implementation`, `research`, `planning`, `review`, `non_coding_action`), then any remaining discovered buckets sorted alphabetically. `other` (the fallback for malformed template paths) sorts with the rest.

### Bug 2: `fest gates apply --json` skip results had empty `template` field

In `GenerateForSequence`, the `create` result correctly set `Template: gate.Template` but the `skip` result for `gate_exists` did not, producing JSON like:

```json
{"type": "skip", "path": ".../05_testing.md", "template": "", "reason": "gate_exists", "task_id": "testing"}
```

Fix: set `Template: gate.Template` on the skip result so it matches the create shape.

### Why the issue felt worse than the actual bug

The reporter believed custom `template:` paths in `quality_gates.implementation[]` were unsupported and worked around it by moving content into canonical `gates/implementation/QUALITY_GATE_*` slots. The underlying apply logic in `renderGateContent` actually resolves `gates/<phaseType>/<gateName>.md` against `festivalPath` correctly for custom paths, so apply did create the right files. The visible breakage was entirely `gates show` lying about what was active.

## Tests

- `TestOrderedPhaseBuckets`: canonical-first ordering, custom buckets sorted alphabetically after canonical, `other` bucket treated as custom.
- `TestExtractPhaseFromTemplate`: existing extraction behavior covered.
- `TestGenerateForSequence_SkipResultPreservesTemplate`: skip result for existing gate carries the configured template path.

## Out of scope (deferred)

Issue 168 also asks whether `fest validate` should warn when a configured gate template path does not resolve. That is a separate design question and is left for a follow-up.

## Test plan

- [x] `go build ./...`
- [x] `just test unit-raw` (all packages green)
- [x] `just lint vet`
- [x] `just lint gopls-tests internal/commands/gates` and `internal/gates`
- [ ] Manual smoke: ritual festival with custom `gates/problem-mining/...` paths now lists those gates under a `problem-mining` section in `fest gates show`.