### PR TITLE
feat(watch): order festival picker by status priority then recency

### DIFF
--- a/internal/commands/shared/festival_picker.go
+++ b/internal/commands/shared/festival_picker.go
@@ -44,7 +44,7 @@ func PickFestivalPath(ctx context.Context, festivalsDir string, opts FestivalPic
 func FestivalPickerItems(festivalsDir string, opts FestivalPickerOptions) []picker.Item {
 	candidates := CollectFestivalPickCandidates(festivalsDir, opts)
 	if len(candidates) == 0 && len(opts.PreferredStatuses) > 0 {
-		opts.PreferredStatuses = nil
+		opts.PreferredStatuses = opts.FallbackStatuses
 		candidates = CollectFestivalPickCandidates(festivalsDir, opts)
 	}
 

--- a/internal/commands/shared/festival_picker_order.go
+++ b/internal/commands/shared/festival_picker_order.go
@@ -9,19 +9,12 @@ import (
 	"github.com/Obedience-Corp/fest/internal/id"
 )
 
-// watchPickerStatusRank maps a status to its display priority for the watch
-// picker. Lower sorts first. Statuses absent from the map sort after all known
-// statuses.
 var watchPickerStatusRank = map[string]int{
 	"active":   0,
 	"ready":    1,
 	"planning": 2,
 }
 
-// orderWatchPickerCandidates returns candidates sorted by status priority
-// (active, ready, planning), then most-recently-modified first, then name.
-// It populates each candidate's ModTime from the filesystem before sorting and
-// leaves the input slice untouched.
 func orderWatchPickerCandidates(candidates []FestivalPickCandidate) []FestivalPickCandidate {
 	ordered := make([]FestivalPickCandidate, len(candidates))
 	copy(ordered, candidates)
@@ -30,9 +23,6 @@ func orderWatchPickerCandidates(candidates []FestivalPickCandidate) []FestivalPi
 	return ordered
 }
 
-// sortWatchPickerCandidates stable-sorts pre-populated candidates in place by the
-// watch picker ordering. It performs no filesystem access, so it is the pure,
-// directly testable core of the ordering.
 func sortWatchPickerCandidates(candidates []FestivalPickCandidate) {
 	sort.SliceStable(candidates, func(i, j int) bool {
 		return lessWatchPickerCandidate(candidates[i], candidates[j])
@@ -65,10 +55,6 @@ func populateCandidateModTimes(candidates []FestivalPickCandidate) {
 	}
 }
 
-// latestModTime returns the most recent modification time found within dir
-// (recursively, including dir itself). It returns the zero time when dir cannot
-// be read, so a candidate is never dropped from the picker on a stat error -- it
-// simply sorts last within its status group.
 func latestModTime(dir string) time.Time {
 	var latest time.Time
 	walkErr := filepath.WalkDir(dir, func(_ string, d os.DirEntry, err error) error {

--- a/internal/commands/shared/festival_picker_order.go
+++ b/internal/commands/shared/festival_picker_order.go
@@ -15,28 +15,42 @@ var watchPickerStatusRank = map[string]int{
 	"planning": 2,
 }
 
+type rankedCandidate struct {
+	candidate FestivalPickCandidate
+	modTime   time.Time
+}
+
 func orderWatchPickerCandidates(candidates []FestivalPickCandidate) []FestivalPickCandidate {
-	ordered := make([]FestivalPickCandidate, len(candidates))
-	copy(ordered, candidates)
-	populateCandidateModTimes(ordered)
-	sortWatchPickerCandidates(ordered)
+	ranked := make([]rankedCandidate, len(candidates))
+	for i, c := range candidates {
+		ranked[i] = rankedCandidate{candidate: c}
+		if !c.StatusDirectory {
+			ranked[i].modTime = latestModTime(c.Path)
+		}
+	}
+	sortRankedCandidates(ranked)
+
+	ordered := make([]FestivalPickCandidate, len(ranked))
+	for i, r := range ranked {
+		ordered[i] = r.candidate
+	}
 	return ordered
 }
 
-func sortWatchPickerCandidates(candidates []FestivalPickCandidate) {
-	sort.SliceStable(candidates, func(i, j int) bool {
-		return lessWatchPickerCandidate(candidates[i], candidates[j])
+func sortRankedCandidates(ranked []rankedCandidate) {
+	sort.SliceStable(ranked, func(i, j int) bool {
+		return lessRankedCandidate(ranked[i], ranked[j])
 	})
 }
 
-func lessWatchPickerCandidate(a, b FestivalPickCandidate) bool {
-	if ra, rb := watchStatusRank(a.Status), watchStatusRank(b.Status); ra != rb {
+func lessRankedCandidate(a, b rankedCandidate) bool {
+	if ra, rb := watchStatusRank(a.candidate.Status), watchStatusRank(b.candidate.Status); ra != rb {
 		return ra < rb
 	}
-	if !a.ModTime.Equal(b.ModTime) {
-		return a.ModTime.After(b.ModTime)
+	if !a.modTime.Equal(b.modTime) {
+		return a.modTime.After(b.modTime)
 	}
-	return a.Name < b.Name
+	return a.candidate.Name < b.candidate.Name
 }
 
 func watchStatusRank(status string) int {
@@ -44,15 +58,6 @@ func watchStatusRank(status string) int {
 		return rank
 	}
 	return len(watchPickerStatusRank)
-}
-
-func populateCandidateModTimes(candidates []FestivalPickCandidate) {
-	for i := range candidates {
-		if candidates[i].StatusDirectory {
-			continue
-		}
-		candidates[i].ModTime = latestModTime(candidates[i].Path)
-	}
 }
 
 func latestModTime(dir string) time.Time {

--- a/internal/commands/shared/festival_picker_order.go
+++ b/internal/commands/shared/festival_picker_order.go
@@ -1,0 +1,91 @@
+package shared
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/Obedience-Corp/fest/internal/id"
+)
+
+// watchPickerStatusRank maps a status to its display priority for the watch
+// picker. Lower sorts first. Statuses absent from the map sort after all known
+// statuses.
+var watchPickerStatusRank = map[string]int{
+	"active":   0,
+	"ready":    1,
+	"planning": 2,
+}
+
+// orderWatchPickerCandidates returns candidates sorted by status priority
+// (active, ready, planning), then most-recently-modified first, then name.
+// It populates each candidate's ModTime from the filesystem before sorting and
+// leaves the input slice untouched.
+func orderWatchPickerCandidates(candidates []FestivalPickCandidate) []FestivalPickCandidate {
+	ordered := make([]FestivalPickCandidate, len(candidates))
+	copy(ordered, candidates)
+	populateCandidateModTimes(ordered)
+	sortWatchPickerCandidates(ordered)
+	return ordered
+}
+
+// sortWatchPickerCandidates stable-sorts pre-populated candidates in place by the
+// watch picker ordering. It performs no filesystem access, so it is the pure,
+// directly testable core of the ordering.
+func sortWatchPickerCandidates(candidates []FestivalPickCandidate) {
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return lessWatchPickerCandidate(candidates[i], candidates[j])
+	})
+}
+
+func lessWatchPickerCandidate(a, b FestivalPickCandidate) bool {
+	if ra, rb := watchStatusRank(a.Status), watchStatusRank(b.Status); ra != rb {
+		return ra < rb
+	}
+	if !a.ModTime.Equal(b.ModTime) {
+		return a.ModTime.After(b.ModTime)
+	}
+	return a.Name < b.Name
+}
+
+func watchStatusRank(status string) int {
+	if rank, ok := watchPickerStatusRank[id.ResolveStatusPath(status)]; ok {
+		return rank
+	}
+	return len(watchPickerStatusRank)
+}
+
+func populateCandidateModTimes(candidates []FestivalPickCandidate) {
+	for i := range candidates {
+		if candidates[i].StatusDirectory {
+			continue
+		}
+		candidates[i].ModTime = latestModTime(candidates[i].Path)
+	}
+}
+
+// latestModTime returns the most recent modification time found within dir
+// (recursively, including dir itself). It returns the zero time when dir cannot
+// be read, so a candidate is never dropped from the picker on a stat error -- it
+// simply sorts last within its status group.
+func latestModTime(dir string) time.Time {
+	var latest time.Time
+	walkErr := filepath.WalkDir(dir, func(_ string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			return nil
+		}
+		if mt := info.ModTime(); mt.After(latest) {
+			latest = mt
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return time.Time{}
+	}
+	return latest
+}

--- a/internal/commands/shared/festival_picker_order_test.go
+++ b/internal/commands/shared/festival_picker_order_test.go
@@ -1,0 +1,142 @@
+package shared
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+var orderBaseTime = time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+
+func at(hours int) time.Time {
+	return orderBaseTime.Add(time.Duration(hours) * time.Hour)
+}
+
+func candidateOrder(candidates []FestivalPickCandidate) []string {
+	names := make([]string, len(candidates))
+	for i, c := range candidates {
+		names[i] = c.Name
+	}
+	return names
+}
+
+func TestSortWatchPickerCandidatesGroupsByStatusThenRecency(t *testing.T) {
+	candidates := []FestivalPickCandidate{
+		{Name: "plan-old", Status: "planning", ModTime: at(1)},
+		{Name: "active-new", Status: "active", ModTime: at(5)},
+		{Name: "ready-mid", Status: "ready", ModTime: at(3)},
+		{Name: "active-old", Status: "active", ModTime: at(2)},
+		{Name: "plan-new", Status: "planning", ModTime: at(4)},
+		{Name: "ready-old", Status: "ready", ModTime: at(1)},
+	}
+
+	sortWatchPickerCandidates(candidates)
+
+	want := []string{"active-new", "active-old", "ready-mid", "ready-old", "plan-new", "plan-old"}
+	if got := candidateOrder(candidates); !reflect.DeepEqual(got, want) {
+		t.Fatalf("order = %#v, want %#v", got, want)
+	}
+}
+
+func TestWatchPickerStatusPrecedenceBeatsRecency(t *testing.T) {
+	candidates := []FestivalPickCandidate{
+		{Name: "plan-newest", Status: "planning", ModTime: at(100)},
+		{Name: "active-oldest", Status: "active", ModTime: at(1)},
+	}
+
+	sortWatchPickerCandidates(candidates)
+
+	want := []string{"active-oldest", "plan-newest"}
+	if got := candidateOrder(candidates); !reflect.DeepEqual(got, want) {
+		t.Fatalf("order = %#v, want %#v", got, want)
+	}
+}
+
+func TestWatchPickerMissingModTimeSortsLastInGroup(t *testing.T) {
+	candidates := []FestivalPickCandidate{
+		{Name: "active-missing", Status: "active"},
+		{Name: "active-dated", Status: "active", ModTime: at(5)},
+		{Name: "ready-dated", Status: "ready", ModTime: at(5)},
+	}
+
+	sortWatchPickerCandidates(candidates)
+
+	want := []string{"active-dated", "active-missing", "ready-dated"}
+	got := candidateOrder(candidates)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("order = %#v, want %#v", got, want)
+	}
+	if len(candidates) != 3 {
+		t.Fatalf("candidate count = %d, want 3 (none dropped)", len(candidates))
+	}
+}
+
+func TestWatchPickerNameTieBreak(t *testing.T) {
+	candidates := []FestivalPickCandidate{
+		{Name: "bbb", Status: "active", ModTime: at(5)},
+		{Name: "aaa", Status: "active", ModTime: at(5)},
+	}
+
+	sortWatchPickerCandidates(candidates)
+
+	want := []string{"aaa", "bbb"}
+	if got := candidateOrder(candidates); !reflect.DeepEqual(got, want) {
+		t.Fatalf("order = %#v, want %#v", got, want)
+	}
+}
+
+func TestWatchPickerUnknownStatusSortsAfterKnown(t *testing.T) {
+	candidates := []FestivalPickCandidate{
+		{Name: "ritual-x", Status: "ritual", ModTime: at(100)},
+		{Name: "active-x", Status: "active", ModTime: at(1)},
+	}
+
+	sortWatchPickerCandidates(candidates)
+
+	want := []string{"active-x", "ritual-x"}
+	if got := candidateOrder(candidates); !reflect.DeepEqual(got, want) {
+		t.Fatalf("order = %#v, want %#v", got, want)
+	}
+}
+
+func TestLatestModTimeReturnsNewestNestedFile(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "001_PHASE")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	top := filepath.Join(dir, "FESTIVAL_GOAL.md")
+	nested := filepath.Join(sub, "TASK.md")
+	for _, f := range []string{top, nested} {
+		if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	newest := at(2)
+	chtimes(t, dir, at(-1))
+	chtimes(t, top, at(1))
+	chtimes(t, sub, at(0))
+	chtimes(t, nested, newest)
+
+	got := latestModTime(dir)
+	if !got.Equal(newest) {
+		t.Fatalf("latestModTime = %v, want %v", got, newest)
+	}
+}
+
+func TestLatestModTimeMissingPathReturnsZero(t *testing.T) {
+	got := latestModTime(filepath.Join(t.TempDir(), "does-not-exist"))
+	if !got.IsZero() {
+		t.Fatalf("latestModTime on missing path = %v, want zero", got)
+	}
+}
+
+func chtimes(t *testing.T, path string, mt time.Time) {
+	t.Helper()
+	if err := os.Chtimes(path, mt, mt); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/commands/shared/festival_picker_order_test.go
+++ b/internal/commands/shared/festival_picker_order_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -14,89 +15,93 @@ func at(hours int) time.Time {
 	return orderBaseTime.Add(time.Duration(hours) * time.Hour)
 }
 
-func candidateOrder(candidates []FestivalPickCandidate) []string {
-	names := make([]string, len(candidates))
-	for i, c := range candidates {
-		names[i] = c.Name
+func ranked(name, status string, mt time.Time) rankedCandidate {
+	return rankedCandidate{candidate: FestivalPickCandidate{Name: name, Status: status}, modTime: mt}
+}
+
+func rankedOrder(items []rankedCandidate) []string {
+	names := make([]string, len(items))
+	for i, r := range items {
+		names[i] = r.candidate.Name
 	}
 	return names
 }
 
 func TestSortWatchPickerCandidatesGroupsByStatusThenRecency(t *testing.T) {
-	candidates := []FestivalPickCandidate{
-		{Name: "plan-old", Status: "planning", ModTime: at(1)},
-		{Name: "active-new", Status: "active", ModTime: at(5)},
-		{Name: "ready-mid", Status: "ready", ModTime: at(3)},
-		{Name: "active-old", Status: "active", ModTime: at(2)},
-		{Name: "plan-new", Status: "planning", ModTime: at(4)},
-		{Name: "ready-old", Status: "ready", ModTime: at(1)},
+	items := []rankedCandidate{
+		ranked("plan-old", "planning", at(1)),
+		ranked("active-new", "active", at(5)),
+		ranked("ready-mid", "ready", at(3)),
+		ranked("active-old", "active", at(2)),
+		ranked("plan-new", "planning", at(4)),
+		ranked("ready-old", "ready", at(1)),
 	}
 
-	sortWatchPickerCandidates(candidates)
+	sortRankedCandidates(items)
 
 	want := []string{"active-new", "active-old", "ready-mid", "ready-old", "plan-new", "plan-old"}
-	if got := candidateOrder(candidates); !reflect.DeepEqual(got, want) {
+	if got := rankedOrder(items); !reflect.DeepEqual(got, want) {
 		t.Fatalf("order = %#v, want %#v", got, want)
 	}
 }
 
 func TestWatchPickerStatusPrecedenceBeatsRecency(t *testing.T) {
-	candidates := []FestivalPickCandidate{
-		{Name: "plan-newest", Status: "planning", ModTime: at(100)},
-		{Name: "active-oldest", Status: "active", ModTime: at(1)},
+	items := []rankedCandidate{
+		ranked("plan-newest", "planning", at(100)),
+		ranked("active-oldest", "active", at(1)),
 	}
 
-	sortWatchPickerCandidates(candidates)
+	sortRankedCandidates(items)
 
 	want := []string{"active-oldest", "plan-newest"}
-	if got := candidateOrder(candidates); !reflect.DeepEqual(got, want) {
+	if got := rankedOrder(items); !reflect.DeepEqual(got, want) {
 		t.Fatalf("order = %#v, want %#v", got, want)
 	}
 }
 
 func TestWatchPickerMissingModTimeSortsLastInGroup(t *testing.T) {
-	candidates := []FestivalPickCandidate{
-		{Name: "active-missing", Status: "active"},
-		{Name: "active-dated", Status: "active", ModTime: at(5)},
-		{Name: "ready-dated", Status: "ready", ModTime: at(5)},
+	items := []rankedCandidate{
+		ranked("active-missing", "active", time.Time{}),
+		ranked("active-dated", "active", at(5)),
+		ranked("ready-dated", "ready", at(5)),
 	}
 
-	sortWatchPickerCandidates(candidates)
+	sortRankedCandidates(items)
 
 	want := []string{"active-dated", "active-missing", "ready-dated"}
-	got := candidateOrder(candidates)
+	got := rankedOrder(items)
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("order = %#v, want %#v", got, want)
 	}
-	if len(candidates) != 3 {
-		t.Fatalf("candidate count = %d, want 3 (none dropped)", len(candidates))
+	if len(items) != 3 {
+		t.Fatalf("candidate count = %d, want 3 (none dropped)", len(items))
 	}
 }
 
 func TestWatchPickerNameTieBreak(t *testing.T) {
-	candidates := []FestivalPickCandidate{
-		{Name: "bbb", Status: "active", ModTime: at(5)},
-		{Name: "aaa", Status: "active", ModTime: at(5)},
+	items := []rankedCandidate{
+		ranked("bbb", "active", at(5)),
+		ranked("aaa", "active", at(5)),
 	}
 
-	sortWatchPickerCandidates(candidates)
+	sortRankedCandidates(items)
 
 	want := []string{"aaa", "bbb"}
-	if got := candidateOrder(candidates); !reflect.DeepEqual(got, want) {
+	if got := rankedOrder(items); !reflect.DeepEqual(got, want) {
 		t.Fatalf("order = %#v, want %#v", got, want)
 	}
 }
 
 func TestWatchPickerUnknownStatusSortsAfterKnown(t *testing.T) {
-	candidates := []FestivalPickCandidate{
-		{Name: "ritual-x", Status: "ritual", ModTime: at(100)},
-		{Name: "active-x", Status: "active", ModTime: at(1)},
+	items := []rankedCandidate{
+		ranked("ritual-x", "ritual", at(100)),
+		ranked("active-x", "active", at(1)),
 	}
 
-	sortWatchPickerCandidates(candidates)
+	sortRankedCandidates(items)
 
 	want := []string{"active-x", "ritual-x"}
-	if got := candidateOrder(candidates); !reflect.DeepEqual(got, want) {
+	if got := rankedOrder(items); !reflect.DeepEqual(got, want) {
 		t.Fatalf("order = %#v, want %#v", got, want)
 	}
 }
@@ -138,5 +143,57 @@ func chtimes(t *testing.T, path string, mt time.Time) {
 	t.Helper()
 	if err := os.Chtimes(path, mt, mt); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func writeFestival(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "FESTIVAL_GOAL.md"), []byte("# Goal\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFestivalPickerItemsFallbackStaysWithinFallbackStatuses(t *testing.T) {
+	festivals := t.TempDir()
+	writeFestival(t, filepath.Join(festivals, "ritual", "weekly-RI-WR0001"))
+	writeFestival(t, filepath.Join(festivals, "dungeon", "completed", "2026-05", "old-OW0001"))
+
+	items := FestivalPickerItems(festivals, FestivalPickerOptions{
+		PreferredStatuses:        []string{"active"},
+		FallbackStatuses:         []string{"active", "ready", "planning"},
+		OrderByStatusThenRecency: true,
+	})
+
+	for _, it := range items {
+		if strings.Contains(it.Value, "/ritual/") || strings.Contains(it.Value, "/dungeon/") {
+			t.Fatalf("watch picker leaked a non-watchable festival via fallback: %q", it.Value)
+		}
+	}
+}
+
+func TestFestivalPickerItemsFallbackBroadensWithinWatchableSet(t *testing.T) {
+	festivals := t.TempDir()
+	writeFestival(t, filepath.Join(festivals, "ready", "ready-RW0001"))
+	writeFestival(t, filepath.Join(festivals, "ritual", "weekly-RI-WR0001"))
+
+	items := FestivalPickerItems(festivals, FestivalPickerOptions{
+		PreferredStatuses: []string{"active"},
+		FallbackStatuses:  []string{"active", "ready", "planning"},
+	})
+
+	var found bool
+	for _, it := range items {
+		if strings.Contains(it.Value, "/ritual/") {
+			t.Fatalf("watch picker leaked a ritual festival via fallback: %q", it.Value)
+		}
+		if strings.Contains(it.Value, "ready-RW0001") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("fallback should broaden from empty active to ready")
 	}
 }

--- a/internal/commands/shared/festival_selector.go
+++ b/internal/commands/shared/festival_selector.go
@@ -33,9 +33,7 @@ type FestivalPickCandidate struct {
 	Path            string
 	Status          string
 	StatusDirectory bool
-	// ModTime is the most-recent modification time found under Path. It is only
-	// populated when a caller requests recency ordering (OrderByStatusThenRecency);
-	// otherwise it is the zero time.
+	// ModTime is populated only when OrderByStatusThenRecency is set.
 	ModTime time.Time
 }
 
@@ -46,10 +44,7 @@ type FestivalPickerOptions struct {
 	// status child directories are navigable even before they have festival markers.
 	IncludeUnmarkedFestivalDirectories bool
 	PreferredStatuses                  []string
-	// OrderByStatusThenRecency sorts candidates by watch status priority
-	// (active, ready, planning), then most-recently-modified first, then name.
-	// The interactive watch picker sets this; other surfaces leave it false to
-	// preserve collection order and avoid per-candidate filesystem stats.
+	// OrderByStatusThenRecency sorts by status priority, then newest-modified, then name.
 	OrderByStatusThenRecency bool
 }
 

--- a/internal/commands/shared/festival_selector.go
+++ b/internal/commands/shared/festival_selector.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/id"
@@ -33,8 +32,6 @@ type FestivalPickCandidate struct {
 	Path            string
 	Status          string
 	StatusDirectory bool
-	// ModTime is populated only when OrderByStatusThenRecency is set.
-	ModTime time.Time
 }
 
 // FestivalPickerOptions controls candidate collection for completion and picker surfaces.
@@ -44,6 +41,10 @@ type FestivalPickerOptions struct {
 	// status child directories are navigable even before they have festival markers.
 	IncludeUnmarkedFestivalDirectories bool
 	PreferredStatuses                  []string
+	// FallbackStatuses bounds the empty-result broadening in FestivalPickerItems:
+	// when PreferredStatuses yields nothing, it broadens to these rather than the
+	// unbounded default set.
+	FallbackStatuses []string
 	// OrderByStatusThenRecency sorts by status priority, then newest-modified, then name.
 	OrderByStatusThenRecency bool
 }

--- a/internal/commands/shared/festival_selector.go
+++ b/internal/commands/shared/festival_selector.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/id"
@@ -32,6 +33,10 @@ type FestivalPickCandidate struct {
 	Path            string
 	Status          string
 	StatusDirectory bool
+	// ModTime is the most-recent modification time found under Path. It is only
+	// populated when a caller requests recency ordering (OrderByStatusThenRecency);
+	// otherwise it is the zero time.
+	ModTime time.Time
 }
 
 // FestivalPickerOptions controls candidate collection for completion and picker surfaces.
@@ -41,6 +46,11 @@ type FestivalPickerOptions struct {
 	// status child directories are navigable even before they have festival markers.
 	IncludeUnmarkedFestivalDirectories bool
 	PreferredStatuses                  []string
+	// OrderByStatusThenRecency sorts candidates by watch status priority
+	// (active, ready, planning), then most-recently-modified first, then name.
+	// The interactive watch picker sets this; other surfaces leave it false to
+	// preserve collection order and avoid per-candidate filesystem stats.
+	OrderByStatusThenRecency bool
 }
 
 type selectorMatch struct {
@@ -179,7 +189,11 @@ func CollectFestivalPickCandidates(festivalsDir string, opts FestivalPickerOptio
 	if len(statuses) == 0 {
 		statuses = defaultCandidateStatuses()
 	}
-	return filterFestivalPickCandidates(collectFestivalPickCandidates(festivalsDir, statuses, opts), opts)
+	candidates := filterFestivalPickCandidates(collectFestivalPickCandidates(festivalsDir, statuses, opts), opts)
+	if opts.OrderByStatusThenRecency {
+		candidates = orderWatchPickerCandidates(candidates)
+	}
+	return candidates
 }
 
 func findCampaignFestivalsDir(ctx context.Context, cwd string) (string, error) {

--- a/internal/commands/watch/completion.go
+++ b/internal/commands/watch/completion.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
-	"github.com/Obedience-Corp/fest/internal/id"
 	"github.com/spf13/cobra"
 )
 
@@ -22,10 +21,13 @@ func completeWatchSelector(_ *cobra.Command, _ []string, toComplete string) ([]s
 }
 
 func watchSelectorCompletions(ctx context.Context, cwd, toComplete string) ([]string, error) {
-	// Dungeon is terminal and never watched; restrict to working statuses.
+	// Restrict completion to watchable statuses (active, ready, planning).
+	// Ritual templates and terminal dungeon/* festivals are never watched.
+	// No ordering option here: completion stays alphabetical and avoids the
+	// per-candidate filesystem stats the interactive picker performs.
 	return shared.CompleteFestivalPickSelectors(ctx, cwd, toComplete, shared.FestivalPickerOptions{
 		IncludeStatusDirectories: false,
-		PreferredStatuses:        id.WorkingStatusDirectories,
+		PreferredStatuses:        watchPickerStatuses,
 	})
 }
 

--- a/internal/commands/watch/completion.go
+++ b/internal/commands/watch/completion.go
@@ -21,10 +21,6 @@ func completeWatchSelector(_ *cobra.Command, _ []string, toComplete string) ([]s
 }
 
 func watchSelectorCompletions(ctx context.Context, cwd, toComplete string) ([]string, error) {
-	// Restrict completion to watchable statuses (active, ready, planning).
-	// Ritual templates and terminal dungeon/* festivals are never watched.
-	// No ordering option here: completion stays alphabetical and avoids the
-	// per-candidate filesystem stats the interactive picker performs.
 	return shared.CompleteFestivalPickSelectors(ctx, cwd, toComplete, shared.FestivalPickerOptions{
 		IncludeStatusDirectories: false,
 		PreferredStatuses:        watchPickerStatuses,

--- a/internal/commands/watch/completion_test.go
+++ b/internal/commands/watch/completion_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
-	"github.com/Obedience-Corp/fest/internal/id"
 )
 
 func TestWatchCompletionExcludesStatusDirectories(t *testing.T) {
@@ -24,10 +23,10 @@ func TestWatchCompletionExcludesDungeonFestivals(t *testing.T) {
 	makeWatchTestFestival(t, filepath.Join(festivals, "active", "launch-work-LW0001"))
 	makeWatchTestFestival(t, filepath.Join(festivals, "dungeon", "completed", "2026-05-01", "old-work-OW0001"))
 
-	// Production watch setting: restrict completion to working statuses.
+	// Production watch setting: restrict completion to watchable statuses.
 	working := shared.CollectFestivalPickCandidates(festivals, shared.FestivalPickerOptions{
 		IncludeStatusDirectories: false,
-		PreferredStatuses:        id.WorkingStatusDirectories,
+		PreferredStatuses:        watchPickerStatuses,
 	})
 	if candidateNamePresent(working, "old-work-OW0001") {
 		t.Fatalf("watch completion must exclude dungeon festivals (terminal, never watched): %v", candidateNames(working))
@@ -43,6 +42,23 @@ func TestWatchCompletionExcludesDungeonFestivals(t *testing.T) {
 	})
 	if !candidateNamePresent(all, "old-work-OW0001") {
 		t.Fatalf("default collection should still surface dungeon festivals: %v", candidateNames(all))
+	}
+}
+
+func TestWatchCompletionExcludesRitualFestivals(t *testing.T) {
+	festivals := t.TempDir()
+	makeWatchTestFestival(t, filepath.Join(festivals, "active", "launch-work-LW0001"))
+	makeWatchTestFestival(t, filepath.Join(festivals, "ritual", "weekly-review-RI-WR0001"))
+
+	working := shared.CollectFestivalPickCandidates(festivals, shared.FestivalPickerOptions{
+		IncludeStatusDirectories: false,
+		PreferredStatuses:        watchPickerStatuses,
+	})
+	if candidateNamePresent(working, "weekly-review-RI-WR0001") {
+		t.Fatalf("watch completion must exclude ritual festivals (templates, never watched): %v", candidateNames(working))
+	}
+	if !candidateNamePresent(working, "launch-work-LW0001") {
+		t.Fatalf("watch completion should include working festivals: %v", candidateNames(working))
 	}
 }
 

--- a/internal/commands/watch/resolver.go
+++ b/internal/commands/watch/resolver.go
@@ -210,14 +210,10 @@ func isFestivalNotFound(err error) bool {
 	return stderrors.As(err, &structured) && structured.Code == errors.ErrCodeNotFound
 }
 
-// watchPickerStatuses are the statuses surfaced by `fest watch`, in display
-// priority order. Ritual templates are excluded: `fest ritual run` copies a
-// ritual into active/ before there is anything to watch, so the template is
-// never itself a watch target. dungeon/* is terminal and likewise never watched.
+// watchPickerStatuses are watch targets, in display priority order. Ritual is a
+// template (run into active/ first) and dungeon is terminal, so neither is watched.
 var watchPickerStatuses = []string{"active", "ready", "planning"}
 
-// pickerStatuses narrows the watch picker to the watchable status dir the user is
-// inside, else all watchable statuses (active, ready, planning).
 func pickerStatuses(cwd, festivalsDir string) []string {
 	if narrowed := preferredPickerStatuses(cwd, festivalsDir); len(narrowed) > 0 {
 		return narrowed

--- a/internal/commands/watch/resolver.go
+++ b/internal/commands/watch/resolver.go
@@ -100,6 +100,7 @@ func (r targetResolver) resolve(ctx context.Context, selector string) (*show.Fes
 	path, err := r.pickFestival(ctx, festivalsDir, shared.FestivalPickerOptions{
 		IncludeStatusDirectories: false,
 		PreferredStatuses:        pickerStatuses(cwd, festivalsDir),
+		FallbackStatuses:         watchPickerStatuses,
 		OrderByStatusThenRecency: true,
 	})
 	if err != nil {

--- a/internal/commands/watch/resolver.go
+++ b/internal/commands/watch/resolver.go
@@ -100,6 +100,7 @@ func (r targetResolver) resolve(ctx context.Context, selector string) (*show.Fes
 	path, err := r.pickFestival(ctx, festivalsDir, shared.FestivalPickerOptions{
 		IncludeStatusDirectories: false,
 		PreferredStatuses:        pickerStatuses(cwd, festivalsDir),
+		OrderByStatusThenRecency: true,
 	})
 	if err != nil {
 		return nil, err
@@ -209,13 +210,19 @@ func isFestivalNotFound(err error) bool {
 	return stderrors.As(err, &structured) && structured.Code == errors.ErrCodeNotFound
 }
 
-// pickerStatuses narrows the watch picker to the working status dir the user is
-// inside, else all working statuses. Dungeon is terminal, so never offered.
+// watchPickerStatuses are the statuses surfaced by `fest watch`, in display
+// priority order. Ritual templates are excluded: `fest ritual run` copies a
+// ritual into active/ before there is anything to watch, so the template is
+// never itself a watch target. dungeon/* is terminal and likewise never watched.
+var watchPickerStatuses = []string{"active", "ready", "planning"}
+
+// pickerStatuses narrows the watch picker to the watchable status dir the user is
+// inside, else all watchable statuses (active, ready, planning).
 func pickerStatuses(cwd, festivalsDir string) []string {
 	if narrowed := preferredPickerStatuses(cwd, festivalsDir); len(narrowed) > 0 {
 		return narrowed
 	}
-	return id.WorkingStatusDirectories
+	return watchPickerStatuses
 }
 
 func preferredPickerStatuses(cwd, festivalsDir string) []string {
@@ -227,7 +234,7 @@ func preferredPickerStatuses(cwd, festivalsDir string) []string {
 	if strings.HasPrefix(rel, "../") {
 		return nil
 	}
-	for _, status := range id.WorkingStatusDirectories {
+	for _, status := range watchPickerStatuses {
 		status = filepath.ToSlash(id.ResolveStatusPath(status))
 		if rel == status || strings.HasPrefix(rel, status+"/") {
 			return []string{status}

--- a/internal/commands/watch/resolver_test.go
+++ b/internal/commands/watch/resolver_test.go
@@ -292,8 +292,6 @@ func TestPreferredPickerStatusesIgnoresDungeon(t *testing.T) {
 }
 
 func TestPreferredPickerStatusesIgnoresRitual(t *testing.T) {
-	// Ritual festivals are templates, not watch targets, so a ritual cwd must
-	// not narrow to ritual; it falls back to all watchable statuses.
 	got := preferredPickerStatuses("/campaign/festivals/ritual/weekly-review-RI-WR0001", "/campaign/festivals")
 	if got != nil {
 		t.Fatalf("preferred statuses for a ritual cwd = %#v, want nil", got)

--- a/internal/commands/watch/resolver_test.go
+++ b/internal/commands/watch/resolver_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
 	"github.com/Obedience-Corp/fest/internal/commands/show"
 	festerrors "github.com/Obedience-Corp/fest/internal/errors"
-	"github.com/Obedience-Corp/fest/internal/id"
 )
 
 func TestTargetResolverSelectorWinsOverContext(t *testing.T) {
@@ -209,6 +208,9 @@ func TestTargetResolverPickerUsesWorkspaceContext(t *testing.T) {
 	if !reflect.DeepEqual(gotOptions.PreferredStatuses, []string{"active"}) {
 		t.Fatalf("preferred statuses = %#v", gotOptions.PreferredStatuses)
 	}
+	if !gotOptions.OrderByStatusThenRecency {
+		t.Fatal("watch picker must order by status priority then recency")
+	}
 }
 
 func TestTargetResolverPickerCancellationIsDistinct(t *testing.T) {
@@ -289,10 +291,31 @@ func TestPreferredPickerStatusesIgnoresDungeon(t *testing.T) {
 	}
 }
 
-func TestPickerStatusesFallsBackToWorkingStatuses(t *testing.T) {
+func TestPreferredPickerStatusesIgnoresRitual(t *testing.T) {
+	// Ritual festivals are templates, not watch targets, so a ritual cwd must
+	// not narrow to ritual; it falls back to all watchable statuses.
+	got := preferredPickerStatuses("/campaign/festivals/ritual/weekly-review-RI-WR0001", "/campaign/festivals")
+	if got != nil {
+		t.Fatalf("preferred statuses for a ritual cwd = %#v, want nil", got)
+	}
+}
+
+func TestPickerStatusesFallsBackToWatchableStatuses(t *testing.T) {
 	got := pickerStatuses("/campaign/festivals/dungeon/completed/2026-05", "/campaign/festivals")
-	if !reflect.DeepEqual(got, id.WorkingStatusDirectories) {
-		t.Fatalf("picker statuses for a dungeon cwd = %#v, want WorkingStatusDirectories", got)
+	if !reflect.DeepEqual(got, watchPickerStatuses) {
+		t.Fatalf("picker statuses for a dungeon cwd = %#v, want watchPickerStatuses", got)
+	}
+}
+
+func TestWatchableStatusesExcludeRitualAndOrderActiveFirst(t *testing.T) {
+	want := []string{"active", "ready", "planning"}
+	if !reflect.DeepEqual(watchPickerStatuses, want) {
+		t.Fatalf("watchPickerStatuses = %#v, want %#v", watchPickerStatuses, want)
+	}
+	for _, status := range watchPickerStatuses {
+		if status == "ritual" || strings.HasPrefix(status, "dungeon") {
+			t.Fatalf("watch picker must not surface %q (not a watch target)", status)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Orders the `fest watch` festival selection picker by lifecycle priority instead
of the current order-by-accident:

1. **active**, then **ready**, then **planning**
2. within each group, **most recently modified first**

It also excludes **ritual** festivals from `fest watch` (picker and shell
completion). A ritual is a repeatable template: `fest ritual run` copies it into
`active/` with a counter suffix, and that copy is what you watch. The template is
never the live festival, so it is not a watch target. `dungeon/*` stays excluded
(terminal).

## Root cause

The picker preserves candidate-collection order for the unfiltered list
(`internal/tui/picker/picker.go` only re-sorts on a typed query). The watch
resolver passed `PreferredStatuses: id.WorkingStatusDirectories`, which is
lifecycle order `[planning, ready, active, ritual]`, so the picker showed
planning first with ritual templates mixed in. `fest go` was already active-first
(it uses `defaultCandidateStatuses()` built from `id.PrimaryStatusDirs`), so this
was scoped to `fest watch`.

## Changes

- **`internal/commands/watch`**: new `watchPickerStatuses = [active, ready, planning]`
  (priority order, ritual + dungeon excluded), reused by both the picker resolver
  and shell completion. The resolver now requests recency ordering.
- **`internal/commands/shared`**: new opt-in `OrderByStatusThenRecency` picker
  option and a `ModTime` candidate field. Ordering is a pure, fixture-testable
  comparator (status rank -> mtime desc -> name) over a filesystem step that takes
  each festival's most-recent file mtime. Festivals whose mtime cannot be read sort
  last in their group and are never dropped.

Only the interactive watch picker opts in. `fest go` and watch completion keep
their existing alphabetical order and do no per-candidate stat work.

## Behavior changes

- Watch picker order is now active -> ready -> planning, newest-first per group.
- `fest watch` no longer surfaces ritual festivals in the picker or in
  `fest watch <TAB>` completion.

## Testing

- `just build` / `golangci-lint run ./...` (0 issues) / full `go test ./...` green.
- New pure comparator tests (grouping, status-precedence-beats-recency,
  missing-mtime-sorts-last, name tie-break, unknown-status-last) and host-temp
  `latestModTime` tests.
- New watch tests: watchable statuses exclude ritual and are active-first; ritual
  cwd does not narrow; picker passes the ordering flag; completion excludes ritual.

## Design

Design package: `workflow/design/fest-watch-picker-ordering-2026-06-15/` in the
campaign repo. Methodology note:
`docs/tribal-knowledge/ritual-templates-excluded-from-watch.md`.
