### PR TITLE
feat(chain): add 'fest chain add' to add festivals to chains (WI-72f9af)

### DIFF
--- a/internal/chain/types.go
+++ b/internal/chain/types.go
@@ -39,9 +39,9 @@ type Metadata struct {
 	ID            string        `yaml:"id"`
 	Name          string        `yaml:"name"`
 	Goal          string        `yaml:"goal,omitempty"`
-	CreatedAt     time.Time     `yaml:"created_at"`
+	CreatedAt     time.Time     `yaml:"created_at,omitempty"`
 	Status        ChainStatus   `yaml:"status"`
-	StatusHistory []StatusEntry `yaml:"status_history"`
+	StatusHistory []StatusEntry `yaml:"status_history,omitempty"`
 }
 
 // StatusEntry is a single lifecycle state transition in the audit trail.

--- a/internal/chain/write.go
+++ b/internal/chain/write.go
@@ -1,0 +1,57 @@
+package chain
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/Obedience-Corp/fest/internal/errors"
+	"gopkg.in/yaml.v3"
+)
+
+// Write marshals a Chain to YAML and writes it atomically to path. It renders a
+// clean document from the struct (dropping any explanatory comments the create
+// template added) and replaces the destination via a temp file in the same
+// directory followed by an atomic rename, so a failed write never leaves a
+// partial or corrupt chain file in place.
+func Write(path string, c *Chain) error {
+	if c == nil {
+		return errors.Validation("cannot write nil chain")
+	}
+
+	data, err := yaml.Marshal(c)
+	if err != nil {
+		return errors.Wrap(err, "marshaling chain").WithCode(errors.ErrCodeParse)
+	}
+
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".chain-*.yaml.tmp")
+	if err != nil {
+		return errors.IO("creating temp chain file", err).WithField("dir", dir)
+	}
+	tmpPath := tmp.Name()
+
+	cleanup := func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+	}
+
+	if _, err := tmp.Write(data); err != nil {
+		cleanup()
+		return errors.IO("writing temp chain file", err).WithField("path", tmpPath)
+	}
+	if err := tmp.Sync(); err != nil {
+		cleanup()
+		return errors.IO("syncing temp chain file", err).WithField("path", tmpPath)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return errors.IO("closing temp chain file", err).WithField("path", tmpPath)
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return errors.IO("replacing chain file", err).WithField("path", path)
+	}
+
+	return nil
+}

--- a/internal/chain/write.go
+++ b/internal/chain/write.go
@@ -1,24 +1,29 @@
 package chain
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 
 	"github.com/Obedience-Corp/fest/internal/errors"
-	"gopkg.in/yaml.v3"
+	"github.com/Obedience-Corp/fest/internal/yamlutil"
 )
 
 // Write marshals a Chain to YAML and writes it atomically to path. It renders a
 // clean document from the struct (dropping any explanatory comments the create
 // template added) and replaces the destination via a temp file in the same
 // directory followed by an atomic rename, so a failed write never leaves a
-// partial or corrupt chain file in place.
-func Write(path string, c *Chain) error {
+// partial or corrupt chain file in place. It uses 2-space indentation
+// (yamlutil.Marshal) to match the rest of the repo's chain files.
+func Write(ctx context.Context, path string, c *Chain) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if c == nil {
 		return errors.Validation("cannot write nil chain")
 	}
 
-	data, err := yaml.Marshal(c)
+	data, err := yamlutil.Marshal(c)
 	if err != nil {
 		return errors.Wrap(err, "marshaling chain").WithCode(errors.ErrCodeParse)
 	}

--- a/internal/chain/write_test.go
+++ b/internal/chain/write_test.go
@@ -1,0 +1,98 @@
+package chain
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrite_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.yaml")
+	require.NoError(t, os.WriteFile(src, []byte(validChainYAML), 0o644))
+
+	original, err := Parse(context.Background(), src)
+	require.NoError(t, err)
+
+	out := filepath.Join(dir, "out.yaml")
+	require.NoError(t, Write(out, original))
+
+	reparsed, err := Parse(context.Background(), out)
+	require.NoError(t, err)
+
+	assert.Equal(t, original.ChainVersion, reparsed.ChainVersion)
+	assert.Equal(t, original.Metadata.ID, reparsed.Metadata.ID)
+	assert.Equal(t, original.Metadata.Name, reparsed.Metadata.Name)
+	assert.Equal(t, original.Metadata.Status, reparsed.Metadata.Status)
+	assert.Len(t, reparsed.Metadata.StatusHistory, len(original.Metadata.StatusHistory))
+	assert.Equal(t, original.Festivals, reparsed.Festivals)
+	assert.Equal(t, original.Edges, reparsed.Edges)
+	assert.Equal(t, original.Waves, reparsed.Waves)
+}
+
+func TestWrite_DropsTemplateComments(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.yaml")
+	commented := "# explanatory header comment\n" + validChainYAML
+	require.NoError(t, os.WriteFile(src, []byte(commented), 0o644))
+
+	c, err := Parse(context.Background(), src)
+	require.NoError(t, err)
+
+	out := filepath.Join(dir, "out.yaml")
+	require.NoError(t, Write(out, c))
+
+	data, err := os.ReadFile(out)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "explanatory header comment")
+}
+
+func TestWrite_AtomicNoTempLeftBehind(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "out.yaml")
+
+	c, err := ParseBytes(context.Background(), []byte(validChainYAML))
+	require.NoError(t, err)
+	require.NoError(t, Write(out, c))
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name())
+		assert.False(t, strings.HasSuffix(e.Name(), ".tmp"),
+			"temp file left behind: %s", e.Name())
+	}
+	assert.Equal(t, []string{"out.yaml"}, names)
+}
+
+func TestWrite_OverwriteDoesNotCorruptOnReParse(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "out.yaml")
+	require.NoError(t, os.WriteFile(out, []byte("stale: contents\n"), 0o644))
+
+	c, err := ParseBytes(context.Background(), []byte(validChainYAML))
+	require.NoError(t, err)
+	require.NoError(t, Write(out, c))
+
+	reparsed, err := Parse(context.Background(), out)
+	require.NoError(t, err)
+	assert.Equal(t, "EC0001", reparsed.Metadata.ID)
+}
+
+func TestWrite_NilChain(t *testing.T) {
+	err := Write(filepath.Join(t.TempDir(), "x.yaml"), nil)
+	assert.Error(t, err)
+}
+
+func TestWrite_BadDir(t *testing.T) {
+	c, err := ParseBytes(context.Background(), []byte(validChainYAML))
+	require.NoError(t, err)
+	err = Write("/nonexistent-dir-xyz/out.yaml", c)
+	assert.Error(t, err)
+}

