### PR TITLE
Support standalone workflow show and watch

### DIFF
--- a/internal/commands/progress/watch.go
+++ b/internal/commands/progress/watch.go
@@ -45,6 +45,9 @@ func runWatchMode(ctx context.Context, mgr *progress.Manager, loc *show.Location
 	w, err := watch.New(watch.Config{
 		Paths:    watchPaths,
 		Debounce: 100 * time.Millisecond,
+		OnError: func(err error) {
+			fmt.Fprintf(os.Stderr, "%s file watch error: %v\n", ui.Warning("Warning:"), err)
+		},
 	}, func() {
 		clearScreen()
 		// Refresh progress manager to get latest data
@@ -54,7 +57,7 @@ func runWatchMode(ctx context.Context, mgr *progress.Manager, loc *show.Location
 		}
 		if err := showProgressOverview(ctx, mgr, loc, opts); err != nil {
 			// Log error but don't fail - just show stale data
-			_ = err
+			fmt.Fprintf(os.Stderr, "%s could not refresh progress view: %v\n", ui.Warning("Warning:"), err)
 		}
 		printWatchFooter(false, opts.interval)
 	})

--- a/internal/commands/show/show.go
+++ b/internal/commands/show/show.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/id"
 	"github.com/Obedience-Corp/fest/internal/pathutil"
+	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/workspace"
 	"github.com/spf13/cobra"
 )
