### PR TITLE
Fix create festival agent rollback

### DIFF
--- a/docs/cli-reference/fest_create_festival.md
+++ b/docs/cli-reference/fest_create_festival.md
@@ -9,7 +9,7 @@ fest create festival [flags]
 ### Options
 
 ```
-      --agent                 Strict mode: require markers, auto-validate, block on errors, JSON output
+      --agent                 Strict mode: process markers, auto-validate, rollback on blocking errors, JSON output
       --dest string           Destination under festivals/: planning or ritual (use 'fest promote' to advance to active) (default "planning")
       --dry-run               Show template markers without creating file
       --goal string           Festival goal
@@ -37,4 +37,3 @@ fest create festival [flags]
 ### SEE ALSO
 
 * [fest create](fest_create.md)	 - Create festivals, phases, sequences, or tasks (TUI)
-

--- a/internal/commands/festival/create_festival.go
+++ b/internal/commands/festival/create_festival.go
@@ -267,6 +267,7 @@ type createResult struct {
 	markersTotal      int
 	allMarkers        []map[string]any
 	validationResult  *ValidationSummary
+	registered        bool
 }
 
 // RunCreateFestival executes the create festival command logic.
@@ -320,7 +321,7 @@ func RunCreateFestival(ctx context.Context, opts *CreateFestivalOptions) error {
 		return emitCreateFestivalCreatedError(ctx, cfg, res, err)
 	}
 
-	registerFestival(ctx, cfg)
+	registerFestival(ctx, cfg, res)
 
 	// Ensure fest contract entries are present in .campaign/watchers.yaml.
 	// This is idempotent: if fest init already wrote them, WriteEntries
@@ -647,7 +648,9 @@ func recordInitialSize(ctx context.Context, cfg *createConfig, festConfig *confi
 }
 
 // registerFestival records the festival in the ID registry with event logging.
-func registerFestival(ctx context.Context, cfg *createConfig) {
+// On success it marks res.registered so rollback only cleans up the registry
+// when a write actually happened.
+func registerFestival(ctx context.Context, cfg *createConfig, res *createResult) {
 	regPath := registry.GetEventsPath(cfg.festivalsRoot)
 	reg, regErr := registry.Load(ctx, regPath)
 	if regErr != nil {
@@ -662,7 +665,9 @@ func registerFestival(ctx context.Context, cfg *createConfig) {
 		CreatedAt: now,
 		UpdatedAt: now,
 	}
-	_ = reg.AddWithEvent(ctx, regEntry)
+	if err := reg.AddWithEvent(ctx, regEntry); err == nil && res != nil {
+		res.registered = true
+	}
 }
 
 // processAllMarkers processes REPLACE markers in all created files.
@@ -917,13 +922,15 @@ func rollbackCreatedFestival(ctx context.Context, cfg *createConfig, res *create
 		}
 	}
 
-	regPath := registry.GetEventsPath(cfg.festivalsRoot)
-	reg, err := registry.Load(ctx, regPath)
-	if err != nil {
-		failures = append(failures, fmt.Sprintf("loading registry for rollback: %v", err))
-	} else if reg.Exists(ctx, cfg.festivalID) {
-		if err := reg.DeleteWithEvent(ctx, cfg.festivalID); err != nil {
-			failures = append(failures, fmt.Sprintf("deleting registry entry: %v", err))
+	if res != nil && res.registered {
+		regPath := registry.GetEventsPath(cfg.festivalsRoot)
+		reg, err := registry.Load(ctx, regPath)
+		if err != nil {
+			failures = append(failures, fmt.Sprintf("loading registry for rollback: %v", err))
+		} else if reg.Exists(ctx, cfg.festivalID) {
+			if err := reg.DeleteWithEvent(ctx, cfg.festivalID); err != nil {
+				failures = append(failures, fmt.Sprintf("deleting registry entry: %v", err))
+			}
 		}
 	}
 

--- a/internal/commands/festival/create_festival.go
+++ b/internal/commands/festival/create_festival.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -24,6 +25,7 @@ import (
 	tpl "github.com/Obedience-Corp/fest/internal/template"
 	"github.com/Obedience-Corp/fest/internal/types"
 	"github.com/Obedience-Corp/fest/internal/ui"
+	"github.com/Obedience-Corp/fest/internal/validator"
 	"github.com/Obedience-Corp/fest/internal/workspace"
 	"github.com/Obedience-Corp/obey-shared/contract"
 	"github.com/google/uuid"
@@ -51,6 +53,7 @@ type createFestivalResult struct {
 	OK                bool               `json:"ok"`
 	Action            string             `json:"action"`
 	Festival          map[string]string  `json:"festival,omitempty"`
+	CreatedPath       string             `json:"created_path,omitempty"`
 	Created           []string           `json:"created,omitempty"`
 	AutoPhasesCreated []string           `json:"auto_phases_created,omitempty"`
 	GatesDirectory    string             `json:"gates_directory,omitempty"`
@@ -61,10 +64,28 @@ type createFestivalResult struct {
 	Markers           []map[string]any   `json:"markers,omitempty"`
 	MarkersFilled     int                `json:"markers_filled,omitempty"`
 	MarkersTotal      int                `json:"markers_total,omitempty"`
+	MarkersUnfilled   int                `json:"markers_unfilled,omitempty"`
+	UnfilledMarkers   []markerFileResult `json:"unfilled_markers,omitempty"`
 	Validation        *ValidationSummary `json:"validation,omitempty"`
+	RolledBack        *bool              `json:"rolled_back,omitempty"`
+	RollbackError     string             `json:"rollback_error,omitempty"`
 	Errors            []map[string]any   `json:"errors,omitempty"`
 	Warnings          []string           `json:"warnings,omitempty"`
 	Extra             map[string]any     `json:"extra,omitempty"`
+}
+
+type markerFileResult struct {
+	File        string                 `json:"file"`
+	Count       int                    `json:"count"`
+	MarkerTypes []string               `json:"marker_types,omitempty"`
+	Level       string                 `json:"level,omitempty"`
+	Markers     []markerOccurrenceInfo `json:"markers,omitempty"`
+}
+
+type markerOccurrenceInfo struct {
+	Line       int    `json:"line"`
+	MarkerType string `json:"marker_type"`
+	Content    string `json:"content"`
 }
 
 // createConfig holds all resolved configuration for festival creation.
@@ -121,7 +142,7 @@ func NewCreateFestivalCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Show template markers without creating file")
 	cmd.Flags().BoolVar(&opts.JSONOutput, "json", false, "Emit JSON output")
 	cmd.Flags().StringVar(&opts.Dest, "dest", "planning", "Destination under festivals/: planning or ritual (use 'fest promote' to advance to active)")
-	cmd.Flags().BoolVar(&opts.AgentMode, "agent", false, "Strict mode: require markers, auto-validate, block on errors, JSON output")
+	cmd.Flags().BoolVar(&opts.AgentMode, "agent", false, "Strict mode: process markers, auto-validate, rollback on blocking errors, JSON output")
 	return cmd
 }
 
@@ -265,18 +286,40 @@ func RunCreateFestival(ctx context.Context, opts *CreateFestivalOptions) error {
 
 	created, copiedGates, err := renderFestivalTemplates(ctx, cfg)
 	if err != nil {
-		return emitCreateFestivalError(opts, err)
+		return emitCreateFestivalCreatedError(ctx, cfg, nil, err)
 	}
 
 	res, err := writeFestYaml(ctx, cfg)
 	if err != nil {
-		return emitCreateFestivalError(opts, err)
+		return emitCreateFestivalCreatedError(ctx, cfg, nil, err)
 	}
 	created = append(created, res.festConfigPath)
 
 	created, res.autoPhasesCreated = autoScaffoldPhases(ctx, cfg, created)
 
 	recordInitialSize(ctx, cfg, res.festConfig)
+
+	res.created = created
+	res.copiedGates = copiedGates
+	if err := processAllMarkers(ctx, cfg, res); err != nil {
+		return emitCreateFestivalCreatedError(ctx, cfg, res, err)
+	}
+
+	if opts.DryRun && res.markersTotal > 0 {
+		result := &MarkerResult{Markers: res.allMarkers, Total: res.markersTotal}
+		if err := PrintDryRunMarkers(result, opts.JSONOutput); err != nil {
+			return emitCreateFestivalCreatedError(ctx, cfg, res, err)
+		}
+		return nil
+	}
+
+	if err := validateIfConfigured(ctx, cfg, res); err != nil {
+		if opts.AgentMode && res.validationResult != nil && !res.validationResult.OK && config.ShouldBlockOnErrors(cfg.agentCfg, opts.AgentMode) {
+			return emitCreateFestivalValidationFailure(ctx, cfg, res, err)
+		}
+		return emitCreateFestivalCreatedError(ctx, cfg, res, err)
+	}
+
 	registerFestival(ctx, cfg)
 
 	// Ensure fest contract entries are present in .campaign/watchers.yaml.
@@ -285,24 +328,6 @@ func RunCreateFestival(ctx context.Context, opts *CreateFestivalOptions) error {
 	// fest init ran before camp init (so .campaign/ didn't exist yet),
 	// or where the contract file was deleted and needs regeneration.
 	writeContractEntries(cfg.campaignRoot)
-
-	res.created = created
-	res.copiedGates = copiedGates
-	if err := processAllMarkers(ctx, cfg, res); err != nil {
-		return emitCreateFestivalError(opts, err)
-	}
-
-	if opts.DryRun && res.markersTotal > 0 {
-		result := &MarkerResult{Markers: res.allMarkers, Total: res.markersTotal}
-		if err := PrintDryRunMarkers(result, opts.JSONOutput); err != nil {
-			return emitCreateFestivalError(opts, err)
-		}
-		return nil
-	}
-
-	if err := validateIfConfigured(ctx, cfg, res); err != nil {
-		return emitCreateFestivalError(opts, err)
-	}
 
 	return emitCreateOutput(cfg, res)
 }
@@ -756,14 +781,7 @@ func emitCreateOutput(cfg *createConfig, res *createResult) error {
 
 // emitCreateJSON emits JSON output for festival creation.
 func emitCreateJSON(cfg *createConfig, res *createResult, gatesDir string, remainingMarkers int) error {
-	// Get campaign root for relative path display
-	campaignRoot := cfg.campaignRoot
-	displayPath := func(p string) string {
-		if campaignRoot != "" {
-			return pathutil.DisplayPath(p, campaignRoot)
-		}
-		return p
-	}
+	displayPath := createDisplayPathFunc(cfg)
 
 	warnings := []string{}
 	if remainingMarkers > 0 {
@@ -801,6 +819,7 @@ func emitCreateJSON(cfg *createConfig, res *createResult, gatesDir string, remai
 		OK:                true,
 		Action:            "create_festival",
 		Festival:          festivalMap,
+		CreatedPath:       displayPath(cfg.destDir),
 		Created:           relCreated,
 		AutoPhasesCreated: res.autoPhasesCreated,
 		GatesDirectory:    displayPath(gatesDir),
@@ -813,6 +832,233 @@ func emitCreateJSON(cfg *createConfig, res *createResult, gatesDir string, remai
 		Validation:        res.validationResult,
 		Warnings:          warnings,
 	})
+}
+
+func emitCreateFestivalCreatedError(ctx context.Context, cfg *createConfig, res *createResult, err error) error {
+	if cfg != nil && cfg.opts != nil && cfg.opts.AgentMode {
+		return emitCreateFestivalFailure(ctx, cfg, res, err, nil)
+	}
+	if cfg != nil && cfg.opts != nil {
+		return emitCreateFestivalError(cfg.opts, err)
+	}
+	return err
+}
+
+func emitCreateFestivalValidationFailure(ctx context.Context, cfg *createConfig, res *createResult, err error) error {
+	unfilledMarkers, scanErr := validator.ScanTemplateMarkers(cfg.destDir)
+	if scanErr != nil && err == nil {
+		err = errors.Wrap(scanErr, "scanning unfilled markers")
+	}
+	return emitCreateFestivalFailure(ctx, cfg, res, err, unfilledMarkers)
+}
+
+func emitCreateFestivalFailure(ctx context.Context, cfg *createConfig, res *createResult, err error, unfilledMarkers []validator.MarkerFileResult) error {
+	displayPath := createDisplayPathFunc(cfg)
+	relCreated := createdDisplayPaths(cfg, res)
+	relGates := gateDisplayPaths(cfg, res)
+	markerDetails := markerFileResultsFromValidator(unfilledMarkers)
+	markersUnfilled := countMarkerFileResults(markerDetails)
+	if markersUnfilled == 0 && res != nil {
+		markersUnfilled = res.markersTotal - res.markersFilled
+	}
+
+	rolledBack := true
+	rollbackErr := rollbackCreatedFestival(ctx, cfg, res)
+	if rollbackErr != nil {
+		rolledBack = false
+	}
+	message := "festival creation failed"
+	if err != nil {
+		message = err.Error()
+	}
+
+	result := createFestivalResult{
+		OK:                false,
+		Action:            "create_festival",
+		Festival:          festivalMapForConfig(cfg),
+		CreatedPath:       displayPath(cfg.destDir),
+		Created:           relCreated,
+		AutoPhasesCreated: nil,
+		GatesDirectory:    displayPath(filepath.Join(cfg.destDir, "gates")),
+		FestYAML:          displayPath(festConfigPath(res)),
+		GateTemplates:     relGates,
+		ProjectPath:       displayPath(projectPath(res)),
+		ProjectLinked:     projectLinked(res),
+		MarkersFilled:     markersFilled(res),
+		MarkersTotal:      markersTotal(res),
+		MarkersUnfilled:   markersUnfilled,
+		UnfilledMarkers:   markerDetails,
+		Validation:        validationSummary(res),
+		RolledBack:        &rolledBack,
+		Errors: []map[string]any{{
+			"code":    "error",
+			"message": message,
+		}},
+	}
+	if rollbackErr != nil {
+		result.RollbackError = rollbackErr.Error()
+	}
+
+	_ = emitCreateFestivalJSON(cfg.opts, result)
+	return errors.ErrAlreadyPrinted
+}
+
+func rollbackCreatedFestival(ctx context.Context, cfg *createConfig, res *createResult) error {
+	var failures []string
+
+	if res != nil && res.projectLinked {
+		nav, err := navigation.LoadNavigation()
+		if err != nil {
+			failures = append(failures, fmt.Sprintf("removing navigation link: %v", err))
+		} else if nav.RemoveLink(cfg.dirName) {
+			if err := nav.Save(); err != nil {
+				failures = append(failures, fmt.Sprintf("saving navigation rollback: %v", err))
+			}
+		}
+	}
+
+	regPath := registry.GetEventsPath(cfg.festivalsRoot)
+	reg, err := registry.Load(ctx, regPath)
+	if err != nil {
+		failures = append(failures, fmt.Sprintf("loading registry for rollback: %v", err))
+	} else if reg.Exists(ctx, cfg.festivalID) {
+		if err := reg.DeleteWithEvent(ctx, cfg.festivalID); err != nil {
+			failures = append(failures, fmt.Sprintf("deleting registry entry: %v", err))
+		}
+	}
+
+	if err := os.RemoveAll(cfg.destDir); err != nil {
+		failures = append(failures, fmt.Sprintf("removing created festival directory: %v", err))
+	}
+
+	if len(failures) > 0 {
+		return fmt.Errorf("%s", strings.Join(failures, "; "))
+	}
+	return nil
+}
+
+func createDisplayPathFunc(cfg *createConfig) func(string) string {
+	return func(p string) string {
+		if p == "" {
+			return ""
+		}
+		if cfg != nil && cfg.campaignRoot != "" {
+			return pathutil.DisplayPath(p, cfg.campaignRoot)
+		}
+		return p
+	}
+}
+
+func festivalMapForConfig(cfg *createConfig) map[string]string {
+	festivalMap := map[string]string{
+		"name":      cfg.opts.Name,
+		"slug":      cfg.slug,
+		"dest":      cfg.destCategory,
+		"id":        cfg.festivalID,
+		"directory": cfg.dirName,
+	}
+	if cfg.festivalTypeName != "" {
+		festivalMap["type"] = cfg.festivalTypeName
+	}
+	return festivalMap
+}
+
+func createdDisplayPaths(cfg *createConfig, res *createResult) []string {
+	if res == nil || len(res.created) == 0 {
+		return nil
+	}
+	displayPath := createDisplayPathFunc(cfg)
+	relCreated := make([]string, len(res.created))
+	for i, p := range res.created {
+		relCreated[i] = displayPath(p)
+	}
+	return relCreated
+}
+
+func gateDisplayPaths(cfg *createConfig, res *createResult) []string {
+	if res == nil || len(res.copiedGates) == 0 {
+		return nil
+	}
+	displayPath := createDisplayPathFunc(cfg)
+	relGates := make([]string, len(res.copiedGates))
+	for i, p := range res.copiedGates {
+		relGates[i] = displayPath(p)
+	}
+	return relGates
+}
+
+func markerFileResultsFromValidator(results []validator.MarkerFileResult) []markerFileResult {
+	if len(results) == 0 {
+		return nil
+	}
+	out := make([]markerFileResult, 0, len(results))
+	for _, result := range results {
+		markers := make([]markerOccurrenceInfo, 0, len(result.Markers))
+		for _, marker := range result.Markers {
+			markers = append(markers, markerOccurrenceInfo{
+				Line:       marker.Line,
+				MarkerType: marker.MarkerType,
+				Content:    marker.Content,
+			})
+		}
+		markerTypes := append([]string(nil), result.MarkerTypes...)
+		sort.Strings(markerTypes)
+		out = append(out, markerFileResult{
+			File:        result.RelPath,
+			Count:       result.MarkerCount,
+			MarkerTypes: markerTypes,
+			Level:       result.Level,
+			Markers:     markers,
+		})
+	}
+	return out
+}
+
+func countMarkerFileResults(results []markerFileResult) int {
+	total := 0
+	for _, result := range results {
+		total += result.Count
+	}
+	return total
+}
+
+func festConfigPath(res *createResult) string {
+	if res == nil {
+		return ""
+	}
+	return res.festConfigPath
+}
+
+func projectPath(res *createResult) string {
+	if res == nil {
+		return ""
+	}
+	return res.projectPath
+}
+
+func projectLinked(res *createResult) bool {
+	return res != nil && res.projectLinked
+}
+
+func markersFilled(res *createResult) int {
+	if res == nil {
+		return 0
+	}
+	return res.markersFilled
+}
+
+func markersTotal(res *createResult) int {
+	if res == nil {
+		return 0
+	}
+	return res.markersTotal
+}
+
+func validationSummary(res *createResult) *ValidationSummary {
+	if res == nil {
+		return nil
+	}
+	return res.validationResult
 }
 
 func parseTags(s string) []string {
@@ -840,6 +1086,9 @@ func emitCreateFestivalError(opts *CreateFestivalOptions, err error) error {
 				"message": err.Error(),
 			}},
 		})
+		if opts.AgentMode {
+			return errors.ErrAlreadyPrinted
+		}
 		return nil
 	}
 	return err

--- a/internal/commands/festival/create_festival.go
+++ b/internal/commands/festival/create_festival.go
@@ -932,7 +932,7 @@ func rollbackCreatedFestival(ctx context.Context, cfg *createConfig, res *create
 	}
 
 	if len(failures) > 0 {
-		return fmt.Errorf("%s", strings.Join(failures, "; "))
+		return errors.New(strings.Join(failures, "; "))
 	}
 	return nil
 }

--- a/internal/validator/templates.go
+++ b/internal/validator/templates.go
@@ -134,12 +134,12 @@ func scanTemplateMarkersInContent(content string) ([]TemplateMarkerOccurrence, [
 
 		lineWithoutCode := stripInlineCode(line)
 		for _, marker := range templateMarkers {
-			for _, content := range extractMarkerContents(lineWithoutCode, marker) {
+			for _, markerText := range extractMarkerContents(lineWithoutCode, marker) {
 				markerTypes[marker] = true
 				occurrences = append(occurrences, TemplateMarkerOccurrence{
 					Line:       i + 1,
 					MarkerType: marker,
-					Content:    content,
+					Content:    markerText,
 				})
 			}
 		}

--- a/internal/validator/templates.go
+++ b/internal/validator/templates.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/Obedience-Corp/fest/internal/frontmatter"
@@ -32,10 +33,18 @@ func stripInlineCode(line string) string {
 
 // MarkerFileResult holds per-file marker scan results.
 type MarkerFileResult struct {
-	RelPath     string
-	MarkerCount int
-	MarkerTypes []string
-	Level       string
+	RelPath     string                     `json:"file"`
+	MarkerCount int                        `json:"count"`
+	MarkerTypes []string                   `json:"marker_types,omitempty"`
+	Level       string                     `json:"level,omitempty"`
+	Markers     []TemplateMarkerOccurrence `json:"markers,omitempty"`
+}
+
+// TemplateMarkerOccurrence describes a single unfilled marker location.
+type TemplateMarkerOccurrence struct {
+	Line       int    `json:"line"`
+	MarkerType string `json:"marker_type"`
+	Content    string `json:"content"`
 }
 
 // ValidateTemplateMarkers scans .md files for unfilled markers with phase-aware severity.
@@ -43,7 +52,28 @@ type MarkerFileResult struct {
 func ValidateTemplateMarkers(festivalPath string) ([]Issue, error) {
 	var issues []Issue
 
-	_ = filepath.Walk(festivalPath, func(path string, info os.FileInfo, err error) error {
+	results, err := ScanTemplateMarkers(festivalPath)
+	if err != nil {
+		return nil, err
+	}
+	for _, result := range results {
+		issues = append(issues, Issue{
+			Level:   result.Level,
+			Code:    CodeUnfilledTemplate,
+			Path:    result.RelPath,
+			Message: fmt.Sprintf("File contains %d unfilled template markers (%s)", result.MarkerCount, strings.Join(result.MarkerTypes, ", ")),
+			Fix:     "Edit file and replace template markers with actual content",
+		})
+	}
+	return issues, nil
+}
+
+// ScanTemplateMarkers scans .md files for unfilled markers and returns
+// per-file detail suitable for validation output and agent JSON responses.
+func ScanTemplateMarkers(festivalPath string) ([]MarkerFileResult, error) {
+	var results []MarkerFileResult
+
+	err := filepath.Walk(festivalPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil || info.IsDir() {
 			return nil
 		}
@@ -63,100 +93,99 @@ func ValidateTemplateMarkers(festivalPath string) ([]Issue, error) {
 			return nil
 		}
 
-		// Scan line-by-line, skipping code blocks
-		lines := strings.Split(string(content), "\n")
-		inCodeBlock := false
-		fileMarkerCount := 0
-		foundMarkers := make(map[string]bool)
-
-		for _, line := range lines {
-			// Toggle fence state on ``` lines (handles ```go, ```yaml, etc.)
-			if strings.HasPrefix(strings.TrimSpace(line), "```") {
-				inCodeBlock = !inCodeBlock
-				continue
-			}
-			// Skip markers inside code blocks - they're documentation examples
-			if inCodeBlock {
-				continue
-			}
-			// Strip inline code (backticks) before checking for markers
-			lineWithoutCode := stripInlineCode(line)
-			for _, m := range templateMarkers {
-				count := strings.Count(lineWithoutCode, m)
-				if count > 0 {
-					fileMarkerCount += count
-					foundMarkers[m] = true
-				}
-			}
+		fileMarkers, markerTypes := scanTemplateMarkersInContent(string(content))
+		if len(fileMarkers) == 0 {
+			return nil
 		}
 
