### PR TITLE
Polish standalone workflow UX

### DIFF
--- a/internal/commands/festival/create_workflow.go
+++ b/internal/commands/festival/create_workflow.go
@@ -61,20 +61,27 @@ func NewCreateWorkflowCommand() *cobra.Command {
 	opts := &CreateWorkflowOptions{}
 	cmd := &cobra.Command{
 		Use:   "workflow",
-		Short: "Create a WORKFLOW.md for a phase from structured step definitions",
-		Long: `Generate a WORKFLOW.md file for an existing phase directory.
+		Short: "Create a standalone or phase WORKFLOW.md from structured step definitions",
+		Long: `Generate a parseable WORKFLOW.md from prompts, inline JSON, or a steps file.
 
-Takes structured JSON input (inline or file) and produces a parseable WORKFLOW.md
-that matches the format expected by the workflow parser.
+Outside a festival phase, this creates WORKFLOW.md in the current directory,
+initializes .workflow/ runtime state, and starts a tracked run so fest next works
+immediately.
+
+Inside a festival phase, or when --path/--festival targets a phase, this writes
+the phase WORKFLOW.md without standalone runtime state.
 
 Examples:
-  # From a steps file
+  # Standalone workflow in the current directory
+  fest create workflow demo
+
+  # Standalone workflow from inline JSON (for agents)
+  fest create workflow demo --steps '{"title":"Review","steps":[...]}'
+
+  # Phase workflow from a steps file
   fest create workflow --steps-file steps.json --position after
 
-  # Inline JSON (for agents)
-  fest create workflow --steps '{"title":"Review","steps":[...]}' --position before
-
-  # With explicit phase path
+  # Explicit phase path
   fest create workflow --steps-file steps.json --path ./004_POLISH`,
 		Annotations: map[string]string{
 			"scope": string(scope.Global),
@@ -91,12 +98,12 @@ Examples:
 	cmd.Flags().StringVar(&opts.Steps, "steps", "", "Inline JSON with workflow definition")
 	cmd.Flags().StringVar(&opts.StepsFile, "steps-file", "", "Path to JSON file with workflow definition")
 	cmd.Flags().StringVar(&opts.Position, "position", "after", "Workflow position relative to sequences (before|after)")
-	cmd.Flags().StringVar(&opts.Path, "path", ".", "Phase directory path")
+	cmd.Flags().StringVar(&opts.Path, "path", ".", "Phase directory path (festival mode)")
 	cmd.Flags().StringVar(&opts.Festival, "festival", "", "Festival root override")
 	cmd.Flags().BoolVar(&opts.JSONOutput, "json", false, "Emit JSON output")
 	cmd.Flags().BoolVar(&opts.AgentMode, "agent", false, "Strict agent mode (implies --json)")
 	cmd.Flags().StringVar(&opts.Type, "type", "task", "workflow type (standalone mode only)")
-	cmd.Flags().BoolVar(&opts.NoInit, "no-init", false, "skip .workflow/ runtime init (standalone mode only)")
+	cmd.Flags().BoolVar(&opts.NoInit, "no-init", false, "skip .workflow/ runtime init (advanced standalone mode)")
 	return cmd
 }
 

--- a/internal/commands/festival/create_workflow_standalone_test.go
+++ b/internal/commands/festival/create_workflow_standalone_test.go
@@ -37,6 +37,29 @@ func TestRejectFestivalOnlyFlags(t *testing.T) {
 	}
 }
 
+func TestCreateWorkflowHelpMentionsStandaloneFlow(t *testing.T) {
+	cmd := NewCreateWorkflowCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("help command: %v", err)
+	}
+	help := out.String()
+	for _, want := range []string{
+		"Generate a parseable WORKFLOW.md",
+		"current directory",
+		"starts a tracked run so fest next works",
+		"fest create workflow demo",
+	} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("help missing %q:\n%s", want, help)
+		}
+	}
+}
+
 func TestPromptForStandaloneInput_HappyPath(t *testing.T) {
 	in := strings.NewReader("My Title\nThe intent line\nALIGN|Get aligned\nBUILD|Do the work\n\n")
 	var out bytes.Buffer

--- a/internal/commands/workflow/show.go
+++ b/internal/commands/workflow/show.go
@@ -215,8 +215,8 @@ func runStandaloneShow(ctx context.Context, res *standalone.Result, stepNum int)
 				return festerrors.Wrap(lerr, "loading active run state").
 					WithHint("the .workflow/ runtime is unreadable; resolve the underlying I/O error or rerun `fest workflow init` after manual cleanup")
 			}
-			if state != nil && state.CurrentStep > 0 {
-				current = state.CurrentStep
+			if state != nil {
+				current = standaloneShowStep(state, len(steps))
 			}
 		}
 		if current == 0 {
@@ -248,4 +248,24 @@ func runStandaloneShow(ctx context.Context, res *standalone.Result, stepNum int)
 		fmt.Println("(anonymous; first mutation will bootstrap to tracked mode)")
 	}
 	return nil
+}
+
+func standaloneShowStep(state *localstore.RunState, totalSteps int) int {
+	if totalSteps == 0 || state == nil {
+		return 0
+	}
+	if state.Status == "completed" || state.CompletedSteps >= totalSteps {
+		return totalSteps
+	}
+	if state.CurrentStep > state.CompletedSteps {
+		return state.CurrentStep
+	}
+	next := state.CompletedSteps + 1
+	if next < 1 {
+		return 1
+	}
+	if next > totalSteps {
+		return totalSteps
+	}
+	return next
 }

--- a/internal/commands/workflow/standalone_show_test.go
+++ b/internal/commands/workflow/standalone_show_test.go
@@ -1,0 +1,94 @@
+package workflow
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/workflow/localstore"
+	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
+)
+
+func setupTrackedStandaloneShowFixture(t *testing.T) (*standalone.Result, *localstore.Store) {
+	t.Helper()
+	dir := t.TempDir()
+	doc := filepath.Join(dir, "WORKFLOW.md")
+	body := `---
+workflow_version: 1
+workflow_id: wf-test
+---
+
+## Step 1: PLAN
+
+**Goal:** Plan it.
+
+## Step 2: DO
+
+**Goal:** Do it.
+`
+	if err := os.WriteFile(doc, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runtimeDir := filepath.Join(dir, ".workflow")
+	store := localstore.Open(runtimeDir, doc)
+	if err := store.Init(context.Background(), localstore.InitOptions{WorkflowID: "wf-test"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.StartRun(context.Background(), ""); err != nil {
+		t.Fatal(err)
+	}
+	return &standalone.Result{
+		Mode:        standalone.ModeTracked,
+		StartDir:    dir,
+		WorkflowDoc: doc,
+		RuntimeDir:  runtimeDir,
+	}, store
+}
+
+func TestRunStandaloneShowTracksNextUnstartedStep(t *testing.T) {
+	res, store := setupTrackedStandaloneShowFixture(t)
+	if err := store.AppendEvent(context.Background(), localstore.Event{EventType: localstore.EventStepStart}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AppendEvent(context.Background(), localstore.Event{EventType: localstore.EventStepDone}); err != nil {
+		t.Fatal(err)
+	}
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = runStandaloneShow(context.Background(), res, 0)
+	})
+	if runErr != nil {
+		t.Fatal(runErr)
+	}
+	if !strings.Contains(out, "Step 2 of 2: DO") {
+		t.Fatalf("show should render the next unstarted step after advance:\n%s", out)
+	}
+	if strings.Contains(out, "Step 1 of 2: PLAN") {
+		t.Fatalf("show rendered stale completed step:\n%s", out)
+	}
+}
+
+func TestStandaloneShowStep(t *testing.T) {
+	cases := []struct {
+		name  string
+		state *localstore.RunState
+		total int
+		want  int
+	}{
+		{"nil state", nil, 2, 0},
+		{"new run", &localstore.RunState{Status: "active"}, 2, 1},
+		{"after completed step", &localstore.RunState{Status: "active", CurrentStep: 1, CompletedSteps: 1}, 2, 2},
+		{"in progress", &localstore.RunState{Status: "active", CurrentStep: 2, CompletedSteps: 1}, 2, 2},
+		{"complete", &localstore.RunState{Status: "completed", CurrentStep: 2, CompletedSteps: 2}, 2, 2},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := standaloneShowStep(c.state, c.total); got != c.want {
+				t.Fatalf("standaloneShowStep() = %d, want %d", got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- update `fest create workflow --help` to describe standalone workflows as the default current-directory path
- make standalone `fest workflow show` render the next actionable step after an advance, matching `fest next`
- add focused coverage for the help text and standalone show step selection

## Validation
- `go test ./internal/commands/festival ./internal/commands/workflow ./internal/commands/show`
- `go test -run 'TestCreateWorkflowHelpMentionsStandaloneFlow|TestRunStandaloneShowTracksNextUnstartedStep|TestStandaloneShowStep' ./internal/commands/festival ./internal/commands/workflow`
- `go test -short ./...`
- `GOBIN=/private/tmp/fest-polish-bin just install stable`
- local smoke: `fest create workflow demo --steps ...`, `fest next --json`, `fest workflow show`, `fest workflow advance`, then `fest next --json` and `fest workflow show` both reported step 2
