### PR TITLE
Support standalone workflow show and watch

### DIFF
--- a/internal/commands/show/show.go
+++ b/internal/commands/show/show.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/id"
 	"github.com/Obedience-Corp/fest/internal/pathutil"
+	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/workspace"
 	"github.com/spf13/cobra"
 )
@@ -46,6 +47,9 @@ SUBCOMMANDS:
   fest show all          List all festivals grouped by status
   fest show <name>       Show details of a specific festival by name
   fest show --festival <selector>  Show a festival by explicit selector (campaign workspace)`,
+		Annotations: map[string]string{
+			"scope": string(scope.Global),
+		},
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.festival != "" && len(args) > 0 {
@@ -188,6 +192,22 @@ func runShowCurrent(ctx context.Context, opts *showOptions) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return errors.IO("getting current directory", err)
+	}
+
+	standaloneWorkflow, err := ResolveStandaloneWorkflow(ctx, cwd)
+	if err != nil {
+		return err
+	}
+	if standaloneWorkflow != nil {
+		if opts.watch {
+			return WatchStandaloneWorkflow(ctx, standaloneWorkflow, WatchOptions{
+				Summary:    opts.summary,
+				Goals:      opts.goals,
+				Collapsed:  opts.collapsed,
+				InProgress: opts.inProgress,
+			})
+		}
+		return emitStandaloneWorkflow(standaloneWorkflow, opts)
 	}
 
 	campaignRoot, _ := workspace.DetectCampaign(ctx, "")

--- a/internal/commands/show/standalone.go
+++ b/internal/commands/show/standalone.go
@@ -1,0 +1,416 @@
+package show
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Obedience-Corp/fest/internal/commands/shared"
+	"github.com/Obedience-Corp/fest/internal/errors"
+	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+	"github.com/Obedience-Corp/fest/internal/ui"
+	filewatch "github.com/Obedience-Corp/fest/internal/watch"
+	"github.com/Obedience-Corp/fest/internal/workflow/localstore"
+	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
+)
+
+// StandaloneWorkflowInfo is the display-ready view of a standalone WORKFLOW.md.
+type StandaloneWorkflowInfo struct {
+	Mode           string
+	StartDir       string
+	WorkflowDoc    string
+	RuntimeDir     string
+	RunID          string
+	RunStatus      string
+	CurrentStep    int
+	TotalSteps     int
+	CompletedSteps int
+	Blocked        bool
+	DocHashChanged bool
+	RenderMode     string
+	Steps          []shared.WorkflowStepView
+}
+
+// ResolveStandaloneWorkflow resolves and loads a standalone WORKFLOW.md view.
+// Festival contexts return nil so callers can continue with festival handling.
+func ResolveStandaloneWorkflow(ctx context.Context, startDir string) (*StandaloneWorkflowInfo, error) {
+	res, err := standalone.Resolve(ctx, startDir)
+	if err != nil {
+		return nil, err
+	}
+	switch res.Mode {
+	case standalone.ModeAnonymous, standalone.ModeTracked:
+		return loadStandaloneWorkflow(ctx, res)
+	default:
+		return nil, nil
+	}
+}
+
+func loadStandaloneWorkflow(ctx context.Context, res *standalone.Result) (*StandaloneWorkflowInfo, error) {
+	steps, err := wf.NewParser().Parse(ctx, res.WorkflowDoc)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing WORKFLOW.md").WithField("path", res.WorkflowDoc)
+	}
+	if len(steps) == 0 {
+		return nil, errors.Validation("WORKFLOW.md has no parseable steps").
+			WithField("path", res.WorkflowDoc).
+			WithHint("add at least one '## Step 1: NAME' header")
+	}
+
+	mode := "standalone-anonymous"
+	runStatus := "not-started"
+	var state *localstore.RunState
+	if res.Mode == standalone.ModeTracked {
+		mode = "standalone-tracked"
+		store := localstore.Open(res.RuntimeDir, res.WorkflowDoc)
+		var err error
+		state, err = store.LoadActive(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if state != nil {
+			runStatus = state.Status
+		}
+	}
+
+	views, current, completed, renderMode := buildStandaloneStepViews(steps, state)
+	info := &StandaloneWorkflowInfo{
+		Mode:           mode,
+		StartDir:       res.StartDir,
+		WorkflowDoc:    res.WorkflowDoc,
+		RuntimeDir:     res.RuntimeDir,
+		RunStatus:      runStatus,
+		CurrentStep:    current,
+		TotalSteps:     len(steps),
+		CompletedSteps: completed,
+		RenderMode:     renderMode,
+		Steps:          views,
+	}
+	if state != nil {
+		info.RunID = state.RunID
+		info.Blocked = state.Blocked
+		info.DocHashChanged = state.DocHashChanged
+	}
+	return info, nil
+}
+
+func buildStandaloneStepViews(steps []wf.WorkflowStep, state *localstore.RunState) ([]shared.WorkflowStepView, int, int, string) {
+	total := len(steps)
+	current, renderMode := standaloneRenderPosition(state, total)
+	completed := 0
+	if state != nil {
+		completed = clampStepCount(state.CompletedSteps, total)
+		if state.Status == "completed" {
+			completed = total
+		}
+	}
+
+	views := make([]shared.WorkflowStepView, len(steps))
+	for i, step := range steps {
+		position := i + 1
+		status := wf.StepStatusPending
+		if position <= completed || renderMode == "complete" {
+			status = wf.StepStatusCompleted
+		} else if position == current {
+			switch {
+			case state != nil && state.Blocked:
+				status = wf.StepStatusBlocked
+			case renderMode == "in_progress":
+				status = wf.StepStatusInProgress
+			default:
+				status = wf.StepStatusPending
+			}
+		}
+
+		views[i] = shared.WorkflowStepView{
+			Number:        step.Number,
+			Name:          step.Name,
+			Status:        status,
+			IsCurrent:     position == current && renderMode != "complete",
+			HasCheckpoint: step.HasCheckpoint(),
+			Goal:          step.Goal,
+		}
+	}
+	return views, current, completed, renderMode
+}
+
+func standaloneRenderPosition(state *localstore.RunState, totalSteps int) (int, string) {
+	if totalSteps == 0 {
+		return 0, "no_run"
+	}
+	if state == nil {
+		return 1, "next_up"
+	}
+	if state.Status == "completed" || state.CompletedSteps >= totalSteps {
+		return totalSteps, "complete"
+	}
+	if state.CurrentStep > state.CompletedSteps {
+		return clampStepCount(state.CurrentStep, totalSteps), "in_progress"
+	}
+	next := state.CompletedSteps + 1
+	if next > totalSteps {
+		return totalSteps, "complete"
+	}
+	if next < 1 {
+		return 1, "next_up"
+	}
+	return next, "next_up"
+}
+
+func clampStepCount(n, total int) int {
+	if n < 0 {
+		return 0
+	}
+	if total > 0 && n > total {
+		return total
+	}
+	return n
+}
+
+func emitStandaloneWorkflow(info *StandaloneWorkflowInfo, opts *showOptions) error {
+	if opts.json {
+		return emitStandaloneWorkflowJSON(info)
+	}
+	if opts.summary {
+		fmt.Print(FormatStandaloneWorkflowSummary(info))
+		return nil
+	}
+	fmt.Print(FormatStandaloneWorkflowProgress(info))
+	return nil
+}
+
+// FormatStandaloneWorkflowSummary renders aggregate standalone workflow state.
+func FormatStandaloneWorkflowSummary(info *StandaloneWorkflowInfo) string {
+	var sb strings.Builder
+	writeStandaloneHeader(&sb, info)
+	return sb.String()
+}
+
+// FormatStandaloneWorkflowProgress renders standalone workflow state plus steps.
+func FormatStandaloneWorkflowProgress(info *StandaloneWorkflowInfo) string {
+	var sb strings.Builder
+	writeStandaloneHeader(&sb, info)
+	sb.WriteString("\n")
+	sb.WriteString(shared.RenderWorkflowSteps(info.Steps, false))
+	if current := currentStandaloneStep(info); current != nil {
+		fmt.Fprintf(&sb, "\nCurrent: Step %d - %s\n", current.Number, current.Name)
+	}
+	if info.DocHashChanged {
+		fmt.Fprintf(&sb, "%s WORKFLOW.md has changed since this run started\n", ui.Warning("!"))
+	}
+	if info.RenderMode != "complete" {
+		if info.Mode == "standalone-anonymous" {
+			sb.WriteString("First mutating command: ")
+		} else {
+			sb.WriteString("Next: ")
+		}
+		sb.WriteString(ui.Accent("fest workflow advance"))
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+func writeStandaloneHeader(sb *strings.Builder, info *StandaloneWorkflowInfo) {
+	sb.WriteString("Workflow Progress\n")
+	sb.WriteString("-----------------\n")
+	fmt.Fprintf(sb, "Workflow: %s\n", info.WorkflowDoc)
+	fmt.Fprintf(sb, "Mode: %s\n", strings.TrimPrefix(info.Mode, "standalone-"))
+	if info.RunID != "" {
+		fmt.Fprintf(sb, "Run: %s (%s)\n", info.RunID, info.RunStatus)
+	} else {
+		fmt.Fprintf(sb, "Status: %s\n", info.RunStatus)
+	}
+	if info.Blocked {
+		fmt.Fprintf(sb, "Blocked: true\n")
+	}
+	fmt.Fprintf(sb, "Progress: %s steps\n", shared.RenderWorkflowProgress(info.CompletedSteps, info.TotalSteps))
+}
+
+func currentStandaloneStep(info *StandaloneWorkflowInfo) *shared.WorkflowStepView {
+	if info == nil || info.RenderMode == "complete" {
+		return nil
+	}
+	for i := range info.Steps {
+		if info.Steps[i].IsCurrent {
+			return &info.Steps[i]
+		}
+	}
+	return nil
+}
+
+type standaloneWorkflowJSON struct {
+	Mode           string                   `json:"mode"`
+	WorkflowDoc    string                   `json:"workflow_doc"`
+	RuntimeDir     string                   `json:"runtime_dir,omitempty"`
+	RunID          string                   `json:"run_id,omitempty"`
+	RunStatus      string                   `json:"run_status"`
+	CurrentStep    int                      `json:"current_step"`
+	TotalSteps     int                      `json:"total_steps"`
+	CompletedSteps int                      `json:"completed_steps"`
+	Blocked        bool                     `json:"blocked,omitempty"`
+	DocHashChanged bool                     `json:"doc_hash_changed,omitempty"`
+	Steps          []standaloneWorkflowStep `json:"steps"`
+}
+
+type standaloneWorkflowStep struct {
+	Number        int    `json:"number"`
+	Name          string `json:"name"`
+	Status        string `json:"status"`
+	Current       bool   `json:"current,omitempty"`
+	HasCheckpoint bool   `json:"has_checkpoint,omitempty"`
+	Goal          string `json:"goal,omitempty"`
+}
+
+func emitStandaloneWorkflowJSON(info *StandaloneWorkflowInfo) error {
+	out := standaloneWorkflowJSON{
+		Mode:           info.Mode,
+		WorkflowDoc:    info.WorkflowDoc,
+		RuntimeDir:     info.RuntimeDir,
+		RunID:          info.RunID,
+		RunStatus:      info.RunStatus,
+		CurrentStep:    info.CurrentStep,
+		TotalSteps:     info.TotalSteps,
+		CompletedSteps: info.CompletedSteps,
+		Blocked:        info.Blocked,
+		DocHashChanged: info.DocHashChanged,
+		Steps:          make([]standaloneWorkflowStep, 0, len(info.Steps)),
+	}
+	for _, step := range info.Steps {
+		out.Steps = append(out.Steps, standaloneWorkflowStep{
+			Number:        step.Number,
+			Name:          step.Name,
+			Status:        string(step.Status),
+			Current:       step.IsCurrent,
+			HasCheckpoint: step.HasCheckpoint,
+			Goal:          step.Goal,
+		})
+	}
+	if err := shared.EncodeJSON(os.Stdout, out); err != nil {
+		return errors.Wrap(err, "encoding JSON output")
+	}
+	return nil
+}
+
+// WatchStandaloneWorkflow watches and refreshes a standalone WORKFLOW.md view.
+func WatchStandaloneWorkflow(ctx context.Context, info *StandaloneWorkflowInfo, opts WatchOptions) error {
+	if info == nil {
+		return errors.Validation("standalone workflow is required")
+	}
+	startDir := info.StartDir
+	if startDir == "" {
+		startDir = filepath.Dir(info.WorkflowDoc)
+	}
+	return runStandaloneWatchMode(ctx, startDir, opts)
+}
+
+func runStandaloneWatchMode(ctx context.Context, startDir string, opts WatchOptions) error {
+	render := func() (*StandaloneWorkflowInfo, error) {
+		info, err := ResolveStandaloneWorkflow(ctx, startDir)
+		if err != nil {
+			return nil, err
+		}
+		if info == nil {
+			return nil, errors.NotFound("standalone workflow").WithField("path", startDir)
+		}
+		return info, nil
+	}
+
+	info, err := render()
+	if err != nil {
+		return err
+	}
+	clearScreen()
+	if err := renderStandaloneWorkflowView(info, opts); err != nil {
+		return err
+	}
+	printWatchFooter(false)
+
+	w, err := filewatch.New(filewatch.Config{
+		Paths:    standaloneWatchPaths(info),
+		Debounce: 100 * time.Millisecond,
+	}, func() {
+		refreshed, err := render()
+		if err != nil {
+			return
+		}
+		clearScreen()
+		if err := renderStandaloneWorkflowView(refreshed, opts); err != nil {
+			return
+		}
+		printWatchFooter(false)
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "File watching unavailable (%v), using polling fallback\n", err)
+		return runStandalonePollingMode(ctx, startDir, opts)
+	}
+	defer func() { _ = w.Close() }()
+
+	return w.Watch(ctx)
+}
+
+func runStandalonePollingMode(ctx context.Context, startDir string, opts WatchOptions) error {
+	clearScreen()
+	if err := renderStandaloneWorkflowFromStartDir(ctx, startDir, opts); err != nil {
+		return err
+	}
+	printWatchFooter(true)
+
+	ticker := time.NewTicker(pollingInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Println()
+			return nil
+		case <-ticker.C:
+			clearScreen()
+			if err := renderStandaloneWorkflowFromStartDir(ctx, startDir, opts); err != nil {
+				return err
+			}
+			printWatchFooter(true)
+		}
+	}
+}
+
+func renderStandaloneWorkflowFromStartDir(ctx context.Context, startDir string, opts WatchOptions) error {
+	info, err := ResolveStandaloneWorkflow(ctx, startDir)
+	if err != nil {
+		return err
+	}
+	if info == nil {
+		return errors.NotFound("standalone workflow").WithField("path", startDir)
+	}
+	return renderStandaloneWorkflowView(info, opts)
+}
+
+func renderStandaloneWorkflowView(info *StandaloneWorkflowInfo, opts WatchOptions) error {
+	showOpts := &showOptions{summary: opts.Summary}
+	return emitStandaloneWorkflow(info, showOpts)
+}
+
+func standaloneWatchPaths(info *StandaloneWorkflowInfo) []string {
+	seen := map[string]bool{}
+	paths := []string{}
+	add := func(path string) {
+		if path == "" || seen[path] {
+			return
+		}
+		seen[path] = true
+		paths = append(paths, path)
+	}
+
+	add(filepath.Dir(info.WorkflowDoc))
+	add(info.WorkflowDoc)
+	add(info.RuntimeDir)
+	if info.RuntimeDir != "" {
+		add(filepath.Join(info.RuntimeDir, "runs"))
+	}
+	if info.RuntimeDir != "" && info.RunID != "" {
+		add(filepath.Join(info.RuntimeDir, "runs", info.RunID))
+	}
+	return paths
+}

--- a/internal/commands/show/standalone_test.go
+++ b/internal/commands/show/standalone_test.go
@@ -1,0 +1,103 @@
+package show
+
+import (
+	"strings"
+	"testing"
+
+	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+	"github.com/Obedience-Corp/fest/internal/workflow/localstore"
+)
+
+func TestBuildStandaloneStepViewsAnonymousMarksFirstStepCurrent(t *testing.T) {
+	steps := []wf.WorkflowStep{
+		{Number: 1, Name: "First", Goal: "Start"},
+		{Number: 2, Name: "Second"},
+	}
+
+	views, current, completed, renderMode := buildStandaloneStepViews(steps, nil)
+
+	if current != 1 {
+		t.Fatalf("current = %d, want 1", current)
+	}
+	if completed != 0 {
+		t.Fatalf("completed = %d, want 0", completed)
+	}
+	if renderMode != "next_up" {
+		t.Fatalf("renderMode = %q, want next_up", renderMode)
+	}
+	if !views[0].IsCurrent {
+		t.Fatal("first step should be marked current")
+	}
+	if views[0].Status != wf.StepStatusPending {
+		t.Fatalf("first status = %q, want pending", views[0].Status)
+	}
+	if views[1].Status != wf.StepStatusPending {
+		t.Fatalf("second status = %q, want pending", views[1].Status)
+	}
+}
+
+func TestBuildStandaloneStepViewsTrackedRunProgress(t *testing.T) {
+	steps := []wf.WorkflowStep{
+		{Number: 1, Name: "First"},
+		{Number: 2, Name: "Second"},
+		{Number: 3, Name: "Third"},
+	}
+	state := &localstore.RunState{
+		Status:         "active",
+		CurrentStep:    2,
+		CompletedSteps: 1,
+	}
+
+	views, current, completed, renderMode := buildStandaloneStepViews(steps, state)
+
+	if current != 2 {
+		t.Fatalf("current = %d, want 2", current)
+	}
+	if completed != 1 {
+		t.Fatalf("completed = %d, want 1", completed)
+	}
+	if renderMode != "in_progress" {
+		t.Fatalf("renderMode = %q, want in_progress", renderMode)
+	}
+	if views[0].Status != wf.StepStatusCompleted {
+		t.Fatalf("step 1 status = %q, want completed", views[0].Status)
+	}
+	if views[1].Status != wf.StepStatusInProgress || !views[1].IsCurrent {
+		t.Fatalf("step 2 = status %q current %v, want in_progress/current", views[1].Status, views[1].IsCurrent)
+	}
+	if views[2].Status != wf.StepStatusPending {
+		t.Fatalf("step 3 status = %q, want pending", views[2].Status)
+	}
+}
+
+func TestFormatStandaloneWorkflowProgressIncludesStepsAndProgress(t *testing.T) {
+	steps := []wf.WorkflowStep{
+		{Number: 1, Name: "First", Goal: "Start"},
+		{Number: 2, Name: "Second"},
+	}
+	views, current, completed, renderMode := buildStandaloneStepViews(steps, nil)
+	info := &StandaloneWorkflowInfo{
+		Mode:           "standalone-anonymous",
+		WorkflowDoc:    "/tmp/demo/WORKFLOW.md",
+		RunStatus:      "not-started",
+		CurrentStep:    current,
+		TotalSteps:     len(steps),
+		CompletedSteps: completed,
+		RenderMode:     renderMode,
+		Steps:          views,
+	}
+
+	got := FormatStandaloneWorkflowProgress(info)
+	for _, want := range []string{
+		"Workflow Progress",
+		"Progress: 0/2 (0%) steps",
+		"Step 1: First",
+		"Step 2: Second",
+		"Current: Step 1 - First",
+		"fest workflow advance",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("formatted output missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/commands/watch/command.go
+++ b/internal/commands/watch/command.go
@@ -3,8 +3,10 @@ package watch
 
 import (
 	"context"
+	"os"
 
 	"github.com/Obedience-Corp/fest/internal/commands/show"
+	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/spf13/cobra"
 )
@@ -16,8 +18,10 @@ type options struct {
 }
 
 type commandDeps struct {
-	resolve func(context.Context, string) (*show.FestivalInfo, error)
-	watch   func(context.Context, *show.FestivalInfo, show.WatchOptions) error
+	resolve           func(context.Context, string) (*show.FestivalInfo, error)
+	resolveStandalone func(context.Context) (*show.StandaloneWorkflowInfo, error)
+	watch             func(context.Context, *show.FestivalInfo, show.WatchOptions) error
+	watchStandalone   func(context.Context, *show.StandaloneWorkflowInfo, show.WatchOptions) error
 }
 
 // NewWatchCommand creates the watch command.
@@ -30,8 +34,18 @@ func defaultCommandDeps() commandDeps {
 		resolve: func(ctx context.Context, selector string) (*show.FestivalInfo, error) {
 			return defaultResolver().resolve(ctx, selector)
 		},
-		watch: show.WatchFestival,
+		resolveStandalone: defaultResolveStandaloneWorkflow,
+		watch:             show.WatchFestival,
+		watchStandalone:   show.WatchStandaloneWorkflow,
 	}
+}
+
+func defaultResolveStandaloneWorkflow(ctx context.Context) (*show.StandaloneWorkflowInfo, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, errors.IO("getting current directory", err)
+	}
+	return show.ResolveStandaloneWorkflow(ctx, cwd)
 }
 
 func newWatchCommand(deps commandDeps) *cobra.Command {
@@ -44,7 +58,8 @@ func newWatchCommand(deps commandDeps) *cobra.Command {
 
 With a selector, fest watch resolves a festival by directory name or logical ID.
 Without a selector, it watches the current festival when run from a festival
-directory, or the linked festival when run from a linked project directory.
+directory, the linked festival when run from a linked project directory, or a
+standalone WORKFLOW.md from that workflow directory.
 
 From a campaign or festivals workspace in an interactive terminal, fest watch
 opens a festival picker. Watch mode refreshes in place until you press Ctrl+C.
@@ -55,7 +70,7 @@ It does not change your shell directory.`,
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: completeWatchSelector,
 		Annotations: map[string]string{
-			"scope":        string(scope.Workspace),
+			"scope":        string(scope.Global),
 			"interactive":  "true",
 			"long_running": "true",
 		},
