### PR TITLE
fix(chain): use CH namespace for chain IDs

### DIFF
--- a/internal/commands/chain/create.go
+++ b/internal/commands/chain/create.go
@@ -16,6 +16,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const chainIDPrefix = "CH"
+
 func newCreateCmd() *cobra.Command {
 	var (
 		name string
@@ -59,10 +61,9 @@ func runCreate(cmd *cobra.Command, name, goal string) error {
 		return errors.IO("creating chains directory", err)
 	}
 
-	// Generate chain ID from name prefix.
+	// Generate chain IDs from the fixed chain namespace.
 	slug := strings.ToLower(strings.ReplaceAll(name, " ", "-"))
-	prefix := chainIDPrefix(name)
-	id := nextChainID(chainsDir, prefix)
+	id := nextChainID(chainsDir, chainIDPrefix)
 
 	// Render embedded chain template.
 	tplData, err := chaintpl.Templates.ReadFile("chain_template.yaml")
@@ -147,16 +148,4 @@ func nextChainID(chainsDir, prefix string) string {
 
 func createChainFile(path string) (*os.File, error) {
 	return os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
-}
-
-// chainIDPrefix extracts a 2-letter uppercase prefix from the chain name.
-func chainIDPrefix(name string) string {
-	words := strings.Fields(strings.TrimSpace(name))
-	if len(words) >= 2 {
-		return strings.ToUpper(string(words[0][0])) + strings.ToUpper(string(words[1][0]))
-	}
-	if len(name) >= 2 {
-		return strings.ToUpper(name[:2])
-	}
-	return "CH"
 }

--- a/internal/commands/chain/create_test.go
+++ b/internal/commands/chain/create_test.go
@@ -12,27 +12,31 @@ import (
 func TestNextChainIDUsesMaxNumericSuffix(t *testing.T) {
 	chainsDir := t.TempDir()
 
-	require.NoError(t, os.WriteFile(filepath.Join(chainsDir, "alpha-beta-AB0001.yaml"), []byte("one"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(chainsDir, "alpha-beta-AB0003.yaml"), []byte("three"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(chainsDir, "alpha-beta-CH0001.yaml"), []byte("one"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(chainsDir, "alpha-beta-CH0003.yaml"), []byte("three"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(chainsDir, "other-XY0007.yaml"), []byte("other"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(chainsDir, "README.md"), []byte("ignore"), 0o644))
 
-	got := nextChainID(chainsDir, "AB")
-	assert.Equal(t, "AB0004", got)
+	got := nextChainID(chainsDir, chainIDPrefix)
+	assert.Equal(t, "CH0004", got)
 }
 
 func TestNextChainIDIgnoresMalformedPrefixMatches(t *testing.T) {
 	chainsDir := t.TempDir()
 
-	require.NoError(t, os.WriteFile(filepath.Join(chainsDir, "AB-not-a-number.yaml"), []byte("x"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(chainsDir, "alpha-beta-AB0002.yaml"), []byte("y"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(chainsDir, "CH-not-a-number.yaml"), []byte("x"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(chainsDir, "alpha-beta-CH0002.yaml"), []byte("y"), 0o644))
 
-	got := nextChainID(chainsDir, "AB")
-	assert.Equal(t, "AB0003", got)
+	got := nextChainID(chainsDir, chainIDPrefix)
+	assert.Equal(t, "CH0003", got)
+}
+
+func TestChainIDPrefixUsesChainNamespace(t *testing.T) {
+	assert.Equal(t, "CH", chainIDPrefix)
 }
 
 func TestCreateChainFileDoesNotOverwriteExistingFile(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "alpha-beta-AB0001.yaml")
+	path := filepath.Join(t.TempDir(), "alpha-beta-CH0001.yaml")
 	original := "original chain contents"
 	require.NoError(t, os.WriteFile(path, []byte(original), 0o644))
 


### PR DESCRIPTION
## Summary
- generate festival chain IDs from the fixed `CH` namespace instead of deriving prefixes from chain names
- update chain creation tests to assert the `CH####` convention
- keep existing chain parsing compatible with already-created non-CH files

## Verification
- `go test ./internal/commands/chain ./internal/chain`
- `just test unit`
- `just lint gopls-tests internal/commands/chain`
- `just lint vet`
- `just build quick`