### PR TITLE
Add fest workflow renumber (closes #187)

### DIFF
--- a/internal/commands/workflow/renumber.go
+++ b/internal/commands/workflow/renumber.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -78,7 +79,7 @@ Examples:
 				return errors.Wrap(err, "resolving path").WithField("path", path)
 			}
 
-			return runWorkflowRenumber(cmd.OutOrStdout(), absPath, dryRun, backup)
+			return runWorkflowRenumber(cmd.Context(), cmd.OutOrStdout(), absPath, dryRun, backup)
 		},
 	}
 
@@ -89,7 +90,14 @@ Examples:
 	return cmd
 }
 
-func runWorkflowRenumber(out io.Writer, path string, dryRun, backup bool) error {
+func runWorkflowRenumber(ctx context.Context, out io.Writer, path string, dryRun, backup bool) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return errors.Wrap(err, "context cancelled before reading workflow file").WithField("path", path)
+	}
+
 	content, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -100,7 +108,7 @@ func runWorkflowRenumber(out io.Writer, path string, dryRun, backup bool) error 
 		return errors.IO("reading workflow file", err).WithField("path", path)
 	}
 
-	plan, planErr := buildRenumberPlan(string(content))
+	plan, planErr := buildRenumberPlan(ctx, string(content))
 	if planErr != nil {
 		return planErr.WithField("path", path)
 	}