-		if fileMarkerCount > 0 {
-			markerTypes := make([]string, 0, len(foundMarkers))
-			for m := range foundMarkers {
-				markerTypes = append(markerTypes, m)
-			}
-
-			// Phase-aware severity
-			level := resolveMarkerLevel(festivalPath, rel)
-
-			issues = append(issues, Issue{
-				Level:   level,
-				Code:    CodeUnfilledTemplate,
-				Path:    rel,
-				Message: fmt.Sprintf("File contains %d unfilled template markers (%s)", fileMarkerCount, strings.Join(markerTypes, ", ")),
-				Fix:     "Edit file and replace template markers with actual content",
-			})
-		}
-
+		results = append(results, MarkerFileResult{
+			RelPath:     rel,
+			MarkerCount: len(fileMarkers),
+			MarkerTypes: markerTypes,
+			Level:       resolveMarkerLevel(festivalPath, rel),
+			Markers:     fileMarkers,
+		})
 		return nil
 	})
-	return issues, nil
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].RelPath < results[j].RelPath
+	})
+	return results, nil
+}
+
+func scanTemplateMarkersInContent(content string) ([]TemplateMarkerOccurrence, []string) {
+	lines := strings.Split(content, "\n")
+	inCodeBlock := false
+	markerTypes := make(map[string]bool)
+	var occurrences []TemplateMarkerOccurrence
+
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "```") {
+			inCodeBlock = !inCodeBlock
+			continue
+		}
+		if inCodeBlock {
+			continue
+		}
+
+		lineWithoutCode := stripInlineCode(line)
+		for _, marker := range templateMarkers {
+			for _, content := range extractMarkerContents(lineWithoutCode, marker) {
+				markerTypes[marker] = true
+				occurrences = append(occurrences, TemplateMarkerOccurrence{
+					Line:       i + 1,
+					MarkerType: marker,
+					Content:    content,
+				})
+			}
+		}
+	}
+
+	types := make([]string, 0, len(markerTypes))
+	for markerType := range markerTypes {
+		types = append(types, markerType)
+	}
+	sort.Strings(types)
+
+	return occurrences, types
+}
+
+func extractMarkerContents(line, marker string) []string {
+	var contents []string
+	endMarker := "]"
+	if marker == "{{ " {
+		endMarker = "}}"
+	}
+
+	offset := 0
+	for {
+		idx := strings.Index(line[offset:], marker)
+		if idx == -1 {
+			break
+		}
+		start := offset + idx
+		end := strings.Index(line[start:], endMarker)
+		if end == -1 {
+			contents = append(contents, strings.TrimSpace(line[start:]))
+			offset = start + len(marker)
+			continue
+		}
+		end += start + len(endMarker)
+		contents = append(contents, strings.TrimSpace(line[start:end]))
+		offset = end
+	}
+
+	return contents
 }
 
 // CheckTemplatesFilled returns true if no unfilled template markers remain.
 func CheckTemplatesFilled(festivalPath string) bool {
-	filled := true
-	_ = filepath.Walk(festivalPath, func(path string, info os.FileInfo, err error) error {
-		if err != nil || info.IsDir() || !strings.HasSuffix(path, ".md") {
-			return nil
-		}
-		rel, _ := filepath.Rel(festivalPath, path)
-		if strings.HasPrefix(rel, ".") || strings.Contains(rel, "/.") {
-			return nil
-		}
-		// Skip gates/ directory - these are intentional template files
-		if strings.HasPrefix(rel, "gates/") || strings.HasPrefix(rel, "gates"+string(filepath.Separator)) {
-			return nil
-		}
-		b, err := os.ReadFile(path)
-		if err != nil {
-			return nil
-		}
-		// Scan line-by-line, skipping code blocks
-		lines := strings.Split(string(b), "\n")
-		inCodeBlock := false
-		for _, line := range lines {
-			// Toggle fence state on ``` lines
-			if strings.HasPrefix(strings.TrimSpace(line), "```") {
-				inCodeBlock = !inCodeBlock
-				continue
-			}
-			// Skip markers inside code blocks - they're documentation examples
-			if inCodeBlock {
-				continue
-			}
-			// Strip inline code (backticks) before checking for markers
-			lineWithoutCode := stripInlineCode(line)
-			for _, m := range templateMarkers {
-				if strings.Contains(lineWithoutCode, m) {
-					filled = false
-					return filepath.SkipAll
-				}
-			}
-		}
-		return nil
-	})
-	return filled
+	results, err := ScanTemplateMarkers(festivalPath)
+	return err == nil && len(results) == 0
 }
 
 // resolveMarkerLevel determines the severity level for template markers

