### PR TITLE
fix(chain,watch): dungeon-aware chain resolution + watch completion; chain context ergonomics

### DIFF
--- a/internal/chain/resolve.go
+++ b/internal/chain/resolve.go
@@ -36,6 +36,32 @@ func Resolve(ctx context.Context, c *Chain, searchDirs []string) (map[string]Res
 	return resolved, nil
 }
 
+// ResolveAvailable resolves festival references best-effort: refs whose
+// directory cannot be found are omitted from the result rather than failing the
+// entire resolution (as Resolve does). Use this when partial chain state is
+// acceptable — computing live statuses for display or dependency gates, where
+// one missing or not-yet-created festival should not blank out the rest of the
+// chain. Use Resolve when every ref must resolve (e.g. chain validation).
+func ResolveAvailable(ctx context.Context, c *Chain, searchDirs []string) (map[string]ResolvedFestival, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	resolved := make(map[string]ResolvedFestival, len(c.Festivals))
+	for _, node := range c.Festivals {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		path, err := findFestivalDir(ctx, node.ID, searchDirs)
+		if err != nil {
+			continue // best-effort: omit unresolved refs
+		}
+		resolved[node.Ref] = ResolvedFestival{Node: node, Path: path}
+	}
+
+	return resolved, nil
+}
+
 // findFestivalDir searches the given directories for a subdirectory whose name
 // contains the festival ID (e.g., "hedera-foundation-HF0001" contains "HF0001").
 func findFestivalDir(ctx context.Context, festivalID string, searchDirs []string) (string, error) {
@@ -48,6 +74,7 @@ func findFestivalDir(ctx context.Context, festivalID string, searchDirs []string
 		if err != nil {
 			continue // skip unreadable directories
 		}
+		dungeon := isDungeonStatusDir(dir)
 		for _, entry := range entries {
 			if !entry.IsDir() {
 				continue
@@ -55,10 +82,56 @@ func findFestivalDir(ctx context.Context, festivalID string, searchDirs []string
 			if matchesFestivalID(entry.Name(), festivalID) {
 				return filepath.Join(dir, entry.Name()), nil
 			}
+			// Dungeon status dirs interpose a dated bucket between the status
+			// dir and the festival (dungeon/<status>/YYYY-MM-DD/<festival>), so
+			// descend one level into date buckets to match festivals there.
+			if dungeon && isDateBucket(entry.Name()) {
+				if path, ok := matchFestivalInDir(filepath.Join(dir, entry.Name()), festivalID); ok {
+					return path, nil
+				}
+			}
 		}
 	}
 
 	return "", errors.NotFound("festival").WithField("festivalID", festivalID)
+}
+
+// matchFestivalInDir returns the path of a festival directory matching
+// festivalID located directly inside dir, if present.
+func matchFestivalInDir(dir, festivalID string) (string, bool) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", false
+	}
+	for _, entry := range entries {
+		if entry.IsDir() && matchesFestivalID(entry.Name(), festivalID) {
+			return filepath.Join(dir, entry.Name()), true
+		}
+	}
+	return "", false
+}
+
+// isDungeonStatusDir reports whether dir is a dungeon status directory
+// (festivals/dungeon/{completed,archived,someday}), which holds festivals one
+// level deeper inside dated YYYY-MM-DD buckets.
+func isDungeonStatusDir(dir string) bool {
+	return filepath.Base(filepath.Dir(dir)) == "dungeon"
+}
+
+// isDateBucket reports whether name is a YYYY-MM-DD dungeon bucket directory.
+func isDateBucket(name string) bool {
+	if len(name) != 10 || name[4] != '-' || name[7] != '-' {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		if i == 4 || i == 7 {
+			continue
+		}
+		if name[i] < '0' || name[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // matchesFestivalID checks whether a directory name matches a festival ID.

--- a/internal/chain/resolve.go
+++ b/internal/chain/resolve.go
@@ -36,12 +36,9 @@ func Resolve(ctx context.Context, c *Chain, searchDirs []string) (map[string]Res
 	return resolved, nil
 }
 
-// ResolveAvailable resolves festival references best-effort: refs whose
-// directory cannot be found are omitted from the result rather than failing the
-// entire resolution (as Resolve does). Use this when partial chain state is
-// acceptable — computing live statuses for display or dependency gates, where
-// one missing or not-yet-created festival should not blank out the rest of the
-// chain. Use Resolve when every ref must resolve (e.g. chain validation).
+// ResolveAvailable is like Resolve but best-effort: unresolved refs are omitted
+// instead of failing the whole resolution, so one missing festival does not blank
+// out the rest of the chain. Use Resolve when every ref must resolve.
 func ResolveAvailable(ctx context.Context, c *Chain, searchDirs []string) (map[string]ResolvedFestival, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -82,9 +79,7 @@ func findFestivalDir(ctx context.Context, festivalID string, searchDirs []string
 			if matchesFestivalID(entry.Name(), festivalID) {
 				return filepath.Join(dir, entry.Name()), nil
 			}
-			// Dungeon status dirs interpose a dated bucket between the status
-			// dir and the festival (dungeon/<status>/YYYY-MM-DD/<festival>), so
-			// descend one level into date buckets to match festivals there.
+			// Dungeon dirs nest festivals under a date bucket; descend one level.
 			if dungeon && isDateBucket(entry.Name()) {
 				if path, ok := matchFestivalInDir(filepath.Join(dir, entry.Name()), festivalID); ok {
 					return path, nil
@@ -96,8 +91,6 @@ func findFestivalDir(ctx context.Context, festivalID string, searchDirs []string
 	return "", errors.NotFound("festival").WithField("festivalID", festivalID)
 }
 
-// matchFestivalInDir returns the path of a festival directory matching
-// festivalID located directly inside dir, if present.
 func matchFestivalInDir(dir, festivalID string) (string, bool) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -111,20 +104,25 @@ func matchFestivalInDir(dir, festivalID string) (string, bool) {
 	return "", false
 }
 
-// isDungeonStatusDir reports whether dir is a dungeon status directory
-// (festivals/dungeon/{completed,archived,someday}), which holds festivals one
-// level deeper inside dated YYYY-MM-DD buckets.
 func isDungeonStatusDir(dir string) bool {
 	return filepath.Base(filepath.Dir(dir)) == "dungeon"
 }
 
-// isDateBucket reports whether name is a YYYY-MM-DD dungeon bucket directory.
+// isDateBucket matches a dungeon date bucket: YYYY-MM-DD or legacy YYYY-MM
+// (mirrors show.LooksLikeDateDir; kept local to avoid importing a commands pkg).
 func isDateBucket(name string) bool {
-	if len(name) != 10 || name[4] != '-' || name[7] != '-' {
+	// YYYY-MM (len 7) or YYYY-MM-DD (len 10).
+	if len(name) != 7 && len(name) != 10 {
+		return false
+	}
+	if name[4] != '-' {
+		return false
+	}
+	if len(name) == 10 && name[7] != '-' {
 		return false
 	}
 	for i := 0; i < len(name); i++ {
-		if i == 4 || i == 7 {
+		if i == 4 || (len(name) == 10 && i == 7) {
 			continue
 		}
 		if name[i] < '0' || name[i] > '9' {

--- a/internal/chain/resolve_test.go
+++ b/internal/chain/resolve_test.go
@@ -176,6 +176,19 @@ func TestResolveAvailable_OmitsMissingRefs(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestResolve_FindsFestivalInLegacyMonthBucket(t *testing.T) {
+	root := t.TempDir()
+	// Legacy dungeon buckets use YYYY-MM (no day); the resolver must still descend.
+	require.NoError(t, os.MkdirAll(
+		filepath.Join(root, "dungeon", "completed", "2026-05", "old-work-OW0001"), 0o755))
+
+	c := &Chain{Festivals: []FestivalNode{{Ref: "ow", ID: "OW0001", Name: "old-work"}}}
+
+	resolved, err := Resolve(context.Background(), c, []string{filepath.Join(root, "dungeon", "completed")})
+	require.NoError(t, err)
+	assert.Contains(t, resolved["ow"].Path, filepath.Join("2026-05", "old-work-OW0001"))
+}
+
 func TestResolveAvailable_FindsDungeonFestival(t *testing.T) {
 	root := t.TempDir()
 	require.NoError(t, os.MkdirAll(
@@ -203,6 +216,10 @@ func TestIsDateBucket(t *testing.T) {
 	}{
 		{"2026-06-04", true},
 		{"2026-12-31", true},
+		{"2026-05", true},  // legacy YYYY-MM bucket
+		{"2025-01", true},  // legacy YYYY-MM bucket
+		{"2026-5", false},  // single-digit month
+		{"2026", false},    // year only
 		{"chains", false},
 		{"2026-6-4", false},
 		{"2026-06-04-extra", false},

--- a/internal/chain/resolve_test.go
+++ b/internal/chain/resolve_test.go
@@ -117,6 +117,105 @@ func TestResolve_SkipsUnreadableDir(t *testing.T) {
 	assert.Contains(t, resolved["a"].Path, "alpha-A0001")
 }
 
+func TestResolve_FindsFestivalInDungeonDatedBucket(t *testing.T) {
+	root := t.TempDir()
+	// Working festival sits directly under its status dir.
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "active", "onboarding-parity-FA0010"), 0o755))
+	// Completed festival lives inside a dated dungeon bucket.
+	require.NoError(t, os.MkdirAll(
+		filepath.Join(root, "dungeon", "completed", "2026-06-04", "audit-remediation-FA0009"), 0o755))
+
+	c := &Chain{
+		Festivals: []FestivalNode{
+			{Ref: "audit", ID: "FA0009", Name: "audit-remediation"},
+			{Ref: "onboarding", ID: "FA0010", Name: "onboarding-parity"},
+		},
+	}
+
+	searchDirs := []string{
+		filepath.Join(root, "active"),
+		filepath.Join(root, "dungeon", "completed"),
+	}
+
+	resolved, err := Resolve(context.Background(), c, searchDirs)
+	require.NoError(t, err)
+	assert.Equal(t,
+		filepath.Join(root, "dungeon", "completed", "2026-06-04", "audit-remediation-FA0009"),
+		resolved["audit"].Path)
+	assert.Equal(t, filepath.Join(root, "active", "onboarding-parity-FA0010"), resolved["onboarding"].Path)
+}
+
+func TestResolve_IgnoresNonDateDungeonSubdirs(t *testing.T) {
+	root := t.TempDir()
+	// A non-date subdir (e.g. the dungeon chains dir) must not be descended.
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "dungeon", "completed", "chains"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "dungeon", "completed", "chains", "decoy-FA0009"), 0o755))
+
+	c := &Chain{Festivals: []FestivalNode{{Ref: "x", ID: "FA0009", Name: "audit"}}}
+
+	_, err := Resolve(context.Background(), c, []string{filepath.Join(root, "dungeon", "completed")})
+	assert.Error(t, err, "should not match festivals under non-date subdirectories")
+}
+
+func TestResolveAvailable_OmitsMissingRefs(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "alpha-A0001"), 0o755))
+
+	c := &Chain{
+		Festivals: []FestivalNode{
+			{Ref: "a", ID: "A0001", Name: "alpha"},
+			{Ref: "missing", ID: "M0001", Name: "missing"},
+		},
+	}
+
+	resolved, err := ResolveAvailable(context.Background(), c, []string{root})
+	require.NoError(t, err)
+	assert.Len(t, resolved, 1, "missing ref should be omitted, not fail the whole resolution")
+	assert.Contains(t, resolved["a"].Path, "alpha-A0001")
+	_, ok := resolved["missing"]
+	assert.False(t, ok)
+}
+
+func TestResolveAvailable_FindsDungeonFestival(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(
+		filepath.Join(root, "dungeon", "completed", "2026-06-04", "audit-remediation-FA0009"), 0o755))
+
+	c := &Chain{Festivals: []FestivalNode{{Ref: "audit", ID: "FA0009", Name: "audit-remediation"}}}
+
+	resolved, err := ResolveAvailable(context.Background(), c, []string{filepath.Join(root, "dungeon", "completed")})
+	require.NoError(t, err)
+	assert.Contains(t, resolved["audit"].Path, filepath.Join("2026-06-04", "audit-remediation-FA0009"))
+}
+
+func TestResolveAvailable_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	c := &Chain{Festivals: []FestivalNode{{Ref: "a", ID: "A0001", Name: "alpha"}}}
+	_, err := ResolveAvailable(ctx, c, []string{"/tmp"})
+	assert.Error(t, err)
+}
+
+func TestIsDateBucket(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"2026-06-04", true},
+		{"2026-12-31", true},
+		{"chains", false},
+		{"2026-6-4", false},
+		{"2026-06-04-extra", false},
+		{"audit-remediation-FA0009", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isDateBucket(tt.name))
+		})
+	}
+}
+
 func TestMatchesFestivalID(t *testing.T) {
 	tests := []struct {
 		dirName    string

--- a/internal/commands/chain/check.go
+++ b/internal/commands/chain/check.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/errors"
 	tpl "github.com/Obedience-Corp/fest/internal/template"
 	"github.com/Obedience-Corp/fest/internal/ui"
+	"github.com/Obedience-Corp/fest/internal/workspace"
 	"github.com/spf13/cobra"
 )
 
@@ -150,13 +151,18 @@ func findChainForFestival(ctx context.Context, refOrID, chainIDFlag string) (*ch
 		WithHint("specify a chain with --chain or ensure the festival is in a chain")
 }
 
-// festivalsRoot returns the festivals root directory.
+// festivalsRoot resolves the campaign's festivals dir from inside festivals/, a
+// linked project dir, or the campaign root (tpl.FindFestivalsRoot only handles
+// the first; workspace.FindFestivals covers the rest).
 func festivalsRoot() (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return "", errors.IO("getting working directory", err)
 	}
-	root, err := tpl.FindFestivalsRoot(cwd)
+	if root, err := tpl.FindFestivalsRoot(cwd); err == nil {
+		return root, nil
+	}
+	root, err := workspace.FindFestivals(cwd)
 	if err != nil {
 		return "", errors.Wrap(err, "finding festivals root").WithCode(errors.ErrCodeConfig)
 	}

--- a/internal/commands/chain/check.go
+++ b/internal/commands/chain/check.go
@@ -16,12 +16,23 @@ func newCheckCmd() *cobra.Command {
 	var chainID string
 
 	cmd := &cobra.Command{
-		Use:   "check <ref-or-id>",
+		Use:   "check [ref-or-id]",
 		Short: "Check if a festival is unblocked within its chain",
-		Long:  "Quick check whether a specific festival's hard dependencies are met.",
-		Args:  cobra.ExactArgs(1),
+		Long: "Quick check whether a specific festival's hard dependencies are met. " +
+			"The festival ref or id is optional when it can be inferred from the " +
+			"current festival or linked project.",
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runCheck(cmd.Context(), args[0], chainID)
+			refOrID := firstArg(args)
+			if refOrID == "" {
+				festID, ok := resolveCurrentFestivalID(cmd.Context())
+				if !ok {
+					return errors.Validation("festival ref or id required").
+						WithHint("run from inside a festival or linked project, or pass a ref/id")
+				}
+				refOrID = festID
+			}
+			return runCheck(cmd.Context(), refOrID, chainID)
 		},
 	}
 

--- a/internal/commands/chain/complete.go
+++ b/internal/commands/chain/complete.go
@@ -20,14 +20,26 @@ func newCompleteCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "complete <chain-id>",
+		Use:   "complete [chain-id]",
 		Short: "Complete and archive a chain",
 		Long: `Mark a chain as completed and move it to festivals/dungeon/completed/chains/.
 
-All festivals in the chain must be completed unless --force is used.`,
-		Args: cobra.ExactArgs(1),
+All festivals in the chain must be completed unless --force is used.
+
+The chain id is optional when it can be inferred from the current festival or
+linked project, or selected interactively. Because this archives the chain, an
+inferred or picked target must be confirmed, and a non-interactive run requires
+the chain id to be passed explicitly.`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runComplete(cmd.Context(), args[0], force, notes)
+			chainID, inferred, err := resolveChainID(cmd.Context(), firstArg(args))
+			if err != nil {
+				return err
+			}
+			if inferred && !confirmChainCompletion(chainID) {
+				return nil
+			}
+			return runComplete(cmd.Context(), chainID, force, notes)
 		},
 	}
 

--- a/internal/commands/chain/context.go
+++ b/internal/commands/chain/context.go
@@ -16,7 +16,6 @@ import (
 	"golang.org/x/term"
 )
 
-// firstArg returns the first positional argument, or "" if none were given.
 func firstArg(args []string) string {
 	if len(args) > 0 {
 		return args[0]
@@ -24,9 +23,8 @@ func firstArg(args []string) string {
 	return ""
 }
 
-// resolveCurrentFestivalID infers the festival the user is currently working in,
-// from the cwd (inside a festival directory) or a linked project working
-// directory. Returns ("", false) when no festival context is available.
+// resolveCurrentFestivalID infers the current festival id from the cwd festival
+// dir or a linked project working dir, or ("", false).
 func resolveCurrentFestivalID(ctx context.Context) (string, bool) {
 	if err := ctx.Err(); err != nil {
 		return "", false
@@ -44,8 +42,6 @@ func resolveCurrentFestivalID(ctx context.Context) (string, bool) {
 	return "", false
 }
 
-// festivalIDFromMarkers walks up from cwd looking for a festival fest.yaml and
-// returns its metadata id, or "" if cwd is not inside a festival.
 func festivalIDFromMarkers(cwd string) string {
 	dir := cwd
 	for {
@@ -62,8 +58,6 @@ func festivalIDFromMarkers(cwd string) string {
 	}
 }
 
-// festivalIDFromLink resolves a linked project working directory to the linked
-// festival's id, or "" if cwd is not inside a linked project.
 func festivalIDFromLink(cwd string) string {
 	nav, err := navigation.LoadNavigation()
 	if err != nil {
@@ -84,11 +78,9 @@ func festivalIDFromLink(cwd string) string {
 	return cfg.Metadata.ID
 }
 
-// resolveChainID returns the chain id to operate on. An explicit id is returned
-// as-is. Otherwise the current festival context is used to find its chain;
-// failing that, an interactive picker is shown in a TTY. inferred reports
-// whether the id was inferred or picked rather than passed explicitly, so
-// mutating commands can confirm before acting.
+// resolveChainID returns the chain id: explicit if given, else inferred from the
+// current festival's chain, else picked interactively in a TTY. inferred is true
+// when not passed explicitly, so mutating commands can confirm first.
 func resolveChainID(ctx context.Context, explicit string) (chainID string, inferred bool, err error) {
 	if explicit != "" {
 		return explicit, false, nil
@@ -116,9 +108,8 @@ func resolveChainID(ctx context.Context, explicit string) (chainID string, infer
 	return picked, true, nil
 }
 
-// pickChainID opens an interactive picker over the campaign's non-terminal
-// chains and returns the selected chain id. Returns "" when stdout is not a TTY,
-// no selectable chains exist, or the user cancels.
+// pickChainID picks a non-terminal chain interactively, or returns "" when not a
+// TTY, no chains exist, or cancelled.
 func pickChainID(ctx context.Context, festivalsRoot string) (string, error) {
 	if !term.IsTerminal(int(os.Stdin.Fd())) || !term.IsTerminal(int(os.Stderr.Fd())) {
 		return "", nil
@@ -132,7 +123,7 @@ func pickChainID(ctx context.Context, festivalsRoot string) (string, error) {
 	items := make([]picker.Item, 0, len(chains))
 	for _, c := range chains {
 		if c.Metadata.Status == chainpkg.StatusCompleted {
-			continue // terminal chains are not actionable targets
+			continue
 		}
 		items = append(items, picker.Item{
 			Name:  fmt.Sprintf("[%s] %s", c.Metadata.ID, c.Metadata.Name),
@@ -153,10 +144,8 @@ func pickChainID(ctx context.Context, festivalsRoot string) (string, error) {
 	return selected.Value, nil
 }
 
-// confirmChainCompletion asks the user to confirm archiving a chain that was
-// inferred or picked rather than named explicitly. In a non-interactive
-// environment it refuses (returns false) and asks for an explicit id, so a
-// mutating archive is never performed on an inferred target without consent.
+// confirmChainCompletion confirms archiving an inferred/picked chain; refuses in
+// a non-interactive shell so an inferred target is never archived without consent.
 func confirmChainCompletion(chainID string) bool {
 	if !term.IsTerminal(int(os.Stdin.Fd())) || !term.IsTerminal(int(os.Stderr.Fd())) {
 		fmt.Fprintf(os.Stderr,

--- a/internal/commands/chain/context.go
+++ b/internal/commands/chain/context.go
@@ -1,0 +1,173 @@
+package chain
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	chainpkg "github.com/Obedience-Corp/fest/internal/chain"
+	"github.com/Obedience-Corp/fest/internal/config"
+	"github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/navigation"
+	"github.com/Obedience-Corp/fest/internal/tui/picker"
+	"golang.org/x/term"
+)
+
+// firstArg returns the first positional argument, or "" if none were given.
+func firstArg(args []string) string {
+	if len(args) > 0 {
+		return args[0]
+	}
+	return ""
+}
+
+// resolveCurrentFestivalID infers the festival the user is currently working in,
+// from the cwd (inside a festival directory) or a linked project working
+// directory. Returns ("", false) when no festival context is available.
+func resolveCurrentFestivalID(ctx context.Context) (string, bool) {
+	if err := ctx.Err(); err != nil {
+		return "", false
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", false
+	}
+	if festID := festivalIDFromMarkers(cwd); festID != "" {
+		return festID, true
+	}
+	if festID := festivalIDFromLink(cwd); festID != "" {
+		return festID, true
+	}
+	return "", false
+}
+
+// festivalIDFromMarkers walks up from cwd looking for a festival fest.yaml and
+// returns its metadata id, or "" if cwd is not inside a festival.
+func festivalIDFromMarkers(cwd string) string {
+	dir := cwd
+	for {
+		if _, err := os.Stat(filepath.Join(dir, config.FestivalConfigFileName)); err == nil {
+			if cfg, err := config.LoadFestivalConfig(dir, ""); err == nil && cfg.Metadata.HasMetadata() {
+				return cfg.Metadata.ID
+			}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+// festivalIDFromLink resolves a linked project working directory to the linked
+// festival's id, or "" if cwd is not inside a linked project.
+func festivalIDFromLink(cwd string) string {
+	nav, err := navigation.LoadNavigation()
+	if err != nil {
+		return ""
+	}
+	name := nav.FindFestivalForPath(cwd)
+	if name == "" {
+		return ""
+	}
+	link, ok := nav.GetLink(name)
+	if !ok || link.FestivalPath == "" {
+		return ""
+	}
+	cfg, err := config.LoadFestivalConfig(link.FestivalPath, "")
+	if err != nil || !cfg.Metadata.HasMetadata() {
+		return ""
+	}
+	return cfg.Metadata.ID
+}
+
+// resolveChainID returns the chain id to operate on. An explicit id is returned
+// as-is. Otherwise the current festival context is used to find its chain;
+// failing that, an interactive picker is shown in a TTY. inferred reports
+// whether the id was inferred or picked rather than passed explicitly, so
+// mutating commands can confirm before acting.
+func resolveChainID(ctx context.Context, explicit string) (chainID string, inferred bool, err error) {
+	if explicit != "" {
+		return explicit, false, nil
+	}
+
+	root, err := festivalsRoot()
+	if err != nil {
+		return "", false, err
+	}
+
+	if festID, ok := resolveCurrentFestivalID(ctx); ok {
+		if c, _, findErr := chainpkg.FindForFestival(ctx, festID, root); findErr == nil && c != nil {
+			return c.Metadata.ID, true, nil
+		}
+	}
+
+	picked, pickErr := pickChainID(ctx, root)
+	if pickErr != nil {
+		return "", false, pickErr
+	}
+	if picked == "" {
+		return "", false, errors.Validation("chain id required").
+			WithHint("pass a chain id, or run from inside a festival or linked project in an interactive terminal")
+	}
+	return picked, true, nil
+}
+
+// pickChainID opens an interactive picker over the campaign's non-terminal
+// chains and returns the selected chain id. Returns "" when stdout is not a TTY,
+// no selectable chains exist, or the user cancels.
+func pickChainID(ctx context.Context, festivalsRoot string) (string, error) {
+	if !term.IsTerminal(int(os.Stdin.Fd())) || !term.IsTerminal(int(os.Stderr.Fd())) {
+		return "", nil
+	}
+
+	chains, err := chainpkg.DiscoverAll(ctx, festivalsRoot)
+	if err != nil {
+		return "", errors.Wrap(err, "discovering chains")
+	}
+
+	items := make([]picker.Item, 0, len(chains))
+	for _, c := range chains {
+		if c.Metadata.Status == chainpkg.StatusCompleted {
+			continue // terminal chains are not actionable targets
+		}
+		items = append(items, picker.Item{
+			Name:  fmt.Sprintf("[%s] %s", c.Metadata.ID, c.Metadata.Name),
+			Value: c.Metadata.ID,
+		})
+	}
+	if len(items) == 0 {
+		return "", nil
+	}
+
+	selected, err := picker.Run(items, navigation.Score)
+	if err != nil {
+		return "", errors.Wrap(err, "running chain picker")
+	}
+	if selected == nil {
+		return "", nil
+	}
+	return selected.Value, nil
+}
+
+// confirmChainCompletion asks the user to confirm archiving a chain that was
+// inferred or picked rather than named explicitly. In a non-interactive
+// environment it refuses (returns false) and asks for an explicit id, so a
+// mutating archive is never performed on an inferred target without consent.
+func confirmChainCompletion(chainID string) bool {
+	if !term.IsTerminal(int(os.Stdin.Fd())) || !term.IsTerminal(int(os.Stderr.Fd())) {
+		fmt.Fprintf(os.Stderr,
+			"refusing to complete inferred chain %s non-interactively; pass the chain id explicitly\n", chainID)
+		return false
+	}
+	fmt.Fprintf(os.Stderr, "Complete and archive chain %s? [y/N]: ", chainID)
+	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	if err != nil {
+		return false
+	}
+	line = strings.ToLower(strings.TrimSpace(line))
+	return line == "y" || line == "yes"
+}

--- a/internal/commands/chain/context_test.go
+++ b/internal/commands/chain/context_test.go
@@ -1,0 +1,113 @@
+package chain
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFestivalConfig(t *testing.T, dir, festivalID string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "version: \"1.0\"\nmetadata:\n  id: " + festivalID +
+		"\n  status_history:\n    - status: active\n"
+	if err := os.WriteFile(filepath.Join(dir, "fest.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFirstArg(t *testing.T) {
+	if got := firstArg(nil); got != "" {
+		t.Fatalf("firstArg(nil) = %q, want empty", got)
+	}
+	if got := firstArg([]string{"CH0001"}); got != "CH0001" {
+		t.Fatalf("firstArg = %q, want CH0001", got)
+	}
+}
+
+func TestFestivalIDFromMarkers(t *testing.T) {
+	root := t.TempDir()
+	fest := filepath.Join(root, "festivals", "active", "demo-FA0010")
+	writeFestivalConfig(t, fest, "FA0010")
+
+	if got := festivalIDFromMarkers(fest); got != "FA0010" {
+		t.Fatalf("from festival dir = %q, want FA0010", got)
+	}
+
+	nested := filepath.Join(fest, "001_PHASE", "01_seq")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := festivalIDFromMarkers(nested); got != "FA0010" {
+		t.Fatalf("from nested dir = %q, want FA0010 (should walk up)", got)
+	}
+
+	if got := festivalIDFromMarkers(root); got != "" {
+		t.Fatalf("from non-festival dir = %q, want empty", got)
+	}
+}
+
+func TestResolveChainID_ExplicitWins(t *testing.T) {
+	chainID, inferred, err := resolveChainID(context.Background(), "CH0001")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if chainID != "CH0001" {
+		t.Fatalf("chainID = %q, want CH0001", chainID)
+	}
+	if inferred {
+		t.Fatal("explicit id must not be marked inferred")
+	}
+}
+
+func TestResolveCurrentFestivalID_FromMarkers(t *testing.T) {
+	root := t.TempDir()
+	fest := filepath.Join(root, "festivals", "active", "demo-FA0010")
+	writeFestivalConfig(t, fest, "FA0010")
+	t.Chdir(fest)
+
+	got, ok := resolveCurrentFestivalID(context.Background())
+	if !ok || got != "FA0010" {
+		t.Fatalf("resolveCurrentFestivalID = %q, %v; want FA0010, true", got, ok)
+	}
+}
+
+func TestResolveCurrentFestivalID_NoContext(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if got, ok := resolveCurrentFestivalID(context.Background()); ok {
+		t.Fatalf("expected no festival context, got %q", got)
+	}
+}
+
+func TestPickChainID_NonInteractiveReturnsEmpty(t *testing.T) {
+	// Tests run without a TTY, so the picker must no-op rather than block.
+	got, err := pickChainID(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("non-interactive pickChainID = %q, want empty", got)
+	}
+}
+
+func TestResolveChainID_NoContextNonInteractiveErrors(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "festivals", ".festival"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(filepath.Join(root, "festivals"))
+
+	_, _, err := resolveChainID(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected an error when no chain id, no inferable context, and not a TTY")
+	}
+}
+
+func TestConfirmChainCompletion_NonInteractiveRefuses(t *testing.T) {
+	if confirmChainCompletion("CH0001") {
+		t.Fatal("non-interactive confirmation must refuse (return false)")
+	}
+}

--- a/internal/commands/chain/context_test.go
+++ b/internal/commands/chain/context_test.go
@@ -111,3 +111,43 @@ func TestConfirmChainCompletion_NonInteractiveRefuses(t *testing.T) {
 		t.Fatal("non-interactive confirmation must refuse (return false)")
 	}
 }
+
+func setupCampaign(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, d := range []string{".campaign", filepath.Join("festivals", ".festival"), filepath.Join("projects", "demo")} {
+		if err := os.MkdirAll(filepath.Join(root, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func TestFestivalsRoot_ResolvesFromLinkedProjectDir(t *testing.T) {
+	// A chain command run from a linked project working directory (outside
+	// festivals/) must still resolve the campaign's festivals root, so context
+	// inference is not blocked before the navigation lookup runs.
+	root := setupCampaign(t)
+	t.Chdir(filepath.Join(root, "projects", "demo"))
+
+	got, err := festivalsRoot()
+	if err != nil {
+		t.Fatalf("festivalsRoot from a project dir should resolve, got err: %v", err)
+	}
+	if filepath.Base(got) != "festivals" {
+		t.Fatalf("festivalsRoot = %q, want a .../festivals dir", got)
+	}
+}
+
+func TestFestivalsRoot_ResolvesFromInsideFestivals(t *testing.T) {
+	root := setupCampaign(t)
+	t.Chdir(filepath.Join(root, "festivals"))
+
+	got, err := festivalsRoot()
+	if err != nil {
+		t.Fatalf("festivalsRoot from inside festivals/ should resolve, got err: %v", err)
+	}
+	if filepath.Base(got) != "festivals" {
+		t.Fatalf("festivalsRoot = %q, want a .../festivals dir", got)
+	}
+}

--- a/internal/commands/chain/create.go
+++ b/internal/commands/chain/create.go
@@ -11,7 +11,6 @@ import (
 
 	chaintpl "github.com/Obedience-Corp/fest/embedded/templates/chain"
 	"github.com/Obedience-Corp/fest/internal/errors"
-	tpl "github.com/Obedience-Corp/fest/internal/template"
 	"github.com/Obedience-Corp/fest/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -46,14 +45,9 @@ func runCreate(cmd *cobra.Command, name, goal string) error {
 		return err
 	}
 
-	cwd, err := os.Getwd()
+	root, err := festivalsRoot()
 	if err != nil {
-		return errors.IO("getting working directory", err)
-	}
-
-	root, err := tpl.FindFestivalsRoot(cwd)
-	if err != nil {
-		return errors.Wrap(err, "finding festivals root").WithCode(errors.ErrCodeConfig)
+		return err
 	}
 
 	chainsDir := filepath.Join(root, "chains")

--- a/internal/commands/chain/graph.go
+++ b/internal/commands/chain/graph.go
@@ -17,12 +17,18 @@ func newGraphCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "graph <chain-id>",
+		Use:   "graph [chain-id]",
 		Short: "Visualize chain dependency graph",
-		Long:  "Render the chain's dependency graph as ASCII waves or Mermaid diagram syntax.",
-		Args:  cobra.ExactArgs(1),
+		Long: "Render the chain's dependency graph as ASCII waves or Mermaid diagram " +
+			"syntax. The chain id is optional when it can be inferred from the current " +
+			"festival or linked project, or selected interactively in a terminal.",
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runGraph(cmd.Context(), args[0], mermaid, live)
+			chainID, _, err := resolveChainID(cmd.Context(), firstArg(args))
+			if err != nil {
+				return err
+			}
+			return runGraph(cmd.Context(), chainID, mermaid, live)
 		},
 	}
 

--- a/internal/commands/chain/list.go
+++ b/internal/commands/chain/list.go
@@ -9,7 +9,6 @@ import (
 
 	chainpkg "github.com/Obedience-Corp/fest/internal/chain"
 	"github.com/Obedience-Corp/fest/internal/errors"
-	tpl "github.com/Obedience-Corp/fest/internal/template"
 	"github.com/Obedience-Corp/fest/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -35,14 +34,9 @@ func runList(ctx context.Context, statusFilter string) error {
 		return err
 	}
 
-	cwd, err := os.Getwd()
+	root, err := festivalsRoot()
 	if err != nil {
-		return errors.IO("getting working directory", err)
-	}
-
-	root, err := tpl.FindFestivalsRoot(cwd)
-	if err != nil {
-		return errors.Wrap(err, "finding festivals root").WithCode(errors.ErrCodeConfig)
+		return err
 	}
 
 	chains, err := discoverChains(ctx, filepath.Join(root, "chains"))

--- a/internal/commands/chain/live.go
+++ b/internal/commands/chain/live.go
@@ -8,9 +8,7 @@ import (
 
 	chainpkg "github.com/Obedience-Corp/fest/internal/chain"
 	"github.com/Obedience-Corp/fest/internal/config"
-	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/id"
-	tpl "github.com/Obedience-Corp/fest/internal/template"
 )
 
 // resolveChainStatuses resolves live festival statuses for a chain by reading
@@ -21,14 +19,9 @@ func resolveChainStatuses(ctx context.Context, c *chainpkg.Chain) (map[string]ch
 		return nil, err
 	}
 
-	cwd, err := os.Getwd()
+	root, err := festivalsRoot()
 	if err != nil {
-		return nil, errors.IO("getting working directory", err)
-	}
-
-	root, err := tpl.FindFestivalsRoot(cwd)
-	if err != nil {
-		return nil, errors.Wrap(err, "finding festivals root").WithCode(errors.ErrCodeConfig)
+		return nil, err
 	}
 
 	// Build search directories from all lifecycle status paths.
@@ -37,8 +30,7 @@ func resolveChainStatuses(ctx context.Context, c *chainpkg.Chain) (map[string]ch
 		searchDirs[i] = filepath.Join(root, d)
 	}
 
-	// Resolve festival refs to filesystem paths best-effort so one unresolvable
-	// member does not blank out the whole chain's live status.
+	// Best-effort so one unresolvable member does not blank the whole chain.
 	resolved, resolveErr := chainpkg.ResolveAvailable(ctx, c, searchDirs)
 
 	statuses := make(map[string]chainpkg.FestivalStatus, len(c.Festivals))

--- a/internal/commands/chain/live.go
+++ b/internal/commands/chain/live.go
@@ -37,8 +37,9 @@ func resolveChainStatuses(ctx context.Context, c *chainpkg.Chain) (map[string]ch
 		searchDirs[i] = filepath.Join(root, d)
 	}
 
-	// Resolve festival refs to filesystem paths.
-	resolved, resolveErr := chainpkg.Resolve(ctx, c, searchDirs)
+	// Resolve festival refs to filesystem paths best-effort so one unresolvable
+	// member does not blank out the whole chain's live status.
+	resolved, resolveErr := chainpkg.ResolveAvailable(ctx, c, searchDirs)
 
 	statuses := make(map[string]chainpkg.FestivalStatus, len(c.Festivals))
 

--- a/internal/commands/chain/status.go
+++ b/internal/commands/chain/status.go
@@ -9,7 +9,6 @@ import (
 
 	chainpkg "github.com/Obedience-Corp/fest/internal/chain"
 	"github.com/Obedience-Corp/fest/internal/errors"
-	tpl "github.com/Obedience-Corp/fest/internal/template"
 	"github.com/Obedience-Corp/fest/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -137,14 +136,9 @@ func progressBar(completed, total, width int) string {
 
 // findChainByID searches for a chain file by its ID across active and completed dirs.
 func findChainByID(ctx context.Context, chainID string) (*chainpkg.Chain, string, error) {
-	cwd, err := os.Getwd()
+	root, err := festivalsRoot()
 	if err != nil {
-		return nil, "", errors.IO("getting working directory", err)
-	}
-
-	root, err := tpl.FindFestivalsRoot(cwd)
-	if err != nil {
-		return nil, "", errors.Wrap(err, "finding festivals root").WithCode(errors.ErrCodeConfig)
+		return nil, "", err
 	}
 
 	searchDirs := []string{

--- a/internal/commands/chain/status.go
+++ b/internal/commands/chain/status.go
@@ -16,11 +16,18 @@ import (
 
 func newStatusCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "status <chain-id>",
+		Use:   "status [chain-id]",
 		Short: "Show chain status and progress",
-		Args:  cobra.ExactArgs(1),
+		Long: "Show chain status and progress. The chain id is optional when it can " +
+			"be inferred from the current festival or linked project, or selected " +
+			"interactively in a terminal.",
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runStatus(cmd.Context(), args[0])
+			chainID, _, err := resolveChainID(cmd.Context(), firstArg(args))
+			if err != nil {
+				return err
+			}
+			return runStatus(cmd.Context(), chainID)
 		},
 	}
 }

--- a/internal/commands/chain/validate.go
+++ b/internal/commands/chain/validate.go
@@ -14,18 +14,22 @@ func newValidateCmd() *cobra.Command {
 	var cross bool
 
 	cmd := &cobra.Command{
-		Use:   "validate <chain-id>",
+		Use:   "validate [chain-id]",
 		Short: "Validate a festival chain",
-		Long:  "Run all structural validation checks (S1-S10) against a chain definition.\nUse --cross to validate across all chains.",
-		Args:  cobra.MaximumNArgs(1),
+		Long: "Run all structural validation checks (S1-S10) against a chain definition.\n" +
+			"The chain id is optional when it can be inferred from the current festival " +
+			"or linked project, or selected interactively in a terminal.\n" +
+			"Use --cross to validate across all chains.",
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if cross {
 				return runCrossValidate(cmd.Context())
 			}
-			if len(args) == 0 {
-				return errors.Validation("chain-id required (or use --cross for cross-chain validation)")
+			chainID, _, err := resolveChainID(cmd.Context(), firstArg(args))
+			if err != nil {
+				return err
 			}
-			return runValidate(cmd.Context(), args[0])
+			return runValidate(cmd.Context(), chainID)
 		},
 	}
 

--- a/internal/commands/next/next.go
+++ b/internal/commands/next/next.go
@@ -464,8 +464,9 @@ func printChainContext(ctx context.Context, festivalPath string, festivalComplet
 		searchDirs[i] = filepath.Join(root, d)
 	}
 
-	// Resolve live statuses.
-	resolved, _ := chainpkg.Resolve(ctx, c, searchDirs)
+	// Resolve live statuses best-effort so a missing chain member does not
+	// blank out the rest of the chain.
+	resolved, _ := chainpkg.ResolveAvailable(ctx, c, searchDirs)
 	statuses := make(map[string]chainpkg.FestivalStatus, len(c.Festivals))
 	for _, node := range c.Festivals {
 		rf, ok := resolved[node.Ref]

--- a/internal/commands/next/next.go
+++ b/internal/commands/next/next.go
@@ -464,8 +464,7 @@ func printChainContext(ctx context.Context, festivalPath string, festivalComplet
 		searchDirs[i] = filepath.Join(root, d)
 	}
 
-	// Resolve live statuses best-effort so a missing chain member does not
-	// blank out the rest of the chain.
+	// Best-effort so a missing chain member does not blank the rest of the chain.
 	resolved, _ := chainpkg.ResolveAvailable(ctx, c, searchDirs)
 	statuses := make(map[string]chainpkg.FestivalStatus, len(c.Festivals))
 	for _, node := range c.Festivals {

--- a/internal/commands/promote/promote.go
+++ b/internal/commands/promote/promote.go
@@ -320,8 +320,7 @@ func checkChainDependencies(ctx context.Context, festival *show.FestivalInfo) (b
 		searchDirs[i] = filepath.Join(root, d)
 	}
 
-	// Resolve live statuses best-effort: a missing or not-yet-created chain
-	// member must not blank out the upstream we are gating on.
+	// Best-effort: a missing chain member must not blank the upstream we gate on.
 	resolved, _ := chainpkg.ResolveAvailable(ctx, c, searchDirs)
 	statuses := make(map[string]chainpkg.FestivalStatus, len(c.Festivals))
 	for _, node := range c.Festivals {

--- a/internal/commands/promote/promote.go
+++ b/internal/commands/promote/promote.go
@@ -320,8 +320,9 @@ func checkChainDependencies(ctx context.Context, festival *show.FestivalInfo) (b
 		searchDirs[i] = filepath.Join(root, d)
 	}
 
-	// Resolve live statuses.
-	resolved, _ := chainpkg.Resolve(ctx, c, searchDirs)
+	// Resolve live statuses best-effort: a missing or not-yet-created chain
+	// member must not blank out the upstream we are gating on.
+	resolved, _ := chainpkg.ResolveAvailable(ctx, c, searchDirs)
 	statuses := make(map[string]chainpkg.FestivalStatus, len(c.Festivals))
 	for _, node := range c.Festivals {
 		rf, ok := resolved[node.Ref]

--- a/internal/commands/promote/promote_test.go
+++ b/internal/commands/promote/promote_test.go
@@ -127,3 +127,86 @@ func TestDungeonFlagValidation(t *testing.T) {
 		})
 	}
 }
+
+func writeGateFestival(t *testing.T, dir, festivalID, status string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "version: \"1.0\"\nmetadata:\n  id: " + festivalID +
+		"\n  status_history:\n    - status: " + status + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "fest.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeGateChain(t *testing.T, path string) {
+	t.Helper()
+	yaml := `chain_version: "1.0"
+metadata:
+  id: CH0001
+  name: onboarding-readiness
+  created_at: 2026-01-01T00:00:00Z
+  status: active
+festivals:
+  - ref: audit
+    id: FA0009
+    name: audit-remediation
+  - ref: onboarding
+    id: FA0010
+    name: onboarding-parity
+edges:
+  - from: audit
+    to: onboarding
+    type: hard
+`
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// setupChainGateCampaign builds a campaign with a CH0001 chain (hard edge
+// FA0009 -> FA0010), FA0010 in ready, and FA0009 at upstreamStatus in the given
+// upstreamDir relative to festivals/. Returns the FA0010 festival dir.
+func setupChainGateCampaign(t *testing.T, upstreamRelDir, upstreamStatus string) string {
+	t.Helper()
+	root := t.TempDir()
+	festivals := filepath.Join(root, "festivals")
+	if err := os.MkdirAll(filepath.Join(festivals, ".festival"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(festivals, "chains"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeGateChain(t, filepath.Join(festivals, "chains", "onboarding-readiness-CH0001.yaml"))
+
+	fa10 := filepath.Join(festivals, "ready", "onboarding-parity-FA0010")
+	writeGateFestival(t, fa10, "FA0010", "ready")
+	writeGateFestival(t, filepath.Join(festivals, upstreamRelDir, "audit-remediation-FA0009"), "FA0009", upstreamStatus)
+
+	t.Chdir(festivals)
+	return fa10
+}
+
+func TestCheckChainDependencies_DungeonCompletedUpstreamDoesNotBlock(t *testing.T) {
+	fa10 := setupChainGateCampaign(t, filepath.Join("dungeon", "completed", "2026-06-04"), "completed")
+
+	festival := &show.FestivalInfo{Name: "onboarding-parity", Path: fa10, Status: "ready"}
+	blocked, msg := checkChainDependencies(t.Context(), festival)
+	if blocked {
+		t.Fatalf("expected no block when upstream FA0009 is completed in the dungeon, got: %s", msg)
+	}
+}
+
+func TestCheckChainDependencies_IncompleteUpstreamStillBlocks(t *testing.T) {
+	fa10 := setupChainGateCampaign(t, "active", "active")
+
+	festival := &show.FestivalInfo{Name: "onboarding-parity", Path: fa10, Status: "ready"}
+	blocked, msg := checkChainDependencies(t.Context(), festival)
+	if !blocked {
+		t.Fatal("expected a block when upstream FA0009 is still active (not completed)")
+	}
+	if !strings.Contains(msg, "FA0009") {
+		t.Fatalf("block message should name the incomplete upstream, got: %s", msg)
+	}
+}

--- a/internal/commands/watch/completion.go
+++ b/internal/commands/watch/completion.go
@@ -22,8 +22,7 @@ func completeWatchSelector(_ *cobra.Command, _ []string, toComplete string) ([]s
 }
 
 func watchSelectorCompletions(ctx context.Context, cwd, toComplete string) ([]string, error) {
-	// Dungeon festivals are terminal and never watched, so restrict completion
-	// to working statuses (planning/ready/active/ritual).
+	// Dungeon is terminal and never watched; restrict to working statuses.
 	return shared.CompleteFestivalPickSelectors(ctx, cwd, toComplete, shared.FestivalPickerOptions{
 		IncludeStatusDirectories: false,
 		PreferredStatuses:        id.WorkingStatusDirectories,

--- a/internal/commands/watch/completion.go
+++ b/internal/commands/watch/completion.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
+	"github.com/Obedience-Corp/fest/internal/id"
 	"github.com/spf13/cobra"
 )
 
@@ -21,8 +22,11 @@ func completeWatchSelector(_ *cobra.Command, _ []string, toComplete string) ([]s
 }
 
 func watchSelectorCompletions(ctx context.Context, cwd, toComplete string) ([]string, error) {
+	// Dungeon festivals are terminal and never watched, so restrict completion
+	// to working statuses (planning/ready/active/ritual).
 	return shared.CompleteFestivalPickSelectors(ctx, cwd, toComplete, shared.FestivalPickerOptions{
 		IncludeStatusDirectories: false,
+		PreferredStatuses:        id.WorkingStatusDirectories,
 	})
 }
 

--- a/internal/commands/watch/completion_test.go
+++ b/internal/commands/watch/completion_test.go
@@ -1,10 +1,13 @@
 package watch
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
+	"github.com/Obedience-Corp/fest/internal/id"
 )
 
 func TestWatchCompletionExcludesStatusDirectories(t *testing.T) {
@@ -16,11 +19,58 @@ func TestWatchCompletionExcludesStatusDirectories(t *testing.T) {
 	}
 }
 
-func TestWatchCompletionIncludesDungeonDateBucketFestivals(t *testing.T) {
-	got := formatWatchSelectorCompletions(watchCompletionCandidates(), "")
-	if !containsString(got, "old-work-OW0001") {
-		t.Fatalf("watch completion should include dungeon date-bucket festivals, got %#v", got)
+func TestWatchCompletionExcludesDungeonFestivals(t *testing.T) {
+	festivals := t.TempDir()
+	makeWatchTestFestival(t, filepath.Join(festivals, "active", "launch-work-LW0001"))
+	makeWatchTestFestival(t, filepath.Join(festivals, "dungeon", "completed", "2026-05-01", "old-work-OW0001"))
+
+	// Production watch setting: restrict completion to working statuses.
+	working := shared.CollectFestivalPickCandidates(festivals, shared.FestivalPickerOptions{
+		IncludeStatusDirectories: false,
+		PreferredStatuses:        id.WorkingStatusDirectories,
+	})
+	if candidateNamePresent(working, "old-work-OW0001") {
+		t.Fatalf("watch completion must exclude dungeon festivals (terminal, never watched): %v", candidateNames(working))
 	}
+	if !candidateNamePresent(working, "launch-work-LW0001") {
+		t.Fatalf("watch completion should include working festivals: %v", candidateNames(working))
+	}
+
+	// Without the working-status restriction the default surfaces dungeon
+	// festivals — the leak the fix avoids by passing WorkingStatusDirectories.
+	all := shared.CollectFestivalPickCandidates(festivals, shared.FestivalPickerOptions{
+		IncludeStatusDirectories: false,
+	})
+	if !candidateNamePresent(all, "old-work-OW0001") {
+		t.Fatalf("default collection should still surface dungeon festivals: %v", candidateNames(all))
+	}
+}
+
+func makeWatchTestFestival(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "FESTIVAL_GOAL.md"), []byte("# Goal\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func candidateNames(candidates []shared.FestivalPickCandidate) []string {
+	names := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		names = append(names, c.Name)
+	}
+	return names
+}
+
+func candidateNamePresent(candidates []shared.FestivalPickCandidate, name string) bool {
+	for _, c := range candidates {
+		if c.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 func TestWatchCompletionFuzzyNarrowsByNameAndID(t *testing.T) {

--- a/internal/commands/watch/resolver.go
+++ b/internal/commands/watch/resolver.go
@@ -209,10 +209,8 @@ func isFestivalNotFound(err error) bool {
 	return stderrors.As(err, &structured) && structured.Code == errors.ErrCodeNotFound
 }
 
-// pickerStatuses returns the statuses to offer in the interactive watch picker.
-// If cwd is inside a specific working status dir, it narrows to that status;
-// otherwise it offers all working statuses. Dungeon festivals are terminal and
-// never watched, so they are never offered.
+// pickerStatuses narrows the watch picker to the working status dir the user is
+// inside, else all working statuses. Dungeon is terminal, so never offered.
 func pickerStatuses(cwd, festivalsDir string) []string {
 	if narrowed := preferredPickerStatuses(cwd, festivalsDir); len(narrowed) > 0 {
 		return narrowed
@@ -220,9 +218,6 @@ func pickerStatuses(cwd, festivalsDir string) []string {
 	return id.WorkingStatusDirectories
 }
 
-// preferredPickerStatuses narrows the picker to the single working status dir
-// the user is currently inside, if any. It never returns a dungeon status, so a
-// terminal location does not surface dungeon festivals in the picker.
 func preferredPickerStatuses(cwd, festivalsDir string) []string {
 	rel, err := filepath.Rel(festivalsDir, cwd)
 	if err != nil || rel == "." || rel == ".." {

--- a/internal/commands/watch/resolver.go
+++ b/internal/commands/watch/resolver.go
@@ -99,7 +99,7 @@ func (r targetResolver) resolve(ctx context.Context, selector string) (*show.Fes
 
 	path, err := r.pickFestival(ctx, festivalsDir, shared.FestivalPickerOptions{
 		IncludeStatusDirectories: false,
-		PreferredStatuses:        preferredPickerStatuses(cwd, festivalsDir),
+		PreferredStatuses:        pickerStatuses(cwd, festivalsDir),
 	})
 	if err != nil {
 		return nil, err
@@ -209,6 +209,20 @@ func isFestivalNotFound(err error) bool {
 	return stderrors.As(err, &structured) && structured.Code == errors.ErrCodeNotFound
 }
 
+// pickerStatuses returns the statuses to offer in the interactive watch picker.
+// If cwd is inside a specific working status dir, it narrows to that status;
+// otherwise it offers all working statuses. Dungeon festivals are terminal and
+// never watched, so they are never offered.
+func pickerStatuses(cwd, festivalsDir string) []string {
+	if narrowed := preferredPickerStatuses(cwd, festivalsDir); len(narrowed) > 0 {
+		return narrowed
+	}
+	return id.WorkingStatusDirectories
+}
+
+// preferredPickerStatuses narrows the picker to the single working status dir
+// the user is currently inside, if any. It never returns a dungeon status, so a
+// terminal location does not surface dungeon festivals in the picker.
 func preferredPickerStatuses(cwd, festivalsDir string) []string {
 	rel, err := filepath.Rel(festivalsDir, cwd)
 	if err != nil || rel == "." || rel == ".." {
@@ -218,7 +232,7 @@ func preferredPickerStatuses(cwd, festivalsDir string) []string {
 	if strings.HasPrefix(rel, "../") {
 		return nil
 	}
-	for _, status := range id.StatusDirectories {
+	for _, status := range id.WorkingStatusDirectories {
 		status = filepath.ToSlash(id.ResolveStatusPath(status))
 		if rel == status || strings.HasPrefix(rel, status+"/") {
 			return []string{status}

--- a/internal/commands/watch/resolver_test.go
+++ b/internal/commands/watch/resolver_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
 	"github.com/Obedience-Corp/fest/internal/commands/show"
 	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/id"
 )
 
 func TestTargetResolverSelectorWinsOverContext(t *testing.T) {
@@ -272,10 +273,26 @@ func TestTargetResolverInvalidPickedPathReturnsContext(t *testing.T) {
 	}
 }
 
-func TestPreferredPickerStatusesDerivesDungeonSubstatus(t *testing.T) {
+func TestPreferredPickerStatusesNarrowsToWorkingStatus(t *testing.T) {
+	got := preferredPickerStatuses("/campaign/festivals/active/launch-LW0001", "/campaign/festivals")
+	if !reflect.DeepEqual(got, []string{"active"}) {
+		t.Fatalf("preferred statuses = %#v, want [active]", got)
+	}
+}
+
+func TestPreferredPickerStatusesIgnoresDungeon(t *testing.T) {
+	// Dungeon festivals are terminal and never watched, so a dungeon cwd must
+	// not narrow (or surface) dungeon festivals in the picker.
 	got := preferredPickerStatuses("/campaign/festivals/dungeon/completed/2026-05", "/campaign/festivals")
-	if !reflect.DeepEqual(got, []string{"dungeon/completed"}) {
-		t.Fatalf("preferred statuses = %#v", got)
+	if got != nil {
+		t.Fatalf("preferred statuses for a dungeon cwd = %#v, want nil", got)
+	}
+}
+
+func TestPickerStatusesFallsBackToWorkingStatuses(t *testing.T) {
+	got := pickerStatuses("/campaign/festivals/dungeon/completed/2026-05", "/campaign/festivals")
+	if !reflect.DeepEqual(got, id.WorkingStatusDirectories) {
+		t.Fatalf("picker statuses for a dungeon cwd = %#v, want WorkingStatusDirectories", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes two dungeon-correctness bugs in `fest` chain/watch handling and adds chain-command context ergonomics. Design workitem: `obey-campaign:workflow/design/fest-chain-and-watch-dungeon-2026-06-05/`.

Three commits, one per concern, reviewable independently.

## A — `fix(chain)`: resolve dungeoned festivals in chain status + promote gate

**Bug:** `fest promote` (ready → active) falsely blocked on a completed upstream festival that had been moved to `dungeon/completed/<date>/`, demanding `--force`.

`findFestivalDir` (`internal/chain/resolve.go`) scanned only one directory level, so festivals inside a dated dungeon bucket (`dungeon/<status>/YYYY-MM-DD/<festival>`) were never found. The promote chain-dependency gate, `fest next` chain context, and `fest chain status` all resolve festival status through this path, so a dungeoned-completed upstream read as `planning` → incomplete.

- `findFestivalDir` now descends one level into `YYYY-MM-DD` buckets for dungeon status dirs (mirrors the existing `FindNextRitualRun` dungeon-descent idiom).
- Added `ResolveAvailable`, a best-effort sibling of `Resolve` that omits unresolved refs instead of nil-ing the whole map (mirrors `DiscoverAll` vs `DiscoverAllStrict`), so one missing chain member no longer blanks the rest of the chain. `promote`, `next`, and `chain` live status use it.

Tests: dungeon-bucket resolution (strict + best-effort), non-date subdir is not descended, best-effort omits missing refs, and gate-level tests proving a dungeon-completed upstream does **not** block while an active upstream still does.

## C — `fix(watch)`: exclude dungeon festivals from completion and picker

**Bug:** `fest watch` tab-completion (and the interactive picker) offered dungeon festivals. Dungeon is terminal — nothing there is watched.

The watch enumeration passed no `PreferredStatuses`, so candidate collection fell back to the full `StatusDirectories` set (which includes `dungeon/*`).

- Completion now passes `id.WorkingStatusDirectories` → only `planning/ready/active/ritual`.
- The picker is constrained the same way: `preferredPickerStatuses` no longer derives a dungeon substatus, and `pickerStatuses` falls back to working statuses.
- The shared default and `fgo` dungeon navigation are untouched — this is a watch-local constraint.

Tests: a real disk-level test proving working-status collection excludes a dungeon festival while the default surfaces it; picker-status tests. The prior test that asserted dungeon festivals were *included* is replaced.

## B — `feat(chain)`: infer festival/chain context + interactive picker

Chain subcommands required the chain id (or festival ref) explicitly even when the festival context was already knowable — unlike `fest next/commit/watch`.

- `chain status/graph/validate/complete` now take an optional `[chain-id]`; when omitted they infer it from the current festival (a `fest.yaml` ancestor of the cwd, or a linked project dir via the navigation registry) and its chain via `FindForFestival`. `chain check` infers the festival ref/id the same way.
- When no context is available and stdout is a TTY, an interactive chain picker (reusing the shared bubbletea picker) lets the user select a non-terminal chain. In a non-interactive shell the previous missing-argument behavior is preserved, so scripts and agents still fail fast.
- `chain complete` is mutating, so an inferred or picked target must be confirmed, and a non-interactive run refuses an inferred target and asks for an explicit id — a chain is never archived on a guessed target without consent.

Tests: marker/walk-up festival detection, explicit-id passthrough, current-festival resolution, and the non-interactive picker/confirm/no-context paths.

## End-to-end verification

`fest chain status` with **no argument**, run from inside a `ready` festival whose only hard upstream is completed-and-dungeoned:

```
$ cd festivals/ready/onboarding-FA0010 && fest chain status
Chain: onboarding-readiness (CH0001)        # ← inferred, no chain-id passed (B)
Status: active

Edges:
  audit --hard--> onboarding

Progress: ███████████████░░░░░░░░░░░░░░░ [1/2] 50%   # ← dungeoned FA0009 resolves as completed (A)

Unblocked:
  onboarding (FA0010) onboarding-parity     # ← FA0010 unblocked: its hard dep is satisfied
```

Before this change the same command required an explicit chain id, and FA0009 resolved as `planning`, leaving FA0010 blocked (the same false negative that made `fest promote` demand `--force`).

## Gates

- `go build ./...`: clean
- `go vet ./...`: clean
- `go test ./...`: 90 packages pass
- `just lint all` (golangci-lint): 0 issues