@@ -124,13 +132,17 @@ func runWorkflowRenumber(out io.Writer, path string, dryRun, backup bool) error 
 	}
 
 	if backup {
-		if err := os.WriteFile(path+".bak", content, 0o644); err != nil {
+		if err := writeFileAtomic(ctx, path+".bak", content, 0o644); err != nil {
 			return errors.IO("writing backup", err).WithField("path", path+".bak")
 		}
 	}
 
 	updated := applyRenumber(string(content), plan)
-	if err := os.WriteFile(path, []byte(updated), 0o644); err != nil {
+	mode := os.FileMode(0o644)
+	if info, statErr := os.Stat(path); statErr == nil {
+		mode = info.Mode().Perm()
+	}
+	if err := writeFileAtomic(ctx, path, []byte(updated), mode); err != nil {
 		return errors.IO("writing workflow file", err).WithField("path", path)
 	}
 
@@ -138,7 +150,14 @@ func runWorkflowRenumber(out io.Writer, path string, dryRun, backup bool) error 
 	return nil
 }
 
-func buildRenumberPlan(content string) (renumberPlan, *errors.Error) {
+func buildRenumberPlan(ctx context.Context, content string) (renumberPlan, *errors.Error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return renumberPlan{}, errors.Wrap(err, "context cancelled before building renumber plan")
+	}
+
 	re := wf.StepHeaderRegexp()
 	matches := re.FindAllStringSubmatchIndex(content, -1)
 
@@ -188,6 +207,49 @@ func buildRenumberPlan(content string) (renumberPlan, *errors.Error) {
 	}
 
 	return plan, nil
+}
+
+func writeFileAtomic(ctx context.Context, path string, content []byte, mode os.FileMode) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
 }
 
 type duplicate struct {

--- a/internal/commands/workflow/renumber.go
+++ b/internal/commands/workflow/renumber.go
@@ -1,0 +1,260 @@
+package workflow
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/Obedience-Corp/fest/internal/errors"
+	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+	"github.com/Obedience-Corp/fest/internal/scope"
+	"github.com/spf13/cobra"
+)
+
+const defaultWorkflowFile = "WORKFLOW.md"
+
+type renumberPlan struct {
+	headings []renumberHeading
+	changes  int
+}
+
+type renumberHeading struct {
+	line      int
+	numStart  int
+	numEnd    int
+	oldNumber int
+	newNumber int
+	suffix    string
+}
+
+func newRenumberCmd() *cobra.Command {
+	var (
+		dryRun     bool
+		skipDryRun bool
+		backup     bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "renumber [path]",
+		Short: "Renumber step headings in a WORKFLOW.md to a contiguous 1-indexed sequence",
+		Annotations: map[string]string{
+			"scope": string(scope.Global),
+		},
+		Long: `Renumber the "## Step N:" headings inside a WORKFLOW.md so they form a
+contiguous 1-indexed sequence (Step 1, Step 2, ..., Step K) in document order.
+
+Only the heading lines are touched. Step body text, the Workflow State Tracking
+table, and any other markdown content are left exactly as written.
+
+The default target is ./WORKFLOW.md. Pass an explicit path to target another file.
+
+Like other renumber commands, --dry-run is the default so you can preview the
+plan; pass --skip-dry-run to write changes immediately.
+
+Known v1 limitations:
+  - Cross-references inside step bodies (for example "see Step 3") are not
+    rewritten. Update those references by hand after renumbering if needed.
+
+Examples:
+  fest workflow renumber                              # preview ./WORKFLOW.md
+  fest workflow renumber ./phases/001_PLAN/WORKFLOW.md
+  fest workflow renumber --skip-dry-run               # apply changes
+  fest workflow renumber --skip-dry-run --backup      # write .bak alongside`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if skipDryRun {
+				dryRun = false
+			}
+
+			path := defaultWorkflowFile
+			if len(args) > 0 {
+				path = args[0]
+			}
+
+			absPath, err := filepath.Abs(path)
+			if err != nil {
+				return errors.Wrap(err, "resolving path").WithField("path", path)
+			}
+
+			return runWorkflowRenumber(cmd.OutOrStdout(), absPath, dryRun, backup)
+		},
+	}
+
+	cmd.Flags().BoolVar(&dryRun, "dry-run", true, "preview changes without writing")
+	cmd.Flags().BoolVar(&skipDryRun, "skip-dry-run", false, "skip preview and apply changes immediately")
+	cmd.Flags().BoolVar(&backup, "backup", false, "write a .bak copy of the original before applying")
+
+	return cmd
+}
+
+func runWorkflowRenumber(out io.Writer, path string, dryRun, backup bool) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return errors.NotFound(fmt.Sprintf("WORKFLOW.md at %s", path)).
+				WithField("path", path).
+				WithHint("Pass an explicit path or cd into a directory containing WORKFLOW.md")
+		}
+		return errors.IO("reading workflow file", err).WithField("path", path)
+	}
+
+	plan, planErr := buildRenumberPlan(string(content))
+	if planErr != nil {
+		return planErr.WithField("path", path)
+	}
+
+	if len(plan.headings) == 0 {
+		return errors.Validation("no '## Step N:' headings found, nothing to renumber").
+			WithField("path", path).
+			WithHint("Confirm the file contains step headings in the expected format")
+	}
+
+	if plan.changes == 0 {
+		_, _ = fmt.Fprintf(out, "nothing to renumber: %d step(s) already in contiguous 1-indexed order\n", len(plan.headings))
+		return nil
+	}
+
+	printPlan(out, path, plan, dryRun)
+
+	if dryRun {
+		_, _ = fmt.Fprintln(out, "\n(dry-run) no changes written. Pass --skip-dry-run to apply.")
+		return nil
+	}
+
+	if backup {
+		if err := os.WriteFile(path+".bak", content, 0o644); err != nil {
+			return errors.IO("writing backup", err).WithField("path", path+".bak")
+		}
+	}
+
+	updated := applyRenumber(string(content), plan)
+	if err := os.WriteFile(path, []byte(updated), 0o644); err != nil {
+		return errors.IO("writing workflow file", err).WithField("path", path)
+	}
+
+	_, _ = fmt.Fprintf(out, "\nrenumbered %d heading(s) in %s\n", plan.changes, path)
+	return nil
+}
+
+func buildRenumberPlan(content string) (renumberPlan, *errors.Error) {
+	re := wf.StepHeaderRegexp()
+	matches := re.FindAllStringSubmatchIndex(content, -1)
+
+	plan := renumberPlan{}
+	if len(matches) == 0 {
+		return plan, nil
+	}
+
+	seen := map[int][]int{}
+	plan.headings = make([]renumberHeading, 0, len(matches))
+
+	for i, m := range matches {
+		numStr := content[m[2]:m[3]]
+		num, convErr := strconv.Atoi(numStr)
+		if convErr != nil {
+			return renumberPlan{}, errors.Parse("invalid step number", convErr).
+				WithField("value", numStr)
+		}
+
+		line := lineNumber(content, m[0])
+		suffix := content[m[3]:m[1]]
+
+		h := renumberHeading{
+			line:      line,
+			numStart:  m[2],
+			numEnd:    m[3],
+			oldNumber: num,
+			newNumber: i + 1,
+			suffix:    suffix,
+		}
+		plan.headings = append(plan.headings, h)
+		seen[num] = append(seen[num], line)
+
+		if h.oldNumber != h.newNumber {
+			plan.changes++
+		}
+	}
+
+	var dupes []duplicate
+	for num, lines := range seen {
+		if len(lines) > 1 {
+			dupes = append(dupes, duplicate{number: num, lines: lines})
+		}
+	}
+	if len(dupes) > 0 {
+		return renumberPlan{}, formatDuplicateError(dupes)
+	}
+
+	return plan, nil
+}
+
+type duplicate struct {
+	number int
+	lines  []int
+}
+
+func formatDuplicateError(dupes []duplicate) *errors.Error {
+	msg := "duplicate step numbers detected; refusing to renumber"
+	e := errors.Validation(msg).WithHint("Resolve duplicates manually before renumbering. Auto-merging is ambiguous.")
+	for _, d := range dupes {
+		key := fmt.Sprintf("Step %d", d.number)
+		e = e.WithField(key, formatLines(d.lines))
+	}
+	return e
+}
+
+func formatLines(lines []int) string {
+	out := ""
+	for i, l := range lines {
+		if i > 0 {
+			out += ", "
+		}
+		out += fmt.Sprintf("line %d", l)
+	}
+	return out
+}
+
+func lineNumber(content string, offset int) int {
+	if offset > len(content) {
+		offset = len(content)
+	}
+	n := 1
+	for i := 0; i < offset; i++ {
+		if content[i] == '\n' {
+			n++
+		}
+	}
+	return n
+}
+
+func applyRenumber(content string, plan renumberPlan) string {
+	if len(plan.headings) == 0 {
+		return content
+	}
+	out := make([]byte, 0, len(content)+len(plan.headings)*2)
+	cursor := 0
+	for _, h := range plan.headings {
+		out = append(out, content[cursor:h.numStart]...)
+		out = append(out, strconv.Itoa(h.newNumber)...)
+		cursor = h.numEnd
+	}
+	out = append(out, content[cursor:]...)
+	return string(out)
+}
+
+func printPlan(out io.Writer, path string, plan renumberPlan, dryRun bool) {
+	label := "Plan"
+	if dryRun {
+		label = "Dry-run plan"
+	}
+	_, _ = fmt.Fprintf(out, "%s for %s:\n", label, path)
+	for _, h := range plan.headings {
+		marker := "  "
+		if h.oldNumber != h.newNumber {
+			marker = "* "
+		}
+		_, _ = fmt.Fprintf(out, "%sline %d: Step %d -> Step %d%s\n", marker, h.line, h.oldNumber, h.newNumber, h.suffix)
+	}
+}