@@ -46,6 +47,9 @@ SUBCOMMANDS:
   fest show all          List all festivals grouped by status
   fest show <name>       Show details of a specific festival by name
   fest show --festival <selector>  Show a festival by explicit selector (campaign workspace)`,
+		Annotations: map[string]string{
+			"scope": string(scope.Global),
+		},
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.festival != "" && len(args) > 0 {
@@ -188,6 +192,11 @@ func runShowCurrent(ctx context.Context, opts *showOptions) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return errors.IO("getting current directory", err)
+	}
+
+	handled, err := runShowStandaloneCurrent(ctx, cwd, opts)
+	if err != nil || handled {
+		return err
 	}
 
 	campaignRoot, _ := workspace.DetectCampaign(ctx, "")

--- a/internal/commands/show/standalone.go
+++ b/internal/commands/show/standalone.go
@@ -1,0 +1,376 @@
+package show
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Obedience-Corp/fest/internal/commands/shared"
+	"github.com/Obedience-Corp/fest/internal/errors"
+	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+	"github.com/Obedience-Corp/fest/internal/ui"
+	"github.com/Obedience-Corp/fest/internal/workflow/localstore"
+	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
+)
+
+const (
+	standaloneModeAnonymous = "standalone-anonymous"
+	standaloneModeTracked   = "standalone-tracked"
+
+	renderModeNoRun      = "no_run"
+	renderModeNextUp     = "next_up"
+	renderModeInProgress = "in_progress"
+	renderModeComplete   = "complete"
+)
+
+// StandaloneWorkflowInfo is the display-ready view of a standalone WORKFLOW.md.
+type StandaloneWorkflowInfo struct {
+	Mode           string
+	StartDir       string
+	WorkflowDoc    string
+	RuntimeDir     string
+	RunID          string
+	RunStatus      string
+	CurrentStep    int
+	TotalSteps     int
+	CompletedSteps int
+	Blocked        bool
+	DocHashChanged bool
+	RenderMode     string
+	Steps          []shared.WorkflowStepView
+}
+
+// ResolveStandaloneWorkflow resolves and loads a standalone WORKFLOW.md view.
+// Festival contexts return nil so callers can continue with festival handling.
+func ResolveStandaloneWorkflow(ctx context.Context, startDir string) (*StandaloneWorkflowInfo, error) {
+	res, err := standalone.Resolve(ctx, startDir)
+	if err != nil {
+		return nil, err
+	}
+	switch res.Mode {
+	case standalone.ModeAnonymous, standalone.ModeTracked:
+		return loadStandaloneWorkflow(ctx, res)
+	default:
+		return nil, nil
+	}
+}
+
+func loadStandaloneWorkflow(ctx context.Context, res *standalone.Result) (*StandaloneWorkflowInfo, error) {
+	steps, err := wf.NewParser().Parse(ctx, res.WorkflowDoc)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing WORKFLOW.md").WithField("path", res.WorkflowDoc)
+	}
+	if len(steps) == 0 {
+		return nil, errors.Validation("WORKFLOW.md has no parseable steps").
+			WithField("path", res.WorkflowDoc).
+			WithHint("add at least one '## Step 1: NAME' header")
+	}
+
+	mode := standaloneModeAnonymous
+	runStatus := "not-started"
+	var state *localstore.RunState
+	if res.Mode == standalone.ModeTracked {
+		mode = standaloneModeTracked
+		store := localstore.Open(res.RuntimeDir, res.WorkflowDoc)
+		var err error
+		state, err = store.LoadActive(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if state != nil {
+			runStatus = state.Status
+		}
+	}
+
+	views, current, completed, renderMode := buildStandaloneStepViews(steps, state)
+	info := &StandaloneWorkflowInfo{
+		Mode:           mode,
+		StartDir:       res.StartDir,
+		WorkflowDoc:    res.WorkflowDoc,
+		RuntimeDir:     res.RuntimeDir,
+		RunStatus:      runStatus,
+		CurrentStep:    current,
+		TotalSteps:     len(steps),
+		CompletedSteps: completed,
+		RenderMode:     renderMode,
+		Steps:          views,
+	}
+	if state != nil {
+		info.RunID = state.RunID
+		info.Blocked = state.Blocked
+		info.DocHashChanged = state.DocHashChanged
+	}
+	return info, nil
+}
+
+func buildStandaloneStepViews(steps []wf.WorkflowStep, state *localstore.RunState) ([]shared.WorkflowStepView, int, int, string) {
+	total := len(steps)
+	current, renderMode := standaloneRenderPosition(state, total)
+	completed := 0
+	if state != nil {
+		completed = clampStepCount(state.CompletedSteps, total)
+		if state.Status == "completed" {
+			completed = total
+		}
+	}
+
+	views := make([]shared.WorkflowStepView, len(steps))
+	for i, step := range steps {
+		position := i + 1
+		status := wf.StepStatusPending
+		if position <= completed || renderMode == renderModeComplete {
+			status = wf.StepStatusCompleted
+		} else if position == current {
+			switch {
+			case state != nil && state.Blocked:
+				status = wf.StepStatusBlocked
+			case renderMode == renderModeInProgress:
+				status = wf.StepStatusInProgress
+			default:
+				status = wf.StepStatusPending
+			}
+		}
+
+		views[i] = shared.WorkflowStepView{
+			Number:        step.Number,
+			Name:          step.Name,
+			Status:        status,
+			IsCurrent:     position == current && renderMode != renderModeComplete,
+			HasCheckpoint: step.HasCheckpoint(),
+			Goal:          step.Goal,
+		}
+	}
+	return views, current, completed, renderMode
+}
+
+func standaloneRenderPosition(state *localstore.RunState, totalSteps int) (int, string) {
+	if totalSteps == 0 {
+		return 0, renderModeNoRun
+	}
+	if state == nil {
+		return 1, renderModeNextUp
+	}
+	if state.Status == "completed" || state.CompletedSteps >= totalSteps {
+		return totalSteps, renderModeComplete
+	}
+	if state.CurrentStep > state.CompletedSteps {
+		return clampStepCount(state.CurrentStep, totalSteps), renderModeInProgress
+	}
+	next := state.CompletedSteps + 1
+	if next > totalSteps {
+		return totalSteps, renderModeComplete
+	}
+	if next < 1 {
+		return 1, renderModeNextUp
+	}
+	return next, renderModeNextUp
+}
+
+func clampStepCount(n, total int) int {
+	if n < 0 {
+		return 0
+	}
+	if total > 0 && n > total {
+		return total
+	}
+	return n
+}
+
+func emitStandaloneWorkflow(info *StandaloneWorkflowInfo, opts *showOptions) error {
+	renderOpts := standaloneRenderOptionsFromShow(opts)
+	if opts != nil && opts.json {
+		return emitStandaloneWorkflowJSON(info)
+	}
+	if renderOpts.Summary {
+		fmt.Print(FormatStandaloneWorkflowSummary(info))
+		return nil
+	}
+	fmt.Print(formatStandaloneWorkflowProgress(info, renderOpts))
+	return nil
+}
+
+func runShowStandaloneCurrent(ctx context.Context, cwd string, opts *showOptions) (bool, error) {
+	standaloneWorkflow, err := ResolveStandaloneWorkflow(ctx, cwd)
+	if err != nil {
+		return false, err
+	}
+	if standaloneWorkflow == nil {
+		return false, nil
+	}
+	if opts != nil && opts.watch {
+		return true, WatchStandaloneWorkflow(ctx, standaloneWorkflow, WatchOptions{
+			Summary:    opts.summary,
+			Goals:      opts.goals,
+			Collapsed:  opts.collapsed,
+			InProgress: opts.inProgress,
+		})
+	}
+	return true, emitStandaloneWorkflow(standaloneWorkflow, opts)
+}
+
+type standaloneRenderOptions struct {
+	Summary    bool
+	ShowGoals  bool
+	Collapsed  bool
+	InProgress bool
+}
+
+func standaloneRenderOptionsFromShow(opts *showOptions) standaloneRenderOptions {
+	if opts == nil {
+		return standaloneRenderOptions{}
+	}
+	return standaloneRenderOptions{
+		Summary:    opts.summary,
+		ShowGoals:  opts.goals,
+		Collapsed:  opts.collapsed,
+		InProgress: opts.inProgress,
+	}
+}
+
+func standaloneRenderOptionsFromWatch(opts WatchOptions) standaloneRenderOptions {
+	return standaloneRenderOptions{
+		Summary:    opts.Summary,
+		ShowGoals:  opts.Goals,
+		Collapsed:  opts.Collapsed,
+		InProgress: opts.InProgress,
+	}
+}
+
+// FormatStandaloneWorkflowSummary renders aggregate standalone workflow state.
+func FormatStandaloneWorkflowSummary(info *StandaloneWorkflowInfo) string {
+	var sb strings.Builder
+	writeStandaloneHeader(&sb, info)
+	return sb.String()
+}
+
+// FormatStandaloneWorkflowProgress renders standalone workflow state plus steps.
+func FormatStandaloneWorkflowProgress(info *StandaloneWorkflowInfo) string {
+	return formatStandaloneWorkflowProgress(info, standaloneRenderOptions{})
+}
+
+func formatStandaloneWorkflowProgress(info *StandaloneWorkflowInfo, opts standaloneRenderOptions) string {
+	var sb strings.Builder
+	writeStandaloneHeader(&sb, info)
+	current := currentStandaloneStep(info)
+	if opts.Collapsed {
+		if current != nil {
+			fmt.Fprintf(&sb, "Current: Step %d - %s\n", current.Number, current.Name)
+		}
+		return sb.String()
+	}
+
+	sb.WriteString("\n")
+	sb.WriteString(renderStandaloneSteps(info.Steps, opts))
+	if current != nil {
+		fmt.Fprintf(&sb, "\nCurrent: Step %d - %s\n", current.Number, current.Name)
+	}
+	if info.DocHashChanged {
+		fmt.Fprintf(&sb, "%s WORKFLOW.md has changed since this run started\n", ui.Warning("!"))
+	}
+	if info.RenderMode != renderModeComplete {
+		if info.Mode == standaloneModeAnonymous {
+			sb.WriteString("First mutating command: ")
+		} else {
+			sb.WriteString("Next: ")
+		}
+		sb.WriteString(ui.Accent("fest workflow advance"))
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+func renderStandaloneSteps(steps []shared.WorkflowStepView, opts standaloneRenderOptions) string {
+	filtered := steps
+	if opts.InProgress {
+		filtered = make([]shared.WorkflowStepView, 0, len(steps))
+		for _, step := range steps {
+			if step.Status == wf.StepStatusCompleted || step.Status == wf.StepStatusSkipped {
+				continue
+			}
+			filtered = append(filtered, step)
+		}
+	}
+	return shared.RenderWorkflowSteps(filtered, !opts.ShowGoals)
+}
+
+func writeStandaloneHeader(sb *strings.Builder, info *StandaloneWorkflowInfo) {
+	sb.WriteString("Workflow Progress\n")
+	sb.WriteString("-----------------\n")
+	fmt.Fprintf(sb, "Workflow: %s\n", info.WorkflowDoc)
+	fmt.Fprintf(sb, "Mode: %s\n", strings.TrimPrefix(info.Mode, "standalone-"))
+	if info.RunID != "" {
+		fmt.Fprintf(sb, "Run: %s (%s)\n", info.RunID, info.RunStatus)
+	} else {
+		fmt.Fprintf(sb, "Status: %s\n", info.RunStatus)
+	}
+	if info.Blocked {
+		fmt.Fprintf(sb, "Blocked: true\n")
+	}
+	fmt.Fprintf(sb, "Progress: %s steps\n", shared.RenderWorkflowProgress(info.CompletedSteps, info.TotalSteps))
+}
+
+func currentStandaloneStep(info *StandaloneWorkflowInfo) *shared.WorkflowStepView {
+	if info == nil || info.RenderMode == renderModeComplete {
+		return nil
+	}
+	for i := range info.Steps {
+		if info.Steps[i].IsCurrent {
+			return &info.Steps[i]
+		}
+	}
+	return nil
+}
+
+type standaloneWorkflowJSON struct {
+	Mode           string                   `json:"mode"`
+	WorkflowDoc    string                   `json:"workflow_doc"`
+	RuntimeDir     string                   `json:"runtime_dir,omitempty"`
+	RunID          string                   `json:"run_id,omitempty"`
+	RunStatus      string                   `json:"run_status"`
+	CurrentStep    int                      `json:"current_step"`
+	TotalSteps     int                      `json:"total_steps"`
+	CompletedSteps int                      `json:"completed_steps"`
+	Blocked        bool                     `json:"blocked,omitempty"`
+	DocHashChanged bool                     `json:"doc_hash_changed,omitempty"`
+	Steps          []standaloneWorkflowStep `json:"steps"`
+}
+
+type standaloneWorkflowStep struct {
+	Number        int    `json:"number"`
+	Name          string `json:"name"`
+	Status        string `json:"status"`
+	Current       bool   `json:"current,omitempty"`
+	HasCheckpoint bool   `json:"has_checkpoint,omitempty"`
+	Goal          string `json:"goal,omitempty"`
+}
+
+func emitStandaloneWorkflowJSON(info *StandaloneWorkflowInfo) error {
+	out := standaloneWorkflowJSON{
+		Mode:           info.Mode,
+		WorkflowDoc:    info.WorkflowDoc,
+		RuntimeDir:     info.RuntimeDir,
+		RunID:          info.RunID,
+		RunStatus:      info.RunStatus,
+		CurrentStep:    info.CurrentStep,
+		TotalSteps:     info.TotalSteps,
+		CompletedSteps: info.CompletedSteps,
+		Blocked:        info.Blocked,
+		DocHashChanged: info.DocHashChanged,
+		Steps:          make([]standaloneWorkflowStep, 0, len(info.Steps)),
+	}
+	for _, step := range info.Steps {
+		out.Steps = append(out.Steps, standaloneWorkflowStep{
+			Number:        step.Number,
+			Name:          step.Name,
+			Status:        string(step.Status),
+			Current:       step.IsCurrent,
+			HasCheckpoint: step.HasCheckpoint,
+			Goal:          step.Goal,
+		})
+	}
+	if err := shared.EncodeJSON(os.Stdout, out); err != nil {
+		return errors.Wrap(err, "encoding JSON output")
+	}
+	return nil
+}

--- a/internal/commands/show/standalone_test.go
+++ b/internal/commands/show/standalone_test.go
@@ -1,0 +1,146 @@
+package show
+
+import (
+	"strings"
+	"testing"
+
+	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+	"github.com/Obedience-Corp/fest/internal/workflow/localstore"
+)
+
+func TestBuildStandaloneStepViewsAnonymousMarksFirstStepCurrent(t *testing.T) {
+	steps := []wf.WorkflowStep{
+		{Number: 1, Name: "First", Goal: "Start"},
+		{Number: 2, Name: "Second"},
+	}
+
+	views, current, completed, renderMode := buildStandaloneStepViews(steps, nil)
+
+	if current != 1 {
+		t.Fatalf("current = %d, want 1", current)
+	}
+	if completed != 0 {
+		t.Fatalf("completed = %d, want 0", completed)
+	}
+	if renderMode != renderModeNextUp {
+		t.Fatalf("renderMode = %q, want %s", renderMode, renderModeNextUp)
+	}
+	if !views[0].IsCurrent {
+		t.Fatal("first step should be marked current")
+	}
+	if views[0].Status != wf.StepStatusPending {
+		t.Fatalf("first status = %q, want pending", views[0].Status)
+	}
+	if views[1].Status != wf.StepStatusPending {
+		t.Fatalf("second status = %q, want pending", views[1].Status)
+	}
+}
+
+func TestBuildStandaloneStepViewsTrackedRunProgress(t *testing.T) {
+	steps := []wf.WorkflowStep{
+		{Number: 1, Name: "First"},
+		{Number: 2, Name: "Second"},
+		{Number: 3, Name: "Third"},
+	}
+	state := &localstore.RunState{
+		Status:         "active",
+		CurrentStep:    2,
+		CompletedSteps: 1,
+	}
+
+	views, current, completed, renderMode := buildStandaloneStepViews(steps, state)
+
+	if current != 2 {
+		t.Fatalf("current = %d, want 2", current)
+	}
+	if completed != 1 {
+		t.Fatalf("completed = %d, want 1", completed)
+	}
+	if renderMode != renderModeInProgress {
+		t.Fatalf("renderMode = %q, want %s", renderMode, renderModeInProgress)
+	}
+	if views[0].Status != wf.StepStatusCompleted {
+		t.Fatalf("step 1 status = %q, want completed", views[0].Status)
+	}
+	if views[1].Status != wf.StepStatusInProgress || !views[1].IsCurrent {
+		t.Fatalf("step 2 = status %q current %v, want in_progress/current", views[1].Status, views[1].IsCurrent)
+	}
+	if views[2].Status != wf.StepStatusPending {
+		t.Fatalf("step 3 status = %q, want pending", views[2].Status)
+	}
+}
+
+func TestFormatStandaloneWorkflowProgressIncludesStepsAndProgress(t *testing.T) {
+	steps := []wf.WorkflowStep{
+		{Number: 1, Name: "First", Goal: "Start"},
+		{Number: 2, Name: "Second"},
+	}
+	views, current, completed, renderMode := buildStandaloneStepViews(steps, nil)
+	info := &StandaloneWorkflowInfo{
+		Mode:           standaloneModeAnonymous,
+		WorkflowDoc:    "/tmp/demo/WORKFLOW.md",
+		RunStatus:      "not-started",
+		CurrentStep:    current,
+		TotalSteps:     len(steps),
+		CompletedSteps: completed,
+		RenderMode:     renderMode,
+		Steps:          views,
+	}
+
+	got := FormatStandaloneWorkflowProgress(info)
+	for _, want := range []string{
+		"Workflow Progress",
+		"Progress: 0/2 (0%) steps",
+		"Step 1: First",
+		"Step 2: Second",
+		"Current: Step 1 - First",
+		"fest workflow advance",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("formatted output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestFormatStandaloneWorkflowProgressHonorsRenderOptions(t *testing.T) {
+	steps := []wf.WorkflowStep{
+		{Number: 1, Name: "First", Goal: "Start here"},
+		{Number: 2, Name: "Second", Goal: "Continue"},
+	}
+	views, current, completed, renderMode := buildStandaloneStepViews(steps, &localstore.RunState{
+		Status:         "active",
+		CurrentStep:    2,
+		CompletedSteps: 1,
+	})
+	info := &StandaloneWorkflowInfo{
+		Mode:           standaloneModeTracked,
+		WorkflowDoc:    "/tmp/demo/WORKFLOW.md",
+		RunStatus:      "active",
+		CurrentStep:    current,
+		TotalSteps:     len(steps),
+		CompletedSteps: completed,
+		RenderMode:     renderMode,
+		Steps:          views,
+	}
+
+	collapsed := formatStandaloneWorkflowProgress(info, standaloneRenderOptions{Collapsed: true})
+	if strings.Contains(collapsed, "Step 1: First") || strings.Contains(collapsed, "Step 2: Second") {
+		t.Fatalf("collapsed output should omit step list:\n%s", collapsed)
+	}
+	if !strings.Contains(collapsed, "Current: Step 2 - Second") {
+		t.Fatalf("collapsed output should include current step:\n%s", collapsed)
+	}
+
+	inProgress := formatStandaloneWorkflowProgress(info, standaloneRenderOptions{InProgress: true})
+	if strings.Contains(inProgress, "Step 1: First") {
+		t.Fatalf("in-progress output should omit completed steps:\n%s", inProgress)
+	}
+	if !strings.Contains(inProgress, "Step 2: Second") {
+		t.Fatalf("in-progress output should include current step:\n%s", inProgress)
+	}
+
+	withGoals := formatStandaloneWorkflowProgress(info, standaloneRenderOptions{ShowGoals: true})
+	if !strings.Contains(withGoals, "Goal: Continue") {
+		t.Fatalf("goals output should include current goal:\n%s", withGoals)
+	}
+}

--- a/internal/commands/show/standalone_watch.go
+++ b/internal/commands/show/standalone_watch.go
@@ -1,0 +1,129 @@
+package show
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/ui"
+	filewatch "github.com/Obedience-Corp/fest/internal/watch"
+)
+
+// WatchStandaloneWorkflow watches and refreshes a standalone WORKFLOW.md view.
+func WatchStandaloneWorkflow(ctx context.Context, info *StandaloneWorkflowInfo, opts WatchOptions) error {
+	if info == nil {
+		return errors.Validation("standalone workflow is required")
+	}
+	startDir := info.StartDir
+	if startDir == "" {
+		startDir = filepath.Dir(info.WorkflowDoc)
+	}
+	return runStandaloneWatchMode(ctx, startDir, opts)
+}
+
+func runStandaloneWatchMode(ctx context.Context, startDir string, opts WatchOptions) error {
+	session := &standaloneWatchSession{startDir: startDir, opts: opts}
+	w, err := filewatch.New(filewatch.Config{
+		Debounce: filewatch.DefaultDebounce,
+		OnError:  session.reportWatchError,
+	}, func() {
+		session.renderOrWarn(ctx, false)
+	})
+	if err != nil {
+		wrapped := errors.IO("creating standalone workflow watcher", err)
+		fmt.Fprintf(os.Stderr, "File watching unavailable (%v), using polling fallback\n", wrapped)
+		return runStandalonePollingMode(ctx, startDir, opts)
+	}
+	defer func() { _ = w.Close() }()
+
+	session.watcher = w
+	if err := session.render(ctx, false); err != nil {
+		return err
+	}
+	return w.Watch(ctx)
+}
+
+func runStandalonePollingMode(ctx context.Context, startDir string, opts WatchOptions) error {
+	ticker := time.NewTicker(pollingInterval)
+	defer ticker.Stop()
+
+	session := &standaloneWatchSession{startDir: startDir, opts: opts}
+	if err := session.render(ctx, true); err != nil {
+		return err
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Println()
+			return nil
+		case <-ticker.C:
+			session.renderOrWarn(ctx, true)
+		}
+	}
+}
+
+type standaloneWatchSession struct {
+	startDir string
+	opts     WatchOptions
+	watcher  *filewatch.Watcher
+}
+
+func (s *standaloneWatchSession) render(ctx context.Context, polling bool) error {
+	info, err := ResolveStandaloneWorkflow(ctx, s.startDir)
+	if err != nil {
+		return err
+	}
+	if info == nil {
+		return errors.NotFound("standalone workflow").WithField("path", s.startDir)
+	}
+
+	clearScreen()
+	fmt.Print(formatStandaloneWorkflowProgress(info, standaloneRenderOptionsFromWatch(s.opts)))
+	printWatchFooter(polling)
+	s.addWatchPaths(info)
+	return nil
+}
+
+func (s *standaloneWatchSession) renderOrWarn(ctx context.Context, polling bool) {
+	if err := s.render(ctx, polling); err != nil {
+		fmt.Fprintf(os.Stderr, "%s could not refresh standalone workflow view: %v\n", ui.Warning("Warning:"), err)
+	}
+}
+
+func (s *standaloneWatchSession) reportWatchError(err error) {
+	fmt.Fprintf(os.Stderr, "%s file watch error: %v\n", ui.Warning("Warning:"), err)
+}
+
+func (s *standaloneWatchSession) addWatchPaths(info *StandaloneWorkflowInfo) {
+	s.addWatchPath(filepath.Dir(info.WorkflowDoc))
+	s.addWatchPath(info.WorkflowDoc)
+	s.addWatchPath(info.RuntimeDir)
+	if info.RuntimeDir != "" {
+		s.addWatchPath(filepath.Join(info.RuntimeDir, "runs"))
+	}
+	if info.RuntimeDir != "" && info.RunID != "" {
+		s.addWatchPath(filepath.Join(info.RuntimeDir, "runs", info.RunID))
+	}
+}
+
+func (s *standaloneWatchSession) addWatchPath(path string) {
+	if path == "" || s.watcher == nil {
+		return
+	}
+	stat, err := os.Stat(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "%s could not inspect %s: %v\n", ui.Warning("Warning:"), path, err)
+		}
+		return
+	}
+	if !stat.IsDir() && filepath.Base(path) != "WORKFLOW.md" {
+		return
+	}
+	if err := s.watcher.AddPath(path); err != nil {
+		fmt.Fprintf(os.Stderr, "%s could not watch %s: %v\n", ui.Warning("Warning:"), path, err)
+	}
+}

--- a/internal/commands/show/watch.go
+++ b/internal/commands/show/watch.go
@@ -70,6 +70,9 @@ func runWatchMode(ctx context.Context, festival *FestivalInfo, opts *showOptions
 	w, err := watch.New(watch.Config{
 		Paths:    watchPaths,
 		Debounce: 100 * time.Millisecond,
+		OnError: func(err error) {
+			fmt.Fprintf(os.Stderr, "%s file watch error: %v\n", ui.Warning("Warning:"), err)
+		},
 	}, func() {
 		clearScreen()
 		// Refresh festival info to get latest data
@@ -79,7 +82,7 @@ func runWatchMode(ctx context.Context, festival *FestivalInfo, opts *showOptions
 		}
 		if err := renderFestivalView(ctx, festival, opts); err != nil {
 			// Log error but don't fail - just show stale data
-			_ = err
+			fmt.Fprintf(os.Stderr, "%s could not refresh festival view: %v\n", ui.Warning("Warning:"), err)
 		}
 		printWatchFooter(false)
 	})

--- a/internal/commands/watch/command.go
+++ b/internal/commands/watch/command.go
@@ -3,8 +3,10 @@ package watch
 
 import (
 	"context"
+	"os"
 
 	"github.com/Obedience-Corp/fest/internal/commands/show"
+	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/spf13/cobra"
 )
@@ -16,8 +18,10 @@ type options struct {
 }
 
 type commandDeps struct {
-	resolve func(context.Context, string) (*show.FestivalInfo, error)
-	watch   func(context.Context, *show.FestivalInfo, show.WatchOptions) error
+	resolve           func(context.Context, string) (*show.FestivalInfo, error)
+	resolveStandalone func(context.Context) (*show.StandaloneWorkflowInfo, error)
+	watch             func(context.Context, *show.FestivalInfo, show.WatchOptions) error
+	watchStandalone   func(context.Context, *show.StandaloneWorkflowInfo, show.WatchOptions) error
 }
 
 // NewWatchCommand creates the watch command.
@@ -30,8 +34,18 @@ func defaultCommandDeps() commandDeps {
 		resolve: func(ctx context.Context, selector string) (*show.FestivalInfo, error) {
 			return defaultResolver().resolve(ctx, selector)
 		},
-		watch: show.WatchFestival,
+		resolveStandalone: defaultResolveStandaloneWorkflow,
+		watch:             show.WatchFestival,
+		watchStandalone:   show.WatchStandaloneWorkflow,
 	}
+}
+
+func defaultResolveStandaloneWorkflow(ctx context.Context) (*show.StandaloneWorkflowInfo, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, errors.IO("getting current directory", err)
+	}
+	return show.ResolveStandaloneWorkflow(ctx, cwd)
 }
 
 func newWatchCommand(deps commandDeps) *cobra.Command {
@@ -44,7 +58,8 @@ func newWatchCommand(deps commandDeps) *cobra.Command {
 
 With a selector, fest watch resolves a festival by directory name or logical ID.
 Without a selector, it watches the current festival when run from a festival
-directory, or the linked festival when run from a linked project directory.
+directory, the linked festival when run from a linked project directory, or a
+standalone WORKFLOW.md from that workflow directory.
 
 From a campaign or festivals workspace in an interactive terminal, fest watch
 opens a festival picker. Watch mode refreshes in place until you press Ctrl+C.
@@ -55,7 +70,7 @@ It does not change your shell directory.`,
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: completeWatchSelector,
 		Annotations: map[string]string{
-			"scope":        string(scope.Workspace),
+			"scope":        string(scope.Global),
 			"interactive":  "true",
 			"long_running": "true",
 		},