@@ -77,6 +92,16 @@ func runWatch(ctx context.Context, args []string, opts *options, deps commandDep
 		selector = args[0]
 	}
 
+	if selector == "" && deps.resolveStandalone != nil {
+		workflow, err := deps.resolveStandalone(ctx)
+		if err != nil {
+			return err
+		}
+		if workflow != nil {
+			return watchStandaloneWorkflow(ctx, workflow, *opts, deps)
+		}
+	}
+
 	festival, err := deps.resolve(ctx, selector)
 	if err != nil {
 		if isWatchPickerCancelled(err) {
@@ -89,6 +114,13 @@ func runWatch(ctx context.Context, args []string, opts *options, deps commandDep
 
 func watchFestival(ctx context.Context, festival *show.FestivalInfo, opts options, deps commandDeps) error {
 	return deps.watch(ctx, festival, showWatchOptions(opts))
+}
+
+func watchStandaloneWorkflow(ctx context.Context, workflow *show.StandaloneWorkflowInfo, opts options, deps commandDeps) error {
+	if deps.watchStandalone == nil {
+		return errors.Validation("standalone watch delegate is required")
+	}
+	return deps.watchStandalone(ctx, workflow, showWatchOptions(opts))
 }
 
 func showWatchOptions(opts options) show.WatchOptions {

--- a/internal/commands/watch/command_test.go
+++ b/internal/commands/watch/command_test.go
@@ -81,6 +81,74 @@ func TestWatchCommandDelegatesWithMappedOptions(t *testing.T) {
 	}
 }
 
+func TestWatchCommandStandaloneWorkflowDelegatesBeforeFestivalResolution(t *testing.T) {
+	var gotWorkflow *show.StandaloneWorkflowInfo
+	var gotOptions show.WatchOptions
+	calledStandalone := false
+
+	cmd := newWatchCommand(commandDeps{
+		resolveStandalone: func(context.Context) (*show.StandaloneWorkflowInfo, error) {
+			return &show.StandaloneWorkflowInfo{StartDir: "/workspace/workflow", WorkflowDoc: "/workspace/workflow/WORKFLOW.md"}, nil
+		},
+		resolve: func(context.Context, string) (*show.FestivalInfo, error) {
+			t.Fatal("festival resolver should not be called for standalone workflow context")
+			return nil, nil
+		},
+		watch: func(context.Context, *show.FestivalInfo, show.WatchOptions) error {
+			t.Fatal("festival watch delegate should not be called for standalone workflow context")
+			return nil
+		},
+		watchStandalone: func(_ context.Context, workflow *show.StandaloneWorkflowInfo, opts show.WatchOptions) error {
+			calledStandalone = true
+			gotWorkflow = workflow
+			gotOptions = opts
+			return nil
+		},
+	})
+	cmd.SetArgs([]string{"--summary"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !calledStandalone {
+		t.Fatal("standalone watch delegate was not called")
+	}
+	if gotWorkflow == nil || gotWorkflow.WorkflowDoc != "/workspace/workflow/WORKFLOW.md" {
+		t.Fatalf("workflow = %#v", gotWorkflow)
+	}
+	if !gotOptions.InProgress || !gotOptions.Summary {
+		t.Fatalf("watch options were not mapped for standalone workflow: %#v", gotOptions)
+	}
+}
+
+func TestWatchCommandSelectorSkipsStandaloneResolution(t *testing.T) {
+	calledResolve := false
+	cmd := newWatchCommand(commandDeps{
+		resolveStandalone: func(context.Context) (*show.StandaloneWorkflowInfo, error) {
+			t.Fatal("standalone resolver should not be called when selector is explicit")
+			return nil, nil
+		},
+		resolve: func(_ context.Context, selector string) (*show.FestivalInfo, error) {
+			calledResolve = true
+			if selector != "festival-FS0001" {
+				t.Fatalf("selector = %q", selector)
+			}
+			return &show.FestivalInfo{Path: "/campaign/festivals/active/festival-FS0001"}, nil
+		},
+		watch: func(context.Context, *show.FestivalInfo, show.WatchOptions) error {
+			return nil
+		},
+	})
+	cmd.SetArgs([]string{"festival-FS0001"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !calledResolve {
+		t.Fatal("festival resolver was not called")
+	}
+}
+
 func TestWatchCommandCancellationDoesNotCallDelegate(t *testing.T) {
 	cmd := newWatchCommand(commandDeps{
 		resolve: func(context.Context, string) (*show.FestivalInfo, error) {

--- a/tests/integration/standalone_workflow_test.go
+++ b/tests/integration/standalone_workflow_test.go
@@ -4,6 +4,7 @@
 package integration
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
@@ -195,4 +196,119 @@ Do the second thing.
 		out, err = container.RunFestInDir(showDir, "workflow", "show")
 		require.Error(t, err, "show must surface scanner error from corrupt event stream: %s", out)
 	})
+}
+
+func TestStandaloneWorkflow_TopLevelShowAndWatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	container := GetSharedContainer(t)
+
+	t.Run("ShowAnonymousWorkflow", func(t *testing.T) {
+		dir := "/tmp/standalone-top-show-anonymous"
+		_, _ = container.Exec("rm", "-rf", dir)
+		require.NoError(t, container.WriteFile(dir+"/WORKFLOW.md", `# Top Level Workflow
+
+## Step 1: First
+
+**Goal:** show the first step.
+
+## Step 2: Second
+
+**Goal:** show the second step.
+`))
+
+		out, err := container.RunFestInDir(dir, "show")
+		require.NoError(t, err, "fest show should support anonymous WORKFLOW.md: %s", out)
+		require.Contains(t, out, "Workflow Progress")
+		require.Contains(t, out, "Mode: anonymous")
+		require.Contains(t, out, "Progress: 0/2")
+		require.Contains(t, out, "Step 1: First")
+		require.Contains(t, out, "Step 2: Second")
+		require.Contains(t, out, "fest workflow advance")
+
+		jsonOut, err := container.RunFestInDir(dir, "show", "--json")
+		require.NoError(t, err, "fest show --json should support anonymous WORKFLOW.md: %s", jsonOut)
+		require.Contains(t, jsonOut, `"mode": "standalone-anonymous"`)
+		require.Contains(t, jsonOut, `"total_steps": 2`)
+	})
+
+	t.Run("ShowTrackedWorkflowProgress", func(t *testing.T) {
+		dir := "/tmp/standalone-top-show-tracked"
+		_, _ = container.Exec("rm", "-rf", dir)
+		require.NoError(t, container.WriteFile(dir+"/WORKFLOW.md", `# Tracked Workflow
+
+## Step 1: First
+
+**Goal:** complete the first step.
+
+## Step 2: Second
+
+**Goal:** continue to the second step.
+`))
+
+		out, err := container.RunFestInDir(dir, "workflow", "init")
+		require.NoError(t, err, "workflow init: %s", out)
+		out, err = container.RunFestInDir(dir, "workflow", "start")
+		require.NoError(t, err, "workflow start: %s", out)
+		out, err = container.RunFestInDir(dir, "workflow", "advance")
+		require.NoError(t, err, "workflow advance: %s", out)
+
+		out, err = container.RunFestInDir(dir, "show")
+		require.NoError(t, err, "fest show should support tracked WORKFLOW.md: %s", out)
+		require.Contains(t, out, "Mode: tracked")
+		require.Contains(t, out, "Progress: 1/2")
+		require.Contains(t, out, "Step 1: First")
+		require.Contains(t, out, "Step 2: Second")
+		require.Contains(t, out, "Current: Step 2 - Second")
+	})
+
+	t.Run("WatchAnonymousWorkflowInitialRender", func(t *testing.T) {
+		dir := "/tmp/standalone-top-watch-anonymous"
+		_, _ = container.Exec("rm", "-rf", dir)
+		require.NoError(t, container.WriteFile(dir+"/WORKFLOW.md", `# Watch Workflow
+
+## Step 1: First
+
+**Goal:** render first.
+
+## Step 2: Second
+
+**Goal:** render second.
+`))
+
+		output, exitCode := runStandaloneFestWatchBounded(t, container, dir)
+		require.Contains(t, []int{124, 143}, exitCode, "watch should stay running until bounded timeout after initial render")
+		require.Contains(t, output, "Workflow Progress")
+		require.Contains(t, output, "Step 1: First")
+		require.Contains(t, output, "Step 2: Second")
+		require.True(t,
+			strings.Contains(output, "Watching for changes") || strings.Contains(output, "Polling for changes"),
+			"watch output should include watch footer, got:\n%s",
+			output,
+		)
+		require.NotContains(t, output, "festival could not be resolved")
+	})
+}
+
+func runStandaloneFestWatchBounded(t *testing.T, tc *TestContainer, cwd string) (string, int) {
+	t.Helper()
+
+	outputPath := "/tmp/fest-standalone-watch-output"
+	cmd := "cd " + shellQuote(cwd) + " && rm -f " + outputPath + " && set +e; timeout 2s /fest watch"
+	cmd += " > " + outputPath + " 2>&1; code=$?; cat " + outputPath + "; printf '\\n__FEST_STANDALONE_WATCH_EXIT_CODE:%d\\n' \"$code\""
+
+	output, err := tc.runCommand([]string{"sh", "-c", cmd})
+	require.NoError(t, err, "fest watch should start")
+
+	marker := "\n__FEST_STANDALONE_WATCH_EXIT_CODE:"
+	idx := strings.LastIndex(output, marker)
+	require.NotEqual(t, -1, idx, "bounded watch output should include exit marker: %s", output)
+
+	codeText := strings.TrimSpace(output[idx+len(marker):])
+	exitCode, err := strconv.Atoi(codeText)
+	require.NoError(t, err, "bounded watch exit code should parse")
+
+	return output[:idx], exitCode
 }


### PR DESCRIPTION
## Summary

- add top-level `fest show` support for standalone `WORKFLOW.md` directories
- add `fest watch` / `fest show --watch` support for standalone workflow progress rendering
- preserve festival selector, linked project, and picker behavior while allowing bare workflow directories to bypass workspace scope

## Validation

- `go test -short ./...`
- `just build test-binary`
- `go test -v -tags=integration -run TestStandaloneWorkflow_TopLevelShowAndWatch ./tests/integration -timeout 5m`
- `just test integration-dev-watch`
- local smoke: `fest show --no-color` and `fest show --no-color --json` from a temp directory containing only `WORKFLOW.md`