--- a/internal/commands/workflow/renumber_test.go
+++ b/internal/commands/workflow/renumber_test.go
@@ -2,6 +2,8 @@ package workflow
 
 import (
 	"bytes"
+	"context"
+	stderrors "errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -129,7 +131,7 @@ func TestBuildRenumberPlan(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			plan, err := buildRenumberPlan(tt.content)
+			plan, err := buildRenumberPlan(context.Background(), tt.content)
 			if err != nil {
 				t.Fatalf("buildRenumberPlan: %v", err)
 			}
@@ -150,7 +152,7 @@ func TestBuildRenumberPlan(t *testing.T) {
 }
 
 func TestBuildRenumberPlanDuplicatesError(t *testing.T) {
-	_, err := buildRenumberPlan(workflowDuplicates)
+	_, err := buildRenumberPlan(context.Background(), workflowDuplicates)
 	if err == nil {
 		t.Fatal("expected duplicate error, got nil")
 	}
@@ -167,7 +169,7 @@ func TestBuildRenumberPlanDuplicatesError(t *testing.T) {
 }
 
 func TestApplyRenumberPreservesSuffix(t *testing.T) {
-	plan, err := buildRenumberPlan(workflowStepZero)
+	plan, err := buildRenumberPlan(context.Background(), workflowStepZero)
 	if err != nil {
 		t.Fatalf("plan: %v", err)
 	}
@@ -194,7 +196,7 @@ func TestApplyRenumberPreservesSuffix(t *testing.T) {
 }
 
 func TestApplyRenumberGapsCompact(t *testing.T) {
-	plan, err := buildRenumberPlan(workflowGaps)
+	plan, err := buildRenumberPlan(context.Background(), workflowGaps)
 	if err != nil {
 		t.Fatalf("plan: %v", err)
 	}
@@ -221,7 +223,7 @@ func TestRunWorkflowRenumberDryRunDoesNotWrite(t *testing.T) {
 	original, _ := os.ReadFile(path)
 
 	var out bytes.Buffer
-	if err := runWorkflowRenumber(&out, path, true, false); err != nil {
+	if err := runWorkflowRenumber(context.Background(), &out, path, true, false); err != nil {
 		t.Fatalf("runWorkflowRenumber: %v", err)
 	}
 
@@ -241,7 +243,7 @@ func TestRunWorkflowRenumberWrites(t *testing.T) {
 	path := writeTempWorkflow(t, workflowStepZero)
 
 	var out bytes.Buffer
-	if err := runWorkflowRenumber(&out, path, false, false); err != nil {
+	if err := runWorkflowRenumber(context.Background(), &out, path, false, false); err != nil {
 		t.Fatalf("runWorkflowRenumber: %v", err)
 	}
 
@@ -261,7 +263,7 @@ func TestRunWorkflowRenumberBackup(t *testing.T) {
 	path := writeTempWorkflow(t, workflowStepZero)
 
 	var out bytes.Buffer
-	if err := runWorkflowRenumber(&out, path, false, true); err != nil {
+	if err := runWorkflowRenumber(context.Background(), &out, path, false, true); err != nil {
 		t.Fatalf("runWorkflowRenumber: %v", err)
 	}
 
@@ -279,7 +281,7 @@ func TestRunWorkflowRenumberAlreadyCorrectIsNoop(t *testing.T) {
 	original, _ := os.ReadFile(path)
 
 	var out bytes.Buffer
-	if err := runWorkflowRenumber(&out, path, false, false); err != nil {
+	if err := runWorkflowRenumber(context.Background(), &out, path, false, false); err != nil {
 		t.Fatalf("runWorkflowRenumber: %v", err)
 	}
 
@@ -297,7 +299,7 @@ func TestRunWorkflowRenumberDuplicatesError(t *testing.T) {
 	original, _ := os.ReadFile(path)
 
 	var out bytes.Buffer
-	err := runWorkflowRenumber(&out, path, false, false)
+	err := runWorkflowRenumber(context.Background(), &out, path, false, false)
 	if err == nil {
 		t.Fatal("expected duplicate error, got nil")
 	}
@@ -311,11 +313,33 @@ func TestRunWorkflowRenumberDuplicatesError(t *testing.T) {
 	}
 }
 
+func TestRunWorkflowRenumberCancelledContext(t *testing.T) {
+	path := writeTempWorkflow(t, workflowStepZero)
+	original, _ := os.ReadFile(path)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var out bytes.Buffer
+	err := runWorkflowRenumber(ctx, &out, path, false, false)
+	if err == nil {
+		t.Fatal("expected cancelled context error, got nil")
+	}
+	if !stderrors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+
+	current, _ := os.ReadFile(path)
+	if string(current) != string(original) {
+		t.Fatal("cancelled context wrote changes")
+	}
+}
+
 func TestRunWorkflowRenumberEmptyFileError(t *testing.T) {
 	path := writeTempWorkflow(t, "# Just a heading\n\nNo steps here.\n")
 
 	var out bytes.Buffer
-	err := runWorkflowRenumber(&out, path, false, false)
+	err := runWorkflowRenumber(context.Background(), &out, path, false, false)
 	if err == nil {
 		t.Fatal("expected error for file with no steps")
 	}
@@ -328,7 +352,7 @@ func TestRunWorkflowRenumberFileNotFound(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "does-not-exist", "WORKFLOW.md")
 
 	var out bytes.Buffer
-	err := runWorkflowRenumber(&out, missing, true, false)
+	err := runWorkflowRenumber(context.Background(), &out, missing, true, false)
 	if err == nil {
 		t.Fatal("expected error for missing file")
 	}

--- a/internal/commands/workflow/renumber_test.go
+++ b/internal/commands/workflow/renumber_test.go
@@ -1,0 +1,341 @@
+package workflow
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/errors"
+)
+
+const workflowStepZero = `---
+fest_type: workflow
+---
+
+# Sample Workflow
+
+## Step 0: PRECONDITION - Confirm context
+
+**Goal:** start.
+
+## Step 1: SCOPE - Define questions
+
+**Goal:** scope.
+
+## Step 2: DISCOVER - Gather
+
+**Goal:** discover.
+`
+
+const workflowGaps = `# Gaps
+
+## Step 1: ALPHA - first
+
+body
+
+## Step 2: BETA - second
+
+body
+
+## Step 4: DELTA - fourth
+
+body
+
+## Step 5: EPSILON - fifth
+
+body
+`
+
+const workflowAlready = `# Already
+
+## Step 1: A - one
+
+x
+
+## Step 2: B - two
+
+y
+
+## Step 3: C - three
+
+z
+`
+
+const workflowDuplicates = `# Dupes
+
+## Step 1: A
+
+x
+
+## Step 2: B
+
+y
+
+## Step 2: C
+
+z
+
+## Step 3: D
+
+w
+`
+
+func writeTempWorkflow(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writing fixture: %v", err)
+	}
+	return path
+}
+
+func TestBuildRenumberPlan(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		wantCount   int
+		wantChanges int
+		wantFirst   int
+		wantLast    int
+	}{
+		{
+			name:        "step zero shifts to one",
+			content:     workflowStepZero,
+			wantCount:   3,
+			wantChanges: 3,
+			wantFirst:   1,
+			wantLast:    3,
+		},
+		{
+			name:        "gaps compact",
+			content:     workflowGaps,
+			wantCount:   4,
+			wantChanges: 2,
+			wantFirst:   1,
+			wantLast:    4,
+		},
+		{
+			name:        "already correct is no-op",
+			content:     workflowAlready,
+			wantCount:   3,
+			wantChanges: 0,
+			wantFirst:   1,
+			wantLast:    3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan, err := buildRenumberPlan(tt.content)
+			if err != nil {
+				t.Fatalf("buildRenumberPlan: %v", err)
+			}
+			if len(plan.headings) != tt.wantCount {
+				t.Fatalf("headings = %d, want %d", len(plan.headings), tt.wantCount)
+			}
+			if plan.changes != tt.wantChanges {
+				t.Fatalf("changes = %d, want %d", plan.changes, tt.wantChanges)
+			}
+			if plan.headings[0].newNumber != tt.wantFirst {
+				t.Fatalf("first new = %d, want %d", plan.headings[0].newNumber, tt.wantFirst)
+			}
+			if plan.headings[len(plan.headings)-1].newNumber != tt.wantLast {
+				t.Fatalf("last new = %d, want %d", plan.headings[len(plan.headings)-1].newNumber, tt.wantLast)
+			}
+		})
+	}
+}
+
+func TestBuildRenumberPlanDuplicatesError(t *testing.T) {
+	_, err := buildRenumberPlan(workflowDuplicates)
+	if err == nil {
+		t.Fatal("expected duplicate error, got nil")
+	}
+	if err.Code != errors.ErrCodeValidation {
+		t.Fatalf("code = %q, want %q", err.Code, errors.ErrCodeValidation)
+	}
+	if !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("error does not mention duplicates: %v", err)
+	}
+	key := "Step 2"
+	if _, ok := err.Fields[key]; !ok {
+		t.Fatalf("missing field for duplicate step 2; fields = %v", err.Fields)
+	}
+}
+
+func TestApplyRenumberPreservesSuffix(t *testing.T) {
+	plan, err := buildRenumberPlan(workflowStepZero)
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+	updated := applyRenumber(workflowStepZero, plan)
+
+	wantHeaders := []string{
+		"## Step 1: PRECONDITION - Confirm context",
+		"## Step 2: SCOPE - Define questions",
+		"## Step 3: DISCOVER - Gather",
+	}
+	for _, h := range wantHeaders {
+		if !strings.Contains(updated, h) {
+			t.Fatalf("missing header %q in:\n%s", h, updated)
+		}
+	}
+
+	if strings.Contains(updated, "## Step 0:") {
+		t.Fatalf("Step 0 still present after renumber:\n%s", updated)
+	}
+
+	if !strings.Contains(updated, "**Goal:** start.") {
+		t.Fatal("body content was modified")
+	}
+}
+
+func TestApplyRenumberGapsCompact(t *testing.T) {
+	plan, err := buildRenumberPlan(workflowGaps)
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+	updated := applyRenumber(workflowGaps, plan)
+
+	if strings.Contains(updated, "## Step 5:") {
+		t.Fatalf("gaps not compacted (step 5 still present):\n%s", updated)
+	}
+	wantHeaders := []string{
+		"## Step 1: ALPHA - first",
+		"## Step 2: BETA - second",
+		"## Step 3: DELTA - fourth",
+		"## Step 4: EPSILON - fifth",
+	}
+	for _, h := range wantHeaders {
+		if !strings.Contains(updated, h) {
+			t.Fatalf("missing header %q in:\n%s", h, updated)
+		}
+	}
+}
+
+func TestRunWorkflowRenumberDryRunDoesNotWrite(t *testing.T) {
+	path := writeTempWorkflow(t, workflowStepZero)
+	original, _ := os.ReadFile(path)
+
+	var out bytes.Buffer
+	if err := runWorkflowRenumber(&out, path, true, false); err != nil {
+		t.Fatalf("runWorkflowRenumber: %v", err)
+	}
+
+	current, _ := os.ReadFile(path)
+	if string(current) != string(original) {
+		t.Fatal("dry-run wrote changes to disk")
+	}
+	if !strings.Contains(out.String(), "Dry-run plan") {
+		t.Fatalf("missing dry-run banner in output:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Step 0 -> Step 1") {
+		t.Fatalf("missing rename line in output:\n%s", out.String())
+	}
+}
+
+func TestRunWorkflowRenumberWrites(t *testing.T) {
+	path := writeTempWorkflow(t, workflowStepZero)
+
+	var out bytes.Buffer
+	if err := runWorkflowRenumber(&out, path, false, false); err != nil {
+		t.Fatalf("runWorkflowRenumber: %v", err)
+	}
+
+	current, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading result: %v", err)
+	}
+	if !strings.Contains(string(current), "## Step 1: PRECONDITION - Confirm context") {
+		t.Fatalf("step 0 was not renumbered to 1:\n%s", string(current))
+	}
+	if strings.Contains(string(current), "## Step 0:") {
+		t.Fatal("step 0 still present")
+	}
+}
+
+func TestRunWorkflowRenumberBackup(t *testing.T) {
+	path := writeTempWorkflow(t, workflowStepZero)
+
+	var out bytes.Buffer
+	if err := runWorkflowRenumber(&out, path, false, true); err != nil {
+		t.Fatalf("runWorkflowRenumber: %v", err)
+	}
+
+	if _, err := os.Stat(path + ".bak"); err != nil {
+		t.Fatalf("expected backup file at %s.bak: %v", path, err)
+	}
+	backup, _ := os.ReadFile(path + ".bak")
+	if !strings.Contains(string(backup), "## Step 0:") {
+		t.Fatal("backup does not contain original content")
+	}
+}
+
+func TestRunWorkflowRenumberAlreadyCorrectIsNoop(t *testing.T) {
+	path := writeTempWorkflow(t, workflowAlready)
+	original, _ := os.ReadFile(path)
+
+	var out bytes.Buffer
+	if err := runWorkflowRenumber(&out, path, false, false); err != nil {
+		t.Fatalf("runWorkflowRenumber: %v", err)
+	}
+
+	current, _ := os.ReadFile(path)
+	if string(current) != string(original) {
+		t.Fatal("no-op case wrote changes")
+	}
+	if !strings.Contains(out.String(), "nothing to renumber") {
+		t.Fatalf("expected nothing-to-renumber message in output:\n%s", out.String())
+	}
+}
+
+func TestRunWorkflowRenumberDuplicatesError(t *testing.T) {
+	path := writeTempWorkflow(t, workflowDuplicates)
+	original, _ := os.ReadFile(path)
+
+	var out bytes.Buffer
+	err := runWorkflowRenumber(&out, path, false, false)
+	if err == nil {
+		t.Fatal("expected duplicate error, got nil")
+	}
+	if !errors.Is(err, errors.ErrCodeValidation) {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+
+	current, _ := os.ReadFile(path)
+	if string(current) != string(original) {
+		t.Fatal("duplicates error case still wrote changes")
+	}
+}
+
+func TestRunWorkflowRenumberEmptyFileError(t *testing.T) {
+	path := writeTempWorkflow(t, "# Just a heading\n\nNo steps here.\n")
+
+	var out bytes.Buffer
+	err := runWorkflowRenumber(&out, path, false, false)
+	if err == nil {
+		t.Fatal("expected error for file with no steps")
+	}
+	if !errors.Is(err, errors.ErrCodeValidation) {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+}
+
+func TestRunWorkflowRenumberFileNotFound(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist", "WORKFLOW.md")
+
+	var out bytes.Buffer
+	err := runWorkflowRenumber(&out, missing, true, false)
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !errors.Is(err, errors.ErrCodeNotFound) {
+		t.Fatalf("expected NOT_FOUND error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), missing) {
+		t.Fatalf("error should include path %q: %v", missing, err)
+	}
+}

--- a/internal/commands/workflow/workflow.go
+++ b/internal/commands/workflow/workflow.go
@@ -77,6 +77,7 @@ Examples:
 		newInitCmd(),
 		newStartCmd(),
 		newRunsCmd(),
+		newRenumberCmd(),
 	)
 
 	return cmd

--- a/internal/guidance/workflow/parser.go
+++ b/internal/guidance/workflow/parser.go
@@ -155,6 +155,13 @@ func (p *Parser) parseCheckpoint(section string) CheckpointType {
 	}
 }
 
+// StepHeaderRegexp returns the compiled regexp used to match step headers.
+// Callers that need to locate or rewrite "## Step N: ..." headings (for example,
+// renumber tooling) should use this accessor instead of redefining the pattern.
+func StepHeaderRegexp() *regexp.Regexp {
+	return stepHeaderRe
+}
+
 // StepCount returns the number of steps in a WORKFLOW.md file without parsing fully.
 func (p *Parser) StepCount(ctx context.Context, path string) (int, error) {
 	select {


### PR DESCRIPTION
## Summary

Adds `fest workflow renumber [path]`. Walks `## Step N:` headings in a WORKFLOW.md and rewrites the numbers to form a contiguous 1-indexed sequence in document order. Closes #187.

Default target is `./WORKFLOW.md`. Accepts an explicit path argument.

## Behavior

What it touches:
- Only `## Step N:` heading lines. The heading suffix is preserved verbatim (`## Step 0: PRECONDITION - Confirm...` becomes `## Step 1: PRECONDITION - Confirm...`).

What it leaves alone:
- Step body text (cross-references inside bodies are a known v1 limitation, see below).
- The Workflow State Tracking table inside the doc.
- Every other markdown construct in the file.

Flag ergonomics mirror the existing `fest renumber phase/sequence/task` commands so users have one mental model across all renumber subcommands:
- `--dry-run` (default true) prints the rename plan without writing.
- `--skip-dry-run` applies changes immediately.
- `--backup` writes a `.bak` copy of the original alongside before applying.

Error cases (exit non-zero, no write):
- Duplicate step numbers (e.g. `1, 2, 2, 3`). The offending step numbers and their line numbers are reported.
- No `## Step N:` headings found.
- File not found or unreadable.

Success cases:
- `Step 0..N` -> `Step 1..N+1` (the CW0003 case).
- Gaps `Step 1, 2, 4, 5` -> compact to `Step 1..4`.
- Already-correct `Step 1..K` -> no-op, exit 0, no write.

## Implementation notes

- Reuses the existing step-header regex from `internal/guidance/workflow/parser.go` via a new `StepHeaderRegexp()` accessor. The pattern stays in one place.
- Uses `festerrors` for all error returns (NotFound, IO, Validation, Parse).
- The new command is registered with `scope.Global` because it operates on an explicit file path, not a resolved festival context. This lets you renumber a WORKFLOW.md from any directory.

## Known v1 limitations

- Cross-references inside step bodies (for example `see Step 3`) are not rewritten. Update those by hand after renumbering if needed. The `Long` help text calls this out.

## Test plan

- [x] `just build` passes.
- [x] `just test unit` passes (2105 tests).
- [x] `just lint all` reports 0 issues.
- [x] Unit tests cover: Step 0..N shifts to 1..N+1, gaps compact, already-correct no-op, duplicates error, empty file error, file-not-found error, dry-run does not write, success writes, suffix preservation, backup file written when requested.
- [x] Smoke test on a sample doc: `Step 0,1,2,4` -> `Step 1,2,3,4` end-to-end (dry-run preview matches written output).

## Files

- `internal/commands/workflow/renumber.go` (new)
- `internal/commands/workflow/renumber_test.go` (new)
- `internal/commands/workflow/workflow.go` (wire up subcommand)
- `internal/guidance/workflow/parser.go` (add `StepHeaderRegexp()` accessor)

Closes #187.