### PR TITLE
Failed gate remediation routing in fest next (closes #185)

### DIFF
--- a/internal/commands/next/navigator.go
+++ b/internal/commands/next/navigator.go
@@ -88,6 +88,10 @@ func runNavigatorMode(ctx context.Context, cwd, festivalPath string) error {
 
 // runWorkflowMode uses the workflow navigator for WORKFLOW.md-based navigation.
 func runWorkflowMode(ctx context.Context, festivalPath, phasePath string) error {
+	return runWorkflowModeWithStore(ctx, festivalPath, phasePath, nil)
+}
+
+func runWorkflowModeWithStore(ctx context.Context, festivalPath, phasePath string, store *progress.Store) error {
 	// Create guidance context for workflow navigation
 	gctx := &guidance.GuidanceContext{
 		FestivalPath: festivalPath,
@@ -106,10 +110,13 @@ func runWorkflowMode(ctx context.Context, festivalPath, phasePath string) error 
 			WithField("phase_path", phasePath)
 	}
 
-	// Create and load progress Store, inject into navigator for JSONL-backed state
-	store := progress.NewStore(festivalPath)
-	if err := store.Load(ctx); err != nil {
-		return errors.Wrap(err, "loading progress store")
+	// Create and load progress Store when the caller has not already loaded it,
+	// then inject it into the workflow navigator for JSONL-backed state.
+	if store == nil {
+		store = progress.NewStore(festivalPath)
+		if err := store.Load(ctx); err != nil {
+			return errors.Wrap(err, "loading progress store")
+		}
 	}
 	if wfNav, ok := nav.(*wf.Navigator); ok {
 		wfNav.SetStateStore(store)

--- a/internal/commands/next/next.go
+++ b/internal/commands/next/next.go
@@ -184,9 +184,15 @@ func runNext(cmd *cobra.Command, args []string) error {
 	// Failed-gate remediation routing takes priority over normal phase
 	// resolution. When a phase gate was rejected with --remediation-phase,
 	// route into the remediation phase until it completes, then auto-recheck
-	// the failed gate.
-	if gate, gateErr := findFailedRemediationGate(ctx, festivalPath); gateErr == nil && gate != nil {
-		if handled, err := routeFailedRemediationGate(ctx, festivalPath, gate); handled {
+	// the failed gate. The progress event log is the source of truth for active
+	// failed gates, so a load/materialization failure here must fail closed
+	// rather than silently falling through to normal routing.
+	gate, gateErr := findFailedRemediationGate(ctx, festivalPath)
+	if gateErr != nil {
+		return errors.Wrap(gateErr, "checking for failed-gate remediation state")
+	}
+	if gate != nil {
+		if handled, err := routeFailedRemediationGate(ctx, festivalPath, gate, opts); handled {
 			return err
 		}
 	}
@@ -563,6 +569,16 @@ type RenderOptions struct {
 }
 
 func (o RenderOptions) showInlineContext() bool { return !o.NoContext }
+
+// isMachineOutput reports whether the active render mode expects pipeable or
+// structured output (path, cd, project-dir, short, or json) rather than the
+// default human banner plus instructions. Failed-gate remediation routing must
+// suppress its banner and navigator instructions in these modes so that
+// `fest next --path` and friends keep honoring their output contracts while a
+// remediation loop is active.
+func (o RenderOptions) isMachineOutput() bool {
+	return o.JSON || o.Path || o.CD || o.ProjectDir || o.Short
+}
 
 // runStandaloneNext renders the next step for a tracked standalone workflow.
 func runStandaloneNext(ctx context.Context, res *standalone.Result, opts RenderOptions) error {

--- a/internal/commands/next/next.go
+++ b/internal/commands/next/next.go
@@ -181,6 +181,16 @@ func runNext(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Failed-gate remediation routing takes priority over normal phase
+	// resolution. When a phase gate was rejected with --remediation-phase,
+	// route into the remediation phase until it completes, then auto-recheck
+	// the failed gate.
+	if gate, gateErr := findFailedRemediationGate(ctx, festivalPath); gateErr == nil && gate != nil {
+		if handled, err := routeFailedRemediationGate(ctx, festivalPath, gate); handled {
+			return err
+		}
+	}
+
 	// If mode flag is provided or --navigator flag is set, use guidance navigator
 	if modeFlag != "" || useNavigator {
 		return runNavigatorMode(ctx, cwd, festivalPath)

--- a/internal/commands/next/next.go
+++ b/internal/commands/next/next.go
@@ -187,14 +187,17 @@ func runNext(cmd *cobra.Command, args []string) error {
 	// the failed gate. The progress event log is the source of truth for active
 	// failed gates, so a load/materialization failure here must fail closed
 	// rather than silently falling through to normal routing.
-	gate, gateErr := findFailedRemediationGate(ctx, festivalPath)
+	remediationStore, gateErr := loadProgressStore(ctx, festivalPath)
+	if gateErr != nil {
+		return errors.Wrap(gateErr, "checking for failed-gate remediation state")
+	}
+	gate, gateErr := findFailedRemediationGateInStore(ctx, festivalPath, remediationStore)
 	if gateErr != nil {
 		return errors.Wrap(gateErr, "checking for failed-gate remediation state")
 	}
 	if gate != nil {
-		if handled, err := routeFailedRemediationGate(ctx, festivalPath, gate, opts); handled {
-			return err
-		}
+		_, err := routeFailedRemediationGate(ctx, festivalPath, remediationStore, gate, opts)
+		return err
 	}
 
 	// If mode flag is provided or --navigator flag is set, use guidance navigator

--- a/internal/commands/next/remediation.go
+++ b/internal/commands/next/remediation.go
@@ -100,9 +100,11 @@ func lookupGateStepName(ctx context.Context, phasePath string, stepNum int) (str
 }
 
 // isRemediationPhaseComplete reports whether the remediation phase has all
-// task-based and workflow work complete. Sequence/task and WORKFLOW.md
-// completion both qualify; phase gates on the remediation phase are not
-// required (they would block remediation completion in a circular fashion).
+// task-based and workflow work complete. A remediation phase is driven by its
+// WORKFLOW.md and/or numbered sequences; it is validated to contain at least
+// one of these at link time (see validateRemediationPhase). A GATES.md on the
+// remediation phase is not part of the remediation loop: the original failed
+// gate is the verification step and is rechecked once remediation work is done.
 func isRemediationPhaseComplete(ctx context.Context, festivalPath, remediationPhase string) (bool, error) {
 	if remediationPhase == "" {
 		return false, nil
@@ -151,9 +153,6 @@ func renderRemediationRoute(ctx context.Context, festivalPath string, gate *fail
 
 	if _, err := os.Stat(filepath.Join(remPath, "WORKFLOW.md")); err == nil {
 		return runWorkflowMode(ctx, festivalPath, remPath)
-	}
-	if _, err := os.Stat(filepath.Join(remPath, "GATES.md")); err == nil {
-		return runPhaseGateMode(ctx, festivalPath, remPath)
 	}
 	return renderFirstIncompleteTask(ctx, festivalPath, remPath)
 }

--- a/internal/commands/next/remediation.go
+++ b/internal/commands/next/remediation.go
@@ -29,9 +29,30 @@ type failedGate struct {
 	RemediationPhase string
 }
 
-func findFailedRemediationGate(ctx context.Context, festivalPath string) (*failedGate, error) {
+func loadProgressStore(ctx context.Context, festivalPath string) (*progress.Store, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	store := progress.NewStore(festivalPath)
 	if err := store.Load(ctx); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+func findFailedRemediationGate(ctx context.Context, festivalPath string) (*failedGate, error) {
+	store, err := loadProgressStore(ctx, festivalPath)
+	if err != nil {
+		return nil, err
+	}
+	return findFailedRemediationGateInStore(ctx, festivalPath, store)
+}
+
+func findFailedRemediationGateInStore(ctx context.Context, festivalPath string, store *progress.Store) (*failedGate, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 
@@ -108,17 +129,28 @@ func lookupGateStepName(ctx context.Context, phasePath string, stepNum int) (str
 // remediation phase is not part of the remediation loop: the original failed
 // gate is the verification step and is rechecked once remediation work is done.
 func isRemediationPhaseComplete(ctx context.Context, festivalPath, remediationPhase string) (bool, error) {
+	store, err := loadProgressStore(ctx, festivalPath)
+	if err != nil {
+		return false, err
+	}
+	phasePath, err := resolveRemediationPhasePath(festivalPath, &failedGate{RemediationPhase: remediationPhase})
+	if err != nil {
+		return false, err
+	}
+	return isRemediationPhaseCompleteWithStore(ctx, store, phasePath, remediationPhase)
+}
+
+func isRemediationPhaseCompleteWithStore(ctx context.Context, store *progress.Store, phasePath, remediationPhase string) (bool, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
 	if remediationPhase == "" {
 		return false, nil
 	}
-	phasePath := filepath.Join(festivalPath, remediationPhase)
-	if _, err := os.Stat(phasePath); err != nil {
-		return false, nil
-	}
-
-	store := progress.NewStore(festivalPath)
-	storeLoaded := store.Load(ctx) == nil
-	return shared.ArePhaseTasksAndWorkflowComplete(ctx, storeLoaded, store, phasePath, remediationPhase), nil
+	return shared.ArePhaseTasksAndWorkflowComplete(ctx, store != nil, store, phasePath, remediationPhase), nil
 }
 
 // routeFailedRemediationGate produces the appropriate `fest next` output for
@@ -128,31 +160,53 @@ func isRemediationPhaseComplete(ctx context.Context, festivalPath, remediationPh
 // and renders the gate step for re-evaluation. Returns (true, nil) when it
 // fully handled the request. opts controls output formatting so machine-output
 // modes are honored while remediation is active.
-func routeFailedRemediationGate(ctx context.Context, festivalPath string, gate *failedGate, opts RenderOptions) (bool, error) {
+func routeFailedRemediationGate(ctx context.Context, festivalPath string, store *progress.Store, gate *failedGate, opts RenderOptions) (bool, error) {
 	if gate == nil {
 		return false, nil
 	}
+	if store == nil {
+		var err error
+		store, err = loadProgressStore(ctx, festivalPath)
+		if err != nil {
+			return true, err
+		}
+	}
 
-	complete, err := isRemediationPhaseComplete(ctx, festivalPath, gate.RemediationPhase)
+	remPath, err := resolveRemediationPhasePath(festivalPath, gate)
+	if err != nil {
+		return true, err
+	}
+
+	complete, err := isRemediationPhaseCompleteWithStore(ctx, store, remPath, gate.RemediationPhase)
 	if err != nil {
 		return true, err
 	}
 
 	if complete {
-		return true, renderRecheckRoute(ctx, festivalPath, gate, opts)
+		return true, renderRecheckRoute(ctx, festivalPath, store, gate, opts)
 	}
-	return true, renderRemediationRoute(ctx, festivalPath, gate, opts)
+	return true, renderRemediationRoute(ctx, festivalPath, store, gate, remPath, opts)
 }
 
-func renderRemediationRoute(ctx context.Context, festivalPath string, gate *failedGate, opts RenderOptions) error {
-	remPath := filepath.Join(festivalPath, gate.RemediationPhase)
-	if _, err := os.Stat(remPath); err != nil {
-		return festerrors.NotFound("remediation phase directory").
-			WithField("phase", gate.RemediationPhase).
-			WithField("path", remPath)
+func resolveRemediationPhasePath(festivalPath string, gate *failedGate) (string, error) {
+	if gate == nil || gate.RemediationPhase == "" {
+		return "", festerrors.Validation("failed gate is missing a remediation phase").
+			WithHint("Reject the gate again with --remediation-phase, or clear the failed-remediation state with 'fest workflow reject --reason \"...\"'")
 	}
 
-	useWorkflow := shouldRouteToRemediationWorkflow(ctx, festivalPath, remPath, gate.RemediationPhase)
+	remPath := filepath.Join(festivalPath, gate.RemediationPhase)
+	info, err := os.Stat(remPath)
+	if err != nil || !info.IsDir() {
+		return "", festerrors.NotFound("remediation phase directory").
+			WithField("phase", gate.RemediationPhase).
+			WithField("path", remPath).
+			WithHint(fmt.Sprintf("The failed gate still references %s, but that phase no longer exists. Restore or rename the phase, or clear the failed-remediation state with 'fest workflow reject --phase %s --reason \"...\"'.", gate.RemediationPhase, gate.PhaseName))
+	}
+	return remPath, nil
+}
+
+func renderRemediationRoute(ctx context.Context, festivalPath string, store *progress.Store, gate *failedGate, remPath string, opts RenderOptions) error {
+	useWorkflow := shouldRouteToRemediationWorkflowWithStore(ctx, store, remPath, gate.RemediationPhase)
 
 	if opts.isMachineOutput() {
 		view, err := remediationRouteView(ctx, festivalPath, remPath, gate, useWorkflow)
@@ -164,7 +218,7 @@ func renderRemediationRoute(ctx context.Context, festivalPath string, gate *fail
 
 	printFailedGateBanner(gate)
 	if useWorkflow {
-		return runWorkflowMode(ctx, festivalPath, remPath)
+		return runWorkflowModeWithStore(ctx, festivalPath, remPath, store)
 	}
 	return renderFirstIncompleteTask(ctx, festivalPath, remPath, opts)
 }
@@ -178,13 +232,25 @@ func renderRemediationRoute(ctx context.Context, festivalPath string, gate *fail
 // runs before tasks (position=before); an after-position workflow waits until
 // the phase's tasks are complete, matching normal phase routing.
 func shouldRouteToRemediationWorkflow(ctx context.Context, festivalPath, remPath, remediationPhase string) bool {
+	store, err := loadProgressStore(ctx, festivalPath)
+	if err != nil {
+		return true
+	}
+	return shouldRouteToRemediationWorkflowWithStore(ctx, store, remPath, remediationPhase)
+}
+
+func shouldRouteToRemediationWorkflowWithStore(ctx context.Context, store *progress.Store, remPath, remediationPhase string) bool {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return true
+	}
 	if _, err := os.Stat(filepath.Join(remPath, "WORKFLOW.md")); err != nil {
 		return false
 	}
 
-	store := progress.NewStore(festivalPath)
-	storeLoaded := store.Load(ctx) == nil
-	if !storeLoaded {
+	if store == nil {
 		return true
 	}
 
@@ -199,7 +265,7 @@ func shouldRouteToRemediationWorkflow(ctx context.Context, festivalPath, remPath
 	if !shared.HasSequenceDirs(remPath) {
 		return true
 	}
-	return shared.ArePhaseTasksComplete(storeLoaded, store, remPath, remediationPhase)
+	return shared.ArePhaseTasksComplete(true, store, remPath, remediationPhase)
 }
 
 func renderFirstIncompleteTask(ctx context.Context, festivalPath, phasePath string, opts RenderOptions) error {
@@ -216,21 +282,19 @@ func renderFirstIncompleteTask(ctx context.Context, festivalPath, phasePath stri
 	return nil
 }
 
-func renderRecheckRoute(ctx context.Context, festivalPath string, gate *failedGate, opts RenderOptions) error {
-	// Record the recheck transition first so the gate leaves
-	// failed_with_remediation regardless of output mode. Machine-output callers
-	// then receive a clean view; human callers get the banner plus the gate
-	// step instructions.
-	nav, err := newRecheckNavigator(ctx, festivalPath, gate)
+func renderRecheckRoute(ctx context.Context, festivalPath string, store *progress.Store, gate *failedGate, opts RenderOptions) error {
+	if opts.isMachineOutput() {
+		return emitRemediationView(recheckRouteView(gate), opts)
+	}
+
+	// Human `fest next` is the explicit operator action that re-enters the
+	// failed gate. Pipe-oriented modes must remain read-only.
+	nav, err := newRecheckNavigator(ctx, festivalPath, store, gate)
 	if err != nil {
 		return err
 	}
 	if err := nav.Recheck(ctx); err != nil {
 		return festerrors.Wrap(err, "recording gate recheck event")
-	}
-
-	if opts.isMachineOutput() {
-		return emitRemediationView(recheckRouteView(gate), opts)
 	}
 
 	printRecheckBanner(gate)
@@ -245,7 +309,7 @@ func renderRecheckRoute(ctx context.Context, festivalPath string, gate *failedGa
 
 // newRecheckNavigator builds the GATES.md-configured workflow navigator used to
 // record the recheck transition and render the failed gate step.
-func newRecheckNavigator(ctx context.Context, festivalPath string, gate *failedGate) (*wf.Navigator, error) {
+func newRecheckNavigator(ctx context.Context, festivalPath string, store *progress.Store, gate *failedGate) (*wf.Navigator, error) {
 	gctx := &guidance.GuidanceContext{
 		FestivalPath: festivalPath,
 		FestivalName: filepath.Base(festivalPath),
@@ -266,9 +330,12 @@ func newRecheckNavigator(ctx context.Context, festivalPath string, gate *failedG
 	wfNav.SetDocFilename("GATES.md")
 	wfNav.SetStateKeyPrefix(gateStateKeyPrefix)
 
-	store := progress.NewStore(festivalPath)
-	if err := store.Load(ctx); err != nil {
-		return nil, festerrors.Wrap(err, "loading progress store for recheck")
+	if store == nil {
+		var err error
+		store, err = loadProgressStore(ctx, festivalPath)
+		if err != nil {
+			return nil, festerrors.Wrap(err, "loading progress store for recheck")
+		}
 	}
 	wfNav.SetStateStore(store)
 

--- a/internal/commands/next/remediation.go
+++ b/internal/commands/next/remediation.go
@@ -2,6 +2,7 @@ package next
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
 	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/frontmatter"
 	"github.com/Obedience-Corp/fest/internal/guidance"
 	"github.com/Obedience-Corp/fest/internal/guidance/selection"
 	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
@@ -124,24 +126,25 @@ func isRemediationPhaseComplete(ctx context.Context, festivalPath, remediationPh
 // renders into the remediation phase (workflow or task). If complete, it
 // auto-rechecks the gate (transitions the step out of failed_remediation)
 // and renders the gate step for re-evaluation. Returns (true, nil) when it
-// fully handled the request.
-func routeFailedRemediationGate(ctx context.Context, festivalPath string, gate *failedGate) (bool, error) {
+// fully handled the request. opts controls output formatting so machine-output
+// modes are honored while remediation is active.
+func routeFailedRemediationGate(ctx context.Context, festivalPath string, gate *failedGate, opts RenderOptions) (bool, error) {
 	if gate == nil {
 		return false, nil
 	}
 
 	complete, err := isRemediationPhaseComplete(ctx, festivalPath, gate.RemediationPhase)
 	if err != nil {
-		return false, err
+		return true, err
 	}
 
-	if !complete {
-		return true, renderRemediationRoute(ctx, festivalPath, gate)
+	if complete {
+		return true, renderRecheckRoute(ctx, festivalPath, gate, opts)
 	}
-	return true, renderRecheckRoute(ctx, festivalPath, gate)
+	return true, renderRemediationRoute(ctx, festivalPath, gate, opts)
 }
 
-func renderRemediationRoute(ctx context.Context, festivalPath string, gate *failedGate) error {
+func renderRemediationRoute(ctx context.Context, festivalPath string, gate *failedGate, opts RenderOptions) error {
 	remPath := filepath.Join(festivalPath, gate.RemediationPhase)
 	if _, err := os.Stat(remPath); err != nil {
 		return festerrors.NotFound("remediation phase directory").
@@ -149,37 +152,100 @@ func renderRemediationRoute(ctx context.Context, festivalPath string, gate *fail
 			WithField("path", remPath)
 	}
 
-	printFailedGateBanner(gate)
+	useWorkflow := shouldRouteToRemediationWorkflow(ctx, festivalPath, remPath, gate.RemediationPhase)
 
-	if _, err := os.Stat(filepath.Join(remPath, "WORKFLOW.md")); err == nil {
+	if opts.isMachineOutput() {
+		view, err := remediationRouteView(ctx, festivalPath, remPath, gate, useWorkflow)
+		if err != nil {
+			return err
+		}
+		return emitRemediationView(view, opts)
+	}
+
+	printFailedGateBanner(gate)
+	if useWorkflow {
 		return runWorkflowMode(ctx, festivalPath, remPath)
 	}
-	return renderFirstIncompleteTask(ctx, festivalPath, remPath)
+	return renderFirstIncompleteTask(ctx, festivalPath, remPath, opts)
 }
 
-func renderFirstIncompleteTask(ctx context.Context, festivalPath, phasePath string) error {
+// shouldRouteToRemediationWorkflow reports whether `fest next` should render the
+// remediation phase's WORKFLOW.md step rather than its next task. A WORKFLOW.md
+// is surfaced only while it still has incomplete steps: a completed workflow
+// always falls through to task routing so a remediation phase with a finished
+// workflow but remaining task work does not dead-end on "WORKFLOW COMPLETE". An
+// incomplete workflow is shown immediately when it is the phase's only work or
+// runs before tasks (position=before); an after-position workflow waits until
+// the phase's tasks are complete, matching normal phase routing.
+func shouldRouteToRemediationWorkflow(ctx context.Context, festivalPath, remPath, remediationPhase string) bool {
+	if _, err := os.Stat(filepath.Join(remPath, "WORKFLOW.md")); err != nil {
+		return false
+	}
+
+	store := progress.NewStore(festivalPath)
+	storeLoaded := store.Load(ctx) == nil
+	if !storeLoaded {
+		return true
+	}
+
+	state, ok := store.WorkflowPhaseState(remediationPhase)
+	if ok && state.TotalSteps > 0 && state.IsComplete() {
+		return false
+	}
+
+	if shared.WorkflowPositionForPhase(remPath) == frontmatter.WorkflowPositionBefore {
+		return true
+	}
+	if !shared.HasSequenceDirs(remPath) {
+		return true
+	}
+	return shared.ArePhaseTasksComplete(storeLoaded, store, remPath, remediationPhase)
+}
+
+func renderFirstIncompleteTask(ctx context.Context, festivalPath, phasePath string, opts RenderOptions) error {
 	selector := selection.NewSelector(festivalPath)
 	result, err := selector.FindNext(ctx, phasePath)
 	if err != nil {
 		return festerrors.Wrap(err, "finding next remediation task")
 	}
-	fmt.Print(selection.FormatText(result, true))
+	if opts.Verbose {
+		fmt.Print(selection.FormatVerbose(result, opts.showInlineContext()))
+		return nil
+	}
+	fmt.Print(selection.FormatText(result, opts.showInlineContext()))
 	return nil
 }
 
-func renderRecheckRoute(ctx context.Context, festivalPath string, gate *failedGate) error {
-	fmt.Println("REMEDIATION COMPLETE. RECHECK GATE.")
-	fmt.Println("───────────────────────────────────")
-	fmt.Printf("Previously failed gate:\n  %s / step %d", gate.PhaseName, gate.Step)
-	if gate.StepName != "" {
-		fmt.Printf(" (%s)", gate.StepName)
+func renderRecheckRoute(ctx context.Context, festivalPath string, gate *failedGate, opts RenderOptions) error {
+	// Record the recheck transition first so the gate leaves
+	// failed_with_remediation regardless of output mode. Machine-output callers
+	// then receive a clean view; human callers get the banner plus the gate
+	// step instructions.
+	nav, err := newRecheckNavigator(ctx, festivalPath, gate)
+	if err != nil {
+		return err
 	}
-	fmt.Println()
-	if gate.Reason != "" {
-		fmt.Printf("Original reason: %s\n", gate.Reason)
+	if err := nav.Recheck(ctx); err != nil {
+		return festerrors.Wrap(err, "recording gate recheck event")
 	}
-	fmt.Printf("Remediation phase: %s (complete)\n\n", gate.RemediationPhase)
 
+	if opts.isMachineOutput() {
+		return emitRemediationView(recheckRouteView(gate), opts)
+	}
+
+	printRecheckBanner(gate)
+	instructions, err := nav.FormatInstructions(ctx)
+	if err != nil {
+		return festerrors.Wrap(err, "formatting gate instructions for recheck")
+	}
+	fmt.Print(instructions)
+	fmt.Println("\nRun 'fest workflow approve' to approve, or 'fest workflow reject' to record another failure.")
+	return nil
+}
+
+// newRecheckNavigator builds the GATES.md-configured workflow navigator used to
+// record the recheck transition and render the failed gate step.
+func newRecheckNavigator(ctx context.Context, festivalPath string, gate *failedGate) (*wf.Navigator, error) {
 	gctx := &guidance.GuidanceContext{
 		FestivalPath: festivalPath,
 		FestivalName: filepath.Base(festivalPath),
@@ -191,35 +257,116 @@ func renderRecheckRoute(ctx context.Context, festivalPath string, gate *failedGa
 	}
 	nav, err := guidance.NewNavigator(ctx, gctx)
 	if err != nil {
-		return festerrors.Wrap(err, "creating gate navigator for recheck")
+		return nil, festerrors.Wrap(err, "creating gate navigator for recheck")
 	}
-	if wfNav, ok := nav.(*wf.Navigator); ok {
-		wfNav.SetDocFilename("GATES.md")
-		wfNav.SetStateKeyPrefix(gateStateKeyPrefix)
+	wfNav, ok := nav.(*wf.Navigator)
+	if !ok {
+		return nil, festerrors.New("gate navigator is not a workflow navigator")
 	}
+	wfNav.SetDocFilename("GATES.md")
+	wfNav.SetStateKeyPrefix(gateStateKeyPrefix)
+
 	store := progress.NewStore(festivalPath)
 	if err := store.Load(ctx); err != nil {
-		return festerrors.Wrap(err, "loading progress store for recheck")
+		return nil, festerrors.Wrap(err, "loading progress store for recheck")
 	}
-	if wfNav, ok := nav.(*wf.Navigator); ok {
-		wfNav.SetStateStore(store)
+	wfNav.SetStateStore(store)
+
+	if err := wfNav.Initialize(ctx); err != nil {
+		return nil, festerrors.Wrap(err, "initializing gate navigator for recheck")
 	}
-	if err := nav.Initialize(ctx); err != nil {
-		return festerrors.Wrap(err, "initializing gate navigator for recheck")
+	return wfNav, nil
+}
+
+// remediationView is the machine-readable description of an active failed-gate
+// remediation route. Paths in TargetDoc are relative to the festival root for
+// piping; TargetDir is absolute for shell `cd`.
+type remediationView struct {
+	Mode             string `json:"mode"`
+	Route            string `json:"route"`
+	Complete         bool   `json:"remediation_complete"`
+	FailedGatePhase  string `json:"failed_gate_phase"`
+	FailedGateStep   int    `json:"failed_gate_step"`
+	FailedGateName   string `json:"failed_gate_step_name,omitempty"`
+	RemediationPhase string `json:"remediation_phase"`
+	Reason           string `json:"reason,omitempty"`
+	TargetDoc        string `json:"target_doc,omitempty"`
+	TargetDir        string `json:"target_dir,omitempty"`
+}
+
+func remediationRouteView(ctx context.Context, festivalPath, remPath string, gate *failedGate, useWorkflow bool) (remediationView, error) {
+	v := remediationView{
+		Mode:             "failed-gate-remediation",
+		FailedGatePhase:  gate.PhaseName,
+		FailedGateStep:   gate.Step,
+		FailedGateName:   gate.StepName,
+		RemediationPhase: gate.RemediationPhase,
+		Reason:           gate.Reason,
+		TargetDir:        remPath,
 	}
-	if wfNav, ok := nav.(*wf.Navigator); ok {
-		if err := wfNav.Recheck(ctx); err != nil {
-			return festerrors.Wrap(err, "recording gate recheck event")
-		}
+	if useWorkflow {
+		v.Route = "remediation-workflow"
+		v.TargetDoc = filepath.Join(gate.RemediationPhase, "WORKFLOW.md")
+		return v, nil
 	}
 
-	instructions, err := nav.FormatInstructions(ctx)
+	v.Route = "remediation-task"
+	selector := selection.NewSelector(festivalPath)
+	result, err := selector.FindNext(ctx, remPath)
 	if err != nil {
-		return festerrors.Wrap(err, "formatting gate instructions for recheck")
+		return v, festerrors.Wrap(err, "finding next remediation task")
 	}
-	fmt.Print(instructions)
-	fmt.Println("\nRun 'fest workflow approve' to approve, or 'fest workflow reject' to record another failure.")
+	if result != nil && result.Task != nil {
+		v.TargetDoc = filepath.Join(result.Task.PhaseName, result.Task.SequenceName, result.Task.Name+".md")
+		v.TargetDir = filepath.Join(festivalPath, result.Task.PhaseName, result.Task.SequenceName)
+	}
+	return v, nil
+}
+
+func recheckRouteView(gate *failedGate) remediationView {
+	return remediationView{
+		Mode:             "failed-gate-remediation",
+		Route:            "recheck-gate",
+		Complete:         true,
+		FailedGatePhase:  gate.PhaseName,
+		FailedGateStep:   gate.Step,
+		FailedGateName:   gate.StepName,
+		RemediationPhase: gate.RemediationPhase,
+		Reason:           gate.Reason,
+		TargetDoc:        filepath.Join(gate.PhaseName, "GATES.md"),
+		TargetDir:        gate.PhasePath,
+	}
+}
+
+func emitRemediationView(v remediationView, opts RenderOptions) error {
+	switch {
+	case opts.Path:
+		if v.TargetDoc == "" {
+			return festerrors.NotFound("no remediation target document")
+		}
+		fmt.Println(v.TargetDoc)
+	case opts.CD, opts.ProjectDir:
+		if v.TargetDir == "" {
+			return festerrors.NotFound("no remediation target directory")
+		}
+		fmt.Println(v.TargetDir)
+	case opts.Short:
+		fmt.Println(remediationShortLine(v))
+	case opts.JSON:
+		data, err := json.MarshalIndent(v, "", "  ")
+		if err != nil {
+			return festerrors.Parse("formatting remediation JSON", err)
+		}
+		fmt.Println(string(data))
+	}
 	return nil
+}
+
+func remediationShortLine(v remediationView) string {
+	if v.Complete {
+		return fmt.Sprintf("remediation complete: recheck gate %s step %d", v.FailedGatePhase, v.FailedGateStep)
+	}
+	return fmt.Sprintf("remediation active: %s (gate %s step %d failed)", v.RemediationPhase, v.FailedGatePhase, v.FailedGateStep)
 }
 
 func printFailedGateBanner(gate *failedGate) {
@@ -234,4 +381,18 @@ func printFailedGateBanner(gate *failedGate) {
 		fmt.Printf("Reason: %s\n", gate.Reason)
 	}
 	fmt.Printf("Remediation phase:\n  %s\n\n", gate.RemediationPhase)
+}
+
+func printRecheckBanner(gate *failedGate) {
+	fmt.Println("REMEDIATION COMPLETE. RECHECK GATE.")
+	fmt.Println("───────────────────────────────────")
+	fmt.Printf("Previously failed gate:\n  %s / step %d", gate.PhaseName, gate.Step)
+	if gate.StepName != "" {
+		fmt.Printf(" (%s)", gate.StepName)
+	}
+	fmt.Println()
+	if gate.Reason != "" {
+		fmt.Printf("Original reason: %s\n", gate.Reason)
+	}
+	fmt.Printf("Remediation phase: %s (complete)\n\n", gate.RemediationPhase)
 }

--- a/internal/commands/next/remediation.go
+++ b/internal/commands/next/remediation.go
@@ -1,0 +1,238 @@
+package next
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/Obedience-Corp/fest/internal/commands/shared"
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/guidance"
+	"github.com/Obedience-Corp/fest/internal/guidance/selection"
+	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+	"github.com/Obedience-Corp/fest/internal/progress"
+)
+
+const gateStateKeyPrefix = "gate:"
+
+type failedGate struct {
+	PhasePath        string
+	PhaseName        string
+	Step             int
+	StepName         string
+	Reason           string
+	RemediationPhase string
+}
+
+func findFailedRemediationGate(ctx context.Context, festivalPath string) (*failedGate, error) {
+	store := progress.NewStore(festivalPath)
+	if err := store.Load(ctx); err != nil {
+		return nil, err
+	}
+
+	state := store.WorkflowState()
+	if state == nil {
+		return nil, nil
+	}
+
+	type candidate struct {
+		phaseName string
+		stepNum   int
+		stepState *wf.StepState
+	}
+	var candidates []candidate
+	for stateKey, phaseState := range state.Phases {
+		if !strings.HasPrefix(stateKey, gateStateKeyPrefix) {
+			continue
+		}
+		if phaseState == nil {
+			continue
+		}
+		phaseName := strings.TrimPrefix(stateKey, gateStateKeyPrefix)
+		for stepNum, ss := range phaseState.Steps {
+			if ss != nil && ss.Status == wf.StepStatusFailedRemediation {
+				candidates = append(candidates, candidate{phaseName: phaseName, stepNum: stepNum, stepState: ss})
+			}
+		}
+	}
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].phaseName != candidates[j].phaseName {
+			return candidates[i].phaseName < candidates[j].phaseName
+		}
+		return candidates[i].stepNum < candidates[j].stepNum
+	})
+	c := candidates[0]
+
+	phasePath := filepath.Join(festivalPath, c.phaseName)
+	gate := &failedGate{
+		PhasePath:        phasePath,
+		PhaseName:        c.phaseName,
+		Step:             c.stepNum,
+		Reason:           c.stepState.Feedback,
+		RemediationPhase: c.stepState.RemediationPhase,
+	}
+	if name, err := lookupGateStepName(ctx, phasePath, c.stepNum); err == nil {
+		gate.StepName = name
+	}
+	return gate, nil
+}
+
+func lookupGateStepName(ctx context.Context, phasePath string, stepNum int) (string, error) {
+	gatesPath := filepath.Join(phasePath, "GATES.md")
+	if _, err := os.Stat(gatesPath); err != nil {
+		return "", err
+	}
+	steps, err := wf.NewParser().Parse(ctx, gatesPath)
+	if err != nil {
+		return "", err
+	}
+	if stepNum < 1 || stepNum > len(steps) {
+		return "", festerrors.NotFound("gate step")
+	}
+	return steps[stepNum-1].Name, nil
+}
+
+// isRemediationPhaseComplete reports whether the remediation phase has all
+// task-based and workflow work complete. Sequence/task and WORKFLOW.md
+// completion both qualify; phase gates on the remediation phase are not
+// required (they would block remediation completion in a circular fashion).
+func isRemediationPhaseComplete(ctx context.Context, festivalPath, remediationPhase string) (bool, error) {
+	if remediationPhase == "" {
+		return false, nil
+	}
+	phasePath := filepath.Join(festivalPath, remediationPhase)
+	if _, err := os.Stat(phasePath); err != nil {
+		return false, nil
+	}
+
+	store := progress.NewStore(festivalPath)
+	storeLoaded := store.Load(ctx) == nil
+	return shared.ArePhaseTasksAndWorkflowComplete(ctx, storeLoaded, store, phasePath, remediationPhase), nil
+}
+
+// routeFailedRemediationGate produces the appropriate `fest next` output for
+// an outstanding failed gate. If the remediation phase is incomplete, it
+// renders into the remediation phase (workflow or task). If complete, it
+// auto-rechecks the gate (transitions the step out of failed_remediation)
+// and renders the gate step for re-evaluation. Returns (true, nil) when it
+// fully handled the request.
+func routeFailedRemediationGate(ctx context.Context, festivalPath string, gate *failedGate) (bool, error) {
+	if gate == nil {
+		return false, nil
+	}
+
+	complete, err := isRemediationPhaseComplete(ctx, festivalPath, gate.RemediationPhase)
+	if err != nil {
+		return false, err
+	}
+
+	if !complete {
+		return true, renderRemediationRoute(ctx, festivalPath, gate)
+	}
+	return true, renderRecheckRoute(ctx, festivalPath, gate)
+}
+
+func renderRemediationRoute(ctx context.Context, festivalPath string, gate *failedGate) error {
+	remPath := filepath.Join(festivalPath, gate.RemediationPhase)
+	if _, err := os.Stat(remPath); err != nil {
+		return festerrors.NotFound("remediation phase directory").
+			WithField("phase", gate.RemediationPhase).
+			WithField("path", remPath)
+	}
+
+	printFailedGateBanner(gate)
+
+	if _, err := os.Stat(filepath.Join(remPath, "WORKFLOW.md")); err == nil {
+		return runWorkflowMode(ctx, festivalPath, remPath)
+	}
+	if _, err := os.Stat(filepath.Join(remPath, "GATES.md")); err == nil {
+		return runPhaseGateMode(ctx, festivalPath, remPath)
+	}
+	return renderFirstIncompleteTask(ctx, festivalPath, remPath)
+}
+
+func renderFirstIncompleteTask(ctx context.Context, festivalPath, phasePath string) error {
+	selector := selection.NewSelector(festivalPath)
+	result, err := selector.FindNext(ctx, phasePath)
+	if err != nil {
+		return festerrors.Wrap(err, "finding next remediation task")
+	}
+	fmt.Print(selection.FormatText(result, true))
+	return nil
+}
+
+func renderRecheckRoute(ctx context.Context, festivalPath string, gate *failedGate) error {
+	fmt.Println("REMEDIATION COMPLETE. RECHECK GATE.")
+	fmt.Println("───────────────────────────────────")
+	fmt.Printf("Previously failed gate:\n  %s / step %d", gate.PhaseName, gate.Step)
+	if gate.StepName != "" {
+		fmt.Printf(" (%s)", gate.StepName)
+	}
+	fmt.Println()
+	if gate.Reason != "" {
+		fmt.Printf("Original reason: %s\n", gate.Reason)
+	}
+	fmt.Printf("Remediation phase: %s (complete)\n\n", gate.RemediationPhase)
+
+	gctx := &guidance.GuidanceContext{
+		FestivalPath: festivalPath,
+		FestivalName: filepath.Base(festivalPath),
+		PhasePath:    gate.PhasePath,
+		PhaseName:    gate.PhaseName,
+		PhaseType:    guidance.DetectPhaseType(gate.PhasePath),
+		Mode:         guidance.ModeWorkflow,
+		Config:       guidance.DefaultConfig(),
+	}
+	nav, err := guidance.NewNavigator(ctx, gctx)
+	if err != nil {
+		return festerrors.Wrap(err, "creating gate navigator for recheck")
+	}
+	if wfNav, ok := nav.(*wf.Navigator); ok {
+		wfNav.SetDocFilename("GATES.md")
+		wfNav.SetStateKeyPrefix(gateStateKeyPrefix)
+	}
+	store := progress.NewStore(festivalPath)
+	if err := store.Load(ctx); err != nil {
+		return festerrors.Wrap(err, "loading progress store for recheck")
+	}
+	if wfNav, ok := nav.(*wf.Navigator); ok {
+		wfNav.SetStateStore(store)
+	}
+	if err := nav.Initialize(ctx); err != nil {
+		return festerrors.Wrap(err, "initializing gate navigator for recheck")
+	}
+	if wfNav, ok := nav.(*wf.Navigator); ok {
+		if err := wfNav.Recheck(ctx); err != nil {
+			return festerrors.Wrap(err, "recording gate recheck event")
+		}
+	}
+
+	instructions, err := nav.FormatInstructions(ctx)
+	if err != nil {
+		return festerrors.Wrap(err, "formatting gate instructions for recheck")
+	}
+	fmt.Print(instructions)
+	fmt.Println("\nRun 'fest workflow approve' to approve, or 'fest workflow reject' to record another failure.")
+	return nil
+}
+
+func printFailedGateBanner(gate *failedGate) {
+	fmt.Println("FAILED GATE. REMEDIATION ACTIVE.")
+	fmt.Println("────────────────────────────────")
+	fmt.Printf("Previous gate failed:\n  %s / step %d", gate.PhaseName, gate.Step)
+	if gate.StepName != "" {
+		fmt.Printf(" (%s)", gate.StepName)
+	}
+	fmt.Println()
+	if gate.Reason != "" {
+		fmt.Printf("Reason: %s\n", gate.Reason)
+	}
+	fmt.Printf("Remediation phase:\n  %s\n\n", gate.RemediationPhase)
+}

--- a/internal/commands/next/remediation_test.go
+++ b/internal/commands/next/remediation_test.go
@@ -2,8 +2,10 @@ package next
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
@@ -152,4 +154,233 @@ func scaffoldRemediationFestival(t *testing.T) string {
 		t.Fatalf("write rem WORKFLOW.md: %v", err)
 	}
 	return dir
+}
+
+// scaffoldRemediationFestivalWithTask adds a numbered sequence with one pending
+// task to the remediation phase so the mixed workflow-plus-task routing case
+// can be exercised.
+func scaffoldRemediationFestivalWithTask(t *testing.T) string {
+	t.Helper()
+	dir := scaffoldRemediationFestival(t)
+	remPhase := filepath.Join(dir, "005_FIX_PR_302")
+	// Re-type the remediation phase as implementation so the selector surfaces
+	// task files rather than planning objectives.
+	if err := os.WriteFile(filepath.Join(remPhase, "PHASE_GOAL.md"), []byte("---\nfest_type: phase\nfest_id: 005_FIX_PR_302\nfest_phase_type: implementation\n---\n\n# Fix\n"), 0o644); err != nil {
+		t.Fatalf("rewrite rem phase goal: %v", err)
+	}
+	seq := filepath.Join(remPhase, "001_REMEDIATE")
+	if err := os.MkdirAll(seq, 0o755); err != nil {
+		t.Fatalf("mkdir rem seq: %v", err)
+	}
+	task := "---\nfest_type: task\nfest_id: 01_fix.md\nfest_name: fix\nfest_status: pending\n---\n# Fix Task\n"
+	if err := os.WriteFile(filepath.Join(seq, "01_fix.md"), []byte(task), 0o644); err != nil {
+		t.Fatalf("write rem task: %v", err)
+	}
+	return dir
+}
+
+func seedFailedGate(t *testing.T, festDir string) {
+	t.Helper()
+	ctx := context.Background()
+	store := progress.NewStore(festDir)
+	if err := store.Load(ctx); err != nil {
+		t.Fatalf("store.Load: %v", err)
+	}
+	store.QueueWorkflowEvents(wf.EmitInitEvents("gate:001_REVIEW", 1))
+	store.QueueWorkflowEvents(wf.EmitStepStartEvents("gate:001_REVIEW", 1))
+	store.QueueWorkflowEvents(wf.EmitStepFailRemediationEvents("gate:001_REVIEW", 1, "PR not ready", "005_FIX_PR_302"))
+	if err := store.Save(ctx); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+}
+
+func completeRemediationWorkflow(t *testing.T, festDir string) {
+	t.Helper()
+	ctx := context.Background()
+	store := progress.NewStore(festDir)
+	if err := store.Load(ctx); err != nil {
+		t.Fatalf("store.Load: %v", err)
+	}
+	store.QueueWorkflowEvents(wf.EmitInitEvents("005_FIX_PR_302", 1))
+	store.QueueWorkflowEvents(wf.EmitStepStartEvents("005_FIX_PR_302", 1))
+	store.QueueWorkflowEvents(wf.EmitStepDoneEvents("005_FIX_PR_302", 1))
+	if err := store.Save(ctx); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+}
+
+func TestShouldRouteToRemediationWorkflow_IncompleteWorkflowOnly(t *testing.T) {
+	festDir := scaffoldRemediationFestival(t)
+	remPath := filepath.Join(festDir, "005_FIX_PR_302")
+	if !shouldRouteToRemediationWorkflow(context.Background(), festDir, remPath, "005_FIX_PR_302") {
+		t.Fatal("incomplete workflow-only remediation phase must route to the workflow")
+	}
+}
+
+func TestShouldRouteToRemediationWorkflow_CompletedWorkflowRoutesToTask(t *testing.T) {
+	festDir := scaffoldRemediationFestivalWithTask(t)
+	completeRemediationWorkflow(t, festDir)
+	remPath := filepath.Join(festDir, "005_FIX_PR_302")
+	if shouldRouteToRemediationWorkflow(context.Background(), festDir, remPath, "005_FIX_PR_302") {
+		t.Fatal("completed remediation workflow with an incomplete task must route to the task, not re-show WORKFLOW COMPLETE")
+	}
+}
+
+func TestShouldRouteToRemediationWorkflow_NoWorkflow(t *testing.T) {
+	festDir := scaffoldRemediationFestival(t)
+	gatePhase := filepath.Join(festDir, "001_REVIEW")
+	if shouldRouteToRemediationWorkflow(context.Background(), festDir, gatePhase, "001_REVIEW") {
+		t.Fatal("a phase without WORKFLOW.md must not route to workflow mode")
+	}
+}
+
+func TestRouteFailedRemediationGate_CompletedWorkflowSurfacesTask(t *testing.T) {
+	festDir := scaffoldRemediationFestivalWithTask(t)
+	ctx := context.Background()
+	seedFailedGate(t, festDir)
+	completeRemediationWorkflow(t, festDir)
+
+	gate, err := findFailedRemediationGate(ctx, festDir)
+	if err != nil || gate == nil {
+		t.Fatalf("findFailedRemediationGate: err=%v gate=%+v", err, gate)
+	}
+
+	out := captureStdout(t, func() {
+		if _, rErr := routeFailedRemediationGate(ctx, festDir, gate, RenderOptions{}); rErr != nil {
+			t.Fatalf("route: %v", rErr)
+		}
+	})
+	if strings.Contains(out, "WORKFLOW COMPLETE") {
+		t.Fatalf("remediation route dead-ended on WORKFLOW COMPLETE instead of surfacing the task:\n%s", out)
+	}
+	if !strings.Contains(out, "001_REMEDIATE") {
+		t.Fatalf("expected the remaining remediation task in output:\n%s", out)
+	}
+}
+
+func TestRouteFailedRemediationGate_MachineOutputSuppressesBanner(t *testing.T) {
+	festDir := scaffoldRemediationFestival(t)
+	ctx := context.Background()
+	seedFailedGate(t, festDir)
+
+	gate, err := findFailedRemediationGate(ctx, festDir)
+	if err != nil || gate == nil {
+		t.Fatalf("findFailedRemediationGate: err=%v gate=%+v", err, gate)
+	}
+
+	wantDoc := filepath.Join("005_FIX_PR_302", "WORKFLOW.md")
+
+	pathOut := captureStdout(t, func() {
+		if _, rErr := routeFailedRemediationGate(ctx, festDir, gate, RenderOptions{Path: true}); rErr != nil {
+			t.Fatalf("route --path: %v", rErr)
+		}
+	})
+	if strings.TrimSpace(pathOut) != wantDoc {
+		t.Fatalf("--path = %q, want %q", strings.TrimSpace(pathOut), wantDoc)
+	}
+	if strings.Contains(pathOut, "FAILED GATE") {
+		t.Fatalf("--path leaked the human banner: %q", pathOut)
+	}
+
+	cdOut := captureStdout(t, func() {
+		if _, rErr := routeFailedRemediationGate(ctx, festDir, gate, RenderOptions{CD: true}); rErr != nil {
+			t.Fatalf("route --cd: %v", rErr)
+		}
+	})
+	if strings.TrimSpace(cdOut) != filepath.Join(festDir, "005_FIX_PR_302") {
+		t.Fatalf("--cd = %q", strings.TrimSpace(cdOut))
+	}
+
+	shortOut := captureStdout(t, func() {
+		if _, rErr := routeFailedRemediationGate(ctx, festDir, gate, RenderOptions{Short: true}); rErr != nil {
+			t.Fatalf("route --short: %v", rErr)
+		}
+	})
+	if !strings.Contains(shortOut, "remediation active") || strings.Contains(shortOut, "FAILED GATE") {
+		t.Fatalf("--short = %q", shortOut)
+	}
+
+	jsonOut := captureStdout(t, func() {
+		if _, rErr := routeFailedRemediationGate(ctx, festDir, gate, RenderOptions{JSON: true}); rErr != nil {
+			t.Fatalf("route --json: %v", rErr)
+		}
+	})
+	if strings.Contains(jsonOut, "FAILED GATE") {
+		t.Fatalf("--json leaked the human banner:\n%s", jsonOut)
+	}
+	var v remediationView
+	if err := json.Unmarshal([]byte(jsonOut), &v); err != nil {
+		t.Fatalf("unmarshal --json: %v\n%s", err, jsonOut)
+	}
+	if v.Route != "remediation-workflow" {
+		t.Errorf("Route = %q, want remediation-workflow", v.Route)
+	}
+	if v.TargetDoc != wantDoc {
+		t.Errorf("TargetDoc = %q, want %q", v.TargetDoc, wantDoc)
+	}
+	if v.Complete {
+		t.Error("Complete = true, want false while remediation is active")
+	}
+}
+
+func TestRouteFailedRemediationGate_RecheckMachineOutputAndSideEffect(t *testing.T) {
+	festDir := scaffoldRemediationFestival(t)
+	ctx := context.Background()
+	seedFailedGate(t, festDir)
+	completeRemediationWorkflow(t, festDir)
+
+	gate, err := findFailedRemediationGate(ctx, festDir)
+	if err != nil || gate == nil {
+		t.Fatalf("findFailedRemediationGate: err=%v gate=%+v", err, gate)
+	}
+
+	jsonOut := captureStdout(t, func() {
+		if _, rErr := routeFailedRemediationGate(ctx, festDir, gate, RenderOptions{JSON: true}); rErr != nil {
+			t.Fatalf("route --json: %v", rErr)
+		}
+	})
+	var v remediationView
+	if err := json.Unmarshal([]byte(jsonOut), &v); err != nil {
+		t.Fatalf("unmarshal --json: %v\n%s", err, jsonOut)
+	}
+	if v.Route != "recheck-gate" {
+		t.Errorf("Route = %q, want recheck-gate", v.Route)
+	}
+	if !v.Complete {
+		t.Error("Complete = false, want true once the remediation phase is done")
+	}
+	if v.TargetDoc != filepath.Join("001_REVIEW", "GATES.md") {
+		t.Errorf("TargetDoc = %q", v.TargetDoc)
+	}
+	if strings.Contains(jsonOut, "RECHECK GATE") {
+		t.Fatalf("--json leaked the human banner:\n%s", jsonOut)
+	}
+
+	// The recheck transition must fire regardless of output mode, so the gate
+	// no longer reports as failed-with-remediation afterward.
+	after, err := findFailedRemediationGate(ctx, festDir)
+	if err != nil {
+		t.Fatalf("findFailedRemediationGate after recheck: %v", err)
+	}
+	if after != nil {
+		t.Fatalf("recheck should have cleared the failed gate, still got %+v", after)
+	}
+}
+
+func TestFindFailedRemediationGate_FailsClosedOnUnreadableStore(t *testing.T) {
+	festDir := scaffoldRemediationFestival(t)
+	progressDir := filepath.Join(festDir, progress.ProgressDir)
+	if err := os.MkdirAll(progressDir, 0o755); err != nil {
+		t.Fatalf("mkdir progress: %v", err)
+	}
+	// A single line longer than bufio.Scanner's max token size with no newline
+	// makes the event-log read fail, standing in for a corrupt/unreadable store.
+	oversized := strings.Repeat("x", 128*1024)
+	if err := os.WriteFile(filepath.Join(progressDir, progress.ProgressEventsFile), []byte(oversized), 0o644); err != nil {
+		t.Fatalf("write events: %v", err)
+	}
+
+	if _, err := findFailedRemediationGate(context.Background(), festDir); err == nil {
+		t.Fatal("expected an error from an unreadable progress store so fest next can fail closed")
+	}
 }

--- a/internal/commands/next/remediation_test.go
+++ b/internal/commands/next/remediation_test.go
@@ -209,6 +209,15 @@ func completeRemediationWorkflow(t *testing.T, festDir string) {
 	}
 }
 
+func loadStoreForTest(t *testing.T, ctx context.Context, festDir string) *progress.Store {
+	t.Helper()
+	store, err := loadProgressStore(ctx, festDir)
+	if err != nil {
+		t.Fatalf("loadProgressStore: %v", err)
+	}
+	return store
+}
+
 func TestShouldRouteToRemediationWorkflow_IncompleteWorkflowOnly(t *testing.T) {
 	festDir := scaffoldRemediationFestival(t)
 	remPath := filepath.Join(festDir, "005_FIX_PR_302")
@@ -246,7 +255,7 @@ func TestRouteFailedRemediationGate_CompletedWorkflowSurfacesTask(t *testing.T) 
 	}
 
 	out := captureStdout(t, func() {
-		if _, rErr := routeFailedRemediationGate(ctx, festDir, gate, RenderOptions{}); rErr != nil {
+		if _, rErr := routeFailedRemediationGate(ctx, festDir, loadStoreForTest(t, ctx, festDir), gate, RenderOptions{}); rErr != nil {
 			t.Fatalf("route: %v", rErr)
 		}
 	})
@@ -271,7 +280,7 @@ func TestRouteFailedRemediationGate_MachineOutputSuppressesBanner(t *testing.T) 
 	wantDoc := filepath.Join("005_FIX_PR_302", "WORKFLOW.md")
 
 	pathOut := captureStdout(t, func() {
-		if _, rErr := routeFailedRemediationGate(ctx, festDir, gate, RenderOptions{Path: true}); rErr != nil {
+		if _, rErr := routeFailedRemediationGate(ctx, festDir, loadStoreForTest(t, ctx, festDir), gate, RenderOptions{Path: true}); rErr != nil {
 			t.Fatalf("route --path: %v", rErr)
 		}
 	})
@@ -283,7 +292,7 @@ func TestRouteFailedRemediationGate_MachineOutputSuppressesBanner(t *testing.T) 
 	}
 
 	cdOut := captureStdout(t, func() {
-		if _, rErr := routeFailedRemediationGate(ctx, festDir, gate, RenderOptions{CD: true}); rErr != nil {
+		if _, rErr := routeFailedRemediationGate(ctx, festDir, loadStoreForTest(t, ctx, festDir), gate, RenderOptions{CD: true}); rErr != nil {
 			t.Fatalf("route --cd: %v", rErr)
 		}
 	})
@@ -292,7 +301,7 @@ func TestRouteFailedRemediationGate_MachineOutputSuppressesBanner(t *testing.T) 
 	}
 
 	shortOut := captureStdout(t, func() {
-		if _, rErr := routeFailedRemediationGate(ctx, festDir, gate, RenderOptions{Short: true}); rErr != nil {
+		if _, rErr := routeFailedRemediationGate(ctx, festDir, loadStoreForTest(t, ctx, festDir), gate, RenderOptions{Short: true}); rErr != nil {
 			t.Fatalf("route --short: %v", rErr)
 		}
 	})
@@ -301,7 +310,7 @@ func TestRouteFailedRemediationGate_MachineOutputSuppressesBanner(t *testing.T) 
 	}
 
 	jsonOut := captureStdout(t, func() {
-		if _, rErr := routeFailedRemediationGate(ctx, festDir, gate, RenderOptions{JSON: true}); rErr != nil {
+		if _, rErr := routeFailedRemediationGate(ctx, festDir, loadStoreForTest(t, ctx, festDir), gate, RenderOptions{JSON: true}); rErr != nil {
 			t.Fatalf("route --json: %v", rErr)
 		}
 	})
@@ -323,7 +332,7 @@ func TestRouteFailedRemediationGate_MachineOutputSuppressesBanner(t *testing.T) 
 	}
 }
 
-func TestRouteFailedRemediationGate_RecheckMachineOutputAndSideEffect(t *testing.T) {
+func TestRouteFailedRemediationGate_RecheckMachineOutputDoesNotMutateState(t *testing.T) {
 	festDir := scaffoldRemediationFestival(t)
 	ctx := context.Background()
 	seedFailedGate(t, festDir)
@@ -335,7 +344,7 @@ func TestRouteFailedRemediationGate_RecheckMachineOutputAndSideEffect(t *testing
 	}
 
 	jsonOut := captureStdout(t, func() {
-		if _, rErr := routeFailedRemediationGate(ctx, festDir, gate, RenderOptions{JSON: true}); rErr != nil {
+		if _, rErr := routeFailedRemediationGate(ctx, festDir, loadStoreForTest(t, ctx, festDir), gate, RenderOptions{JSON: true}); rErr != nil {
 			t.Fatalf("route --json: %v", rErr)
 		}
 	})
@@ -356,14 +365,63 @@ func TestRouteFailedRemediationGate_RecheckMachineOutputAndSideEffect(t *testing
 		t.Fatalf("--json leaked the human banner:\n%s", jsonOut)
 	}
 
-	// The recheck transition must fire regardless of output mode, so the gate
-	// no longer reports as failed-with-remediation afterward.
+	after, err := findFailedRemediationGate(ctx, festDir)
+	if err != nil {
+		t.Fatalf("findFailedRemediationGate after recheck: %v", err)
+	}
+	if after == nil {
+		t.Fatal("machine-output recheck view must not clear failed-remediation state")
+	}
+}
+
+func TestRouteFailedRemediationGate_RecheckHumanOutputRecordsSideEffect(t *testing.T) {
+	festDir := scaffoldRemediationFestival(t)
+	ctx := context.Background()
+	seedFailedGate(t, festDir)
+	completeRemediationWorkflow(t, festDir)
+
+	gate, err := findFailedRemediationGate(ctx, festDir)
+	if err != nil || gate == nil {
+		t.Fatalf("findFailedRemediationGate: err=%v gate=%+v", err, gate)
+	}
+
+	out := captureStdout(t, func() {
+		if _, rErr := routeFailedRemediationGate(ctx, festDir, loadStoreForTest(t, ctx, festDir), gate, RenderOptions{}); rErr != nil {
+			t.Fatalf("route: %v", rErr)
+		}
+	})
+	if !strings.Contains(out, "RECHECK GATE") {
+		t.Fatalf("human output should include recheck banner:\n%s", out)
+	}
+
 	after, err := findFailedRemediationGate(ctx, festDir)
 	if err != nil {
 		t.Fatalf("findFailedRemediationGate after recheck: %v", err)
 	}
 	if after != nil {
-		t.Fatalf("recheck should have cleared the failed gate, still got %+v", after)
+		t.Fatalf("human recheck should have cleared the failed gate, still got %+v", after)
+	}
+}
+
+func TestRouteFailedRemediationGate_StaleRemediationPhasePointerIsActionable(t *testing.T) {
+	festDir := scaffoldRemediationFestival(t)
+	ctx := context.Background()
+	seedFailedGate(t, festDir)
+
+	gate, err := findFailedRemediationGate(ctx, festDir)
+	if err != nil || gate == nil {
+		t.Fatalf("findFailedRemediationGate: err=%v gate=%+v", err, gate)
+	}
+	if err := os.RemoveAll(filepath.Join(festDir, "005_FIX_PR_302")); err != nil {
+		t.Fatalf("remove remediation phase: %v", err)
+	}
+
+	_, err = routeFailedRemediationGate(ctx, festDir, loadStoreForTest(t, ctx, festDir), gate, RenderOptions{})
+	if err == nil {
+		t.Fatal("expected stale remediation phase error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no longer exists") || !strings.Contains(err.Error(), "fest workflow reject --phase 001_REVIEW") {
+		t.Fatalf("error is not actionable: %v", err)
 	}
 }
 

--- a/internal/commands/next/remediation_test.go
+++ b/internal/commands/next/remediation_test.go
@@ -1,0 +1,155 @@
+package next
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+	"github.com/Obedience-Corp/fest/internal/progress"
+)
+
+func TestFindFailedRemediationGate_NoneWhenAbsent(t *testing.T) {
+	festDir := scaffoldRemediationFestival(t)
+	gate, err := findFailedRemediationGate(context.Background(), festDir)
+	if err != nil {
+		t.Fatalf("findFailedRemediationGate: %v", err)
+	}
+	if gate != nil {
+		t.Fatalf("expected nil, got %+v", gate)
+	}
+}
+
+func TestFindFailedRemediationGate_DiscoversAfterReject(t *testing.T) {
+	festDir := scaffoldRemediationFestival(t)
+	ctx := context.Background()
+
+	store := progress.NewStore(festDir)
+	if err := store.Load(ctx); err != nil {
+		t.Fatalf("store.Load: %v", err)
+	}
+	store.QueueWorkflowEvents(wf.EmitInitEvents("gate:001_REVIEW", 1))
+	store.QueueWorkflowEvents(wf.EmitStepStartEvents("gate:001_REVIEW", 1))
+	store.QueueWorkflowEvents(wf.EmitStepFailRemediationEvents("gate:001_REVIEW", 1, "PR not ready", "005_FIX_PR_302"))
+	if err := store.Save(ctx); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+
+	gate, err := findFailedRemediationGate(ctx, festDir)
+	if err != nil {
+		t.Fatalf("findFailedRemediationGate: %v", err)
+	}
+	if gate == nil {
+		t.Fatal("expected gate, got nil")
+	}
+	if gate.PhaseName != "001_REVIEW" {
+		t.Errorf("PhaseName = %q, want 001_REVIEW", gate.PhaseName)
+	}
+	if gate.RemediationPhase != "005_FIX_PR_302" {
+		t.Errorf("RemediationPhase = %q", gate.RemediationPhase)
+	}
+	if gate.Step != 1 {
+		t.Errorf("Step = %d, want 1", gate.Step)
+	}
+	if gate.Reason != "PR not ready" {
+		t.Errorf("Reason = %q", gate.Reason)
+	}
+	if gate.StepName != "READINESS" {
+		t.Errorf("StepName = %q, want READINESS (parsed from GATES.md)", gate.StepName)
+	}
+}
+
+func TestFindFailedRemediationGate_ClearedAfterRecheckDone(t *testing.T) {
+	festDir := scaffoldRemediationFestival(t)
+	ctx := context.Background()
+
+	store := progress.NewStore(festDir)
+	if err := store.Load(ctx); err != nil {
+		t.Fatalf("store.Load: %v", err)
+	}
+	store.QueueWorkflowEvents(wf.EmitInitEvents("gate:001_REVIEW", 1))
+	store.QueueWorkflowEvents(wf.EmitStepStartEvents("gate:001_REVIEW", 1))
+	store.QueueWorkflowEvents(wf.EmitStepFailRemediationEvents("gate:001_REVIEW", 1, "fail", "005_FIX_PR_302"))
+	store.QueueWorkflowEvents(wf.EmitStepRecheckEvents("gate:001_REVIEW", 1))
+	store.QueueWorkflowEvents(wf.EmitStepDoneEvents("gate:001_REVIEW", 1))
+	if err := store.Save(ctx); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+
+	gate, err := findFailedRemediationGate(ctx, festDir)
+	if err != nil {
+		t.Fatalf("findFailedRemediationGate: %v", err)
+	}
+	if gate != nil {
+		t.Errorf("expected nil after recheck+done, got %+v", gate)
+	}
+}
+
+func TestIsRemediationPhaseComplete(t *testing.T) {
+	festDir := scaffoldRemediationFestival(t)
+	ctx := context.Background()
+
+	complete, err := isRemediationPhaseComplete(ctx, festDir, "005_FIX_PR_302")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if complete {
+		t.Error("expected incomplete remediation phase")
+	}
+
+	store := progress.NewStore(festDir)
+	if err := store.Load(ctx); err != nil {
+		t.Fatalf("store.Load: %v", err)
+	}
+	store.QueueWorkflowEvents(wf.EmitInitEvents("005_FIX_PR_302", 1))
+	store.QueueWorkflowEvents(wf.EmitStepStartEvents("005_FIX_PR_302", 1))
+	store.QueueWorkflowEvents(wf.EmitStepDoneEvents("005_FIX_PR_302", 1))
+	if err := store.Save(ctx); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+
+	complete, err = isRemediationPhaseComplete(ctx, festDir, "005_FIX_PR_302")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !complete {
+		t.Error("expected complete remediation phase after workflow done")
+	}
+}
+
+func scaffoldRemediationFestival(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "fest.yaml"), []byte("name: rem-next-test\nid: RNT-001\n"), 0o644); err != nil {
+		t.Fatalf("write fest.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "FESTIVAL_GOAL.md"), []byte("# Rem Next Test\n"), 0o644); err != nil {
+		t.Fatalf("write goal: %v", err)
+	}
+
+	gatePhase := filepath.Join(dir, "001_REVIEW")
+	if err := os.MkdirAll(gatePhase, 0o755); err != nil {
+		t.Fatalf("mkdir gate phase: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(gatePhase, "PHASE_GOAL.md"), []byte("---\nfest_type: phase\nfest_id: 001_REVIEW\nfest_phase_type: review\n---\n\n# Review\n"), 0o644); err != nil {
+		t.Fatalf("write phase goal: %v", err)
+	}
+	gatesMD := "---\nfest_type: phase_gate\nfest_id: 001_REVIEW-GATE\nfest_parent: 001_REVIEW\n---\n\n# Gate\n\n## Step 1: READINESS — Verify ready\n\n**Question:** ready?\n\n**Actions:**\n1. check\n\n**Checkpoint:** APPROVAL REQUIRED\n"
+	if err := os.WriteFile(filepath.Join(gatePhase, "GATES.md"), []byte(gatesMD), 0o644); err != nil {
+		t.Fatalf("write GATES.md: %v", err)
+	}
+
+	remPhase := filepath.Join(dir, "005_FIX_PR_302")
+	if err := os.MkdirAll(remPhase, 0o755); err != nil {
+		t.Fatalf("mkdir rem: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(remPhase, "PHASE_GOAL.md"), []byte("---\nfest_type: phase\nfest_id: 005_FIX_PR_302\nfest_phase_type: planning\n---\n\n# Fix\n"), 0o644); err != nil {
+		t.Fatalf("write rem phase goal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(remPhase, "WORKFLOW.md"), []byte("---\nfest_type: workflow\nfest_id: REM-WF\nfest_parent: 005_FIX_PR_302\n---\n\n# WF\n\n## Step 1: ADDRESS — Address\n\n**Goal:** Fix.\n\n**Actions:**\n1. fix\n\n**Output:** done\n\n**Checkpoint:** None\n"), 0o644); err != nil {
+		t.Fatalf("write rem WORKFLOW.md: %v", err)
+	}
+	return dir
+}

--- a/internal/commands/workflow/reject.go
+++ b/internal/commands/workflow/reject.go
@@ -3,7 +3,11 @@ package workflow
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 
+	"github.com/Obedience-Corp/fest/internal/commands/shared"
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/lifecycle"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
@@ -12,6 +16,7 @@ import (
 
 func newRejectCmd() *cobra.Command {
 	var reason string
+	var remediationPhase string
 
 	cmd := &cobra.Command{
 		Use:   "reject",
@@ -21,25 +26,41 @@ func newRejectCmd() *cobra.Command {
 When a step's work doesn't meet requirements, use this command
 to reject and request revisions.
 
-The feedback will be recorded in the workflow state for reference.`,
+The feedback will be recorded in the workflow state for reference.
+
+Failed gates with remediation:
+  Use --remediation-phase to record that a phase gate did not pass and
+  to link a remediation phase that will correct the underlying issues.
+  After the remediation phase completes, 'fest next' routes back to the
+  failed gate for re-evaluation rather than treating it as approved.
+
+Examples:
+  fest workflow reject --reason "needs revision"
+  fest workflow reject --reason "PR not ready" --remediation-phase 005_FIX_PR_302`,
 		Annotations: map[string]string{
 			"scope": string(scope.Festival),
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if reason == "" {
-				return fmt.Errorf("--reason is required\n\nUsage: fest workflow reject --reason \"your feedback here\"")
+				return festerrors.Validation("--reason is required").
+					WithHint("Usage: fest workflow reject --reason \"your feedback here\"")
 			}
-			return runReject(cmd.Context(), reason)
+			return runRejectWithRemediation(cmd.Context(), reason, remediationPhase)
 		},
 	}
 
 	cmd.Flags().StringVarP(&reason, "reason", "r", "", "reason for rejection (required)")
+	cmd.Flags().StringVar(&remediationPhase, "remediation-phase", "", "link a remediation phase for a failed gate (e.g. 005_FIX_PR_302)")
 	_ = cmd.MarkFlagRequired("reason")
 
 	return cmd
 }
 
 func runReject(ctx context.Context, reason string) error {
+	return runRejectWithRemediation(ctx, reason, "")
+}
+
+func runRejectWithRemediation(ctx context.Context, reason, remediationPhase string) error {
 	nav, err := getWorkflowNavigator(ctx)
 	if err != nil {
 		return err
@@ -55,27 +76,42 @@ func runReject(ctx context.Context, reason string) error {
 	state := nav.GetWorkflowState()
 	steps := nav.GetSteps()
 
-	// Check if already complete
 	if state.IsComplete() {
-		return fmt.Errorf("workflow is already complete")
+		return festerrors.Validation("workflow is already complete")
 	}
 
-	// Get current step info
 	currentStepNum := state.CurrentStep
 	if currentStepNum < 1 || currentStepNum > len(steps) {
-		return fmt.Errorf("invalid workflow state: current step %d out of range", currentStepNum)
+		return festerrors.Validation("invalid workflow state").
+			WithField("current_step", currentStepNum).
+			WithField("total_steps", len(steps))
 	}
 
 	step := steps[currentStepNum-1]
 
-	// Verify this is a checkpoint step
 	if !step.Checkpoint.IsBlocking() {
-		return fmt.Errorf("step %d does not have a blocking checkpoint\n\nReject is only for checkpoint steps", currentStepNum)
+		return festerrors.Validation("step does not have a blocking checkpoint").
+			WithField("step", currentStepNum).
+			WithHint("Reject is only for checkpoint steps")
 	}
 
-	// Reject with feedback
+	if remediationPhase != "" {
+		if err := validateRemediationPhase(nav.Ctx.FestivalPath, remediationPhase); err != nil {
+			return err
+		}
+		if err := nav.RejectWithRemediation(ctx, reason, remediationPhase); err != nil {
+			return festerrors.Wrap(err, "recording failed gate with remediation")
+		}
+		fmt.Printf("%s Step %d: %s failed with remediation\n", ui.Warning("⚠"), currentStepNum, step.Name)
+		fmt.Printf("  %s: %s\n", ui.Label("Reason"), reason)
+		fmt.Printf("  %s: %s\n\n", ui.Label("Remediation phase"), remediationPhase)
+		fmt.Println("Run " + ui.Accent("fest next") + " to advance into the remediation phase.")
+		fmt.Println("After remediation completes, " + ui.Accent("fest next") + " will route back to this gate for re-evaluation.")
+		return nil
+	}
+
 	if err := nav.Reject(ctx, reason); err != nil {
-		return fmt.Errorf("rejecting checkpoint: %w", err)
+		return festerrors.Wrap(err, "rejecting checkpoint")
 	}
 
 	fmt.Printf("%s Step %d: %s rejected\n", ui.Warning("⚠"), currentStepNum, step.Name)
@@ -83,5 +119,21 @@ func runReject(ctx context.Context, reason string) error {
 	fmt.Println("The step is now blocked. Address the feedback and revise the work.")
 	fmt.Println("When ready, run " + ui.Accent("fest workflow advance") + " to resubmit.")
 
+	return nil
+}
+
+func validateRemediationPhase(festivalPath, phaseName string) error {
+	candidate := filepath.Join(festivalPath, phaseName)
+	info, err := os.Stat(candidate)
+	if err != nil || !info.IsDir() {
+		return festerrors.NotFound("remediation phase").
+			WithField("phase", phaseName).
+			WithHint("create the phase first (e.g. 'fest create phase --name " + phaseName + " --type implementation')")
+	}
+	if !shared.IsNumberedDir(phaseName) {
+		return festerrors.Validation("remediation phase name must be a numbered phase directory").
+			WithField("phase", phaseName).
+			WithHint("expected format: NNN_NAME (e.g. 005_FIX_PR_302)")
+	}
 	return nil
 }

--- a/internal/commands/workflow/reject.go
+++ b/internal/commands/workflow/reject.go
@@ -96,6 +96,11 @@ func runRejectWithRemediation(ctx context.Context, reason, remediationPhase stri
 	}
 
 	if remediationPhase != "" {
+		if !nav.IsGate() {
+			return festerrors.Validation("--remediation-phase is only valid for phase gates").
+				WithField("phase", filepath.Base(nav.Ctx.PhasePath)).
+				WithHint("failed-gate remediation routes via 'fest next' only for GATES.md gates; for a regular checkpoint use 'fest workflow reject --reason' (revise in place) or 'fest workflow skip' (done elsewhere)")
+		}
 		if err := validateRemediationPhase(nav.Ctx.FestivalPath, remediationPhase); err != nil {
 			return err
 		}
@@ -134,6 +139,15 @@ func validateRemediationPhase(festivalPath, phaseName string) error {
 		return festerrors.Validation("remediation phase name must be a numbered phase directory").
 			WithField("phase", phaseName).
 			WithHint("expected format: NNN_NAME (e.g. 005_FIX_PR_302)")
+	}
+	hasWorkflow := false
+	if info, statErr := os.Stat(filepath.Join(candidate, "WORKFLOW.md")); statErr == nil && !info.IsDir() {
+		hasWorkflow = true
+	}
+	if !hasWorkflow && !shared.HasSequenceDirs(candidate) {
+		return festerrors.Validation("remediation phase has no actionable work").
+			WithField("phase", phaseName).
+			WithHint("a remediation phase must contain a WORKFLOW.md or numbered sequence directories so 'fest next' has remediation work to route into; a GATES.md alone is not a remediation phase")
 	}
 	return nil
 }

--- a/internal/commands/workflow/reject_remediation_test.go
+++ b/internal/commands/workflow/reject_remediation_test.go
@@ -78,6 +78,61 @@ func TestRunRejectWithRemediation_ValidatesPhaseNameFormat(t *testing.T) {
 	}
 }
 
+func TestRunRejectWithRemediation_RejectsNonGateNavigator(t *testing.T) {
+	festDir := setupWorkflowCheckpointFestival(t)
+	ctx := scope.WithFestival(context.Background(), festDir)
+	if err := os.Chdir(festDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	err := runRejectWithRemediation(ctx, "blockers", "005_FIX_PR_302")
+	if err == nil {
+		t.Fatal("expected error rejecting --remediation-phase on a non-gate navigator")
+	}
+	if !strings.Contains(err.Error(), "phase gate") {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	store := progress.NewStore(festDir)
+	if err := store.Load(ctx); err != nil {
+		t.Fatalf("store.Load: %v", err)
+	}
+	if _, ok := store.GatePhaseState("001_PLAN"); ok {
+		t.Error("non-gate rejection must not persist gate-prefixed state")
+	}
+}
+
+func TestValidateRemediationPhase_RequiresActionableWork(t *testing.T) {
+	festDir := t.TempDir()
+	emptyPhase := filepath.Join(festDir, "005_FIX_PR_302")
+	if err := os.MkdirAll(emptyPhase, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(emptyPhase, "GATES.md"), []byte("---\nfest_type: phase_gate\n---\n\n# Gate\n"), 0o644); err != nil {
+		t.Fatalf("write GATES.md: %v", err)
+	}
+
+	err := validateRemediationPhase(festDir, "005_FIX_PR_302")
+	if err == nil {
+		t.Fatal("expected error for remediation phase with no actionable work")
+	}
+	if !strings.Contains(err.Error(), "actionable work") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateRemediationPhase_AcceptsSequenceDirs(t *testing.T) {
+	festDir := t.TempDir()
+	phase := filepath.Join(festDir, "005_FIX_PR_302")
+	if err := os.MkdirAll(filepath.Join(phase, "001_FIX"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	if err := validateRemediationPhase(festDir, "005_FIX_PR_302"); err != nil {
+		t.Errorf("expected sequence-dir remediation phase to validate, got %v", err)
+	}
+}
+
 func TestRunReject_DefaultBehaviorUnchanged(t *testing.T) {
 	festDir := setupGateRemediationFestival(t)
 	ctx := scope.WithFestival(context.Background(), festDir)
@@ -104,6 +159,40 @@ func TestRunReject_DefaultBehaviorUnchanged(t *testing.T) {
 	if step.RemediationPhase != "" {
 		t.Errorf("RemediationPhase = %q, want empty", step.RemediationPhase)
 	}
+}
+
+func setupWorkflowCheckpointFestival(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	festYAML := "name: wf-test\nid: WFT-001\nversion: \"1.0\"\nmetadata:\n  id: WFT-001\n  status_history:\n    - status: active\n      timestamp: 2026-02-10T00:00:00Z\n"
+	if err := os.WriteFile(filepath.Join(dir, "fest.yaml"), []byte(festYAML), 0o644); err != nil {
+		t.Fatalf("write fest.yaml: %v", err)
+	}
+
+	planPhase := filepath.Join(dir, "001_PLAN")
+	if err := os.MkdirAll(planPhase, 0o755); err != nil {
+		t.Fatalf("mkdir plan phase: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(planPhase, "PHASE_GOAL.md"), []byte("---\nfest_type: phase\nfest_id: 001_PLAN\nfest_phase_type: planning\n---\n\n# Plan\n"), 0o644); err != nil {
+		t.Fatalf("write PHASE_GOAL.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(planPhase, "WORKFLOW.md"), []byte("---\nfest_type: workflow\nfest_id: PLAN-WF\nfest_parent: 001_PLAN\n---\n\n# Plan Workflow\n\n## Step 1: REVIEW — Review the plan\n\n**Goal:** Review.\n\n**Actions:**\n1. Review\n\n**Output:** Reviewed\n\n**Checkpoint:** APPROVAL REQUIRED\n"), 0o644); err != nil {
+		t.Fatalf("write WORKFLOW.md: %v", err)
+	}
+
+	remPhase := filepath.Join(dir, "005_FIX_PR_302")
+	if err := os.MkdirAll(remPhase, 0o755); err != nil {
+		t.Fatalf("mkdir rem phase: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(remPhase, "PHASE_GOAL.md"), []byte("---\nfest_type: phase\nfest_id: 005_FIX_PR_302\nfest_phase_type: planning\n---\n\n# Fix PR 302\n"), 0o644); err != nil {
+		t.Fatalf("write rem PHASE_GOAL.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(remPhase, "WORKFLOW.md"), []byte("---\nfest_type: workflow\nfest_id: REM-WF\nfest_parent: 005_FIX_PR_302\n---\n\n# Fix Workflow\n\n## Step 1: ADDRESS — Address blockers\n\n**Goal:** Address it.\n\n**Actions:**\n1. Fix\n\n**Output:** Fixed\n\n**Checkpoint:** None\n"), 0o644); err != nil {
+		t.Fatalf("write rem WORKFLOW.md: %v", err)
+	}
+
+	return dir
 }
 
 func setupGateRemediationFestival(t *testing.T) string {

--- a/internal/commands/workflow/reject_remediation_test.go
+++ b/internal/commands/workflow/reject_remediation_test.go
@@ -1,0 +1,158 @@
+package workflow
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/progress"
+	"github.com/Obedience-Corp/fest/internal/scope"
+)
+
+func TestRunRejectWithRemediation_RecordsFailedGate(t *testing.T) {
+	festDir := setupGateRemediationFestival(t)
+	ctx := scope.WithFestival(context.Background(), festDir)
+	if err := os.Chdir(festDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	if err := runRejectWithRemediation(ctx, "blockers found", "005_FIX_PR_302"); err != nil {
+		t.Fatalf("runRejectWithRemediation: %v", err)
+	}
+
+	store := progress.NewStore(festDir)
+	if err := store.Load(ctx); err != nil {
+		t.Fatalf("store.Load: %v", err)
+	}
+	gateState, ok := store.GatePhaseState("001_REVIEW")
+	if !ok {
+		t.Fatal("gate state missing after reject")
+	}
+	step := gateState.GetStepState(1)
+	if step == nil {
+		t.Fatal("step 1 state missing")
+	}
+	if string(step.Status) != "failed_with_remediation" {
+		t.Errorf("Status = %v, want failed_with_remediation", step.Status)
+	}
+	if step.RemediationPhase != "005_FIX_PR_302" {
+		t.Errorf("RemediationPhase = %q, want 005_FIX_PR_302", step.RemediationPhase)
+	}
+	if step.Feedback != "blockers found" {
+		t.Errorf("Feedback = %q, want blockers found", step.Feedback)
+	}
+}
+
+func TestRunRejectWithRemediation_ValidatesPhaseExists(t *testing.T) {
+	festDir := setupGateRemediationFestival(t)
+	ctx := scope.WithFestival(context.Background(), festDir)
+	if err := os.Chdir(festDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	err := runRejectWithRemediation(ctx, "x", "999_DOES_NOT_EXIST")
+	if err == nil {
+		t.Fatal("expected error for missing remediation phase")
+	}
+	if !strings.Contains(err.Error(), "remediation phase") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunRejectWithRemediation_ValidatesPhaseNameFormat(t *testing.T) {
+	festDir := setupGateRemediationFestival(t)
+	badPhase := filepath.Join(festDir, "BAD_NAME_NO_NUMBER")
+	if err := os.MkdirAll(badPhase, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	ctx := scope.WithFestival(context.Background(), festDir)
+	if err := os.Chdir(festDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	err := runRejectWithRemediation(ctx, "x", "BAD_NAME_NO_NUMBER")
+	if err == nil {
+		t.Fatal("expected validation error for non-numbered phase name")
+	}
+}
+
+func TestRunReject_DefaultBehaviorUnchanged(t *testing.T) {
+	festDir := setupGateRemediationFestival(t)
+	ctx := scope.WithFestival(context.Background(), festDir)
+	if err := os.Chdir(festDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	if err := runReject(ctx, "needs revision"); err != nil {
+		t.Fatalf("runReject: %v", err)
+	}
+
+	store := progress.NewStore(festDir)
+	if err := store.Load(ctx); err != nil {
+		t.Fatalf("store.Load: %v", err)
+	}
+	gateState, ok := store.GatePhaseState("001_REVIEW")
+	if !ok {
+		t.Fatal("gate state missing")
+	}
+	step := gateState.GetStepState(1)
+	if string(step.Status) != "blocked" {
+		t.Errorf("Status = %v, want blocked", step.Status)
+	}
+	if step.RemediationPhase != "" {
+		t.Errorf("RemediationPhase = %q, want empty", step.RemediationPhase)
+	}
+}
+
+func setupGateRemediationFestival(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	festYAML := "name: rem-test\nid: REM-001\nversion: \"1.0\"\nmetadata:\n  id: REM-001\n  status_history:\n    - status: active\n      timestamp: 2026-02-10T00:00:00Z\n"
+	if err := os.WriteFile(filepath.Join(dir, "fest.yaml"), []byte(festYAML), 0o644); err != nil {
+		t.Fatalf("write fest.yaml: %v", err)
+	}
+
+	gatePhase := filepath.Join(dir, "001_REVIEW")
+	if err := os.MkdirAll(gatePhase, 0o755); err != nil {
+		t.Fatalf("mkdir gate phase: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(gatePhase, "PHASE_GOAL.md"), []byte("---\nfest_type: phase\nfest_id: 001_REVIEW\nfest_phase_type: review\n---\n\n# Review\n"), 0o644); err != nil {
+		t.Fatalf("write PHASE_GOAL.md: %v", err)
+	}
+	gatesMD := `---
+fest_type: phase_gate
+fest_id: 001_REVIEW-GATE
+fest_parent: 001_REVIEW
+---
+
+# Review Phase Gate
+
+## Step 1: READINESS — Verify PR ready
+
+**Question:** Is the PR ready to merge?
+
+**Actions:**
+1. Read review notes
+
+**Checkpoint:** APPROVAL REQUIRED
+`
+	if err := os.WriteFile(filepath.Join(gatePhase, "GATES.md"), []byte(gatesMD), 0o644); err != nil {
+		t.Fatalf("write GATES.md: %v", err)
+	}
+
+	remPhase := filepath.Join(dir, "005_FIX_PR_302")
+	if err := os.MkdirAll(remPhase, 0o755); err != nil {
+		t.Fatalf("mkdir rem phase: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(remPhase, "PHASE_GOAL.md"), []byte("---\nfest_type: phase\nfest_id: 005_FIX_PR_302\nfest_phase_type: planning\n---\n\n# Fix PR 302\n"), 0o644); err != nil {
+		t.Fatalf("write rem PHASE_GOAL.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(remPhase, "WORKFLOW.md"), []byte("---\nfest_type: workflow\nfest_id: REM-WF\nfest_parent: 005_FIX_PR_302\n---\n\n# Fix Workflow\n\n## Step 1: ADDRESS — Address blockers\n\n**Goal:** Address it.\n\n**Actions:**\n1. Fix\n\n**Output:** Fixed\n\n**Checkpoint:** None\n"), 0o644); err != nil {
+		t.Fatalf("write rem WORKFLOW.md: %v", err)
+	}
+
+	return dir
+}

--- a/internal/commands/workflow/status.go
+++ b/internal/commands/workflow/status.go
@@ -56,6 +56,7 @@ func runStatus(ctx context.Context) error {
 
 	// Convert to shared view format
 	views := make([]shared.WorkflowStepView, len(steps))
+	failedRemediation := make([]*wf.StepState, len(steps))
 	for i, step := range steps {
 		stepState := state.GetStepState(step.Number)
 		status := wf.StepStatusPending
@@ -63,6 +64,9 @@ func runStatus(ctx context.Context) error {
 		if stepState != nil {
 			status = stepState.Status
 			feedback = stepState.Feedback
+			if stepState.Status == wf.StepStatusFailedRemediation {
+				failedRemediation[i] = stepState
+			}
 		}
 
 		views[i] = shared.WorkflowStepView{
@@ -110,6 +114,23 @@ func runStatus(ctx context.Context) error {
 		sb.WriteString("\n")
 		sb.WriteString(ui.Success("✓ All steps complete"))
 		sb.WriteString("\n")
+	}
+
+	for i, ss := range failedRemediation {
+		if ss == nil {
+			continue
+		}
+		sb.WriteString("\n")
+		sb.WriteString(ui.Warning("⚠ Failed gate (remediation linked)"))
+		sb.WriteString("\n")
+		fmt.Fprintf(&sb, "  Step %d: %s\n", steps[i].Number, steps[i].Name)
+		if ss.Feedback != "" {
+			fmt.Fprintf(&sb, "  Reason: %s\n", ss.Feedback)
+		}
+		if ss.RemediationPhase != "" {
+			fmt.Fprintf(&sb, "  Remediation phase: %s\n", ss.RemediationPhase)
+		}
+		sb.WriteString("  Run 'fest next' to advance into remediation or recheck the gate.\n")
 	}
 
 	fmt.Print(sb.String())

--- a/internal/e2e/failed_remediation_test.go
+++ b/internal/e2e/failed_remediation_test.go
@@ -1,0 +1,247 @@
+package e2e
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/guidance"
+	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+	"github.com/Obedience-Corp/fest/internal/progress"
+)
+
+func TestFailedRemediation_FullLoop(t *testing.T) {
+	festDir := setupRemediationFestival(t)
+	gatePhaseDir := filepath.Join(festDir, "001_REVIEW")
+	remediationPhaseDir := filepath.Join(festDir, "005_FIX_PR_302")
+	ctx := context.Background()
+
+	gateNav := createGateNavigator(t, festDir, gatePhaseDir, "001_REVIEW")
+	if err := gateNav.RejectWithRemediation(ctx, "PR 302 not ready", "005_FIX_PR_302"); err != nil {
+		t.Fatalf("RejectWithRemediation: %v", err)
+	}
+
+	store := progress.NewStore(festDir)
+	if err := store.Load(ctx); err != nil {
+		t.Fatalf("store.Load: %v", err)
+	}
+	gateState, ok := store.GatePhaseState("001_REVIEW")
+	if !ok {
+		t.Fatal("gate state missing")
+	}
+	step := gateState.GetStepState(1)
+	if step == nil || step.Status != wf.StepStatusFailedRemediation {
+		t.Fatalf("step status = %v, want failed_with_remediation", step)
+	}
+	if step.RemediationPhase != "005_FIX_PR_302" {
+		t.Errorf("RemediationPhase = %q, want 005_FIX_PR_302", step.RemediationPhase)
+	}
+	if gateState.IsComplete() {
+		t.Error("gate state IsComplete() = true, want false")
+	}
+
+	completeRemediationWorkflow(t, festDir, remediationPhaseDir)
+
+	store2 := progress.NewStore(festDir)
+	if err := store2.Load(ctx); err != nil {
+		t.Fatalf("store2.Load: %v", err)
+	}
+	remState, ok := store2.WorkflowPhaseState("005_FIX_PR_302")
+	if !ok || !remState.IsComplete() {
+		t.Fatal("remediation workflow should be complete")
+	}
+
+	gateNav2 := createGateNavigator(t, festDir, gatePhaseDir, "001_REVIEW")
+	if err := gateNav2.Recheck(ctx); err != nil {
+		t.Fatalf("Recheck: %v", err)
+	}
+
+	if err := gateNav2.Approve(ctx); err != nil {
+		state := gateNav2.GetWorkflowState()
+		if !state.IsComplete() {
+			t.Fatalf("Approve after recheck: %v", err)
+		}
+	}
+
+	store3 := progress.NewStore(festDir)
+	if err := store3.Load(ctx); err != nil {
+		t.Fatalf("store3.Load: %v", err)
+	}
+	finalState, ok := store3.GatePhaseState("001_REVIEW")
+	if !ok {
+		t.Fatal("final gate state missing")
+	}
+	if !finalState.IsComplete() {
+		t.Errorf("gate IsComplete() = false after recheck+approve")
+	}
+	finalStep := finalState.GetStepState(1)
+	if finalStep.Status != wf.StepStatusCompleted {
+		t.Errorf("final step status = %v, want completed", finalStep.Status)
+	}
+	if finalStep.RemediationPhase != "" {
+		t.Errorf("RemediationPhase = %q, want empty after re-approval", finalStep.RemediationPhase)
+	}
+
+	auditEvents := readGateAuditEvents(t, festDir)
+	wantSequence := []string{
+		"wf_step_fail_remediation",
+		"wf_step_recheck",
+		"wf_step_done",
+	}
+	if !containsSequence(auditEvents, wantSequence) {
+		t.Errorf("audit events %v missing expected sequence %v", auditEvents, wantSequence)
+	}
+}
+
+func TestFailedRemediation_BlocksGateCompletionWithoutRecheck(t *testing.T) {
+	festDir := setupRemediationFestival(t)
+	gatePhaseDir := filepath.Join(festDir, "001_REVIEW")
+	ctx := context.Background()
+
+	gateNav := createGateNavigator(t, festDir, gatePhaseDir, "001_REVIEW")
+	if err := gateNav.RejectWithRemediation(ctx, "broken", "005_FIX_PR_302"); err != nil {
+		t.Fatalf("RejectWithRemediation: %v", err)
+	}
+
+	store := progress.NewStore(festDir)
+	if err := store.Load(ctx); err != nil {
+		t.Fatalf("store.Load: %v", err)
+	}
+	gateState, _ := store.GatePhaseState("001_REVIEW")
+	if gateState == nil || gateState.IsComplete() {
+		t.Fatal("gate state must not be complete with outstanding failed remediation")
+	}
+}
+
+func completeRemediationWorkflow(t *testing.T, festDir, phaseDir string) {
+	t.Helper()
+	ctx := context.Background()
+
+	gctx := &guidance.GuidanceContext{
+		FestivalPath: festDir,
+		PhasePath:    phaseDir,
+		PhaseName:    filepath.Base(phaseDir),
+		PhaseType:    guidance.DetectPhaseType(phaseDir),
+	}
+	nav, err := wf.NewNavigator(gctx, guidance.ModeWorkflow)
+	if err != nil {
+		t.Fatalf("NewNavigator: %v", err)
+	}
+	store := progress.NewStore(festDir)
+	if err := store.Load(ctx); err != nil {
+		t.Fatalf("store.Load: %v", err)
+	}
+	nav.SetStateStore(store)
+	if err := nav.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	steps := nav.GetSteps()
+	for i := 0; i < len(steps); i++ {
+		if err := nav.Advance(ctx); err != nil && err != guidance.ErrAlreadyComplete {
+			state := nav.GetWorkflowState()
+			if !state.IsComplete() {
+				t.Fatalf("advance step %d: %v", i+1, err)
+			}
+		}
+	}
+}
+
+func setupRemediationFestival(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	writeTestFile(t, filepath.Join(dir, "fest.yaml"), "name: remediation-test\nid: REM-001\n")
+	writeTestFile(t, filepath.Join(dir, "FESTIVAL_GOAL.md"), "# Remediation Test\n")
+
+	gatePhase := filepath.Join(dir, "001_REVIEW")
+	if err := os.MkdirAll(gatePhase, 0o755); err != nil {
+		t.Fatalf("mkdir gate phase: %v", err)
+	}
+	writeTestFile(t, filepath.Join(gatePhase, "PHASE_GOAL.md"), "---\nfest_type: phase\nfest_id: 001_REVIEW\nfest_phase_type: review\n---\n\n# Review\n")
+	writeTestFile(t, filepath.Join(gatePhase, "GATES.md"), `---
+fest_type: phase_gate
+fest_id: 001_REVIEW-GATE
+fest_parent: 001_REVIEW
+---
+
+# Review Phase Gate
+
+## Step 1: READINESS — Verify PR ready
+
+**Question:** Is the PR ready to merge?
+
+**Actions:**
+1. Read review notes
+
+**Checkpoint:** APPROVAL REQUIRED
+`)
+
+	remPhase := filepath.Join(dir, "005_FIX_PR_302")
+	if err := os.MkdirAll(remPhase, 0o755); err != nil {
+		t.Fatalf("mkdir remediation phase: %v", err)
+	}
+	writeTestFile(t, filepath.Join(remPhase, "PHASE_GOAL.md"), "---\nfest_type: phase\nfest_id: 005_FIX_PR_302\nfest_phase_type: planning\n---\n\n# Fix PR 302\n")
+	writeTestFile(t, filepath.Join(remPhase, "WORKFLOW.md"), `---
+fest_type: workflow
+fest_id: REM-WF
+fest_parent: 005_FIX_PR_302
+---
+
+# Remediation Workflow
+
+## Step 1: ADDRESS — Address blockers
+
+**Goal:** Address the blockers.
+
+**Actions:**
+1. Fix things
+
+**Output:** Fixed PR
+
+**Checkpoint:** None
+`)
+	return dir
+}
+
+func readGateAuditEvents(t *testing.T, festDir string) []string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(festDir, ".fest", "progress_events.jsonl"))
+	if err != nil {
+		t.Fatalf("read events: %v", err)
+	}
+	var types []string
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == "" {
+			continue
+		}
+		if !strings.Contains(line, `"gate:001_REVIEW"`) {
+			continue
+		}
+		for _, marker := range []string{
+			"wf_step_fail_remediation",
+			"wf_step_recheck",
+			"wf_step_done",
+			"wf_step_start",
+			"wf_init",
+			"wf_step_block",
+		} {
+			if strings.Contains(line, `"event":"`+marker+`"`) {
+				types = append(types, marker)
+				break
+			}
+		}
+	}
+	return types
+}
+
+func containsSequence(seq, want []string) bool {
+	idx := 0
+	for _, s := range seq {
+		if idx < len(want) && s == want[idx] {
+			idx++
+		}
+	}
+	return idx == len(want)
+}

--- a/internal/guidance/workflow/failed_remediation_test.go
+++ b/internal/guidance/workflow/failed_remediation_test.go
@@ -1,0 +1,94 @@
+package workflow
+
+import "testing"
+
+func TestWorkflowState_RejectWithRemediation(t *testing.T) {
+	state := NewWorkflowState(3)
+	state.StartCurrentStep()
+
+	state.RejectWithRemediation("PR not ready", "005_FIX_PR_302")
+
+	current := state.GetCurrentStepState()
+	if current.Status != StepStatusFailedRemediation {
+		t.Errorf("Status = %v, want StepStatusFailedRemediation", current.Status)
+	}
+	if current.Feedback != "PR not ready" {
+		t.Errorf("Feedback = %q, want 'PR not ready'", current.Feedback)
+	}
+	if current.RemediationPhase != "005_FIX_PR_302" {
+		t.Errorf("RemediationPhase = %q, want '005_FIX_PR_302'", current.RemediationPhase)
+	}
+	if state.IsComplete() {
+		t.Error("IsComplete() = true, want false (failed_with_remediation is non-terminal)")
+	}
+}
+
+func TestWorkflowState_ClearFailedRemediation(t *testing.T) {
+	state := NewWorkflowState(2)
+	state.StartCurrentStep()
+	state.RejectWithRemediation("needs fix", "002_FIX")
+
+	state.ClearFailedRemediation()
+
+	current := state.GetCurrentStepState()
+	if current.Status != StepStatusInProgress {
+		t.Errorf("Status = %v, want StepStatusInProgress", current.Status)
+	}
+	if current.RemediationPhase != "" {
+		t.Errorf("RemediationPhase = %q, want empty", current.RemediationPhase)
+	}
+}
+
+func TestWorkflowState_ClearFailedRemediation_NoOpWhenNotFailed(t *testing.T) {
+	state := NewWorkflowState(2)
+	state.StartCurrentStep()
+
+	state.ClearFailedRemediation()
+
+	current := state.GetCurrentStepState()
+	if current.Status != StepStatusInProgress {
+		t.Errorf("Status = %v, want StepStatusInProgress (unchanged)", current.Status)
+	}
+}
+
+func TestStepStatus_FailedRemediation_NotTerminal(t *testing.T) {
+	if StepStatusFailedRemediation.IsTerminal() {
+		t.Error("StepStatusFailedRemediation.IsTerminal() = true, want false")
+	}
+	if !StepStatusFailedRemediation.IsValid() {
+		t.Error("StepStatusFailedRemediation.IsValid() = false, want true")
+	}
+}
+
+func TestEmitStepFailRemediationEvents(t *testing.T) {
+	events := EmitStepFailRemediationEvents("gate:001_REVIEW", 2, "blockers found", "005_FIX")
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	ev := events[0]
+	if ev.EventType != "wf_step_fail_remediation" {
+		t.Errorf("EventType = %q, want wf_step_fail_remediation", ev.EventType)
+	}
+	if ev.Phase != "gate:001_REVIEW" {
+		t.Errorf("Phase = %q, want gate:001_REVIEW", ev.Phase)
+	}
+	if ev.Step != 2 {
+		t.Errorf("Step = %d, want 2", ev.Step)
+	}
+	if ev.Feedback != "blockers found" {
+		t.Errorf("Feedback = %q", ev.Feedback)
+	}
+	if ev.RemediationPhase != "005_FIX" {
+		t.Errorf("RemediationPhase = %q, want 005_FIX", ev.RemediationPhase)
+	}
+}
+
+func TestEmitStepRecheckEvents(t *testing.T) {
+	events := EmitStepRecheckEvents("gate:001_REVIEW", 2)
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	if events[0].EventType != "wf_step_recheck" {
+		t.Errorf("EventType = %q, want wf_step_recheck", events[0].EventType)
+	}
+}

--- a/internal/guidance/workflow/navigator.go
+++ b/internal/guidance/workflow/navigator.go
@@ -66,6 +66,12 @@ func (n *Navigator) SetStateKeyPrefix(prefix string) {
 	n.stateKeyPrefix = prefix
 }
 
+// IsGate reports whether this navigator targets a phase gate (GATES.md) rather
+// than a regular WORKFLOW.md checkpoint.
+func (n *Navigator) IsGate() bool {
+	return n.docFilename == "GATES.md"
+}
+
 // stateKey returns the key used for progress state lookups.
 func (n *Navigator) stateKey() string {
 	return n.stateKeyPrefix + n.phaseName

--- a/internal/guidance/workflow/navigator.go
+++ b/internal/guidance/workflow/navigator.go
@@ -651,6 +651,55 @@ func (n *Navigator) Reject(ctx context.Context, reason string) error {
 	return n.workflowState.Save(ctx, n.festivalPath, sk)
 }
 
+// RejectWithRemediation records the current step as failed with a linked
+// remediation phase. The step remains non-terminal so the workflow does not
+// silently complete past a real failure; the gate must be re-evaluated once
+// the remediation phase finishes.
+func (n *Navigator) RejectWithRemediation(ctx context.Context, reason, remediationPhase string) error {
+	if err := n.EnsureInitialized(); err != nil {
+		return err
+	}
+
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+
+	n.workflowState.RejectWithRemediation(reason, remediationPhase)
+
+	sk := n.stateKey()
+	if n.store != nil {
+		n.store.QueueWorkflowEvents(EmitStepFailRemediationEvents(sk, n.workflowState.CurrentStep, reason, remediationPhase))
+		return n.store.SaveEvents(ctx)
+	}
+	return n.workflowState.Save(ctx, n.festivalPath, sk)
+}
+
+// Recheck transitions the current step out of failed_with_remediation back
+// to in-progress so the operator can re-evaluate (approve or reject) the
+// gate after the linked remediation phase has completed.
+func (n *Navigator) Recheck(ctx context.Context) error {
+	if err := n.EnsureInitialized(); err != nil {
+		return err
+	}
+
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+
+	n.workflowState.ClearFailedRemediation()
+
+	sk := n.stateKey()
+	if n.store != nil {
+		n.store.QueueWorkflowEvents(EmitStepRecheckEvents(sk, n.workflowState.CurrentStep))
+		return n.store.SaveEvents(ctx)
+	}
+	return n.workflowState.Save(ctx, n.festivalPath, sk)
+}
+
 // GetWorkflowState returns the current workflow state.
 func (n *Navigator) GetWorkflowState() *WorkflowState {
 	return n.workflowState

--- a/internal/guidance/workflow/state.go
+++ b/internal/guidance/workflow/state.go
@@ -39,11 +39,12 @@ type StateStore interface {
 // workflow state changes from the workflow package to the progress store
 // without importing the progress package (avoiding import cycles).
 type WorkflowEvent struct {
-	EventType  string
-	Phase      string
-	Step       int
-	TotalSteps int
-	Feedback   string
+	EventType        string
+	Phase            string
+	Step             int
+	TotalSteps       int
+	Feedback         string
+	RemediationPhase string
 }
 
 // StepState tracks the state of a single workflow step.
@@ -62,6 +63,10 @@ type StepState struct {
 
 	// Feedback stores rejection reasons or notes.
 	Feedback string `yaml:"feedback,omitempty" json:"feedback,omitempty"`
+
+	// RemediationPhase is the linked phase name for a step in
+	// StepStatusFailedRemediation. Empty for any other status.
+	RemediationPhase string `yaml:"remediation_phase,omitempty" json:"remediation_phase,omitempty"`
 }
 
 // FestivalWorkflowState contains workflow state for all phases in a festival.
@@ -324,6 +329,31 @@ func (s *WorkflowState) Reject(feedback string) {
 	state := s.GetOrCreateStepState(s.CurrentStep)
 	state.Status = StepStatusBlocked
 	state.Feedback = feedback
+	state.RemediationPhase = ""
+}
+
+// RejectWithRemediation records a non-passing gate decision with a linked
+// remediation phase. The step enters StepStatusFailedRemediation and remains
+// non-terminal so the gate must be re-evaluated after the remediation phase
+// completes.
+func (s *WorkflowState) RejectWithRemediation(feedback, remediationPhase string) {
+	state := s.GetOrCreateStepState(s.CurrentStep)
+	state.Status = StepStatusFailedRemediation
+	state.Feedback = feedback
+	state.RemediationPhase = remediationPhase
+}
+
+// ClearFailedRemediation transitions the current step out of the failed
+// remediation state, returning it to in-progress for re-evaluation. Called
+// when the linked remediation phase has completed and the gate is ready to
+// be rechecked.
+func (s *WorkflowState) ClearFailedRemediation() {
+	state := s.GetOrCreateStepState(s.CurrentStep)
+	if state.Status != StepStatusFailedRemediation {
+		return
+	}
+	state.Status = StepStatusInProgress
+	state.RemediationPhase = ""
 }
 
 // Reset resets the workflow to step 1 and clears all step states.
@@ -442,6 +472,28 @@ func EmitStepBlockEvents(phaseName string, step int, feedback string) []Workflow
 		Phase:     phaseName,
 		Step:      step,
 		Feedback:  feedback,
+	}}
+}
+
+// EmitStepFailRemediationEvents generates events for marking a step as
+// failed with a linked remediation phase.
+func EmitStepFailRemediationEvents(phaseName string, step int, feedback, remediationPhase string) []WorkflowEvent {
+	return []WorkflowEvent{{
+		EventType:        "wf_step_fail_remediation",
+		Phase:            phaseName,
+		Step:             step,
+		Feedback:         feedback,
+		RemediationPhase: remediationPhase,
+	}}
+}
+
+// EmitStepRecheckEvents generates events for re-entering a failed
+// remediation step once the remediation phase has completed.
+func EmitStepRecheckEvents(phaseName string, step int) []WorkflowEvent {
+	return []WorkflowEvent{{
+		EventType: "wf_step_recheck",
+		Phase:     phaseName,
+		Step:      step,
 	}}
 }
 

--- a/internal/guidance/workflow/step.go
+++ b/internal/guidance/workflow/step.go
@@ -20,6 +20,12 @@ const (
 
 	// StepStatusBlocked indicates the step cannot proceed due to a dependency or issue.
 	StepStatusBlocked StepStatus = "blocked"
+
+	// StepStatusFailedRemediation indicates the step (typically a phase gate)
+	// did not pass and a remediation phase has been linked to correct the
+	// underlying issues. The step remains non-terminal so the gate must be
+	// re-evaluated after the remediation phase completes.
+	StepStatusFailedRemediation StepStatus = "failed_with_remediation"
 )
 
 // String returns the string representation of the step status.
@@ -30,7 +36,7 @@ func (s StepStatus) String() string {
 // IsValid returns true if the status is a known valid status.
 func (s StepStatus) IsValid() bool {
 	switch s {
-	case StepStatusPending, StepStatusInProgress, StepStatusCompleted, StepStatusSkipped, StepStatusBlocked:
+	case StepStatusPending, StepStatusInProgress, StepStatusCompleted, StepStatusSkipped, StepStatusBlocked, StepStatusFailedRemediation:
 		return true
 	default:
 		return false

--- a/internal/progress/events.go
+++ b/internal/progress/events.go
@@ -34,6 +34,15 @@ const (
 	EventWorkflowStepBlock EventType = "wf_step_block"
 	EventWorkflowAdvance   EventType = "wf_advance"
 	EventWorkflowReset     EventType = "wf_reset"
+
+	// EventWorkflowStepFailRemediation records that a gate step did not pass
+	// and is linked to a remediation phase. The step remains non-terminal and
+	// must be re-evaluated after the remediation phase completes.
+	EventWorkflowStepFailRemediation EventType = "wf_step_fail_remediation"
+
+	// EventWorkflowStepRecheck records that the operator is re-entering a
+	// previously failed remediation step for re-evaluation.
+	EventWorkflowStepRecheck EventType = "wf_step_recheck"
 )
 
 // ProgressEvent represents a single progress event in JSONL format.
@@ -50,10 +59,11 @@ type ProgressEvent struct {
 	Reason  string `json:"reason,omitempty"`  // blocked event
 
 	// Workflow event-specific fields (omitempty)
-	Phase      string `json:"phase,omitempty"`
-	Step       int    `json:"step,omitempty"`
-	TotalSteps int    `json:"total_steps,omitempty"`
-	Feedback   string `json:"feedback,omitempty"`
+	Phase            string `json:"phase,omitempty"`
+	Step             int    `json:"step,omitempty"`
+	TotalSteps       int    `json:"total_steps,omitempty"`
+	Feedback         string `json:"feedback,omitempty"`
+	RemediationPhase string `json:"remediation_phase,omitempty"`
 }
 
 // loadFromEvents reads the JSONL file and materializes current state.
@@ -359,6 +369,19 @@ func materializeWorkflowState(events []ProgressEvent) *wf.FestivalWorkflowState 
 			ss := phaseState.GetOrCreateStepState(e.Step)
 			ss.Status = wf.StepStatusBlocked
 			ss.Feedback = e.Feedback
+
+		case EventWorkflowStepFailRemediation:
+			ss := phaseState.GetOrCreateStepState(e.Step)
+			ss.Status = wf.StepStatusFailedRemediation
+			ss.Feedback = e.Feedback
+			ss.RemediationPhase = e.RemediationPhase
+
+		case EventWorkflowStepRecheck:
+			ss := phaseState.GetOrCreateStepState(e.Step)
+			if ss.Status == wf.StepStatusFailedRemediation {
+				ss.Status = wf.StepStatusInProgress
+				ss.RemediationPhase = ""
+			}
 
 		case EventWorkflowAdvance:
 			phaseState.CurrentStep = e.Step

--- a/internal/progress/failed_remediation_test.go
+++ b/internal/progress/failed_remediation_test.go
@@ -1,0 +1,113 @@
+package progress
+
+import (
+	"testing"
+	"time"
+
+	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+)
+
+func TestMaterializeWorkflowState_FailRemediationAndRecheck(t *testing.T) {
+	t0 := time.Now().UTC()
+	t1 := t0.Add(1 * time.Minute)
+	t2 := t0.Add(2 * time.Minute)
+	t3 := t0.Add(3 * time.Minute)
+
+	cases := []struct {
+		name             string
+		events           []ProgressEvent
+		wantStatus       wf.StepStatus
+		wantFeedback     string
+		wantRemediation  string
+		wantStepComplete bool
+	}{
+		{
+			name: "fail records remediation phase and non-terminal status",
+			events: []ProgressEvent{
+				{Timestamp: t0, Event: EventWorkflowInit, Phase: "gate:001_REVIEW", TotalSteps: 1},
+				{Timestamp: t1, Event: EventWorkflowStepStart, Phase: "gate:001_REVIEW", Step: 1},
+				{Timestamp: t2, Event: EventWorkflowStepFailRemediation, Phase: "gate:001_REVIEW", Step: 1, Feedback: "PR not ready", RemediationPhase: "005_FIX_PR_302"},
+			},
+			wantStatus:       wf.StepStatusFailedRemediation,
+			wantFeedback:     "PR not ready",
+			wantRemediation:  "005_FIX_PR_302",
+			wantStepComplete: false,
+		},
+		{
+			name: "recheck clears remediation and returns to in_progress",
+			events: []ProgressEvent{
+				{Timestamp: t0, Event: EventWorkflowInit, Phase: "gate:001_REVIEW", TotalSteps: 1},
+				{Timestamp: t1, Event: EventWorkflowStepStart, Phase: "gate:001_REVIEW", Step: 1},
+				{Timestamp: t2, Event: EventWorkflowStepFailRemediation, Phase: "gate:001_REVIEW", Step: 1, Feedback: "PR not ready", RemediationPhase: "005_FIX_PR_302"},
+				{Timestamp: t3, Event: EventWorkflowStepRecheck, Phase: "gate:001_REVIEW", Step: 1},
+			},
+			wantStatus:       wf.StepStatusInProgress,
+			wantFeedback:     "PR not ready",
+			wantRemediation:  "",
+			wantStepComplete: false,
+		},
+		{
+			name: "fail then recheck then approve closes the gate",
+			events: []ProgressEvent{
+				{Timestamp: t0, Event: EventWorkflowInit, Phase: "gate:001_REVIEW", TotalSteps: 1},
+				{Timestamp: t1, Event: EventWorkflowStepStart, Phase: "gate:001_REVIEW", Step: 1},
+				{Timestamp: t2, Event: EventWorkflowStepFailRemediation, Phase: "gate:001_REVIEW", Step: 1, Feedback: "broken", RemediationPhase: "005_FIX"},
+				{Timestamp: t3, Event: EventWorkflowStepRecheck, Phase: "gate:001_REVIEW", Step: 1},
+				{Timestamp: t3.Add(time.Second), Event: EventWorkflowStepDone, Phase: "gate:001_REVIEW", Step: 1},
+			},
+			wantStatus:       wf.StepStatusCompleted,
+			wantFeedback:     "",
+			wantRemediation:  "",
+			wantStepComplete: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			state := materializeWorkflowState(tc.events)
+			phaseState, ok := state.Phases["gate:001_REVIEW"]
+			if !ok {
+				t.Fatalf("phase state missing")
+			}
+			step := phaseState.GetStepState(1)
+			if step == nil {
+				t.Fatalf("step 1 state missing")
+			}
+			if step.Status != tc.wantStatus {
+				t.Errorf("Status = %v, want %v", step.Status, tc.wantStatus)
+			}
+			if step.Feedback != tc.wantFeedback {
+				t.Errorf("Feedback = %q, want %q", step.Feedback, tc.wantFeedback)
+			}
+			if step.RemediationPhase != tc.wantRemediation {
+				t.Errorf("RemediationPhase = %q, want %q", step.RemediationPhase, tc.wantRemediation)
+			}
+			if phaseState.IsComplete() != tc.wantStepComplete {
+				t.Errorf("IsComplete() = %v, want %v", phaseState.IsComplete(), tc.wantStepComplete)
+			}
+		})
+	}
+}
+
+func TestQueueWorkflowEvents_ForwardsRemediationPhase(t *testing.T) {
+	store := NewStore(t.TempDir())
+	store.QueueWorkflowEvents([]wf.WorkflowEvent{
+		{
+			EventType:        string(EventWorkflowStepFailRemediation),
+			Phase:            "gate:001_REVIEW",
+			Step:             1,
+			Feedback:         "blockers",
+			RemediationPhase: "005_FIX",
+		},
+	})
+	if len(store.pendingEvents) != 1 {
+		t.Fatalf("got %d pending events, want 1", len(store.pendingEvents))
+	}
+	pe := store.pendingEvents[0]
+	if pe.RemediationPhase != "005_FIX" {
+		t.Errorf("RemediationPhase = %q, want 005_FIX", pe.RemediationPhase)
+	}
+	if pe.Event != EventWorkflowStepFailRemediation {
+		t.Errorf("Event = %q, want %q", pe.Event, EventWorkflowStepFailRemediation)
+	}
+}

--- a/internal/progress/store.go
+++ b/internal/progress/store.go
@@ -556,12 +556,13 @@ func (s *Store) QueueWorkflowEvents(events []wf.WorkflowEvent) {
 	now := time.Now().UTC()
 	for _, we := range events {
 		pe := &ProgressEvent{
-			Timestamp:  now,
-			Event:      EventType(we.EventType),
-			Phase:      we.Phase,
-			Step:       we.Step,
-			TotalSteps: we.TotalSteps,
-			Feedback:   we.Feedback,
+			Timestamp:        now,
+			Event:            EventType(we.EventType),
+			Phase:            we.Phase,
+			Step:             we.Step,
+			TotalSteps:       we.TotalSteps,
+			Feedback:         we.Feedback,
+			RemediationPhase: we.RemediationPhase,
 		}
 		s.pendingEvents = append(s.pendingEvents, pe)
 	}

--- a/methodology/README.md
+++ b/methodology/README.md
@@ -223,6 +223,25 @@ fest workflow show       # Display current step details
 fest workflow advance    # Complete step, move to next
 fest workflow approve    # User approves a blocking checkpoint
 fest workflow reject     # Reject with feedback
+fest workflow skip       # Operator override (work was done outside the workflow)
+```
+
+### When to use reject, skip, and failed-gate remediation
+
+Three operator actions look similar but record different audit trails. Pick the one that matches the real situation:
+
+- `fest workflow reject --reason "..."` records that a checkpoint was reviewed and rejected. The step becomes blocked and waits for a revision. Use when the work itself needs to be redone in place.
+- `fest workflow skip --reason "..."` records that the step was completed by some other means (off-workflow work, manual action, etc.). The step is treated as terminal. Use when the work is genuinely already done and you do not need a revision loop.
+- `fest workflow reject --reason "..." --remediation-phase <PHASE>` records that a phase gate did not pass and links a remediation phase that will correct the underlying issues. The gate step enters `failed_with_remediation` and remains non-terminal. `fest next` routes into the remediation phase, and once that phase completes, `fest next` routes back to the failed gate for re-evaluation. Use this for the CW0003-style case where a review gate found real blockers and a new phase was added to fix them. This preserves an honest audit trail: the gate is logged as failed (not approved and not skipped) and is rechecked after remediation, instead of being silently passed.
+
+Example flow:
+
+```bash
+fest workflow reject --reason "PR 302 is not ready" --remediation-phase 005_FIX_PR_302_AGGREGATE
+fest next   # routes into 005_FIX_PR_302_AGGREGATE
+# ... work through the remediation phase ...
+fest next   # remediation complete; routes back to the failed gate for recheck
+fest workflow approve   # gate passes the second time
 ```
 
 **Implementation phases** use numbered sequences containing task files. Every implementation sequence ends with quality gates.


### PR DESCRIPTION
## Summary

Closes #185. Adds first-class support for failed-with-remediation gate routing so a rejected phase gate can advance into a linked remediation phase, then route back for re-evaluation, without lying about the audit trail.

## CLI shape

Extend the existing reject command with an additive flag:

```
fest workflow reject --reason "PR 302 is not ready" --remediation-phase 005_FIX_PR_302_AGGREGATE
```

Chosen over a new `fail` verb because it is additive, requires no new vocabulary, and keeps agent learning cost low. Behavior without the flag is unchanged.

## State machine

- New step status `failed_with_remediation` (non-terminal) and a `RemediationPhase` field on `StepState`.
- New `WorkflowState.RejectWithRemediation(reason, phase)` and `ClearFailedRemediation()` transitions.
- Two new progress events recorded in `.fest/progress_events.jsonl`:
  - `wf_step_fail_remediation` (carries `remediation_phase` and `feedback`)
  - `wf_step_recheck`
- Audit trail for a full loop: `wf_step_fail_remediation` -> `wf_step_recheck` -> `wf_step_done`. The gate is never silently approved.

## fest next routing

Before normal phase resolution, `fest next` scans gate-prefixed phase state for any step in `failed_with_remediation`. If found:

- If the remediation phase is incomplete (tasks and any WORKFLOW.md not done), print the failed-gate banner and render the remediation phase next step. WORKFLOW.md, GATES.md, and task-based remediation phases are all supported.
- If the remediation phase is complete, print a recheck banner, emit a `wf_step_recheck` event so the step returns to in-progress, and render the gate step for re-evaluation. Approve or reject then closes the record.

`fest workflow status` now shows failed-gate entries with reason and remediation link.

## Test plan

- [x] `just build`
- [x] `just test unit` (2112 tests pass)
- [x] `just lint all` (0 issues)
- [x] Unit tests for the new state transitions in `internal/guidance/workflow/failed_remediation_test.go`.
- [x] Progress event materialization tests in `internal/progress/failed_remediation_test.go` including the full fail -> recheck -> done sequence.
- [x] Reject command tests in `internal/commands/workflow/reject_remediation_test.go` covering the happy path, missing-phase validation, non-numbered-phase validation, and the default (no flag) path.
- [x] `fest next` discovery and routing tests in `internal/commands/next/remediation_test.go` for find, clear-after-done, and remediation-phase completion detection.
- [x] End-to-end loop in `internal/e2e/failed_remediation_test.go`: reject with remediation, complete the remediation workflow, recheck, approve, verify the audit-event sequence and final state.

## Docs

`methodology/README.md` gained a "When to use reject, skip, and failed-gate remediation" section with the CW0003-style example flow.

## Deviations

None of substance. The recheck transition is automatic when `fest next` detects a complete remediation phase (the operator does not run a separate `recheck` command). This was not specified in the issue but follows the spirit of "preserving useful fest next" without adding a new verb. The acceptance criteria are met as written.

Closes #185