### PR TITLE
Start standalone workflow runs on create

### DIFF
--- a/internal/commands/festival/create_workflow_standalone.go
+++ b/internal/commands/festival/create_workflow_standalone.go
@@ -18,8 +18,8 @@ import (
 
 // runStandaloneCreateWorkflow implements `fest create workflow <name>` outside
 // a festival context (D009). It writes <cwd>/WORKFLOW.md from the same
-// WorkflowInput shape festival mode uses, then optionally initializes
-// <cwd>/.workflow/workflow.yaml via localstore.Init.
+// WorkflowInput shape festival mode uses, then initializes
+// <cwd>/.workflow/workflow.yaml and starts a run unless --no-init is set.
 //
 // Festival-only flags (--position, --path, --festival) are rejected here so
 // users get an explicit error rather than confusing silent ignores.
@@ -49,6 +49,17 @@ func runStandaloneCreateWorkflow(ctx context.Context, opts *CreateWorkflowOption
 				WithField("path", target).
 				WithHint("remove it first or pick another directory"))
 	}
+	runtimeDir := filepath.Join(cwd, ".workflow")
+	if !opts.NoInit {
+		if _, err := os.Stat(runtimeDir); err == nil {
+			return emitWorkflowError(opts,
+				errors.Validation(".workflow/ already exists").
+					WithField("path", runtimeDir).
+					WithHint("use `fest workflow start` for an existing tracked workflow, or remove .workflow/ before creating a new one"))
+		} else if !os.IsNotExist(err) {
+			return emitWorkflowError(opts, errors.IO("checking .workflow/", err).WithField("path", runtimeDir))
+		}
+	}
 
 	workflowID := "wf-" + workflow.SanitizeBasenameAsSlug(opts.Name)
 	if err := workflow.ValidateWorkflowID(workflowID); err != nil {
@@ -66,22 +77,34 @@ func runStandaloneCreateWorkflow(ctx context.Context, opts *CreateWorkflowOption
 
 	created := []string{target}
 	runtimeInitialized := false
+	activeRunID := ""
 	if !opts.NoInit {
-		store := localstore.Open(filepath.Join(cwd, ".workflow"), target)
+		store := localstore.Open(runtimeDir, target)
 		if err := store.Init(ctx, localstore.InitOptions{WorkflowID: workflowID}); err != nil {
 			return emitWorkflowError(opts, errors.Wrap(err, "initialize .workflow/"))
 		}
+		runID, err := store.StartRun(ctx, "")
+		if err != nil {
+			_ = os.RemoveAll(runtimeDir)
+			return emitWorkflowError(opts, errors.Wrap(err, "start workflow run"))
+		}
+		activeRunID = runID
 		runtimeInitialized = true
-		created = append(created, filepath.Join(cwd, ".workflow", "workflow.yaml"))
+		created = append(created,
+			filepath.Join(runtimeDir, "workflow.yaml"),
+			filepath.Join(runtimeDir, "runs", runID, "run.yaml"),
+			filepath.Join(runtimeDir, "runs", runID, "progress_events.jsonl"),
+		)
 		if !opts.JSONOutput {
 			fmt.Printf("initialized .workflow/workflow.yaml (workflow_id=%s)\n", workflowID)
+			fmt.Printf("started workflow run %s\n", runID)
 		}
 	} else if !opts.JSONOutput {
 		fmt.Println("skipped .workflow/ init (--no-init); run `fest workflow init` when ready")
 	}
 
 	if opts.JSONOutput {
-		return emitStandaloneWorkflowJSON(opts, input, workflowID, target, created, runtimeInitialized)
+		return emitStandaloneWorkflowJSON(opts, input, workflowID, activeRunID, target, created, runtimeInitialized)
 	}
 
 	fmt.Println("next: fest next")
@@ -92,14 +115,20 @@ func runStandaloneCreateWorkflow(ctx context.Context, opts *CreateWorkflowOption
 // emitStandaloneWorkflowJSON mirrors emitWorkflowOutput's JSON shape for the
 // standalone path so --json / --agent callers receive a structured result
 // instead of an empty stdout. (#173 review)
-func emitStandaloneWorkflowJSON(opts *CreateWorkflowOptions, input *WorkflowInput, workflowID, target string, created []string, runtimeInitialized bool) error {
+func emitStandaloneWorkflowJSON(opts *CreateWorkflowOptions, input *WorkflowInput, workflowID, activeRunID, target string, created []string, runtimeInitialized bool) error {
 	suggestions := []string{
 		"fest next                  - Render the first step",
-		"fest workflow start        - Begin a tracked run",
+		"fest workflow advance      - Complete the current step",
 		"fest workflow show         - Show current step",
 	}
 	if !runtimeInitialized {
-		suggestions = append([]string{"fest workflow init         - Bootstrap .workflow/ runtime"}, suggestions...)
+		suggestions = []string{
+			"fest next                  - Render the first step",
+			"fest workflow advance      - Bootstrap and complete step 1",
+			"fest workflow init         - Bootstrap .workflow/ runtime",
+			"fest workflow start        - Begin a tracked run after init",
+			"fest workflow show         - Show current step",
+		}
 	}
 	return emitWorkflowJSON(opts, createWorkflowResult{
 		OK:     true,
@@ -111,6 +140,7 @@ func emitStandaloneWorkflowJSON(opts *CreateWorkflowOptions, input *WorkflowInpu
 			"title":               input.Title,
 			"steps":               len(input.Steps),
 			"runtime_initialized": runtimeInitialized,
+			"active_run_id":       activeRunID,
 		},
 		Created:     created,
 		Suggestions: suggestions,

--- a/tests/integration/create_workflow_standalone_test.go
+++ b/tests/integration/create_workflow_standalone_test.go
@@ -13,9 +13,9 @@ import (
 const standaloneStepsJSON = `{"title":"My Workflow","description":"Built by integration test","steps":[{"name":"PLAN","goal":"Plan the work","actions":["Think"],"output":"Plan"},{"name":"BUILD","goal":"Build it","actions":["Code"],"output":"Code"}]}`
 
 // TestCreateWorkflowStandalone covers the D009 standalone dispatch surface
-// of `fest create workflow`: writes WORKFLOW.md, initializes .workflow/ unless
-// --no-init is set, refuses overwrite, rejects --festival outside a festival,
-// errors on non-TTY without --steps.
+// of `fest create workflow`: writes WORKFLOW.md, initializes .workflow/ and
+// starts a run unless --no-init is set, refuses overwrite, rejects --festival
+// outside a festival, errors on non-TTY without --steps.
 func TestCreateWorkflowStandalone(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -33,14 +33,25 @@ func TestCreateWorkflowStandalone(t *testing.T) {
 		require.NoError(t, err, "fest create workflow: %s", out)
 		require.Contains(t, out, "created")
 		require.Contains(t, out, "initialized .workflow/workflow.yaml")
+		require.Contains(t, out, "started workflow run")
 		require.Contains(t, out, "workflow_id=wf-demo")
 
 		exists, _ := container.CheckFileExists(dir + "/WORKFLOW.md")
 		require.True(t, exists, "WORKFLOW.md should exist")
 		exists, _ = container.CheckFileExists(dir + "/.workflow/workflow.yaml")
 		require.True(t, exists, ".workflow/workflow.yaml should exist")
+		exists, _ = container.CheckDirExists(dir + "/.workflow/runs")
+		require.True(t, exists, ".workflow/runs should exist")
 		exists, _ = container.CheckFileExists(dir + "/.workitem")
 		require.False(t, exists, "fest must not write .workitem (D007)")
+
+		out, err = container.RunFestInDir(dir, "next", "--json")
+		require.NoError(t, err, "fest next should work immediately after create workflow: %s", out)
+		require.Contains(t, out, `"mode": "standalone-tracked"`)
+		require.Contains(t, out, `"current_step": 1`)
+
+		out, err = container.RunFestInDir(dir, "workflow", "advance")
+		require.NoError(t, err, "fest workflow advance should work after create workflow: %s", out)
 	})
 
 	t.Run("NoInitSkipsRuntime", func(t *testing.T) {
@@ -58,6 +69,26 @@ func TestCreateWorkflowStandalone(t *testing.T) {
 		require.True(t, exists, "WORKFLOW.md should exist")
 		exists, _ = container.CheckDirExists(dir + "/.workflow")
 		require.False(t, exists, ".workflow/ must NOT exist with --no-init")
+	})
+
+	t.Run("RefusesPreexistingRuntimeDir", func(t *testing.T) {
+		const dir = "/tmp/cw-standalone-existing-runtime"
+		_, _ = container.Exec("rm", "-rf", dir)
+		_, err := container.Exec("mkdir", "-p", dir+"/.workflow")
+		require.NoError(t, err)
+		require.NoError(t, container.WriteFile(dir+"/.workflow/notes.txt", "keep me\n"))
+
+		require.NoError(t, container.WriteFile(dir+"/steps.json", standaloneStepsJSON))
+		out, err := container.RunFestInDir(dir, "create", "workflow", "demo", "--steps-file", dir+"/steps.json")
+		require.Error(t, err, "expected error when .workflow/ already exists")
+		require.Contains(t, out, ".workflow/ already exists")
+
+		exists, _ := container.CheckFileExists(dir + "/.workflow/notes.txt")
+		require.True(t, exists, "pre-existing .workflow/ content must not be removed")
+		exists, _ = container.CheckFileExists(dir + "/WORKFLOW.md")
+		require.False(t, exists, "create should refuse before writing WORKFLOW.md")
+		exists, _ = container.CheckFileExists(dir + "/.workflow/workflow.yaml")
+		require.False(t, exists, "create should not add workflow.yaml to pre-existing .workflow/")
 	})
 
 	t.Run("RefusesOverwrite", func(t *testing.T) {
@@ -118,6 +149,8 @@ func TestCreateWorkflowStandalone(t *testing.T) {
 		require.Contains(t, out, `"mode": "standalone"`, "JSON should declare standalone mode: %s", out)
 		require.Contains(t, out, `"workflow_id": "wf-demo"`, "JSON missing workflow_id: %s", out)
 		require.Contains(t, out, `"runtime_initialized": true`, "JSON should report runtime_initialized: %s", out)
+		require.Contains(t, out, `"active_run_id":`, "JSON should report active run: %s", out)
+		require.NotContains(t, out, "fest workflow start", "default create starts the run, so JSON should not suggest start: %s", out)
 	})
 
 	t.Run("StandaloneRejectsNonDefaultPosition", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- start a tracked standalone workflow run when `fest create workflow` initializes `.workflow/`
- keep `fest next` working immediately after the default create workflow path
- reject pre-existing `.workflow/` before creating runtime state so rollback cannot delete files owned by a prior run or partial setup
- update JSON suggestions and integration coverage for the next-ready flow

## Validation
- `go test ./internal/commands/festival ./internal/commands/next ./internal/commands/workflow ./internal/workflow/localstore`
- `go test -short ./...`
- `just build test-binary`
- `go test -tags integration ./tests/integration -run TestCreateWorkflowStandalone -count=1`