### PR TITLE
Validate WORKFLOW.md step numbering (closes #186)

### DIFF
--- a/internal/commands/validation/commands.go
+++ b/internal/commands/validation/commands.go
@@ -324,6 +324,7 @@ func runValidateAll(ctx context.Context, opts *validateOptions) error {
 	validateTemplateChecks(festivalPath, result)
 	validateOrderingChecks(ctx, festivalPath, result)
 	validateAutoLinkChecks(ctx, festivalPath, result)
+	validateWorkflowDocsChecks(ctx, festivalPath, result)
 
 	// Add suggestions based on issues
 	addSuggestions(result)
@@ -442,6 +443,7 @@ func addSuggestions(result *ValidationResult) {
 	hasMissingGates := false
 	hasUnfilledTemplates := false
 	hasNumberingGaps := false
+	hasWorkflowIssues := false
 
 	for _, issue := range result.Issues {
 		switch issue.Code {
@@ -453,6 +455,8 @@ func addSuggestions(result *ValidationResult) {
 			hasUnfilledTemplates = true
 		case CodeNumberingGap:
 			hasNumberingGaps = true
+		case CodeWorkflowNumbering:
+			hasWorkflowIssues = true
 		}
 	}
 
@@ -472,6 +476,10 @@ func addSuggestions(result *ValidationResult) {
 	if hasNumberingGaps {
 		result.Suggestions = append(result.Suggestions,
 			"Run 'fest renumber' to automatically fix numbering gaps")
+	}
+	if hasWorkflowIssues {
+		result.Suggestions = append(result.Suggestions,
+			"Run 'fest workflow validate <path>' against affected WORKFLOW.md files for detailed remediation")
 	}
 }
 

--- a/internal/commands/validation/validate_output.go
+++ b/internal/commands/validation/validate_output.go
@@ -118,6 +118,9 @@ func printValidationResult(display *ui.UI, festivalPath string, result *Validati
 	autoLinkIssues := filterIssuesByPrefix(result.Issues, "autolink_")
 	printValidationSection(display, "AUTO-LINK", autoLinkIssues)
 
+	workflowIssues := filterIssuesByCode(result.Issues, CodeWorkflowNumbering, CodeWorkflowScan)
+	printValidationSection(display, "WORKFLOW", workflowIssues)
+
 	// Score and summary
 	fmt.Println()
 	fmt.Printf("%s %s\n", ui.Label("Score"), ui.Value(fmt.Sprintf("%d/100", result.Score)))

--- a/internal/commands/validation/validate_workflow.go
+++ b/internal/commands/validation/validate_workflow.go
@@ -1,0 +1,70 @@
+package validation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
+)
+
+const (
+	CodeWorkflowNumbering = "workflow_numbering"
+	CodeWorkflowScan      = "workflow_scan"
+)
+
+func validateWorkflowDocsChecks(ctx context.Context, festivalPath string, result *ValidationResult) {
+	walkErr := filepath.WalkDir(festivalPath, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if name == ".fest" || name == ".workflow" || name == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.Name() != "WORKFLOW.md" {
+			return nil
+		}
+		if err := standalone.ValidateStepNumbering(ctx, path); err != nil {
+			result.Issues = append(result.Issues, workflowIssueFromError(path, err))
+		}
+		return nil
+	})
+
+	if walkErr != nil {
+		result.Issues = append(result.Issues, ValidationIssue{
+			Level:   LevelError,
+			Code:    CodeWorkflowScan,
+			Path:    festivalPath,
+			Message: fmt.Sprintf("Failed to scan for WORKFLOW.md files: %v", walkErr),
+		})
+	}
+}
+
+func workflowIssueFromError(path string, err error) ValidationIssue {
+	issue := ValidationIssue{
+		Level: LevelError,
+		Code:  CodeWorkflowNumbering,
+		Path:  path,
+	}
+
+	var ferr *festerrors.Error
+	if errors.As(err, &ferr) {
+		msg := ferr.Message
+		if found, ok := ferr.Fields["found"].(string); ok && found != "" {
+			msg = fmt.Sprintf("%s. Found: %s", msg, found)
+		}
+		issue.Message = msg
+		issue.Fix = ferr.Hint
+		return issue
+	}
+
+	issue.Message = err.Error()
+	return issue
+}

--- a/internal/commands/validation/validate_workflow_test.go
+++ b/internal/commands/validation/validate_workflow_test.go
@@ -1,0 +1,140 @@
+package validation
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+const validWorkflow = `# Workflow
+## Step 1: ONE — a
+**Goal:** g
+## Step 2: TWO — b
+**Goal:** g
+`
+
+const step0Workflow = `# Workflow
+## Step 0: ZERO — z
+**Goal:** g
+## Step 1: ONE — a
+**Goal:** g
+## Step 2: TWO — b
+**Goal:** g
+`
+
+const gapWorkflow = `# Workflow
+## Step 1: ONE — a
+**Goal:** g
+## Step 2: TWO — b
+**Goal:** g
+## Step 4: FOUR — d
+**Goal:** g
+`
+
+func TestValidateWorkflowDocsChecks_DetectsStep0(t *testing.T) {
+	fest := t.TempDir()
+	writeFile(t, filepath.Join(fest, "001_PHASE", "WORKFLOW.md"), step0Workflow)
+
+	result := &ValidationResult{Issues: []ValidationIssue{}}
+	validateWorkflowDocsChecks(context.Background(), fest, result)
+
+	if len(result.Issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d: %+v", len(result.Issues), result.Issues)
+	}
+	issue := result.Issues[0]
+	if issue.Code != CodeWorkflowNumbering {
+		t.Errorf("expected code %s, got %s", CodeWorkflowNumbering, issue.Code)
+	}
+	if issue.Level != LevelError {
+		t.Errorf("expected level error, got %s", issue.Level)
+	}
+	if !strings.Contains(issue.Message, "must start at 1") {
+		t.Errorf("expected message about starting at 1, got: %s", issue.Message)
+	}
+	if !strings.Contains(issue.Message, "Step 0, Step 1, Step 2") {
+		t.Errorf("expected found sequence in message, got: %s", issue.Message)
+	}
+	if !strings.Contains(issue.Fix, "merge Step 0") {
+		t.Errorf("expected remediation in fix, got: %s", issue.Fix)
+	}
+}
+
+func TestValidateWorkflowDocsChecks_DetectsGap(t *testing.T) {
+	fest := t.TempDir()
+	writeFile(t, filepath.Join(fest, "001_PHASE", "WORKFLOW.md"), gapWorkflow)
+
+	result := &ValidationResult{Issues: []ValidationIssue{}}
+	validateWorkflowDocsChecks(context.Background(), fest, result)
+
+	if len(result.Issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d: %+v", len(result.Issues), result.Issues)
+	}
+	if !strings.Contains(result.Issues[0].Message, "not contiguous") {
+		t.Errorf("expected 'not contiguous', got: %s", result.Issues[0].Message)
+	}
+}
+
+func TestValidateWorkflowDocsChecks_PassesValidDoc(t *testing.T) {
+	fest := t.TempDir()
+	writeFile(t, filepath.Join(fest, "001_PHASE", "WORKFLOW.md"), validWorkflow)
+
+	result := &ValidationResult{Issues: []ValidationIssue{}}
+	validateWorkflowDocsChecks(context.Background(), fest, result)
+
+	if len(result.Issues) != 0 {
+		t.Fatalf("expected 0 issues, got %d: %+v", len(result.Issues), result.Issues)
+	}
+}
+
+func TestValidateWorkflowDocsChecks_WalksMultipleDocs(t *testing.T) {
+	fest := t.TempDir()
+	writeFile(t, filepath.Join(fest, "001_PHASE", "WORKFLOW.md"), validWorkflow)
+	writeFile(t, filepath.Join(fest, "002_PHASE", "01_seq", "WORKFLOW.md"), step0Workflow)
+	writeFile(t, filepath.Join(fest, "003_PHASE", "WORKFLOW.md"), gapWorkflow)
+
+	result := &ValidationResult{Issues: []ValidationIssue{}}
+	validateWorkflowDocsChecks(context.Background(), fest, result)
+
+	if len(result.Issues) != 2 {
+		t.Fatalf("expected 2 issues, got %d: %+v", len(result.Issues), result.Issues)
+	}
+}
+
+func TestValidateWorkflowDocsChecks_SkipsRuntimeDirs(t *testing.T) {
+	fest := t.TempDir()
+	writeFile(t, filepath.Join(fest, ".fest", "WORKFLOW.md"), step0Workflow)
+	writeFile(t, filepath.Join(fest, ".workflow", "WORKFLOW.md"), step0Workflow)
+	writeFile(t, filepath.Join(fest, ".git", "WORKFLOW.md"), step0Workflow)
+	writeFile(t, filepath.Join(fest, "001_PHASE", "WORKFLOW.md"), validWorkflow)
+
+	result := &ValidationResult{Issues: []ValidationIssue{}}
+	validateWorkflowDocsChecks(context.Background(), fest, result)
+
+	if len(result.Issues) != 0 {
+		t.Fatalf("expected 0 issues (runtime dirs should be skipped), got %d: %+v", len(result.Issues), result.Issues)
+	}
+}
+
+func TestValidateWorkflowDocsChecks_NoWorkflowFiles(t *testing.T) {
+	fest := t.TempDir()
+	writeFile(t, filepath.Join(fest, "FESTIVAL_OVERVIEW.md"), "# Overview\n")
+
+	result := &ValidationResult{Issues: []ValidationIssue{}}
+	validateWorkflowDocsChecks(context.Background(), fest, result)
+
+	if len(result.Issues) != 0 {
+		t.Fatalf("expected 0 issues when no WORKFLOW.md exists, got %d", len(result.Issues))
+	}
+}

--- a/internal/commands/workflow/validate.go
+++ b/internal/commands/workflow/validate.go
@@ -1,0 +1,73 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/scope"
+	"github.com/Obedience-Corp/fest/internal/workflow/standalone"
+	"github.com/spf13/cobra"
+)
+
+func newValidateCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "validate [path]",
+		Short: "Validate WORKFLOW.md step numbering",
+		Long: `Validate a standalone WORKFLOW.md file for correct step numbering.
+
+Step headings ('## Step N:') must start at 1 and form a contiguous sequence
+with no gaps or duplicates. No other checks are performed (section names,
+state-tracking tables, and checkpoint syntax are deliberately not validated).
+
+If no path is provided, defaults to ./WORKFLOW.md in the current directory.`,
+		Annotations: map[string]string{"scope": string(scope.Global)},
+		Args:        cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path := ""
+			if len(args) > 0 {
+				path = args[0]
+			}
+			return runValidate(cmd.Context(), path)
+		},
+	}
+}
+
+func runValidate(ctx context.Context, path string) error {
+	if path == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return festerrors.IO("getwd", err)
+		}
+		path = filepath.Join(cwd, "WORKFLOW.md")
+	}
+
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return festerrors.Wrap(err, "resolving path").WithField("path", path)
+	}
+
+	info, statErr := os.Stat(abs)
+	if statErr != nil {
+		if os.IsNotExist(statErr) {
+			return festerrors.NotFound("WORKFLOW.md").
+				WithField("path", abs).
+				WithHint("provide a path to an existing WORKFLOW.md or run from a directory that contains one")
+		}
+		return festerrors.IO("stat WORKFLOW.md", statErr).WithField("path", abs)
+	}
+	if info.IsDir() {
+		return festerrors.Validation("path is a directory, expected a WORKFLOW.md file").
+			WithField("path", abs).
+			WithHint("pass the WORKFLOW.md file directly, not its parent directory")
+	}
+
+	if err := standalone.ValidateStepNumbering(ctx, abs); err != nil {
+		return err
+	}
+
+	fmt.Printf("WORKFLOW.md step numbering is valid: %s\n", abs)
+	return nil
+}

