### PR TITLE
feat(chain): add --json to 'fest chain list' (WI-04f47a)

### DIFF
--- a/internal/commands/chain/list.go
+++ b/internal/commands/chain/list.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,23 +14,37 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type chainListItem struct {
+	ID            string   `json:"id"`
+	Name          string   `json:"name"`
+	Status        string   `json:"status"`
+	FestivalCount int      `json:"festival_count"`
+	Refs          []string `json:"refs"`
+}
+
+type chainListResult struct {
+	Chains []chainListItem `json:"chains"`
+}
+
 func newListCmd() *cobra.Command {
 	var statusFilter string
+	var jsonOut bool
 
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all festival chains",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runList(cmd.Context(), statusFilter)
+			return runList(cmd.Context(), statusFilter, jsonOut)
 		},
 	}
 
 	cmd.Flags().StringVar(&statusFilter, "status", "", "filter by status (planning|active|completed)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit structured JSON result")
 
 	return cmd
 }
 
-func runList(ctx context.Context, statusFilter string) error {
+func runList(ctx context.Context, statusFilter string, jsonOut bool) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -48,11 +63,6 @@ func runList(ctx context.Context, statusFilter string) error {
 	dungeonChains, _ := discoverChains(ctx, filepath.Join(root, "dungeon", "completed", "chains"))
 	chains = append(chains, dungeonChains...)
 
-	if len(chains) == 0 {
-		fmt.Println("No chains found. Create one with 'fest chain create --name <name>'.")
-		return nil
-	}
-
 	// Filter if requested.
 	if statusFilter != "" {
 		var filtered []*chainpkg.Chain
@@ -62,6 +72,15 @@ func runList(ctx context.Context, statusFilter string) error {
 			}
 		}
 		chains = filtered
+	}
+
+	if jsonOut {
+		return printChainListJSON(chains)
+	}
+
+	if len(chains) == 0 {
+		fmt.Println("No chains found. Create one with 'fest chain create --name <name>'.")
+		return nil
 	}
 
 	// Group by status.
@@ -95,6 +114,30 @@ func runList(ctx context.Context, statusFilter string) error {
 		}
 	}
 
+	return nil
+}
+
+func printChainListJSON(chains []*chainpkg.Chain) error {
+	items := make([]chainListItem, 0, len(chains))
+	for _, c := range chains {
+		refs := make([]string, len(c.Festivals))
+		for i, f := range c.Festivals {
+			refs[i] = f.Ref
+		}
+		items = append(items, chainListItem{
+			ID:            c.Metadata.ID,
+			Name:          c.Metadata.Name,
+			Status:        string(c.Metadata.Status),
+			FestivalCount: len(c.Festivals),
+			Refs:          refs,
+		})
+	}
+
+	data, err := json.MarshalIndent(chainListResult{Chains: items}, "", "  ")
+	if err != nil {
+		return errors.IO("marshaling chain list", err)
+	}
+	fmt.Println(string(data))
 	return nil
 }
 

--- a/internal/commands/chain/list.go
+++ b/internal/commands/chain/list.go
@@ -63,6 +63,12 @@ func runList(ctx context.Context, statusFilter string, jsonOut bool) error {
 	dungeonChains, _ := discoverChains(ctx, filepath.Join(root, "dungeon", "completed", "chains"))
 	chains = append(chains, dungeonChains...)
 
+	// Human empty-workspace message reflects the unfiltered set; JSON reports the filtered set.
+	if !jsonOut && len(chains) == 0 {
+		fmt.Println("No chains found. Create one with 'fest chain create --name <name>'.")
+		return nil
+	}
+
 	// Filter if requested.
 	if statusFilter != "" {
 		var filtered []*chainpkg.Chain
@@ -76,11 +82,6 @@ func runList(ctx context.Context, statusFilter string, jsonOut bool) error {
 
 	if jsonOut {
 		return printChainListJSON(chains)
-	}
-
-	if len(chains) == 0 {
-		fmt.Println("No chains found. Create one with 'fest chain create --name <name>'.")
-		return nil
 	}
 
 	// Group by status.

--- a/internal/commands/chain/list_test.go
+++ b/internal/commands/chain/list_test.go
@@ -56,6 +56,16 @@ func TestRunList_JSONStatusFilter(t *testing.T) {
 	assert.Empty(t, result.Chains)
 }
 
+func TestRunList_HumanStatusFilterEmptyPrintsNoMessage(t *testing.T) {
+	addTestEnv(t, noWaveChainYAML, "demo-chain.yaml", "A0001", "alpha")
+
+	out := captureStdout(t, func() error {
+		return runList(context.Background(), "active", false)
+	})
+
+	assert.NotContains(t, out, "No chains found")
+}
+
 func TestRunList_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/internal/commands/chain/list_test.go
+++ b/internal/commands/chain/list_test.go
@@ -1,0 +1,63 @@
+package chain
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunList_JSONShape(t *testing.T) {
+	addTestEnv(t, noWaveChainYAML, "demo-chain.yaml", "A0001", "alpha")
+
+	out := captureStdout(t, func() error {
+		return runList(context.Background(), "", true)
+	})
+
+	var result chainListResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	require.Len(t, result.Chains, 1)
+
+	c := result.Chains[0]
+	assert.Equal(t, "CH0001", c.ID)
+	assert.Equal(t, "demo-chain", c.Name)
+	assert.Equal(t, "planning", c.Status)
+	assert.Equal(t, 2, c.FestivalCount)
+	assert.Equal(t, []string{"alpha", "beta"}, c.Refs)
+}
+
+func TestRunList_JSONEmptyWorkspace(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "festivals")
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".festival"), 0o755))
+	t.Chdir(root)
+
+	out := captureStdout(t, func() error {
+		return runList(context.Background(), "", true)
+	})
+
+	var result chainListResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	assert.Empty(t, result.Chains)
+}
+
+func TestRunList_JSONStatusFilter(t *testing.T) {
+	addTestEnv(t, noWaveChainYAML, "demo-chain.yaml", "A0001", "alpha")
+
+	out := captureStdout(t, func() error {
+		return runList(context.Background(), "active", true)
+	})
+
+	var result chainListResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	assert.Empty(t, result.Chains)
+}
+
+func TestRunList_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	assert.Error(t, runList(ctx, "", true))
+}


### PR DESCRIPTION
## Summary

Adds a `--json` flag to `fest chain list`, emitting a stable structured result so machine consumers can read the chain list without screen-scraping the human table.

```json
{ "chains": [ { "id", "name", "status", "festival_count", "refs": [...] } ] }
```

- Empty workspace returns `{ "chains": [] }` (not the human "No chains found" message).
- Human table output is unchanged.
- JSON conventions mirror `fest chain add --json` (snake_case keys, top-level object wrapper).

## Why

festival-app's create-festival modal (FA0011) needs a machine-readable chain list to populate its chain picker. Per the facade principle already applied to `fest chain add` (#195 / WI-72f9af), the app must consume a real fest JSON contract rather than parse the human table. Tracked as design workitem WI-04f47a.

## Tests

`internal/commands/chain/list_test.go`: JSON shape, empty workspace, status filter, context cancellation. `go test ./internal/commands/chain/` passes; `golangci-lint run ./...` reports 0 issues; gofmt/vet clean.