### PR TITLE
fix(workflow): show real phase type in workflow phase step header

### DIFF
--- a/internal/guidance/workflow/navigator.go
+++ b/internal/guidance/workflow/navigator.go
@@ -470,6 +470,17 @@ func (n *Navigator) FormatInstructions(ctx context.Context) (string, error) {
 	return n.formatStep(step, stepState)
 }
 
+// displayPhaseType returns the uppercased phase type for use in rendered headers.
+// It prefers the context's PhaseType (e.g. "ingest", "planning") over the mode
+// string, which is always "workflow" for workflow-based phases and gives no
+// useful identity when multiple workflow phases appear in sequence.
+func (n *Navigator) displayPhaseType() string {
+	if n.Ctx != nil && n.Ctx.PhaseType != "" {
+		return strings.ToUpper(n.Ctx.PhaseType)
+	}
+	return strings.ToUpper(string(n.mode))
+}
+
 // formatComplete renders the completion message using templates.
 func (n *Navigator) formatComplete() string {
 	type stepSummary struct {
@@ -486,7 +497,7 @@ func (n *Navigator) formatComplete() string {
 	}
 
 	data := map[string]any{
-		"PhaseType":  strings.ToUpper(string(n.mode)),
+		"PhaseType":  n.displayPhaseType(),
 		"TotalSteps": n.workflowState.TotalSteps,
 		"Steps":      steps,
 	}
@@ -515,11 +526,10 @@ func (n *Navigator) formatStep(step WorkflowStep, stepState *StepState) (string,
 	status := string(stepState.Status)
 	feedback := stepState.Feedback
 
-	// Show "PHASE GATE" for gate documents, phase type for workflows
-	phaseType := strings.ToUpper(string(n.mode))
 	isGate := n.docFilename == "GATES.md"
+	phaseType := n.displayPhaseType()
 	if isGate {
-		phaseType = strings.ToUpper(n.Ctx.PhaseType) + " PHASE GATE"
+		phaseType = phaseType + " PHASE GATE"
 	}
 
 	data := map[string]any{

--- a/internal/guidance/workflow/navigator_test.go
+++ b/internal/guidance/workflow/navigator_test.go
@@ -702,6 +702,46 @@ func TestNavigator_getAutonomyLevel(t *testing.T) {
 	}
 }
 
+func TestNavigator_FormatInstructions_ShowsPhaseType(t *testing.T) {
+	cases := []struct {
+		phaseType string
+		wantLabel string
+	}{
+		{"ingest", "INGEST PHASE"},
+		{"planning", "PLANNING PHASE"},
+		{"research", "RESEARCH PHASE"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.phaseType, func(t *testing.T) {
+			gctx := createTestGuidanceContext(t)
+			gctx.PhaseType = tc.phaseType
+			createTestWorkflow(t, gctx.FestivalPath)
+
+			nav, err := NewNavigator(gctx, guidance.ModeWorkflow)
+			if err != nil {
+				t.Fatalf("NewNavigator() error = %v", err)
+			}
+
+			if err := nav.Initialize(context.Background()); err != nil {
+				t.Fatalf("Initialize() error = %v", err)
+			}
+
+			instructions, err := nav.FormatInstructions(context.Background())
+			if err != nil {
+				t.Fatalf("FormatInstructions() error = %v", err)
+			}
+
+			if !strings.Contains(instructions, tc.wantLabel) {
+				t.Errorf("instructions missing %q; got:\n%s", tc.wantLabel, instructions)
+			}
+			if strings.Contains(instructions, "WORKFLOW PHASE") {
+				t.Errorf("instructions must not contain generic WORKFLOW PHASE label; got:\n%s", instructions)
+			}
+		})
+	}
+}
+
 // contains checks if a string contains a substring
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))


### PR DESCRIPTION
## Summary

- `Navigator.formatStep` and `formatComplete` were deriving the displayed phase type from `n.mode`, which is always `ModeWorkflow` for workflow-based phases. This caused every workflow phase header to read `WORKFLOW PHASE - Step N of M` regardless of whether the actual phase was ingest, planning, or research, making it impossible for agents to distinguish between consecutive workflow phases.
- Introduced `displayPhaseType()` on `Navigator` that prefers `n.Ctx.PhaseType` (the actual phase type string, e.g. `"ingest"`, `"planning"`) and falls back to `n.mode` only when the context type is absent.
- Gate rendering (`GATES.md` path) was already using `n.Ctx.PhaseType` for the suffix `"INGEST PHASE GATE"` but was mixing it with `n.mode` for non-gate workflow phases. Both paths now call `displayPhaseType()` consistently.

## Changed files

- `internal/guidance/workflow/navigator.go` - Add `displayPhaseType()`, update `formatStep` and `formatComplete` to use it
- `internal/guidance/workflow/navigator_test.go` - Add `TestNavigator_FormatInstructions_ShowsPhaseType` covering ingest, planning, research

## Test plan

- [ ] `just test unit` passes (2233 tests, 0 failures)
- [ ] `just lint all` passes (0 issues)
- [ ] New test `TestNavigator_FormatInstructions_ShowsPhaseType` asserts rendered header contains `INGEST PHASE`, `PLANNING PHASE`, `RESEARCH PHASE` and does not contain the generic `WORKFLOW PHASE` label

Closes intent: workflow-phase-fest-cli-improments-20260320-090647 [WI-ee98f2]