--- a/internal/commands/workflow/validate_test.go
+++ b/internal/commands/workflow/validate_test.go
@@ -1,0 +1,105 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+)
+
+const validateValidWorkflow = `# Workflow
+## Step 1: ONE — a
+**Goal:** g
+## Step 2: TWO — b
+**Goal:** g
+`
+
+const validateStep0Workflow = `# Workflow
+## Step 0: ZERO — z
+**Goal:** g
+## Step 1: ONE — a
+**Goal:** g
+`
+
+func TestRunValidate_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	err := runValidate(context.Background(), filepath.Join(dir, "WORKFLOW.md"))
+	if err == nil {
+		t.Fatalf("expected error for missing file")
+	}
+	var ferr *festerrors.Error
+	if !errors.As(err, &ferr) {
+		t.Fatalf("expected *festerrors.Error, got %T", err)
+	}
+	if ferr.Code != festerrors.ErrCodeNotFound {
+		t.Errorf("expected code %s, got %s", festerrors.ErrCodeNotFound, ferr.Code)
+	}
+}
+
+func TestRunValidate_DirectoryPath(t *testing.T) {
+	dir := t.TempDir()
+	err := runValidate(context.Background(), dir)
+	if err == nil {
+		t.Fatalf("expected error for directory path")
+	}
+	var ferr *festerrors.Error
+	if !errors.As(err, &ferr) {
+		t.Fatalf("expected *festerrors.Error, got %T", err)
+	}
+	if ferr.Code != festerrors.ErrCodeValidation {
+		t.Errorf("expected code %s, got %s", festerrors.ErrCodeValidation, ferr.Code)
+	}
+}
+
+func TestRunValidate_Step0Fails(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	if err := os.WriteFile(path, []byte(validateStep0Workflow), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	err := runValidate(context.Background(), path)
+	if err == nil {
+		t.Fatalf("expected error for Step 0")
+	}
+	var ferr *festerrors.Error
+	if !errors.As(err, &ferr) {
+		t.Fatalf("expected *festerrors.Error, got %T", err)
+	}
+	if !strings.Contains(ferr.Message, "must start at 1") {
+		t.Errorf("expected 'must start at 1' in message, got: %s", ferr.Message)
+	}
+}
+
+func TestRunValidate_ValidPasses(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	if err := os.WriteFile(path, []byte(validateValidWorkflow), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := runValidate(context.Background(), path); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestRunValidate_DefaultsToCwdWorkflowMd(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(validateValidWorkflow), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	prev, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	if err := runValidate(context.Background(), ""); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}

--- a/internal/commands/workflow/workflow.go
+++ b/internal/commands/workflow/workflow.go
@@ -77,6 +77,7 @@ Examples:
 		newInitCmd(),
 		newStartCmd(),
 		newRunsCmd(),
+		newValidateCmd(),
 	)
 
 	return cmd

--- a/internal/workflow/standalone/validate.go
+++ b/internal/workflow/standalone/validate.go
@@ -2,6 +2,8 @@ package standalone
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	festerrors "github.com/Obedience-Corp/fest/internal/errors"
 	wfparser "github.com/Obedience-Corp/fest/internal/guidance/workflow"
@@ -22,4 +24,72 @@ func ValidateWorkflowDoc(ctx context.Context, path string) error {
 			WithHint("add at least one '## Step 1:' heading")
 	}
 	return nil
+}
+
+// ValidateStepNumbering checks that step headings in WORKFLOW.md form a
+// contiguous 1..N sequence with no gaps, duplicates, or off-by-one starts
+// (e.g. Step 0). It is intentionally narrow: it does NOT validate section
+// names, state-tracking syntax, or checkpoints. WORKFLOW.md is the lightweight
+// customizable surface; anything stricter would fight that design. State for
+// tracking lives in .fest/progress_events.jsonl, not in the doc.
+func ValidateStepNumbering(ctx context.Context, path string) error {
+	steps, err := wfparser.NewParser().Parse(ctx, path)
+	if err != nil {
+		return festerrors.Wrap(err, "parsing WORKFLOW.md").WithField("path", path)
+	}
+	if len(steps) == 0 {
+		return nil
+	}
+
+	nums := make([]int, len(steps))
+	for i, s := range steps {
+		nums[i] = s.Number
+	}
+
+	if msg, ok := checkContiguousFromOne(nums); !ok {
+		return festerrors.Validation(msg).
+			WithField("path", path).
+			WithField("found", formatSequence(nums)).
+			WithHint(remediationHint(nums))
+	}
+	return nil
+}
+
+func checkContiguousFromOne(nums []int) (string, bool) {
+	if len(nums) == 0 {
+		return "", true
+	}
+	if nums[0] != 1 {
+		return "WORKFLOW.md: step numbering must start at 1", false
+	}
+	seen := make(map[int]bool, len(nums))
+	for i, n := range nums {
+		if seen[n] {
+			return fmt.Sprintf("WORKFLOW.md: duplicate step number %d", n), false
+		}
+		seen[n] = true
+		if i > 0 && n != nums[i-1]+1 {
+			return fmt.Sprintf("WORKFLOW.md: step numbering is not contiguous (jumped from %d to %d)", nums[i-1], n), false
+		}
+	}
+	return "", true
+}
+
+func formatSequence(nums []int) string {
+	parts := make([]string, len(nums))
+	for i, n := range nums {
+		parts[i] = fmt.Sprintf("Step %d", n)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func remediationHint(nums []int) string {
+	if len(nums) == 0 {
+		return "add a '## Step 1:' heading"
+	}
+	target := fmt.Sprintf("Step 1..%d", len(nums))
+	if nums[0] == 0 {
+		return fmt.Sprintf("Fix one of: a) renumber to %s. b) merge Step 0's content into Step 1 and delete the heading.", target)
+	}
+	return fmt.Sprintf("renumber headings so they form %s with no gaps or duplicates.", target)
 }

--- a/internal/workflow/standalone/validate_test.go
+++ b/internal/workflow/standalone/validate_test.go
@@ -1,0 +1,175 @@
+package standalone
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+)
+
+func writeWorkflow(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write WORKFLOW.md: %v", err)
+	}
+	return path
+}
+
+func TestValidateStepNumbering_Errors(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		wantMessage string
+		wantFound   string
+		wantHint    string
+	}{
+		{
+			name: "starts at step 0",
+			content: `# Workflow
+## Step 0: BOOTSTRAP — Setup
+**Goal:** prep
+## Step 1: REVIEW — Look
+**Goal:** review
+## Step 2: ACT — Do
+**Goal:** act
+`,
+			wantMessage: "step numbering must start at 1",
+			wantFound:   "Step 0, Step 1, Step 2",
+			wantHint:    "merge Step 0",
+		},
+		{
+			name: "gap in numbering",
+			content: `# Workflow
+## Step 1: ONE — a
+**Goal:** g
+## Step 2: TWO — b
+**Goal:** g
+## Step 4: FOUR — d
+**Goal:** g
+`,
+			wantMessage: "not contiguous",
+			wantFound:   "Step 1, Step 2, Step 4",
+			wantHint:    "renumber",
+		},
+		{
+			name: "duplicate step number",
+			content: `# Workflow
+## Step 1: ONE — a
+**Goal:** g
+## Step 2: TWO — b
+**Goal:** g
+## Step 2: TWO_AGAIN — c
+**Goal:** g
+`,
+			wantMessage: "duplicate step number 2",
+			wantFound:   "Step 1, Step 2, Step 2",
+			wantHint:    "renumber",
+		},
+		{
+			name: "starts at step 2",
+			content: `# Workflow
+## Step 2: TWO — b
+**Goal:** g
+## Step 3: THREE — c
+**Goal:** g
+`,
+			wantMessage: "must start at 1",
+			wantFound:   "Step 2, Step 3",
+			wantHint:    "renumber",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeWorkflow(t, tc.content)
+			err := ValidateStepNumbering(context.Background(), path)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			ferr, ok := err.(*festerrors.Error)
+			if !ok {
+				t.Fatalf("expected *festerrors.Error, got %T: %v", err, err)
+			}
+			if ferr.Code != festerrors.ErrCodeValidation {
+				t.Errorf("expected code %s, got %s", festerrors.ErrCodeValidation, ferr.Code)
+			}
+			if !strings.Contains(ferr.Message, tc.wantMessage) {
+				t.Errorf("message %q does not contain %q", ferr.Message, tc.wantMessage)
+			}
+			found, _ := ferr.Fields["found"].(string)
+			if found != tc.wantFound {
+				t.Errorf("found field = %q, want %q", found, tc.wantFound)
+			}
+			if !strings.Contains(ferr.Hint, tc.wantHint) {
+				t.Errorf("hint %q does not contain %q", ferr.Hint, tc.wantHint)
+			}
+		})
+	}
+}
+
+func TestValidateStepNumbering_HappyPaths(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{
+			name: "single step",
+			content: `# Workflow
+## Step 1: ONLY — a
+**Goal:** g
+`,
+		},
+		{
+			name: "contiguous 1..5",
+			content: `# Workflow
+## Step 1: ONE — a
+**Goal:** g
+## Step 2: TWO — b
+**Goal:** g
+## Step 3: THREE — c
+**Goal:** g
+## Step 4: FOUR — d
+**Goal:** g
+## Step 5: FIVE — e
+**Goal:** g
+`,
+		},
+		{
+			name: "no steps at all",
+			content: `# Workflow
+
+Some prose without any step headings.
+`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeWorkflow(t, tc.content)
+			if err := ValidateStepNumbering(context.Background(), path); err != nil {
+				t.Fatalf("expected nil error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateStepNumbering_FileMissing(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "WORKFLOW.md")
+	err := ValidateStepNumbering(context.Background(), missing)
+	if err == nil {
+		t.Fatalf("expected error for missing file, got nil")
+	}
+	ferr, ok := err.(*festerrors.Error)
+	if !ok {
+		t.Fatalf("expected *festerrors.Error, got %T: %v", err, err)
+	}
+	if got, _ := ferr.Fields["path"].(string); got != missing {
+		t.Errorf("expected path field %q, got %q", missing, got)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #186.

`fest validate` previously did not catch WORKFLOW.md files whose `## Step N:` headings did not form a contiguous 1..N sequence. The CW0003 repro had `Step 0..Step 7` because an agent added Step 0 retroactively instead of renumbering. The runtime then silently mis-tracked progress (skipped the orphaned Step 0, advanced past the last step).

This PR adds a shared, deliberately narrow step-numbering validator and wires it into two surfaces.

## What changed

### Shared validator
`internal/workflow/standalone/validate.go`
- New `ValidateStepNumbering(ctx, path)` function. Reuses the existing `internal/guidance/workflow` parser. Reports the first failure with the actual found sequence and concrete remediation options (renumber vs merge Step 0 into Step 1).
- Single check by design: contiguous 1..N. No section name / state table / checkpoint syntax validation. WORKFLOW.md is the lightweight customizable surface; stricter checks would fight that.
- Kept the existing `ValidateWorkflowDoc` untouched so `bootstrap.go` / `init.go` callers do not start failing mid-creation on numbering drift.

### New subcommand
`internal/commands/workflow/validate.go`
- `fest workflow validate [path]` validates a standalone WORKFLOW.md.
- Defaults to `./WORKFLOW.md` when no arg given.
- Exits non-zero on validation failure.
- Distinguishes missing file (NOT_FOUND) from directory-as-path (VALIDATION).

### Festival-tree integration
`internal/commands/validation/validate_workflow.go`
- New `validateWorkflowDocsChecks` walks the festival tree (at any depth: phase, sequence, task) for any `WORKFLOW.md` and runs the shared validator on each.
- Skips `.fest`, `.workflow`, and `.git` directories.
- Surfaces diagnostics under a new `WORKFLOW` section in the `fest validate` report.
- New error code `workflow_numbering` (plus `workflow_scan` for walk failures).
- Adds a suggestion pointing operators at `fest workflow validate <path>` for detailed remediation.

## Test plan

- `just test unit` -> 89 packages, 2108/2108 tests passed.
- `just lint all` -> 0 issues.
- `just build quick` -> binary built.
- Manual CLI exercise:
  - `fest workflow validate` with Step 0..2 -> exits 1, message includes "must start at 1", hint offers renumber-or-merge.
  - `fest workflow validate` with gap 1,2,4 -> exits 1, message says "not contiguous (jumped from 2 to 4)".
  - `fest workflow validate` with valid 1..2 -> exits 0 with success line.
  - `fest workflow validate` with no arg defaults to `./WORKFLOW.md`.
  - `fest validate /tmp/fest-186` against a festival containing a Step 0..2 WORKFLOW.md -> exit 1, WORKFLOW section flags the file with `Found: Step 0, Step 1, Step 2` and the remediation hint.
  - Same festival with valid WORKFLOW.md -> WORKFLOW section passes.

New tests cover error paths first (Step 0, gap, duplicate, starts at Step 2, missing file, directory path) then happy paths (single step, 1..5 contiguous, zero steps file, valid festival tree, multi-doc walk, runtime dir skip).

## Acceptance criteria from #186

- WORKFLOW.md with `Step 0..N` fails both `fest validate` and `fest workflow validate`: verified.
- WORKFLOW.md with `Step 1..N` continues to pass: verified.
- Gaps and duplicates fail with a clear message: verified.
- `fest validate` keeps doing everything it does today: only additive (new WORKFLOW section + new suggestion).

## Notes

- Used raw `git commit` rather than `camp p commit` because this work is in a `projects/worktrees/fest/...` worktree, and `camp p commit` resolves to the main `projects/fest` checkout (different working tree). The campaign-root submodule pointer update can be done as a follow-up after merge.