@@ -77,6 +92,16 @@ func runWatch(ctx context.Context, args []string, opts *options, deps commandDep
 		selector = args[0]
 	}
 
+	if selector == "" && deps.resolveStandalone != nil {
+		workflow, err := deps.resolveStandalone(ctx)
+		if err != nil {
+			return err
+		}
+		if workflow != nil {
+			return watchStandaloneWorkflow(ctx, workflow, *opts, deps)
+		}
+	}
+
 	festival, err := deps.resolve(ctx, selector)
 	if err != nil {
 		if isWatchPickerCancelled(err) {
@@ -89,6 +114,13 @@ func runWatch(ctx context.Context, args []string, opts *options, deps commandDep
 
 func watchFestival(ctx context.Context, festival *show.FestivalInfo, opts options, deps commandDeps) error {
 	return deps.watch(ctx, festival, showWatchOptions(opts))
+}
+
+func watchStandaloneWorkflow(ctx context.Context, workflow *show.StandaloneWorkflowInfo, opts options, deps commandDeps) error {
+	if deps.watchStandalone == nil {
+		return errors.Validation("standalone watch delegate is required")
+	}
+	return deps.watchStandalone(ctx, workflow, showWatchOptions(opts))
 }
 
 func showWatchOptions(opts options) show.WatchOptions {

--- a/internal/commands/watch/command_test.go
+++ b/internal/commands/watch/command_test.go
@@ -81,6 +81,74 @@ func TestWatchCommandDelegatesWithMappedOptions(t *testing.T) {
 	}
 }
 
+func TestWatchCommandStandaloneWorkflowDelegatesBeforeFestivalResolution(t *testing.T) {
+	var gotWorkflow *show.StandaloneWorkflowInfo
+	var gotOptions show.WatchOptions
+	calledStandalone := false
+
+	cmd := newWatchCommand(commandDeps{
+		resolveStandalone: func(context.Context) (*show.StandaloneWorkflowInfo, error) {
+			return &show.StandaloneWorkflowInfo{StartDir: "/workspace/workflow", WorkflowDoc: "/workspace/workflow/WORKFLOW.md"}, nil
+		},
+		resolve: func(context.Context, string) (*show.FestivalInfo, error) {
+			t.Fatal("festival resolver should not be called for standalone workflow context")
+			return nil, nil
+		},
+		watch: func(context.Context, *show.FestivalInfo, show.WatchOptions) error {
+			t.Fatal("festival watch delegate should not be called for standalone workflow context")
+			return nil
+		},
+		watchStandalone: func(_ context.Context, workflow *show.StandaloneWorkflowInfo, opts show.WatchOptions) error {
+			calledStandalone = true
+			gotWorkflow = workflow
+			gotOptions = opts
+			return nil
+		},
+	})
+	cmd.SetArgs([]string{"--summary"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !calledStandalone {
+		t.Fatal("standalone watch delegate was not called")
+	}
+	if gotWorkflow == nil || gotWorkflow.WorkflowDoc != "/workspace/workflow/WORKFLOW.md" {
+		t.Fatalf("workflow = %#v", gotWorkflow)
+	}
+	if !gotOptions.InProgress || !gotOptions.Summary {
+		t.Fatalf("watch options were not mapped for standalone workflow: %#v", gotOptions)
+	}
+}
+
+func TestWatchCommandSelectorSkipsStandaloneResolution(t *testing.T) {
+	calledResolve := false
+	cmd := newWatchCommand(commandDeps{
+		resolveStandalone: func(context.Context) (*show.StandaloneWorkflowInfo, error) {
+			t.Fatal("standalone resolver should not be called when selector is explicit")
+			return nil, nil
+		},
+		resolve: func(_ context.Context, selector string) (*show.FestivalInfo, error) {
+			calledResolve = true
+			if selector != "festival-FS0001" {
+				t.Fatalf("selector = %q", selector)
+			}
+			return &show.FestivalInfo{Path: "/campaign/festivals/active/festival-FS0001"}, nil
+		},
+		watch: func(context.Context, *show.FestivalInfo, show.WatchOptions) error {
+			return nil
+		},
+	})
+	cmd.SetArgs([]string{"festival-FS0001"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !calledResolve {
+		t.Fatal("festival resolver was not called")
+	}
+}
+
 func TestWatchCommandCancellationDoesNotCallDelegate(t *testing.T) {
 	cmd := newWatchCommand(commandDeps{
 		resolve: func(context.Context, string) (*show.FestivalInfo, error) {

--- a/internal/watch/watcher.go
+++ b/internal/watch/watcher.go
@@ -27,6 +27,9 @@ type Config struct {
 	// FallbackPoll is the polling interval to use if fsnotify fails.
 	// If zero, no fallback is used and errors are returned.
 	FallbackPoll time.Duration
+
+	// OnError receives non-fatal watcher errors reported by the OS.
+	OnError func(error)
 }
 
 // Watcher monitors files for changes and calls a callback when changes occur.
@@ -38,6 +41,7 @@ type Watcher struct {
 	mu      sync.Mutex
 	timer   *time.Timer
 	pending bool
+	watched map[string]struct{}
 }
 
 // ErrNoWatchablePaths is returned when none of the specified paths can be watched.
@@ -56,15 +60,24 @@ func New(cfg Config, onChange func()) (*Watcher, error) {
 		return nil, err
 	}
 
-	// Add all paths to the watcher
+	w := &Watcher{
+		config:   cfg,
+		onChange: onChange,
+		watcher:  fsw,
+		watched:  make(map[string]struct{}),
+	}
+
+	// Add all paths to the watcher.
 	watchedCount := 0
 	for _, path := range cfg.Paths {
-		// Only watch paths that exist
-		if _, err := os.Stat(path); err == nil {
-			if err := fsw.Add(path); err != nil {
+		if err := w.AddPath(path); err != nil {
+			if !os.IsNotExist(err) {
 				_ = fsw.Close()
 				return nil, err
 			}
+			continue
+		}
+		if path != "" {
 			watchedCount++
 		}
 	}
@@ -75,11 +88,29 @@ func New(cfg Config, onChange func()) (*Watcher, error) {
 		return nil, ErrNoWatchablePaths
 	}
 
-	return &Watcher{
-		config:   cfg,
-		onChange: onChange,
-		watcher:  fsw,
-	}, nil
+	return w, nil
+}
+
+// AddPath dynamically adds an existing file or directory to the watcher.
+// Re-adding an already watched path is a no-op.
+func (w *Watcher) AddPath(path string) error {
+	if path == "" {
+		return nil
+	}
+	if _, err := os.Stat(path); err != nil {
+		return err
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if _, ok := w.watched[path]; ok {
+		return nil
+	}
+	if err := w.watcher.Add(path); err != nil {
+		return err
+	}
+	w.watched[path] = struct{}{}
+	return nil
 }
 
 // Watch blocks until the context is cancelled, calling onChange when files change.
@@ -95,8 +126,10 @@ func (w *Watcher) Watch(ctx context.Context) error {
 			if !ok {
 				return nil
 			}
-			// Only trigger on write, create, or remove events
-			if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) || event.Has(fsnotify.Remove) {
+			if event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename) {
+				w.removePath(event.Name)
+			}
+			if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) || event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename) {
 				w.scheduleCallback()
 			}
 
@@ -104,10 +137,17 @@ func (w *Watcher) Watch(ctx context.Context) error {
 			if !ok {
 				return nil
 			}
-			// Log but don't fail on transient errors
-			_ = err // Could log this in verbose mode
+			if w.config.OnError != nil {
+				w.config.OnError(err)
+			}
 		}
 	}
+}
+
+func (w *Watcher) removePath(path string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	delete(w.watched, path)
 }
 
 // scheduleCallback schedules the onChange callback after the debounce period.

--- a/internal/watch/watcher_test.go
+++ b/internal/watch/watcher_test.go
@@ -33,6 +33,58 @@ func TestNew(t *testing.T) {
 	}
 }
 
+func TestNewAllowsEmptyPathSet(t *testing.T) {
+	w, err := New(Config{}, func() {})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer func() { _ = w.Close() }()
+}
+
+func TestWatcherAddPathTracksDynamicPath(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	w, err := New(Config{}, func() {})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	if err := w.AddPath(tmpDir); err != nil {
+		t.Fatalf("AddPath() error = %v", err)
+	}
+	if err := w.AddPath(tmpDir); err != nil {
+		t.Fatalf("AddPath() duplicate error = %v", err)
+	}
+	if got := len(w.watched); got != 1 {
+		t.Fatalf("watched path count = %d, want 1", got)
+	}
+}
+
+func TestWatcherRemovePathAllowsReAdd(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	w, err := New(Config{}, func() {})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	if err := w.AddPath(tmpDir); err != nil {
+		t.Fatalf("AddPath() error = %v", err)
+	}
+	w.removePath(tmpDir)
+	if _, ok := w.watched[tmpDir]; ok {
+		t.Fatalf("removePath(%q) left stale cache entry", tmpDir)
+	}
+	if err := w.AddPath(tmpDir); err != nil {
+		t.Fatalf("AddPath() after remove error = %v", err)
+	}
+	if _, ok := w.watched[tmpDir]; !ok {
+		t.Fatalf("AddPath(%q) did not restore cache entry", tmpDir)
+	}
+}
+
 func TestWatcher_Watch_DetectsChanges(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "test.txt")

--- a/tests/integration/standalone_workflow_test.go
+++ b/tests/integration/standalone_workflow_test.go
@@ -4,6 +4,7 @@
 package integration
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
@@ -195,4 +196,168 @@ Do the second thing.
 		out, err = container.RunFestInDir(showDir, "workflow", "show")
 		require.Error(t, err, "show must surface scanner error from corrupt event stream: %s", out)
 	})
+}
+
+func TestStandaloneWorkflow_TopLevelShowAndWatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	container := GetSharedContainer(t)
+
+	t.Run("ShowAnonymousWorkflow", func(t *testing.T) {
+		dir := "/tmp/standalone-top-show-anonymous"
+		_, _ = container.Exec("rm", "-rf", dir)
+		require.NoError(t, container.WriteFile(dir+"/WORKFLOW.md", `# Top Level Workflow
+
+## Step 1: First
+
+**Goal:** show the first step.
+
+## Step 2: Second
+
+**Goal:** show the second step.
+`))
+
+		out, err := container.RunFestInDir(dir, "show")
+		require.NoError(t, err, "fest show should support anonymous WORKFLOW.md: %s", out)
+		require.Contains(t, out, "Workflow Progress")
+		require.Contains(t, out, "Mode: anonymous")
+		require.Contains(t, out, "Progress: 0/2")
+		require.Contains(t, out, "Step 1: First")
+		require.Contains(t, out, "Step 2: Second")
+		require.Contains(t, out, "fest workflow advance")
+
+		jsonOut, err := container.RunFestInDir(dir, "show", "--json")
+		require.NoError(t, err, "fest show --json should support anonymous WORKFLOW.md: %s", jsonOut)
+		require.Contains(t, jsonOut, `"mode": "standalone-anonymous"`)
+		require.Contains(t, jsonOut, `"total_steps": 2`)
+	})
+
+	t.Run("ShowTrackedWorkflowProgress", func(t *testing.T) {
+		dir := "/tmp/standalone-top-show-tracked"
+		_, _ = container.Exec("rm", "-rf", dir)
+		require.NoError(t, container.WriteFile(dir+"/WORKFLOW.md", `# Tracked Workflow
+
+## Step 1: First
+
+**Goal:** complete the first step.
+
+## Step 2: Second
+
+**Goal:** continue to the second step.
+`))
+
+		out, err := container.RunFestInDir(dir, "workflow", "init")
+		require.NoError(t, err, "workflow init: %s", out)
+		out, err = container.RunFestInDir(dir, "workflow", "start")
+		require.NoError(t, err, "workflow start: %s", out)
+		out, err = container.RunFestInDir(dir, "workflow", "advance")
+		require.NoError(t, err, "workflow advance: %s", out)
+
+		out, err = container.RunFestInDir(dir, "show")
+		require.NoError(t, err, "fest show should support tracked WORKFLOW.md: %s", out)
+		require.Contains(t, out, "Mode: tracked")
+		require.Contains(t, out, "Progress: 1/2")
+		require.Contains(t, out, "Step 1: First")
+		require.Contains(t, out, "Step 2: Second")
+		require.Contains(t, out, "Current: Step 2 - Second")
+	})
+
+	t.Run("WatchAnonymousWorkflowInitialRender", func(t *testing.T) {
+		dir := "/tmp/standalone-top-watch-anonymous"
+		_, _ = container.Exec("rm", "-rf", dir)
+		require.NoError(t, container.WriteFile(dir+"/WORKFLOW.md", `# Watch Workflow
+
+## Step 1: First
+
+**Goal:** render first.
+
+## Step 2: Second
+
+**Goal:** render second.
+`))
+
+		output, exitCode := runStandaloneFestWatchBounded(t, container, dir)
+		require.Contains(t, []int{124, 143}, exitCode, "watch should stay running until bounded timeout after initial render")
+		require.Contains(t, output, "Workflow Progress")
+		require.Contains(t, output, "Step 1: First")
+		require.Contains(t, output, "Step 2: Second")
+		require.True(t,
+			strings.Contains(output, "Watching for changes") || strings.Contains(output, "Polling for changes"),
+			"watch output should include watch footer, got:\n%s",
+			output,
+		)
+		require.NotContains(t, output, "festival could not be resolved")
+	})
+
+	t.Run("WatchAnonymousWorkflowRefreshesAfterBootstrap", func(t *testing.T) {
+		dir := "/tmp/standalone-top-watch-bootstrap"
+		_, _ = container.Exec("rm", "-rf", dir)
+		require.NoError(t, container.WriteFile(dir+"/WORKFLOW.md", `# Watch Bootstrap Workflow
+
+## Step 1: First
+
+**Goal:** render first.
+
+## Step 2: Second
+
+**Goal:** render second.
+`))
+
+		output, exitCode := runStandaloneFestWatchWithAdvance(t, container, dir)
+		require.Contains(t, []int{124, 143}, exitCode, "watch should stay running until bounded timeout after refresh")
+		require.Contains(t, output, "Workflow Progress")
+		require.Contains(t, output, "Mode: tracked")
+		require.Contains(t, output, "Progress: 1/2")
+		require.Contains(t, output, "Current: Step 2 - Second")
+		require.Contains(t, output, "Watching for changes")
+		require.NotContains(t, output, "Polling for changes")
+	})
+}
+
+func runStandaloneFestWatchBounded(t *testing.T, tc *TestContainer, cwd string) (string, int) {
+	t.Helper()
+
+	outputPath := "/tmp/fest-standalone-watch-output"
+	cmd := "cd " + shellQuote(cwd) + " && rm -f " + outputPath + " && set +e; timeout 2s /fest watch"
+	cmd += " > " + outputPath + " 2>&1; code=$?; cat " + outputPath + "; printf '\\n__FEST_STANDALONE_WATCH_EXIT_CODE:%d\\n' \"$code\""
+
+	output, err := tc.runCommand([]string{"sh", "-c", cmd})
+	require.NoError(t, err, "fest watch should start")
+
+	marker := "\n__FEST_STANDALONE_WATCH_EXIT_CODE:"
+	idx := strings.LastIndex(output, marker)
+	require.NotEqual(t, -1, idx, "bounded watch output should include exit marker: %s", output)
+
+	codeText := strings.Fields(strings.TrimSpace(output[idx+len(marker):]))
+	require.NotEmpty(t, codeText, "bounded watch exit code should be present")
+	exitCode, err := strconv.Atoi(codeText[0])
+	require.NoError(t, err, "bounded watch exit code should parse")
+
+	return output[:idx], exitCode
+}
+
+func runStandaloneFestWatchWithAdvance(t *testing.T, tc *TestContainer, cwd string) (string, int) {
+	t.Helper()
+
+	outputPath := "/tmp/fest-standalone-watch-bootstrap-output"
+	advancePath := "/tmp/fest-standalone-watch-bootstrap-advance"
+	cmd := "rm -f " + outputPath + " " + advancePath
+	cmd += "; (cd " + shellQuote(cwd) + " && sleep 0.5 && /fest workflow advance > " + advancePath + " 2>&1) &"
+	cmd += " (cd " + shellQuote(cwd) + " && timeout 3s /fest watch > " + outputPath + " 2>&1); code=$?; wait || true; cat " + outputPath + "; printf '\\n__FEST_STANDALONE_WATCH_EXIT_CODE:%d\\n' \"$code\""
+
+	output, err := tc.runCommand([]string{"sh", "-c", cmd})
+	require.NoError(t, err, "fest watch should start and background advance should finish")
+
+	marker := "\n__FEST_STANDALONE_WATCH_EXIT_CODE:"
+	idx := strings.LastIndex(output, marker)
+	require.NotEqual(t, -1, idx, "bounded watch output should include exit marker: %s", output)
+
+	codeText := strings.Fields(strings.TrimSpace(output[idx+len(marker):]))
+	require.NotEmpty(t, codeText, "bounded watch exit code should be present")
+	exitCode, err := strconv.Atoi(codeText[0])
+	require.NoError(t, err, "bounded watch exit code should parse")
+
+	return output[:idx], exitCode
 }


### PR DESCRIPTION
## Summary

- add top-level `fest show` support for standalone `WORKFLOW.md` directories
- add `fest watch` / `fest show --watch` support for standalone workflow progress rendering
- keep standalone watch event-driven with dynamic fsnotify path registration as `.workflow/` appears
- preserve festival selector, linked project, and picker behavior while allowing bare workflow directories to bypass workspace scope

## Validation

- `go test -short ./...`
- `just build test-binary`
- `go test -count=1 -v -tags=integration -run TestStandaloneWorkflow_TopLevelShowAndWatch ./tests/integration -timeout 5m`
- `just test integration-dev-watch`
- local smoke: `fest show --no-color` and `fest show --no-color --json` from a temp directory containing only `WORKFLOW.md`