--- a/tests/integration/create_festival_agent_test.go
+++ b/tests/integration/create_festival_agent_test.go
@@ -1,0 +1,115 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type createFestivalAgentResult struct {
+	OK              bool              `json:"ok"`
+	Festival        map[string]string `json:"festival"`
+	CreatedPath     string            `json:"created_path"`
+	MarkersUnfilled int               `json:"markers_unfilled"`
+	UnfilledMarkers []struct {
+		File    string `json:"file"`
+		Count   int    `json:"count"`
+		Markers []struct {
+			Line       int    `json:"line"`
+			MarkerType string `json:"marker_type"`
+			Content    string `json:"content"`
+		} `json:"markers"`
+	} `json:"unfilled_markers"`
+	Validation *struct {
+		OK     bool `json:"ok"`
+		Errors int  `json:"errors"`
+		Issues []struct {
+			Code string `json:"code"`
+			Path string `json:"path"`
+		} `json:"issues"`
+	} `json:"validation"`
+	RolledBack *bool `json:"rolled_back"`
+	Errors     []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+func TestCreateFestivalAgentValidationFailureRollsBackAndReportsMarkers(t *testing.T) {
+	tc := GetSharedContainer(t)
+	festivalsPath := setupWorkspace(t, tc, "/")
+	writeAgentMarkerTemplates(t, tc, festivalsPath)
+
+	output, err := tc.RunFestInDir(festivalsPath, "create", "festival", "--name", "agent-rollback", "--dest", "planning", "--agent")
+	require.Error(t, err, "agent mode should exit non-zero when strict validation blocks")
+
+	var failed createFestivalAgentResult
+	require.NoError(t, json.Unmarshal([]byte(output), &failed), "agent failure should be JSON: %s", output)
+	require.False(t, failed.OK)
+	require.NotEmpty(t, failed.CreatedPath)
+	require.NotNil(t, failed.RolledBack)
+	require.True(t, *failed.RolledBack)
+	require.Equal(t, 3, failed.MarkersUnfilled)
+	require.Len(t, failed.UnfilledMarkers, 3)
+	seenMarkers := make(map[string]int)
+	for _, file := range failed.UnfilledMarkers {
+		require.NotEmpty(t, file.File)
+		require.Equal(t, 1, file.Count)
+		require.NotEmpty(t, file.Markers)
+		seenMarkers[file.File] = file.Count
+	}
+	require.Equal(t, map[string]int{
+		"FESTIVAL_GOAL.md":     1,
+		"FESTIVAL_OVERVIEW.md": 1,
+		"TODO.md":              1,
+	}, seenMarkers)
+	require.NotNil(t, failed.Validation)
+	require.False(t, failed.Validation.OK)
+	require.NotEmpty(t, failed.Validation.Issues)
+	require.NotEmpty(t, failed.Errors)
+	require.Contains(t, failed.Errors[0].Message, "validation errors detected")
+
+	exists, err := tc.CheckDirExists(failed.CreatedPath)
+	require.NoError(t, err)
+	require.False(t, exists, "strict agent failure should remove the created festival directory")
+
+	dirs, err := tc.ListDirectories(festivalsPath + "/planning")
+	require.NoError(t, err)
+	require.Empty(t, dirs, "strict agent failure should leave no planning festival behind")
+
+	markersArg := `'{"goal":"Goal","overview":"Overview","todo":"Todo"}'`
+	output, err = tc.RunFestInDir(festivalsPath, "create", "festival", "--name", "agent-rollback", "--dest", "planning", "--agent", "--markers", markersArg)
+	require.NoError(t, err, "retry with marker values should succeed: %s", output)
+
+	var succeeded createFestivalAgentResult
+	require.NoError(t, json.Unmarshal([]byte(output), &succeeded), "agent success should be JSON: %s", output)
+	require.True(t, succeeded.OK)
+	require.Equal(t, "AR0001", succeeded.Festival["id"], "retry should reuse the first ID after rollback")
+
+	dirs, err = tc.ListDirectories(festivalsPath + "/planning")
+	require.NoError(t, err)
+	require.Len(t, dirs, 1)
+	require.True(t, strings.Contains(dirs[0], "AR0001"), "created directory should use first ID, got %v", dirs)
+}
+
+func writeAgentMarkerTemplates(t *testing.T, tc *TestContainer, festivalsPath string) {
+	t.Helper()
+
+	templatesDir := festivalsPath + "/.festival/templates/festival"
+	_, err := tc.runCommand([]string{"mkdir", "-p", templatesDir})
+	require.NoError(t, err)
+
+	files := map[string]string{
+		"GOAL.md":     "# Festival Goal\n\n[REPLACE: goal]\n",
+		"OVERVIEW.md": "# Overview\n\n[REPLACE: overview]\n",
+		"RULES.md":    "# Rules\n\nFollow the rules.\n",
+		"TODO.md":     "# TODO\n\n- [REPLACE: todo]\n",
+	}
+	for name, content := range files {
+		require.NoError(t, writeFileInContainer(tc, templatesDir+"/"+name, content), "write template %s", name)
+	}
+}

--- a/tests/integration/create_festival_agent_test.go
+++ b/tests/integration/create_festival_agent_test.go
@@ -96,6 +96,28 @@ func TestCreateFestivalAgentValidationFailureRollsBackAndReportsMarkers(t *testi
 	require.True(t, strings.Contains(dirs[0], "AR0001"), "created directory should use first ID, got %v", dirs)
 }
 
+func TestCreateFestivalAgentValidationFailureLeavesLegacyRegistryIntact(t *testing.T) {
+	tc := GetSharedContainer(t)
+	festivalsPath := setupWorkspace(t, tc, "/")
+	writeAgentMarkerTemplates(t, tc, festivalsPath)
+
+	legacyPath := festivalsPath + "/.festival/.state/id_registry.yaml"
+	eventsPath := festivalsPath + "/.festival/.state/festival_events.jsonl"
+	legacyYAML := "version: \"1\"\nentries:\n  ZZ0001:\n    id: ZZ0001\n    name: Legacy Festival\n    status: planning\n    path: /festivals/planning/legacy-ZZ0001\n"
+	require.NoError(t, writeFileInContainer(tc, legacyPath, legacyYAML))
+
+	_, err := tc.RunFestInDir(festivalsPath, "create", "festival", "--name", "legacy-guard", "--dest", "planning", "--agent")
+	require.Error(t, err, "agent mode should exit non-zero when strict validation blocks")
+
+	legacyExists, err := tc.CheckFileExists(legacyPath)
+	require.NoError(t, err)
+	require.True(t, legacyExists, "failed agent create must not migrate or remove the legacy registry")
+
+	eventsExists, err := tc.CheckFileExists(eventsPath)
+	require.NoError(t, err)
+	require.False(t, eventsExists, "failed agent create must not trigger legacy registry migration")
+}
+
 func writeAgentMarkerTemplates(t *testing.T, tc *TestContainer, festivalsPath string) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

Fixes `fest create festival --agent` so strict agent-mode failures no longer leave behind a created festival directory that looks failed to the caller but exists on disk.

## Root Cause

`--agent` reused the normal human-oriented create pipeline: render files first, run validation later, then return `ok: false` if validation blocked. The JSON response did not disclose the created path or marker details, so agent callers could reasonably treat the failure as side-effect-free and retry, producing duplicate festival IDs.

## Changes

- Roll back the created festival directory on blocking `--agent` validation failures.
- Delay registry and campaign contract writes until after validation succeeds.
- Return structured failure JSON with `created_path`, `markers_unfilled`, `unfilled_markers`, `validation`, `rolled_back`, and rollback errors when relevant.
- Add reusable detailed template marker scanning with file, line, marker type, and marker content.
- Update `fest create festival --agent` help text.
- Add a containerized regression test proving rollback, structured marker details, and retry ID reuse.

## Validation

- `go test ./internal/validator ./internal/commands/festival`
- `just test unit-raw`
- `TESTCONTAINERS_RYUK_DISABLED=true go test -v -tags=integration -run TestCreateFestivalAgentValidationFailureRollsBackAndReportsMarkers -timeout 5m ./tests/integration`
- `git diff --check`