--- a/internal/chain/write_test.go
+++ b/internal/chain/write_test.go
@@ -20,7 +20,7 @@ func TestWrite_RoundTrip(t *testing.T) {
 	require.NoError(t, err)
 
 	out := filepath.Join(dir, "out.yaml")
-	require.NoError(t, Write(out, original))
+	require.NoError(t, Write(context.Background(), out, original))
 
 	reparsed, err := Parse(context.Background(), out)
 	require.NoError(t, err)
@@ -45,7 +45,7 @@ func TestWrite_DropsTemplateComments(t *testing.T) {
 	require.NoError(t, err)
 
 	out := filepath.Join(dir, "out.yaml")
-	require.NoError(t, Write(out, c))
+	require.NoError(t, Write(context.Background(), out, c))
 
 	data, err := os.ReadFile(out)
 	require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestWrite_AtomicNoTempLeftBehind(t *testing.T) {
 
 	c, err := ParseBytes(context.Background(), []byte(validChainYAML))
 	require.NoError(t, err)
-	require.NoError(t, Write(out, c))
+	require.NoError(t, Write(context.Background(), out, c))
 
 	entries, err := os.ReadDir(dir)
 	require.NoError(t, err)
@@ -78,7 +78,7 @@ func TestWrite_OverwriteDoesNotCorruptOnReParse(t *testing.T) {
 
 	c, err := ParseBytes(context.Background(), []byte(validChainYAML))
 	require.NoError(t, err)
-	require.NoError(t, Write(out, c))
+	require.NoError(t, Write(context.Background(), out, c))
 
 	reparsed, err := Parse(context.Background(), out)
 	require.NoError(t, err)
@@ -86,13 +86,13 @@ func TestWrite_OverwriteDoesNotCorruptOnReParse(t *testing.T) {
 }
 
 func TestWrite_NilChain(t *testing.T) {
-	err := Write(filepath.Join(t.TempDir(), "x.yaml"), nil)
+	err := Write(context.Background(), filepath.Join(t.TempDir(), "x.yaml"), nil)
 	assert.Error(t, err)
 }
 
 func TestWrite_BadDir(t *testing.T) {
 	c, err := ParseBytes(context.Background(), []byte(validChainYAML))
 	require.NoError(t, err)
-	err = Write("/nonexistent-dir-xyz/out.yaml", c)
+	err = Write(context.Background(), "/nonexistent-dir-xyz/out.yaml", c)
 	assert.Error(t, err)
 }

--- a/internal/commands/chain/add.go
+++ b/internal/commands/chain/add.go
@@ -1,0 +1,251 @@
+package chain
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	chainpkg "github.com/Obedience-Corp/fest/internal/chain"
+	"github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+// addOptions holds the parsed flags for `fest chain add`.
+type addOptions struct {
+	chain    string
+	festival string
+	after    []string
+	edgeType string
+	note     string
+	json     bool
+}
+
+// addedEdge is the JSON shape for an edge created by the command.
+type addedEdge struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+	Type string `json:"type"`
+	Note string `json:"note,omitempty"`
+}
+
+// addedNode is the JSON shape for the festival node added to the chain.
+type addedNode struct {
+	Ref      string   `json:"ref"`
+	ID       string   `json:"id"`
+	Name     string   `json:"name"`
+	Projects []string `json:"projects,omitempty"`
+}
+
+// validationSummary is the JSON shape for the in-memory validation result.
+type validationSummary struct {
+	Valid  bool     `json:"valid"`
+	Score  int      `json:"score"`
+	Errors []string `json:"errors,omitempty"`
+}
+
+// addResult is the structured result emitted by `fest chain add --json`.
+type addResult struct {
+	ChainID    string            `json:"chain_id"`
+	ChainName  string            `json:"chain_name"`
+	Node       addedNode         `json:"node"`
+	Edges      []addedEdge       `json:"edges"`
+	Validation validationSummary `json:"validation"`
+}
+
+func newAddCmd() *cobra.Command {
+	opts := &addOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add a festival to a chain",
+		Long: "Add a festival as a node in an existing chain, optionally with " +
+			"prerequisite dependency edges. The mutated chain is validated in " +
+			"memory and written only if valid.\n" +
+			"The festival defaults to the current festival context when run inside " +
+			"a festival or linked project.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runAdd(cmd.Context(), opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.chain, "chain", "", "target chain id or name")
+	cmd.Flags().StringVar(&opts.festival, "festival", "", "festival to add (id, name, or path)")
+	cmd.Flags().StringArrayVar(&opts.after, "after", nil, "prerequisite festival ref/id (repeatable)")
+	cmd.Flags().StringVar(&opts.edgeType, "type", string(chainpkg.EdgeHard), "edge type: hard | soft")
+	cmd.Flags().StringVar(&opts.note, "note", "", "optional edge note")
+	cmd.Flags().BoolVar(&opts.json, "json", false, "emit structured JSON result")
+
+	return cmd
+}
+
+func runAdd(ctx context.Context, opts *addOptions) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	edgeType, err := parseEdgeType(opts.edgeType)
+	if err != nil {
+		return err
+	}
+
+	chainID, _, err := resolveChainID(ctx, opts.chain)
+	if err != nil {
+		return err
+	}
+
+	c, path, err := findChainByID(ctx, chainID)
+	if err != nil {
+		return err
+	}
+
+	festival, err := resolveAddFestival(ctx, opts.festival)
+	if err != nil {
+		return err
+	}
+
+	node, edges, err := mutateChain(ctx, c, festival, opts.after, edgeType, opts.note)
+	if err != nil {
+		return err
+	}
+
+	result := chainpkg.Validate(ctx, c)
+	if !result.Valid {
+		return validationError(result)
+	}
+
+	if err := chainpkg.Write(path, c); err != nil {
+		return err
+	}
+
+	if opts.json {
+		return emitAddJSON(c, node, edges, result)
+	}
+	printAddSummary(c, node, edges)
+	return nil
+}
+
+// resolveAddFestival resolves the festival to add, falling back to the current
+// festival context when --festival is omitted.
+func resolveAddFestival(ctx context.Context, flag string) (resolvedFestival, error) {
+	root, err := festivalsRoot()
+	if err != nil {
+		return resolvedFestival{}, err
+	}
+
+	value := flag
+	if value == "" {
+		festID, ok := resolveCurrentFestivalID(ctx)
+		if !ok {
+			return resolvedFestival{}, errors.Validation("festival is required").
+				WithHint("pass --festival <id|name|path> or run from inside a festival or linked project")
+		}
+		value = festID
+	}
+	return resolveFestivalToAdd(ctx, root, value)
+}
+
+// mutateChain appends the festival node and any prerequisite edges to the chain
+// in memory, rejecting duplicates and self-edges, and places the node in a
+// trailing wave when the chain uses waves.
+func mutateChain(ctx context.Context, c *chainpkg.Chain, festival resolvedFestival, after []string, edgeType chainpkg.EdgeType, note string) (chainpkg.FestivalNode, []chainpkg.Edge, error) {
+	if err := ctx.Err(); err != nil {
+		return chainpkg.FestivalNode{}, nil, err
+	}
+
+	for _, f := range c.Festivals {
+		if f.ID == festival.ID {
+			return chainpkg.FestivalNode{}, nil, errors.Validation("festival already in chain").
+				WithField("id", festival.ID).
+				WithField("ref", f.Ref).
+				WithField("chainID", c.Metadata.ID)
+		}
+	}
+
+	node := buildNode(c, festival.ID, festival.Name, festival.Projects)
+	c.Festivals = append(c.Festivals, node)
+
+	var edges []chainpkg.Edge
+	for _, raw := range after {
+		fromRef, err := resolvePrereqRef(c, raw)
+		if err != nil {
+			return chainpkg.FestivalNode{}, nil, err
+		}
+		edge, err := buildEdge(c, fromRef, node.Ref, edgeType, note)
+		if err != nil {
+			return chainpkg.FestivalNode{}, nil, err
+		}
+		c.Edges = append(c.Edges, edge)
+		edges = append(edges, edge)
+	}
+
+	placeInTrailingWave(c, node.Ref)
+
+	return node, edges, nil
+}
+
+// validationError converts a failed validation result into an actionable error
+// listing each structural error.
+func validationError(result *chainpkg.ValidationResult) error {
+	msgs := make([]string, 0, len(result.Errors))
+	for _, e := range result.Errors {
+		msgs = append(msgs, e.Error())
+	}
+	return errors.Validation("chain would be invalid after add; no changes written").
+		WithField("errors", msgs).
+		WithHintf("fix the chain or adjust the add (%s)", strings.Join(msgs, "; "))
+}
+
+func emitAddJSON(c *chainpkg.Chain, node chainpkg.FestivalNode, edges []chainpkg.Edge, result *chainpkg.ValidationResult) error {
+	out := addResult{
+		ChainID:   c.Metadata.ID,
+		ChainName: c.Metadata.Name,
+		Node: addedNode{
+			Ref:      node.Ref,
+			ID:       node.ID,
+			Name:     node.Name,
+			Projects: node.Projects,
+		},
+		Edges:      make([]addedEdge, 0, len(edges)),
+		Validation: summarize(result),
+	}
+	for _, e := range edges {
+		out.Edges = append(out.Edges, addedEdge{
+			From: e.From,
+			To:   e.To,
+			Type: string(e.Type),
+			Note: e.Note,
+		})
+	}
+
+	data, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return errors.Wrap(err, "marshaling add result")
+	}
+	fmt.Println(string(data))
+	return nil
+}
+
+func summarize(result *chainpkg.ValidationResult) validationSummary {
+	s := validationSummary{Valid: result.Valid, Score: result.Score}
+	for _, e := range result.Errors {
+		s.Errors = append(s.Errors, e.Error())
+	}
+	return s
+}
+
+func printAddSummary(c *chainpkg.Chain, node chainpkg.FestivalNode, edges []chainpkg.Edge) {
+	fmt.Println(ui.Label("FESTIVAL ADDED TO CHAIN"))
+	fmt.Printf("  Chain:    %s (%s)\n", c.Metadata.Name, c.Metadata.ID)
+	fmt.Printf("  Festival: %s (%s)\n", node.Name, node.ID)
+	fmt.Printf("  Ref:      %s\n", node.Ref)
+	if len(edges) == 0 {
+		fmt.Println("  Edges:    none (added as a root)")
+	} else {
+		fmt.Printf("  Edges:    %d\n", len(edges))
+		for _, e := range edges {
+			fmt.Printf("    %s -> %s (%s)\n", e.From, e.To, e.Type)
+		}
+	}
+}

--- a/internal/commands/chain/add.go
+++ b/internal/commands/chain/add.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// addOptions holds the parsed flags for `fest chain add`.
 type addOptions struct {
 	chain    string
 	festival string
@@ -22,7 +21,6 @@ type addOptions struct {
 	json     bool
 }
 
-// addedEdge is the JSON shape for an edge created by the command.
 type addedEdge struct {
 	From string `json:"from"`
 	To   string `json:"to"`
@@ -30,7 +28,6 @@ type addedEdge struct {
 	Note string `json:"note,omitempty"`
 }
 
-// addedNode is the JSON shape for the festival node added to the chain.
 type addedNode struct {
 	Ref      string   `json:"ref"`
 	ID       string   `json:"id"`
@@ -38,14 +35,12 @@ type addedNode struct {
 	Projects []string `json:"projects,omitempty"`
 }
 
-// validationSummary is the JSON shape for the in-memory validation result.
 type validationSummary struct {
 	Valid  bool     `json:"valid"`
 	Score  int      `json:"score"`
 	Errors []string `json:"errors,omitempty"`
 }
 
-// addResult is the structured result emitted by `fest chain add --json`.
 type addResult struct {
 	ChainID    string            `json:"chain_id"`
 	ChainName  string            `json:"chain_name"`
@@ -115,7 +110,7 @@ func runAdd(ctx context.Context, opts *addOptions) error {
 		return validationError(result)
 	}
 
-	if err := chainpkg.Write(path, c); err != nil {
+	if err := chainpkg.Write(ctx, path, c); err != nil {
 		return err
 	}
 
@@ -126,8 +121,6 @@ func runAdd(ctx context.Context, opts *addOptions) error {
 	return nil
 }
 
-// resolveAddFestival resolves the festival to add, falling back to the current
-// festival context when --festival is omitted.
 func resolveAddFestival(ctx context.Context, flag string) (resolvedFestival, error) {
 	root, err := festivalsRoot()
 	if err != nil {
@@ -146,9 +139,6 @@ func resolveAddFestival(ctx context.Context, flag string) (resolvedFestival, err
 	return resolveFestivalToAdd(ctx, root, value)
 }
 
-// mutateChain appends the festival node and any prerequisite edges to the chain
-// in memory, rejecting duplicates and self-edges, and places the node in a
-// trailing wave when the chain uses waves.
 func mutateChain(ctx context.Context, c *chainpkg.Chain, festival resolvedFestival, after []string, edgeType chainpkg.EdgeType, note string) (chainpkg.FestivalNode, []chainpkg.Edge, error) {
 	if err := ctx.Err(); err != nil {
 		return chainpkg.FestivalNode{}, nil, err
@@ -185,8 +175,6 @@ func mutateChain(ctx context.Context, c *chainpkg.Chain, festival resolvedFestiv
 	return node, edges, nil
 }
 
-// validationError converts a failed validation result into an actionable error
-// listing each structural error.
 func validationError(result *chainpkg.ValidationResult) error {
 	msgs := make([]string, 0, len(result.Errors))
 	for _, e := range result.Errors {

--- a/internal/commands/chain/add_festival.go
+++ b/internal/commands/chain/add_festival.go
@@ -10,12 +10,8 @@ import (
 	"github.com/Obedience-Corp/fest/internal/errors"
 )
 
-// festivalStatusDirs are the festivals-root subdirectories that hold active
-// festival directories searched when resolving --festival by id or name.
 var festivalStatusDirs = []string{"planning", "active", "ready", "ritual"}
 
-// resolvedFestival holds the metadata and on-disk location of the festival
-// being added to a chain.
 type resolvedFestival struct {
 	ID       string
 	Name     string
@@ -23,10 +19,6 @@ type resolvedFestival struct {
 	Path     string
 }
 
-// resolveFestivalToAdd resolves the --festival value (a path, festival id, or
-// festival name) to its metadata. A value pointing at a directory or fest.yaml
-// is loaded directly; otherwise the festivals-root status dirs are scanned for a
-// festival whose metadata id or name matches.
 func resolveFestivalToAdd(ctx context.Context, root, value string) (resolvedFestival, error) {
 	if err := ctx.Err(); err != nil {
 		return resolvedFestival{}, err
@@ -47,8 +39,6 @@ func resolveFestivalToAdd(ctx context.Context, root, value string) (resolvedFest
 	return loadResolvedFestival(dir)
 }
 
-// festivalDirFromPath returns the festival directory when value is a path to a
-// festival directory or directly to its fest.yaml.
 func festivalDirFromPath(value string) (string, bool) {
 	if !strings.ContainsAny(value, "/\\") && !strings.HasPrefix(value, ".") {
 		return "", false
@@ -69,8 +59,6 @@ func festivalDirFromPath(value string) (string, bool) {
 	return "", false
 }
 
-// findFestivalDirByIdentifier scans the festivals-root status dirs for a festival
-// directory whose fest.yaml metadata id or name matches the identifier.
 func findFestivalDirByIdentifier(ctx context.Context, root, identifier string) (string, error) {
 	for _, sub := range festivalStatusDirs {
 		if err := ctx.Err(); err != nil {
@@ -103,7 +91,6 @@ func findFestivalDirByIdentifier(ctx context.Context, root, identifier string) (
 		WithHint("pass --festival as a festival id, name, or path")
 }
 
-// loadResolvedFestival reads a festival directory's fest.yaml into resolvedFestival.
 func loadResolvedFestival(dir string) (resolvedFestival, error) {
 	cfg, err := config.LoadFestivalConfig(dir, "")
 	if err != nil {
@@ -123,8 +110,6 @@ func loadResolvedFestival(dir string) (resolvedFestival, error) {
 	}, nil
 }
 
-// festivalProjects returns the festival's linked project path as a one-element
-// slice, or nil when unknown. Projects is best-effort per the design.
 func festivalProjects(cfg *config.FestivalConfig) []string {
 	if cfg.ProjectPath == "" {
 		return nil

--- a/internal/commands/chain/add_festival.go
+++ b/internal/commands/chain/add_festival.go
@@ -1,0 +1,133 @@
+package chain
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Obedience-Corp/fest/internal/config"
+	"github.com/Obedience-Corp/fest/internal/errors"
+)
+
+// festivalStatusDirs are the festivals-root subdirectories that hold active
+// festival directories searched when resolving --festival by id or name.
+var festivalStatusDirs = []string{"planning", "active", "ready", "ritual"}
+
+// resolvedFestival holds the metadata and on-disk location of the festival
+// being added to a chain.
+type resolvedFestival struct {
+	ID       string
+	Name     string
+	Projects []string
+	Path     string
+}
+
+// resolveFestivalToAdd resolves the --festival value (a path, festival id, or
+// festival name) to its metadata. A value pointing at a directory or fest.yaml
+// is loaded directly; otherwise the festivals-root status dirs are scanned for a
+// festival whose metadata id or name matches.
+func resolveFestivalToAdd(ctx context.Context, root, value string) (resolvedFestival, error) {
+	if err := ctx.Err(); err != nil {
+		return resolvedFestival{}, err
+	}
+	if value == "" {
+		return resolvedFestival{}, errors.Validation("festival is required").
+			WithHint("pass --festival <id|name|path> or run from inside a festival or linked project")
+	}
+
+	if dir, ok := festivalDirFromPath(value); ok {
+		return loadResolvedFestival(dir)
+	}
+
+	dir, err := findFestivalDirByIdentifier(ctx, root, value)
+	if err != nil {
+		return resolvedFestival{}, err
+	}
+	return loadResolvedFestival(dir)
+}
+
+// festivalDirFromPath returns the festival directory when value is a path to a
+// festival directory or directly to its fest.yaml.
+func festivalDirFromPath(value string) (string, bool) {
+	if !strings.ContainsAny(value, "/\\") && !strings.HasPrefix(value, ".") {
+		return "", false
+	}
+	info, err := os.Stat(value)
+	if err != nil {
+		return "", false
+	}
+	if info.IsDir() {
+		if config.FestivalConfigExists(value) {
+			return value, true
+		}
+		return "", false
+	}
+	if filepath.Base(value) == config.FestivalConfigFileName {
+		return filepath.Dir(value), true
+	}
+	return "", false
+}
+
+// findFestivalDirByIdentifier scans the festivals-root status dirs for a festival
+// directory whose fest.yaml metadata id or name matches the identifier.
+func findFestivalDirByIdentifier(ctx context.Context, root, identifier string) (string, error) {
+	for _, sub := range festivalStatusDirs {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		dir := filepath.Join(root, sub)
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			festDir := filepath.Join(dir, e.Name())
+			if !config.FestivalConfigExists(festDir) {
+				continue
+			}
+			cfg, err := config.LoadFestivalConfig(festDir, "")
+			if err != nil {
+				continue
+			}
+			if cfg.Metadata.ID == identifier || cfg.Metadata.Name == identifier {
+				return festDir, nil
+			}
+		}
+	}
+	return "", errors.NotFound("festival").
+		WithField("identifier", identifier).
+		WithHint("pass --festival as a festival id, name, or path")
+}
+
+// loadResolvedFestival reads a festival directory's fest.yaml into resolvedFestival.
+func loadResolvedFestival(dir string) (resolvedFestival, error) {
+	cfg, err := config.LoadFestivalConfig(dir, "")
+	if err != nil {
+		return resolvedFestival{}, errors.Wrap(err, "loading festival config").
+			WithField("path", dir)
+	}
+	if !cfg.Metadata.HasMetadata() {
+		return resolvedFestival{}, errors.Validation("festival has no metadata id").
+			WithField("path", dir).
+			WithHint("the target festival's fest.yaml must declare metadata.id")
+	}
+	return resolvedFestival{
+		ID:       cfg.Metadata.ID,
+		Name:     cfg.Metadata.Name,
+		Projects: festivalProjects(cfg),
+		Path:     dir,
+	}, nil
+}
+
+// festivalProjects returns the festival's linked project path as a one-element
+// slice, or nil when unknown. Projects is best-effort per the design.
+func festivalProjects(cfg *config.FestivalConfig) []string {
+	if cfg.ProjectPath == "" {
+		return nil
+	}
+	return []string{cfg.ProjectPath}
+}

--- a/internal/commands/chain/add_festival_test.go
+++ b/internal/commands/chain/add_festival_test.go
@@ -1,0 +1,120 @@
+package chain
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	chainpkg "github.com/Obedience-Corp/fest/internal/chain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeFestival(t *testing.T, root, status, id, name string) string {
+	t.Helper()
+	dir := filepath.Join(root, status, name+"-"+id)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	cfg := "version: \"1.0\"\nproject_path: projects/" + name +
+		"\nmetadata:\n  id: " + id + "\n  name: " + name + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "fest.yaml"), []byte(cfg), 0o644))
+	return dir
+}
+
+func TestResolveFestivalToAdd_ByID(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "festivals")
+	writeFestival(t, root, "active", "FA0010", "festival-app-onboarding")
+
+	rf, err := resolveFestivalToAdd(context.Background(), root, "FA0010")
+	require.NoError(t, err)
+	assert.Equal(t, "FA0010", rf.ID)
+	assert.Equal(t, "festival-app-onboarding", rf.Name)
+	assert.Equal(t, []string{"projects/festival-app-onboarding"}, rf.Projects)
+}
+
+func TestResolveFestivalToAdd_ByName(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "festivals")
+	writeFestival(t, root, "ready", "FA0010", "onboarding-parity")
+
+	rf, err := resolveFestivalToAdd(context.Background(), root, "onboarding-parity")
+	require.NoError(t, err)
+	assert.Equal(t, "FA0010", rf.ID)
+}
+
+func TestResolveFestivalToAdd_ByPath(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "festivals")
+	dir := writeFestival(t, root, "planning", "FA0010", "onboarding")
+
+	rf, err := resolveFestivalToAdd(context.Background(), root, dir)
+	require.NoError(t, err)
+	assert.Equal(t, "FA0010", rf.ID)
+	assert.Equal(t, dir, rf.Path)
+}
+
+func TestResolveFestivalToAdd_NotFound(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "festivals")
+	require.NoError(t, os.MkdirAll(root, 0o755))
+	_, err := resolveFestivalToAdd(context.Background(), root, "ZZ9999")
+	assert.Error(t, err)
+}
+
+func TestResolveFestivalToAdd_Empty(t *testing.T) {
+	_, err := resolveFestivalToAdd(context.Background(), t.TempDir(), "")
+	assert.Error(t, err)
+}
+
+// dupIDChainYAML parses structurally (validateStructure does not check S2) but
+// fails Validate with an S2 duplicate-id error, so any add leaves it invalid.
+const dupIDChainYAML = `chain_version: "1.0"
+metadata:
+  id: CH0009
+  name: broken-chain
+  status: planning
+festivals:
+  - ref: alpha
+    id: A0001
+    name: alpha
+  - ref: beta
+    id: A0001
+    name: beta
+edges:
+  - from: alpha
+    to: beta
+    type: hard
+`
+
+func TestRunAdd_InvalidMutationWritesNothing(t *testing.T) {
+	chainsDir := addTestEnv(t, dupIDChainYAML, "broken-CH0009.yaml", "G0001", "gamma")
+	chainPath := filepath.Join(chainsDir, "broken-CH0009.yaml")
+
+	before, err := os.ReadFile(chainPath)
+	require.NoError(t, err)
+
+	opts := &addOptions{chain: "CH0009", festival: "G0001", after: []string{"beta"}, edgeType: "hard"}
+	err = runAdd(context.Background(), opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid")
+
+	after, err := os.ReadFile(chainPath)
+	require.NoError(t, err)
+	assert.Equal(t, string(before), string(after), "chain file must be unchanged on invalid mutation")
+}
+
+func TestRunAdd_ValidMutationWrites(t *testing.T) {
+	chainsDir := addTestEnv(t, noWaveChainYAML, "demo-CH0001.yaml", "G0001", "gamma")
+	chainPath := filepath.Join(chainsDir, "demo-CH0001.yaml")
+
+	before, err := os.ReadFile(chainPath)
+	require.NoError(t, err)
+
+	opts := &addOptions{chain: "CH0001", festival: "G0001", after: []string{"beta"}, edgeType: "hard"}
+	require.NoError(t, runAdd(context.Background(), opts))
+
+	after, err := os.ReadFile(chainPath)
+	require.NoError(t, err)
+	assert.NotEqual(t, string(before), string(after))
+
+	c, err := chainpkg.Parse(context.Background(), chainPath)
+	require.NoError(t, err)
+	assert.Len(t, c.Festivals, 3)
+}

--- a/internal/commands/chain/add_helpers.go
+++ b/internal/commands/chain/add_helpers.go
@@ -11,9 +11,6 @@ import (
 
 var nonSlugChars = regexp.MustCompile(`[^a-z0-9]+`)
 
-// slugifyRef converts a festival name into a chain ref token: lowercase, with
-// runs of non-alphanumeric characters collapsed to single underscores and
-// leading/trailing underscores trimmed. Empty input yields "festival".
 func slugifyRef(name string) string {
 	s := strings.ToLower(strings.TrimSpace(name))
 	s = nonSlugChars.ReplaceAllString(s, "_")
@@ -24,8 +21,6 @@ func slugifyRef(name string) string {
 	return s
 }
 
-// uniqueRef returns base if it is not already in taken, otherwise base with a
-// numeric suffix (_2, _3, ...) until it is unique.
 func uniqueRef(base string, taken map[string]bool) string {
 	if !taken[base] {
 		return base
@@ -38,8 +33,6 @@ func uniqueRef(base string, taken map[string]bool) string {
 	}
 }
 
-// buildNode constructs a FestivalNode for the festival being added, assigning a
-// ref derived from name and deduplicated against the chain's existing refs.
 func buildNode(c *chainpkg.Chain, id, name string, projects []string) chainpkg.FestivalNode {
 	ref := uniqueRef(slugifyRef(name), c.RefSet())
 	return chainpkg.FestivalNode{
@@ -50,8 +43,6 @@ func buildNode(c *chainpkg.Chain, id, name string, projects []string) chainpkg.F
 	}
 }
 
-// resolvePrereqRef maps an --after value (a chain ref or a festival ID) to an
-// existing ref in the chain, erroring if it matches nothing.
 func resolvePrereqRef(c *chainpkg.Chain, after string) (string, error) {
 	if node := c.FestivalByRef(after); node != nil {
 		return after, nil
@@ -67,8 +58,6 @@ func resolvePrereqRef(c *chainpkg.Chain, after string) (string, error) {
 		WithHint("pass the ref or id of a festival already in the chain")
 }
 
-// buildEdge constructs a dependency edge from a resolved prerequisite ref to the
-// added ref, rejecting self-edges and duplicates of edges already in the chain.
 func buildEdge(c *chainpkg.Chain, fromRef, toRef string, edgeType chainpkg.EdgeType, note string) (chainpkg.Edge, error) {
 	if fromRef == toRef {
 		return chainpkg.Edge{}, errors.Validation("cannot add a self-edge").
@@ -89,7 +78,6 @@ func buildEdge(c *chainpkg.Chain, fromRef, toRef string, edgeType chainpkg.EdgeT
 	}, nil
 }
 
-// parseEdgeType validates the --type flag value.
 func parseEdgeType(s string) (chainpkg.EdgeType, error) {
 	switch chainpkg.EdgeType(s) {
 	case chainpkg.EdgeHard:
@@ -127,9 +115,6 @@ func placeInTrailingWave(c *chainpkg.Chain, addedRef string) {
 	})
 }
 
-// waveUnlock builds the unlock expression for the trailing wave: each hard
-// prerequisite of addedRef must be completed. With no hard prerequisites the
-// wave unlocks unconditionally ("none").
 func waveUnlock(c *chainpkg.Chain, addedRef string) string {
 	var conds []string
 	seen := make(map[string]bool)

--- a/internal/commands/chain/add_helpers.go
+++ b/internal/commands/chain/add_helpers.go
@@ -1,0 +1,150 @@
+package chain
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	chainpkg "github.com/Obedience-Corp/fest/internal/chain"
+	"github.com/Obedience-Corp/fest/internal/errors"
+)
+
+var nonSlugChars = regexp.MustCompile(`[^a-z0-9]+`)
+
+// slugifyRef converts a festival name into a chain ref token: lowercase, with
+// runs of non-alphanumeric characters collapsed to single underscores and
+// leading/trailing underscores trimmed. Empty input yields "festival".
+func slugifyRef(name string) string {
+	s := strings.ToLower(strings.TrimSpace(name))
+	s = nonSlugChars.ReplaceAllString(s, "_")
+	s = strings.Trim(s, "_")
+	if s == "" {
+		return "festival"
+	}
+	return s
+}
+
+// uniqueRef returns base if it is not already in taken, otherwise base with a
+// numeric suffix (_2, _3, ...) until it is unique.
+func uniqueRef(base string, taken map[string]bool) string {
+	if !taken[base] {
+		return base
+	}
+	for i := 2; ; i++ {
+		candidate := fmt.Sprintf("%s_%d", base, i)
+		if !taken[candidate] {
+			return candidate
+		}
+	}
+}
+
+// buildNode constructs a FestivalNode for the festival being added, assigning a
+// ref derived from name and deduplicated against the chain's existing refs.
+func buildNode(c *chainpkg.Chain, id, name string, projects []string) chainpkg.FestivalNode {
+	ref := uniqueRef(slugifyRef(name), c.RefSet())
+	return chainpkg.FestivalNode{
+		Ref:      ref,
+		ID:       id,
+		Name:     name,
+		Projects: projects,
+	}
+}
+
+// resolvePrereqRef maps an --after value (a chain ref or a festival ID) to an
+// existing ref in the chain, erroring if it matches nothing.
+func resolvePrereqRef(c *chainpkg.Chain, after string) (string, error) {
+	if node := c.FestivalByRef(after); node != nil {
+		return after, nil
+	}
+	for _, f := range c.Festivals {
+		if f.ID == after {
+			return f.Ref, nil
+		}
+	}
+	return "", errors.Validation("prerequisite festival not found in chain").
+		WithField("after", after).
+		WithField("chainID", c.Metadata.ID).
+		WithHint("pass the ref or id of a festival already in the chain")
+}
+
+// buildEdge constructs a dependency edge from a resolved prerequisite ref to the
+// added ref, rejecting self-edges and duplicates of edges already in the chain.
+func buildEdge(c *chainpkg.Chain, fromRef, toRef string, edgeType chainpkg.EdgeType, note string) (chainpkg.Edge, error) {
+	if fromRef == toRef {
+		return chainpkg.Edge{}, errors.Validation("cannot add a self-edge").
+			WithField("ref", fromRef)
+	}
+	for _, e := range c.Edges {
+		if e.From == fromRef && e.To == toRef {
+			return chainpkg.Edge{}, errors.Validation("duplicate edge").
+				WithField("from", fromRef).
+				WithField("to", toRef)
+		}
+	}
+	return chainpkg.Edge{
+		From: fromRef,
+		To:   toRef,
+		Type: edgeType,
+		Note: note,
+	}, nil
+}
+
+// parseEdgeType validates the --type flag value.
+func parseEdgeType(s string) (chainpkg.EdgeType, error) {
+	switch chainpkg.EdgeType(s) {
+	case chainpkg.EdgeHard:
+		return chainpkg.EdgeHard, nil
+	case chainpkg.EdgeSoft:
+		return chainpkg.EdgeSoft, nil
+	default:
+		return "", errors.Validation(fmt.Sprintf("invalid edge type %q", s)).
+			WithHint("use --type hard or --type soft")
+	}
+}
+
+// placeInTrailingWave appends the added ref to a new trailing wave when the chain
+// already uses waves, so coverage (S7) and ordering (S8) still hold: the new wave
+// gets the next sequential id, and its unlock requires every hard prerequisite of
+// the added festival to be completed, which by construction sits in an earlier
+// wave. Chains without waves are left untouched.
+func placeInTrailingWave(c *chainpkg.Chain, addedRef string) {
+	if len(c.Waves) == 0 {
+		return
+	}
+
+	maxID := 0
+	for _, w := range c.Waves {
+		if w.ID > maxID {
+			maxID = w.ID
+		}
+	}
+
+	c.Waves = append(c.Waves, chainpkg.Wave{
+		ID:        maxID + 1,
+		Name:      fmt.Sprintf("Wave %d", maxID+1),
+		Unlock:    waveUnlock(c, addedRef),
+		Festivals: []string{addedRef},
+	})
+}
+
+// waveUnlock builds the unlock expression for the trailing wave: each hard
+// prerequisite of addedRef must be completed. With no hard prerequisites the
+// wave unlocks unconditionally ("none").
+func waveUnlock(c *chainpkg.Chain, addedRef string) string {
+	var conds []string
+	seen := make(map[string]bool)
+	for _, e := range c.Edges {
+		if e.To != addedRef || e.Type != chainpkg.EdgeHard {
+			continue
+		}
+		if seen[e.From] {
+			continue
+		}
+		seen[e.From] = true
+		conds = append(conds, e.From+":completed")
+	}
+	if len(conds) == 0 {
+		return "none"
+	}
+	return strings.Join(conds, " AND ")
+}

--- a/internal/commands/chain/add_helpers_test.go
+++ b/internal/commands/chain/add_helpers_test.go
@@ -1,0 +1,164 @@
+package chain
+
+import (
+	"testing"
+
+	chainpkg "github.com/Obedience-Corp/fest/internal/chain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSlugifyRef(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"spaces", "Festival App Onboarding", "festival_app_onboarding"},
+		{"hyphens", "festival-app-onboarding-parity", "festival_app_onboarding_parity"},
+		{"mixed punctuation", "Foo: Bar / Baz!", "foo_bar_baz"},
+		{"leading trailing junk", "  --Alpha--  ", "alpha"},
+		{"empty", "   ", "festival"},
+		{"already slug", "alpha_beta", "alpha_beta"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, slugifyRef(tc.in))
+		})
+	}
+}
+
+func TestUniqueRef(t *testing.T) {
+	taken := map[string]bool{"alpha": true, "alpha_2": true}
+	assert.Equal(t, "beta", uniqueRef("beta", taken))
+	assert.Equal(t, "alpha_3", uniqueRef("alpha", taken))
+}
+
+func TestBuildNodeDedupesRef(t *testing.T) {
+	c := &chainpkg.Chain{
+		Festivals: []chainpkg.FestivalNode{
+			{Ref: "alpha", ID: "AL0001", Name: "alpha"},
+		},
+	}
+	node := buildNode(c, "AL0002", "Alpha", []string{"projects/x"})
+	assert.Equal(t, "alpha_2", node.Ref)
+	assert.Equal(t, "AL0002", node.ID)
+	assert.Equal(t, "Alpha", node.Name)
+	assert.Equal(t, []string{"projects/x"}, node.Projects)
+}
+
+func testChain() *chainpkg.Chain {
+	return &chainpkg.Chain{
+		Metadata: chainpkg.Metadata{ID: "CH0001", Name: "demo"},
+		Festivals: []chainpkg.FestivalNode{
+			{Ref: "a", ID: "A0001", Name: "alpha"},
+			{Ref: "b", ID: "B0001", Name: "beta"},
+		},
+		Edges: []chainpkg.Edge{
+			{From: "a", To: "b", Type: chainpkg.EdgeHard},
+		},
+	}
+}
+
+func TestResolvePrereqRef(t *testing.T) {
+	c := testChain()
+
+	gotRef, err := resolvePrereqRef(c, "a")
+	require.NoError(t, err)
+	assert.Equal(t, "a", gotRef)
+
+	gotID, err := resolvePrereqRef(c, "B0001")
+	require.NoError(t, err)
+	assert.Equal(t, "b", gotID)
+
+	_, err = resolvePrereqRef(c, "missing")
+	assert.Error(t, err)
+}
+
+func TestBuildEdgeRejectsSelfEdge(t *testing.T) {
+	c := testChain()
+	_, err := buildEdge(c, "a", "a", chainpkg.EdgeHard, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "self-edge")
+}
+
+func TestBuildEdgeRejectsDuplicate(t *testing.T) {
+	c := testChain()
+	_, err := buildEdge(c, "a", "b", chainpkg.EdgeHard, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate")
+}
+
+func TestBuildEdgeOK(t *testing.T) {
+	c := testChain()
+	e, err := buildEdge(c, "b", "a", chainpkg.EdgeSoft, "note here")
+	require.NoError(t, err)
+	assert.Equal(t, "b", e.From)
+	assert.Equal(t, "a", e.To)
+	assert.Equal(t, chainpkg.EdgeSoft, e.Type)
+	assert.Equal(t, "note here", e.Note)
+}
+
+func TestParseEdgeType(t *testing.T) {
+	hard, err := parseEdgeType("hard")
+	require.NoError(t, err)
+	assert.Equal(t, chainpkg.EdgeHard, hard)
+
+	soft, err := parseEdgeType("soft")
+	require.NoError(t, err)
+	assert.Equal(t, chainpkg.EdgeSoft, soft)
+
+	_, err = parseEdgeType("medium")
+	assert.Error(t, err)
+}
+
+func TestPlaceInTrailingWaveNoOpWhenNoWaves(t *testing.T) {
+	c := testChain()
+	placeInTrailingWave(c, "a")
+	assert.Empty(t, c.Waves)
+}
+
+func TestPlaceInTrailingWaveAppendsSequentialWave(t *testing.T) {
+	c := testChain()
+	c.Festivals = append(c.Festivals, chainpkg.FestivalNode{Ref: "g", ID: "G0001", Name: "gamma"})
+	c.Edges = append(c.Edges, chainpkg.Edge{From: "a", To: "g", Type: chainpkg.EdgeHard})
+	c.Waves = []chainpkg.Wave{
+		{ID: 1, Name: "Foundation", Unlock: "none", Festivals: []string{"a"}},
+		{ID: 2, Name: "Wave 2", Unlock: "a:completed", Festivals: []string{"b"}},
+	}
+
+	placeInTrailingWave(c, "g")
+
+	require.Len(t, c.Waves, 3)
+	last := c.Waves[2]
+	assert.Equal(t, 3, last.ID)
+	assert.Equal(t, []string{"g"}, last.Festivals)
+	assert.Equal(t, "a:completed", last.Unlock)
+}
+
+func TestPlaceInTrailingWaveUnlockNoneForRoot(t *testing.T) {
+	c := testChain()
+	c.Festivals = append(c.Festivals, chainpkg.FestivalNode{Ref: "g", ID: "G0001", Name: "gamma"})
+	c.Waves = []chainpkg.Wave{
+		{ID: 1, Name: "Foundation", Unlock: "none", Festivals: []string{"a", "b"}},
+	}
+
+	placeInTrailingWave(c, "g")
+
+	require.Len(t, c.Waves, 2)
+	assert.Equal(t, "none", c.Waves[1].Unlock)
+}
+
+func TestWaveUnlockMultipleHardPrereqs(t *testing.T) {
+	c := &chainpkg.Chain{
+		Festivals: []chainpkg.FestivalNode{
+			{Ref: "a"}, {Ref: "b"}, {Ref: "g"},
+		},
+		Edges: []chainpkg.Edge{
+			{From: "a", To: "g", Type: chainpkg.EdgeHard},
+			{From: "b", To: "g", Type: chainpkg.EdgeHard},
+			{From: "a", To: "g", Type: chainpkg.EdgeSoft},
+		},
+	}
+	assert.Equal(t, "a:completed AND b:completed", waveUnlock(c, "g"))
+}

--- a/internal/commands/chain/add_test.go
+++ b/internal/commands/chain/add_test.go
@@ -256,6 +256,7 @@ func TestRunAdd_JSONOutput(t *testing.T) {
 func captureStdout(t *testing.T, fn func() error) string {
 	t.Helper()
 	old := os.Stdout
+	t.Cleanup(func() { os.Stdout = old })
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 	os.Stdout = w

--- a/internal/commands/chain/add_test.go
+++ b/internal/commands/chain/add_test.go
@@ -1,0 +1,273 @@
+package chain
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	chainpkg "github.com/Obedience-Corp/fest/internal/chain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const noWaveChainYAML = `chain_version: "1.0"
+metadata:
+  id: CH0001
+  name: demo-chain
+  status: planning
+festivals:
+  - ref: alpha
+    id: A0001
+    name: alpha
+  - ref: beta
+    id: B0001
+    name: beta
+edges:
+  - from: alpha
+    to: beta
+    type: hard
+`
+
+const wavedChainYAML = `chain_version: "1.0"
+metadata:
+  id: CH0002
+  name: waved-chain
+  status: planning
+festivals:
+  - ref: alpha
+    id: A0001
+    name: alpha
+  - ref: beta
+    id: B0001
+    name: beta
+edges:
+  - from: alpha
+    to: beta
+    type: hard
+waves:
+  - id: 1
+    name: Foundation
+    unlock: none
+    festivals: [alpha]
+  - id: 2
+    name: Wave 2
+    unlock: alpha:completed
+    festivals: [beta]
+`
+
+// addTestEnv sets up a festivals root with chains/ and a festival dir, chdirs
+// into it, and returns the chains directory path.
+func addTestEnv(t *testing.T, chainYAML, chainFile, festivalID, festivalName string) string {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "festivals")
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".festival"), 0o755))
+	chainsDir := filepath.Join(root, "chains")
+	require.NoError(t, os.MkdirAll(chainsDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(chainsDir, chainFile), []byte(chainYAML), 0o644))
+
+	festDir := filepath.Join(root, "planning", festivalName+"-"+festivalID)
+	require.NoError(t, os.MkdirAll(festDir, 0o755))
+	cfg := "version: \"1.0\"\nmetadata:\n  id: " + festivalID +
+		"\n  name: " + festivalName + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(festDir, "fest.yaml"), []byte(cfg), 0o644))
+
+	t.Chdir(root)
+	return chainsDir
+}
+
+func TestRunAdd_NoWavesWithEdge(t *testing.T) {
+	chainsDir := addTestEnv(t, noWaveChainYAML, "demo-CH0001.yaml", "G0001", "gamma")
+
+	opts := &addOptions{
+		chain:    "CH0001",
+		festival: "G0001",
+		after:    []string{"beta"},
+		edgeType: "hard",
+	}
+	require.NoError(t, runAdd(context.Background(), opts))
+
+	c, err := chainpkg.Parse(context.Background(), filepath.Join(chainsDir, "demo-CH0001.yaml"))
+	require.NoError(t, err)
+	require.Len(t, c.Festivals, 3)
+
+	node := c.FestivalByRef("gamma")
+	require.NotNil(t, node)
+	assert.Equal(t, "G0001", node.ID)
+
+	var found bool
+	for _, e := range c.Edges {
+		if e.From == "beta" && e.To == "gamma" && e.Type == chainpkg.EdgeHard {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected beta->gamma hard edge")
+	assert.Empty(t, c.Waves)
+}
+
+func TestRunAdd_RepeatableAfterCreatesMultipleEdges(t *testing.T) {
+	chainsDir := addTestEnv(t, noWaveChainYAML, "demo-CH0001.yaml", "G0001", "gamma")
+
+	opts := &addOptions{
+		chain:    "CH0001",
+		festival: "G0001",
+		after:    []string{"alpha", "beta"},
+		edgeType: "soft",
+	}
+	require.NoError(t, runAdd(context.Background(), opts))
+
+	c, err := chainpkg.Parse(context.Background(), filepath.Join(chainsDir, "demo-CH0001.yaml"))
+	require.NoError(t, err)
+
+	var toGamma int
+	for _, e := range c.Edges {
+		if e.To == "gamma" {
+			toGamma++
+			assert.Equal(t, chainpkg.EdgeSoft, e.Type)
+		}
+	}
+	assert.Equal(t, 2, toGamma)
+}
+
+func TestRunAdd_RootNodeNoAfter(t *testing.T) {
+	chainsDir := addTestEnv(t, noWaveChainYAML, "demo-CH0001.yaml", "G0001", "gamma")
+
+	opts := &addOptions{chain: "CH0001", festival: "G0001", edgeType: "hard"}
+	require.NoError(t, runAdd(context.Background(), opts))
+
+	c, err := chainpkg.Parse(context.Background(), filepath.Join(chainsDir, "demo-CH0001.yaml"))
+	require.NoError(t, err)
+	require.Len(t, c.Festivals, 3)
+	for _, e := range c.Edges {
+		assert.NotEqual(t, "gamma", e.To)
+	}
+}
+
+func TestRunAdd_HasWavesAppendsTrailingWave(t *testing.T) {
+	chainsDir := addTestEnv(t, wavedChainYAML, "waved-CH0002.yaml", "G0001", "gamma")
+
+	opts := &addOptions{
+		chain:    "CH0002",
+		festival: "G0001",
+		after:    []string{"beta"},
+		edgeType: "hard",
+	}
+	require.NoError(t, runAdd(context.Background(), opts))
+
+	c, err := chainpkg.Parse(context.Background(), filepath.Join(chainsDir, "waved-CH0002.yaml"))
+	require.NoError(t, err)
+	require.Len(t, c.Waves, 3)
+	last := c.Waves[2]
+	assert.Equal(t, 3, last.ID)
+	assert.Equal(t, []string{"gamma"}, last.Festivals)
+	assert.Equal(t, "beta:completed", last.Unlock)
+
+	result := chainpkg.Validate(context.Background(), c)
+	assert.True(t, result.Valid, "mutated waved chain must validate: %+v", result.Errors)
+}
+
+func TestRunAdd_DuplicateFestivalRejected(t *testing.T) {
+	chainsDir := addTestEnv(t, noWaveChainYAML, "demo-CH0001.yaml", "A0001", "alpha")
+
+	opts := &addOptions{chain: "CH0001", festival: "A0001", edgeType: "hard"}
+	err := runAdd(context.Background(), opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already in chain")
+
+	c, err := chainpkg.Parse(context.Background(), filepath.Join(chainsDir, "demo-CH0001.yaml"))
+	require.NoError(t, err)
+	assert.Len(t, c.Festivals, 2, "no node should be written on duplicate")
+}
+
+func TestRunAdd_SelfEdgeImpossibleButPrereqUnknownRejected(t *testing.T) {
+	chainsDir := addTestEnv(t, noWaveChainYAML, "demo-CH0001.yaml", "G0001", "gamma")
+
+	opts := &addOptions{chain: "CH0001", festival: "G0001", after: []string{"nonexistent"}, edgeType: "hard"}
+	err := runAdd(context.Background(), opts)
+	require.Error(t, err)
+
+	c, err := chainpkg.Parse(context.Background(), filepath.Join(chainsDir, "demo-CH0001.yaml"))
+	require.NoError(t, err)
+	assert.Len(t, c.Festivals, 2, "no write on unknown prerequisite")
+}
+
+func TestRunAdd_InvalidTypeRejected(t *testing.T) {
+	addTestEnv(t, noWaveChainYAML, "demo-CH0001.yaml", "G0001", "gamma")
+	opts := &addOptions{chain: "CH0001", festival: "G0001", edgeType: "medium"}
+	err := runAdd(context.Background(), opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "edge type")
+}
+
+func TestRunAdd_ContextCancelled(t *testing.T) {
+	addTestEnv(t, noWaveChainYAML, "demo-CH0001.yaml", "G0001", "gamma")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	opts := &addOptions{chain: "CH0001", festival: "G0001", edgeType: "hard"}
+	err := runAdd(ctx, opts)
+	assert.Error(t, err)
+}
+
+func TestRunAdd_FestivalByName(t *testing.T) {
+	chainsDir := addTestEnv(t, noWaveChainYAML, "demo-CH0001.yaml", "G0001", "gamma")
+
+	opts := &addOptions{chain: "CH0001", festival: "gamma", after: []string{"beta"}, edgeType: "hard"}
+	require.NoError(t, runAdd(context.Background(), opts))
+
+	c, err := chainpkg.Parse(context.Background(), filepath.Join(chainsDir, "demo-CH0001.yaml"))
+	require.NoError(t, err)
+	assert.NotNil(t, c.FestivalByRef("gamma"))
+}
+
+func TestRunAdd_JSONOutput(t *testing.T) {
+	addTestEnv(t, noWaveChainYAML, "demo-CH0001.yaml", "G0001", "gamma")
+
+	opts := &addOptions{
+		chain:    "CH0001",
+		festival: "G0001",
+		after:    []string{"beta"},
+		edgeType: "hard",
+		note:     "needs beta",
+		json:     true,
+	}
+
+	out := captureStdout(t, func() error {
+		return runAdd(context.Background(), opts)
+	})
+
+	var result addResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	assert.Equal(t, "CH0001", result.ChainID)
+	assert.Equal(t, "demo-chain", result.ChainName)
+	assert.Equal(t, "gamma", result.Node.Ref)
+	assert.Equal(t, "G0001", result.Node.ID)
+	require.Len(t, result.Edges, 1)
+	assert.Equal(t, "beta", result.Edges[0].From)
+	assert.Equal(t, "gamma", result.Edges[0].To)
+	assert.Equal(t, "hard", result.Edges[0].Type)
+	assert.Equal(t, "needs beta", result.Edges[0].Note)
+	assert.True(t, result.Validation.Valid)
+	assert.Equal(t, 100, result.Validation.Score)
+}
+
+func captureStdout(t *testing.T, fn func() error) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	runErr := fn()
+
+	require.NoError(t, w.Close())
+	os.Stdout = old
+	require.NoError(t, runErr)
+
+	var buf bytes.Buffer
+	_, copyErr := io.Copy(&buf, r)
+	require.NoError(t, copyErr)
+	return buf.String()
+}

--- a/internal/commands/chain/chain.go
+++ b/internal/commands/chain/chain.go
@@ -20,6 +20,7 @@ func NewChainCmd() *cobra.Command {
 
 	cmd.AddCommand(
 		newCreateCmd(),
+		newAddCmd(),
 		newListCmd(),
 		newStatusCmd(),
 		newValidateCmd(),

--- a/internal/commands/chain/create.go
+++ b/internal/commands/chain/create.go
@@ -104,7 +104,7 @@ func runCreate(cmd *cobra.Command, name, goal string) error {
 	fmt.Printf("  Name: %s\n", slug)
 	fmt.Printf("  File: %s\n", path)
 	fmt.Println()
-	fmt.Println("Add festivals and edges by editing the chain file directly,")
+	fmt.Println("Add festivals with 'fest chain add --chain " + id + " --festival <id> [--after <ref>]',")
 	fmt.Println("then run 'fest chain validate " + id + "' to verify.")
 
 	return nil


### PR DESCRIPTION
## Summary

Adds `fest chain add`, a command to add a festival to an existing chain as a node, optionally with prerequisite dependency edges. Until now `fest chain create` only made an empty chain shell and printed "add festivals and edges by editing the chain file directly" — there was no command to populate a chain, so membership was hand-edited YAML. This closes that gap.

The command parses the target chain, mutates it in memory (append node + edges, place in a trailing wave when the chain uses waves), validates the result with the existing `chain.Validate`, and writes only if valid via a new atomic `chain.Write`.

Design: `workflow/design/fest-chain-add-member/` in the obey-campaign repo (workitem WI-72f9af), grounded against this source.

## Command surface

```
fest chain add
  --chain string      target chain id or name
  --festival string   festival to add (id, name, or path); defaults to current festival context
  --after stringArray prerequisite festival ref/id (optional, repeatable -> one edge each)
  --type string       edge type: hard | soft (default hard)
  --note string       optional edge note
  --json              emit structured JSON result
```

Creating a brand-new chain stays in `fest chain create`; this command adds to an existing chain.

## Behavior

- Validate-then-write: the mutated chain is validated in memory and written only if valid. An invalid mutation exits non-zero and writes nothing (no partial file).
- Atomic write: new `chain.Write` re-marshals the chain and replaces the file via a temp-file-plus-rename. Clean re-marshal (drops the create template comments); the chain stays valid and readable.
- Waves: chains without waves need no wave handling; chains with waves get the added festival placed in a trailing wave so the S7/S8 validators still pass.
- Rejections: duplicate festival, self-edge, unknown prerequisite, invalid edge type.
- `--festival` defaults to the current festival context; non-TTY requires explicit flags.

## JSON result schema

```json
{
  "chain_id": "CH0001",
  "chain_name": "demo-chain",
  "node": { "ref": "gamma", "id": "G0001", "name": "gamma", "projects": ["projects/gamma"] },
  "edges": [ { "from": "beta", "to": "gamma", "type": "hard", "note": "needs beta" } ],
  "validation": { "valid": true, "score": 100 }
}
```

`node.projects` omitted when unknown; `edges` always present (empty array with no `--after`); `edge.note` omitted when empty; `validation.errors` (string array) omitted when valid.

## Changes

- `internal/chain/write.go` (+test): `chain.Write` clean re-marshal, atomic.
- `internal/commands/chain/add.go`, `add_helpers.go`, `add_festival.go` (+tests): the command, pure helpers (ref slug/dedup, node/edge build, edge-type parse, trailing-wave placement), and `--festival` resolution.
- `internal/commands/chain/chain.go`: register `add`.
- `internal/chain/types.go`: `omitempty` on `Metadata.created_at` and `status_history` so re-marshal of chains lacking those fields stays clean (`chain.Write` is the only Chain marshaler).

## Testing

- `go build ./...` clean; `golangci-lint run ./...` 0 issues; `go vet` and `gofmt` clean.
- Full unit suite green (no regressions). New tests use host `t.TempDir` per the repo convention, covering: `Write` round-trip and atomicity; node/edge/ref construction, dedup, self-edge rejection; validate-then-write (valid writes, invalid writes nothing); no-waves and waved (trailing-wave) cases; `--json`; context cancellation.
- Real-binary smoke: no-waves add, repeatable `--after`, root node, waved trailing-wave placement (then `fest chain validate` VALID 100/100), and the rejection paths.

## Notes / follow-ups

- Interactive TTY prerequisite picker not included (design marked it optional for this PR); non-TTY explicit-flag behavior is implemented, and `--chain` reuses the existing chain picker.
- Removing a member (`fest chain remove`) is a separate future concern.
- Downstream: this unblocks the festival-app create-festival modal (FA0011), whose chain wiring calls `fest chain add` rather than editing chain YAML.
