### PR TITLE
feat(festival): add --seed/--seed-file to 'fest create festival' (WI-88956e)

### DIFF
--- a/internal/commands/festival/create_festival.go
+++ b/internal/commands/festival/create_festival.go
@@ -316,12 +316,27 @@ func RunCreateFestival(ctx context.Context, opts *CreateFestivalOptions) error {
 
 	created, res.autoPhasesCreated = autoScaffoldPhases(ctx, cfg, created)
 
-	recordInitialSize(ctx, cfg, res.festConfig)
-
 	res.created = created
 	res.copiedGates = copiedGates
+
+	// Seed before the initial-size snapshot so seeded content is part of the
+	// creation baseline, not later counted as post-create growth. Skipped on
+	// dry-run. The seed file is registered in res.created after marker processing
+	// so user content is never marker-substituted.
+	if !opts.DryRun {
+		if err := writeSeedFile(cfg, res); err != nil {
+			return emitCreateFestivalCreatedError(ctx, cfg, res, err)
+		}
+	}
+
+	recordInitialSize(ctx, cfg, res.festConfig)
+
 	if err := processAllMarkers(ctx, cfg, res); err != nil {
 		return emitCreateFestivalCreatedError(ctx, cfg, res, err)
+	}
+
+	if res.seedPath != "" {
+		res.created = append(res.created, res.seedPath)
 	}
 
 	if opts.DryRun && res.markersTotal > 0 {
@@ -330,10 +345,6 @@ func RunCreateFestival(ctx context.Context, opts *CreateFestivalOptions) error {
 			return emitCreateFestivalCreatedError(ctx, cfg, res, err)
 		}
 		return nil
-	}
-
-	if err := writeSeedFile(cfg, res); err != nil {
-		return emitCreateFestivalCreatedError(ctx, cfg, res, err)
 	}
 
 	if err := validateIfConfigured(ctx, cfg, res); err != nil {
@@ -714,7 +725,6 @@ func writeSeedFile(cfg *createConfig, res *createResult) error {
 	}
 
 	res.seedPath = seedPath
-	res.created = append(res.created, seedPath)
 	return nil
 }
 

--- a/internal/commands/festival/create_festival.go
+++ b/internal/commands/festival/create_festival.go
@@ -42,6 +42,8 @@ type CreateFestivalOptions struct {
 	VarsFile    string
 	Markers     string // Inline JSON with hint→value mappings
 	MarkersFile string // JSON file path with hint→value mappings
+	Seed        string // Inline seed/input-spec content for the ingest phase
+	SeedFile    string // File whose contents seed the ingest phase
 	SkipMarkers bool   // Skip marker processing
 	DryRun      bool   // Show markers without creating file
 	JSONOutput  bool
@@ -59,6 +61,7 @@ type createFestivalResult struct {
 	GatesDirectory    string             `json:"gates_directory,omitempty"`
 	FestYAML          string             `json:"fest_yaml,omitempty"`
 	GateTemplates     []string           `json:"gate_templates,omitempty"`
+	SeedPath          string             `json:"seed_path,omitempty"`
 	ProjectPath       string             `json:"project_path,omitempty"`
 	ProjectLinked     bool               `json:"project_linked,omitempty"`
 	Markers           []map[string]any   `json:"markers,omitempty"`
@@ -107,6 +110,8 @@ type createConfig struct {
 	tmplCtx          *tpl.Context
 	festivalType     *types.FestivalType
 	festivalTypeName string
+	seedContent      string
+	seedRequested    bool
 }
 
 // NewCreateFestivalCommand adds 'create festival'
@@ -138,6 +143,8 @@ func NewCreateFestivalCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.VarsFile, "vars-file", "", "JSON file with variables")
 	cmd.Flags().StringVar(&opts.Markers, "markers", "", "JSON string with REPLACE marker hint→value mappings")
 	cmd.Flags().StringVar(&opts.MarkersFile, "markers-file", "", "JSON file with REPLACE marker hint→value mappings")
+	cmd.Flags().StringVar(&opts.Seed, "seed", "", "Inline seed content written to the ingest phase input_specs/ (requires a type with an ingest phase)")
+	cmd.Flags().StringVar(&opts.SeedFile, "seed-file", "", "File whose contents seed the ingest phase input_specs/ (mutually exclusive with --seed)")
 	cmd.Flags().BoolVar(&opts.SkipMarkers, "skip-markers", false, "Skip REPLACE marker processing")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Show template markers without creating file")
 	cmd.Flags().BoolVar(&opts.JSONOutput, "json", false, "Emit JSON output")
@@ -268,6 +275,7 @@ type createResult struct {
 	allMarkers        []map[string]any
 	validationResult  *ValidationSummary
 	registered        bool
+	seedPath          string
 }
 
 // RunCreateFestival executes the create festival command logic.
@@ -276,8 +284,17 @@ func RunCreateFestival(ctx context.Context, opts *CreateFestivalOptions) error {
 		return errors.Wrap(err, "context cancelled").WithOp("RunCreateFestival")
 	}
 
+	if opts.Seed != "" && opts.SeedFile != "" {
+		return emitCreateFestivalError(opts, errors.Validation(
+			"--seed and --seed-file are mutually exclusive"))
+	}
+
 	cfg, err := resolveCreateConfig(ctx, opts)
 	if err != nil {
+		return emitCreateFestivalError(opts, err)
+	}
+
+	if err := resolveAndValidateSeed(cfg); err != nil {
 		return emitCreateFestivalError(opts, err)
 	}
 
@@ -312,6 +329,10 @@ func RunCreateFestival(ctx context.Context, opts *CreateFestivalOptions) error {
 			return emitCreateFestivalCreatedError(ctx, cfg, res, err)
 		}
 		return nil
+	}
+
+	if err := writeSeedFile(cfg, res); err != nil {
+		return emitCreateFestivalCreatedError(ctx, cfg, res, err)
 	}
 
 	if err := validateIfConfigured(ctx, cfg, res); err != nil {
@@ -638,6 +659,86 @@ func autoScaffoldPhases(ctx context.Context, cfg *createConfig, created []string
 	return created, autoPhasesCreated
 }
 
+// resolveAndValidateSeed resolves --seed/--seed-file content and verifies the
+// festival type has an ingest phase to seed BEFORE any scaffolding happens, so a
+// type with no ingest phase fails fast instead of leaving a half-created
+// festival. input_specs/ is an ingest-phase concept; types without one are
+// refused rather than silently misplaced.
+func resolveAndValidateSeed(cfg *createConfig) error {
+	content, ok, err := resolveSeedContent(cfg.opts)
+	if err != nil || !ok {
+		return err
+	}
+
+	if _, found := ingestAutoPhaseID(cfg.festivalType); !found {
+		typeName := cfg.festivalTypeName
+		if typeName == "" {
+			typeName = "(none)"
+		}
+		return errors.Validation("festival type has no ingest phase to seed").
+			WithField("type", typeName).
+			WithHint("use --markers, or choose a festival type with an ingest phase")
+	}
+
+	cfg.seedContent = content
+	cfg.seedRequested = true
+	return nil
+}
+
+// writeSeedFile writes the pre-resolved seed content into the festival's ingest
+// phase input_specs/. The ingest phase is guaranteed to exist by
+// resolveAndValidateSeed.
+func writeSeedFile(cfg *createConfig, res *createResult) error {
+	if !cfg.seedRequested {
+		return nil
+	}
+
+	ingestPhaseID, _ := ingestAutoPhaseID(cfg.festivalType)
+	inputSpecsDir := filepath.Join(cfg.destDir, ingestPhaseID, "input_specs")
+	if err := os.MkdirAll(inputSpecsDir, 0755); err != nil {
+		return errors.IO("creating input_specs directory", err).WithField("path", inputSpecsDir)
+	}
+
+	seedPath := filepath.Join(inputSpecsDir, "seed.md")
+	if err := os.WriteFile(seedPath, []byte(cfg.seedContent), 0644); err != nil {
+		return errors.IO("writing seed file", err).WithField("path", seedPath)
+	}
+
+	res.seedPath = seedPath
+	res.created = append(res.created, seedPath)
+	return nil
+}
+
+// resolveSeedContent returns the seed content from --seed or --seed-file.
+// The bool is false when no seed flag was provided.
+func resolveSeedContent(opts *CreateFestivalOptions) (string, bool, error) {
+	if opts.Seed != "" {
+		return opts.Seed, true, nil
+	}
+	if opts.SeedFile != "" {
+		data, err := os.ReadFile(opts.SeedFile)
+		if err != nil {
+			return "", false, errors.IO("reading seed file", err).WithField("path", opts.SeedFile)
+		}
+		return string(data), true, nil
+	}
+	return "", false, nil
+}
+
+// ingestAutoPhaseID returns the phase ID of the festival type's auto-scaffolded
+// ingest phase, matching the IDs autoScaffoldPhases produces.
+func ingestAutoPhaseID(festivalType *types.FestivalType) (string, bool) {
+	if festivalType == nil {
+		return "", false
+	}
+	for i, phaseSpec := range festivalType.GetAutoPhases() {
+		if phaseSpec.Type == "ingest" {
+			return tpl.FormatPhaseID(i+1, phaseSpec.Name), true
+		}
+	}
+	return "", false
+}
+
 // recordInitialSize records the initial content size for token delta tracking.
 func recordInitialSize(ctx context.Context, cfg *createConfig, festConfig *config.FestivalConfig) {
 	initialSize, sizeErr := progress.ComputeDirectorySize(ctx, cfg.destDir)
@@ -830,6 +931,7 @@ func emitCreateJSON(cfg *createConfig, res *createResult, gatesDir string, remai
 		GatesDirectory:    displayPath(gatesDir),
 		FestYAML:          displayPath(res.festConfigPath),
 		GateTemplates:     relGates,
+		SeedPath:          displayPath(res.seedPath),
 		ProjectPath:       displayPath(res.projectPath),
 		ProjectLinked:     res.projectLinked,
 		MarkersFilled:     res.markersFilled,

--- a/internal/commands/festival/create_festival.go
+++ b/internal/commands/festival/create_festival.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -694,6 +695,14 @@ func writeSeedFile(cfg *createConfig, res *createResult) error {
 	}
 
 	ingestPhaseID, _ := ingestAutoPhaseID(cfg.festivalType)
+	// autoScaffoldPhases swallows per-phase failures, so confirm the ingest
+	// phase was actually created before seeding into it; otherwise seeding
+	// would write under a missing phase and falsely report success.
+	if !slices.Contains(res.autoPhasesCreated, ingestPhaseID) {
+		return errors.New("ingest phase was not scaffolded; cannot seed").
+			WithField("phase", ingestPhaseID)
+	}
+
 	inputSpecsDir := filepath.Join(cfg.destDir, ingestPhaseID, "input_specs")
 	if err := os.MkdirAll(inputSpecsDir, 0755); err != nil {
 		return errors.IO("creating input_specs directory", err).WithField("path", inputSpecsDir)

--- a/internal/commands/festival/create_festival_seed_test.go
+++ b/internal/commands/festival/create_festival_seed_test.go
@@ -93,17 +93,10 @@ func TestCreateFestivalSeed_NoSeedLeavesNoSeedFile(t *testing.T) {
 }
 
 func TestCreateFestivalSeed_CountedInInitialSizeBytes(t *testing.T) {
-	baselineDir := runCreateForSeed(t, &CreateFestivalOptions{
-		Name:       "SizeProbe",
-		Type:       "standard",
-		Dest:       "planning",
-		JSONOutput: true,
-	})
-	baselineCfg, err := config.LoadFestivalConfig(baselineDir, "")
-	if err != nil {
-		t.Fatalf("load baseline config: %v", err)
-	}
-
+	// A large seed (9000 bytes) far exceeds the unseeded standard scaffold
+	// (~1KB of .md), so initial_size_bytes can only reach len(seed) if the seed
+	// is counted in the creation baseline. A single-festival lower bound keeps
+	// this deterministic (no cross-creation byte jitter).
 	seed := strings.Repeat("seed content line\n", 500)
 	seededDir := runCreateForSeed(t, &CreateFestivalOptions{
 		Name:       "SizeProbe",
@@ -117,10 +110,9 @@ func TestCreateFestivalSeed_CountedInInitialSizeBytes(t *testing.T) {
 		t.Fatalf("load seeded config: %v", err)
 	}
 
-	growth := seededCfg.Metadata.InitialSizeBytes - baselineCfg.Metadata.InitialSizeBytes
-	if growth < int64(len(seed)) {
-		t.Errorf("seed not counted in initial_size_bytes baseline: growth=%d, seed len=%d (baseline=%d, seeded=%d)",
-			growth, len(seed), baselineCfg.Metadata.InitialSizeBytes, seededCfg.Metadata.InitialSizeBytes)
+	if seededCfg.Metadata.InitialSizeBytes < int64(len(seed)) {
+		t.Errorf("seed not counted in initial_size_bytes: got %d, want >= %d",
+			seededCfg.Metadata.InitialSizeBytes, len(seed))
 	}
 }
 

--- a/internal/commands/festival/create_festival_seed_test.go
+++ b/internal/commands/festival/create_festival_seed_test.go
@@ -1,0 +1,186 @@
+package festival
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/types"
+)
+
+func runCreateForSeed(t *testing.T, opts *CreateFestivalOptions) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	festivalsDir := filepath.Join(tmpDir, "festivals")
+	setupFestivalTemplatesWithMarkers(t, festivalsDir)
+
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	_ = os.Chdir(festivalsDir)
+
+	if err := RunCreateFestival(context.Background(), opts); err != nil {
+		t.Fatalf("RunCreateFestival failed: %v", err)
+	}
+
+	planningDir := filepath.Join(festivalsDir, "planning")
+	entries, err := os.ReadDir(planningDir)
+	if err != nil {
+		t.Fatalf("failed to read planning dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 festival in planning/, got %d", len(entries))
+	}
+	return filepath.Join(planningDir, entries[0].Name())
+}
+
+func TestCreateFestivalSeed_StandardWritesIngestInputSpec(t *testing.T) {
+	festivalDir := runCreateForSeed(t, &CreateFestivalOptions{
+		Name:       "Seeded",
+		Type:       "standard",
+		Dest:       "planning",
+		Seed:       "Initial context: build the widget.",
+		JSONOutput: true,
+	})
+
+	seedPath := filepath.Join(festivalDir, "001_INGEST", "input_specs", "seed.md")
+	content, err := os.ReadFile(seedPath)
+	if err != nil {
+		t.Fatalf("expected seed file at %s: %v", seedPath, err)
+	}
+	if string(content) != "Initial context: build the widget." {
+		t.Errorf("unexpected seed content: %q", string(content))
+	}
+}
+
+func TestCreateFestivalSeed_SeedFileWritesIngestInputSpec(t *testing.T) {
+	srcDir := t.TempDir()
+	srcFile := filepath.Join(srcDir, "seed-input.md")
+	if err := os.WriteFile(srcFile, []byte("from a file"), 0644); err != nil {
+		t.Fatalf("write src seed: %v", err)
+	}
+
+	festivalDir := runCreateForSeed(t, &CreateFestivalOptions{
+		Name:       "SeededFile",
+		Type:       "standard",
+		Dest:       "planning",
+		SeedFile:   srcFile,
+		JSONOutput: true,
+	})
+
+	content, err := os.ReadFile(filepath.Join(festivalDir, "001_INGEST", "input_specs", "seed.md"))
+	if err != nil {
+		t.Fatalf("expected seed file: %v", err)
+	}
+	if string(content) != "from a file" {
+		t.Errorf("unexpected seed content: %q", string(content))
+	}
+}
+
+func TestCreateFestivalSeed_NoSeedLeavesNoSeedFile(t *testing.T) {
+	festivalDir := runCreateForSeed(t, &CreateFestivalOptions{
+		Name:       "Plain",
+		Type:       "standard",
+		Dest:       "planning",
+		JSONOutput: true,
+	})
+
+	if _, err := os.Stat(filepath.Join(festivalDir, "001_INGEST", "input_specs", "seed.md")); !os.IsNotExist(err) {
+		t.Errorf("expected no seed file when --seed is absent, stat err = %v", err)
+	}
+}
+
+func TestCreateFestivalSeed_ImplementationTypeRejected(t *testing.T) {
+	tmpDir := t.TempDir()
+	festivalsDir := filepath.Join(tmpDir, "festivals")
+	setupFestivalTemplatesWithMarkers(t, festivalsDir)
+
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	_ = os.Chdir(festivalsDir)
+
+	err := RunCreateFestival(context.Background(), &CreateFestivalOptions{
+		Name: "ImplSeed",
+		Type: "implementation",
+		Dest: "planning",
+		Seed: "should be refused",
+	})
+	if err == nil {
+		t.Fatal("expected error seeding a type with no ingest phase")
+	}
+
+	entries, _ := os.ReadDir(filepath.Join(festivalsDir, "planning"))
+	if len(entries) != 0 {
+		t.Errorf("fail-fast expected: no festival should be created, found %d", len(entries))
+	}
+}
+
+func TestCreateFestivalSeed_MutualExclusionRejected(t *testing.T) {
+	err := RunCreateFestival(context.Background(), &CreateFestivalOptions{
+		Name:     "Both",
+		Type:     "standard",
+		Dest:     "planning",
+		Seed:     "a",
+		SeedFile: "/tmp/whatever",
+	})
+	if err == nil {
+		t.Fatal("expected error when both --seed and --seed-file are set")
+	}
+}
+
+func TestResolveSeedContent(t *testing.T) {
+	if _, ok, _ := resolveSeedContent(&CreateFestivalOptions{}); ok {
+		t.Error("expected ok=false when no seed flag is set")
+	}
+
+	content, ok, err := resolveSeedContent(&CreateFestivalOptions{Seed: "inline"})
+	if err != nil || !ok || content != "inline" {
+		t.Errorf("inline: got (%q, %v, %v)", content, ok, err)
+	}
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "s.md")
+	_ = os.WriteFile(file, []byte("file content"), 0644)
+	content, ok, err = resolveSeedContent(&CreateFestivalOptions{SeedFile: file})
+	if err != nil || !ok || content != "file content" {
+		t.Errorf("file: got (%q, %v, %v)", content, ok, err)
+	}
+
+	if _, _, err := resolveSeedContent(&CreateFestivalOptions{SeedFile: filepath.Join(dir, "missing.md")}); err == nil {
+		t.Error("expected error for missing seed file")
+	}
+}
+
+func TestIngestAutoPhaseID(t *testing.T) {
+	if _, ok := ingestAutoPhaseID(nil); ok {
+		t.Error("nil type should have no ingest phase")
+	}
+
+	standard := &types.FestivalType{
+		Phases: []types.PhaseSpec{
+			{Name: "INGEST", Type: "ingest", Auto: true},
+			{Name: "PLAN", Type: "planning", Auto: true},
+		},
+	}
+	if id, ok := ingestAutoPhaseID(standard); !ok || id != "001_INGEST" {
+		t.Errorf("standard: got (%q, %v), want (001_INGEST, true)", id, ok)
+	}
+
+	impl := &types.FestivalType{
+		Phases: []types.PhaseSpec{
+			{Name: "IMPLEMENT", Type: "implementation", Auto: true},
+		},
+	}
+	if _, ok := ingestAutoPhaseID(impl); ok {
+		t.Error("implementation type should have no ingest phase")
+	}
+
+	nonAutoIngest := &types.FestivalType{
+		Phases: []types.PhaseSpec{
+			{Name: "INGEST", Type: "ingest", Auto: false},
+		},
+	}
+	if _, ok := ingestAutoPhaseID(nonAutoIngest); ok {
+		t.Error("non-auto ingest phase is not scaffolded at create time")
+	}
+}

--- a/internal/commands/festival/create_festival_seed_test.go
+++ b/internal/commands/festival/create_festival_seed_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/Obedience-Corp/fest/internal/config"
 	"github.com/Obedience-Corp/fest/internal/types"
 )
 
@@ -87,6 +89,38 @@ func TestCreateFestivalSeed_NoSeedLeavesNoSeedFile(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(festivalDir, "001_INGEST", "input_specs", "seed.md")); !os.IsNotExist(err) {
 		t.Errorf("expected no seed file when --seed is absent, stat err = %v", err)
+	}
+}
+
+func TestCreateFestivalSeed_CountedInInitialSizeBytes(t *testing.T) {
+	baselineDir := runCreateForSeed(t, &CreateFestivalOptions{
+		Name:       "SizeProbe",
+		Type:       "standard",
+		Dest:       "planning",
+		JSONOutput: true,
+	})
+	baselineCfg, err := config.LoadFestivalConfig(baselineDir, "")
+	if err != nil {
+		t.Fatalf("load baseline config: %v", err)
+	}
+
+	seed := strings.Repeat("seed content line\n", 500)
+	seededDir := runCreateForSeed(t, &CreateFestivalOptions{
+		Name:       "SizeProbe",
+		Type:       "standard",
+		Dest:       "planning",
+		Seed:       seed,
+		JSONOutput: true,
+	})
+	seededCfg, err := config.LoadFestivalConfig(seededDir, "")
+	if err != nil {
+		t.Fatalf("load seeded config: %v", err)
+	}
+
+	growth := seededCfg.Metadata.InitialSizeBytes - baselineCfg.Metadata.InitialSizeBytes
+	if growth < int64(len(seed)) {
+		t.Errorf("seed not counted in initial_size_bytes baseline: growth=%d, seed len=%d (baseline=%d, seeded=%d)",
+			growth, len(seed), baselineCfg.Metadata.InitialSizeBytes, seededCfg.Metadata.InitialSizeBytes)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds type-aware seeding of a new festival's **ingest phase** `input_specs/` at creation time:

```
--seed string        inline seed content (markdown)
--seed-file string   file whose contents seed the ingest phase (mutually exclusive with --seed)
```

On success the content is written to `<festival>/<NNN_INGEST>/input_specs/seed.md` and the path is reported in `--json` as `seed_path`.

## Type-awareness (the important part)

`input_specs/` is an **ingest-phase** concept, and festival types differ — `standard`/`research` have an ingest phase; `implementation` (`skip_ingestion`) and others may not. Seeding is **validated before any scaffolding** (fail-fast): a type with no auto ingest phase is refused with a clear error and **no partial festival is created**. fest owns this because only fest knows each type's phase layout (`FestivalType.GetAutoPhases()`).

## Why

festival-app's create-festival modal (FA0011) wants to let users seed starting context. Per the facade principle (and to avoid the app writing into fest's festival directory, which it cannot lay out correctly per-type), fest owns seeding and the app calls `fest create festival --seed`. Tracked as design workitem WI-88956e.

## Tests

`create_festival_seed_test.go`: standard happy path (inline + file), no-seed leaves no file, implementation-type rejection (fail-fast, no festival created), `--seed`+`--seed-file` mutual exclusion, and pure unit tests for `resolveSeedContent` / `ingestAutoPhaseID`. Full festival package tests pass; `golangci-lint run ./...` 0 issues; gofmt/vet clean. Existing create behavior unchanged.