### PR TITLE
fix(link): guard against silently hijacking an active festival's project link

### DIFF
--- a/internal/commands/navigation/go_link.go
+++ b/internal/commands/navigation/go_link.go
@@ -165,6 +165,15 @@ func linkFestivalToProject(ctx context.Context, cwd, targetPath string) error {
 	// Get the festival path for reverse navigation
 	festivalPath := loc.Festival.Path
 
+	if existing, existingFestivalPath, hasConflict := nav.ProjectConflict(festivalName, projectPath); hasConflict {
+		if isActiveFestivalPath(existingFestivalPath) {
+			return festErrors.Validation("project is already linked to an active festival").
+				WithField("existing_festival", existing).
+				WithField("project", projectPath).
+				WithField("hint", "use 'fest link --force' to override, or run 'fest unlink' from the active festival first")
+		}
+	}
+
 	// Set the bidirectional link with festival path
 	nav.SetLinkWithPath(festivalName, projectPath, festivalPath)
 

--- a/internal/commands/navigation/link.go
+++ b/internal/commands/navigation/link.go
@@ -21,6 +21,7 @@ import (
 type linkOptions struct {
 	showLink bool
 	json     bool
+	force    bool
 }
 
 // NewLinkCommand creates the link command
@@ -65,6 +66,7 @@ Use 'fest unlink' to remove the link for current festival.`,
 
 	cmd.Flags().BoolVar(&opts.showLink, "show", false, "show current link")
 	cmd.Flags().BoolVar(&opts.json, "json", false, "output in JSON format")
+	cmd.Flags().BoolVar(&opts.force, "force", false, "overwrite an existing active festival link")
 
 	return cmd
 }
@@ -144,6 +146,18 @@ func runLink(ctx context.Context, targetPath string, opts *linkOptions) error {
 	// Create link with festival path for reverse navigation
 	festivalName := loc.Festival.Name
 	festivalPath := loc.Festival.Path
+
+	if !opts.force {
+		if existing, existingFestivalPath, hasConflict := nav.ProjectConflict(festivalName, absPath); hasConflict {
+			if isActiveFestivalPath(existingFestivalPath) {
+				return errors.Validation("project is already linked to an active festival").
+					WithField("existing_festival", existing).
+					WithField("project", absPath).
+					WithField("hint", "use --force to override, or run 'fest unlink' from the active festival first")
+			}
+		}
+	}
+
 	nav.SetLinkWithPath(festivalName, absPath, festivalPath)
 
 	// Save navigation state
@@ -437,4 +451,20 @@ func findFestivalStatus(festivalsDir, festivalName string) string {
 		}
 	}
 	return ""
+}
+
+// isActiveFestivalPath reports whether the stored festival path is inside the active/ directory.
+// A festival path of "" means the link predates festival-path tracking; treat it as active
+// to be safe (prefer the existing link when uncertain).
+func isActiveFestivalPath(festivalPath string) bool {
+	if festivalPath == "" {
+		return true
+	}
+	parts := strings.Split(filepath.ToSlash(festivalPath), "/")
+	for _, part := range parts {
+		if part == "active" {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/navigation/state.go
+++ b/internal/navigation/state.go
@@ -189,6 +189,21 @@ func (n *Navigation) SetLinkWithPath(festivalName, projectPath, festivalPath str
 	n.ProjectLinks[projectPath] = festivalName
 }
 
+// ProjectConflict returns information about a conflicting project link, if one exists.
+// It reports the existing festival name, its stored festival path, and whether it
+// differs from the requesting festival. Callers use this to warn before overwriting.
+func (n *Navigation) ProjectConflict(festivalName, projectPath string) (existingFestival string, existingFestivalPath string, hasConflict bool) {
+	existing, ok := n.ProjectLinks[projectPath]
+	if !ok || existing == festivalName {
+		return "", "", false
+	}
+	existingLink := n.Links[existing]
+	if existingLink != nil {
+		return existing, existingLink.FestivalPath, true
+	}
+	return existing, "", true
+}
+
 // GetLink retrieves a project link for a festival
 func (n *Navigation) GetLink(festivalName string) (*Link, bool) {
 	link, ok := n.Links[festivalName]

--- a/internal/navigation/state_test.go
+++ b/internal/navigation/state_test.go
@@ -606,3 +606,96 @@ func TestNavigation_RelinkWithSaveLoadCycle(t *testing.T) {
 		t.Errorf("After persist, expected 1 project link, got %d", len(nav3.ProjectLinks))
 	}
 }
+
+func TestNavigation_ProjectConflict_NoConflict(t *testing.T) {
+	setupTestCampaign(t)
+
+	nav, err := LoadNavigation()
+	if err != nil {
+		t.Fatalf("LoadNavigation() error = %v", err)
+	}
+
+	nav.SetLink("festival-a", "/path/to/project-a")
+
+	existing, _, hasConflict := nav.ProjectConflict("festival-a", "/path/to/project-a")
+	if hasConflict {
+		t.Errorf("ProjectConflict() should not report conflict for same festival, got existing=%q", existing)
+	}
+
+	_, _, hasConflict = nav.ProjectConflict("festival-b", "/path/to/project-b")
+	if hasConflict {
+		t.Error("ProjectConflict() should not report conflict for unlinked project")
+	}
+}
+
+func TestNavigation_ProjectConflict_ActiveFestivalBlocked(t *testing.T) {
+	setupTestCampaign(t)
+
+	nav, err := LoadNavigation()
+	if err != nil {
+		t.Fatalf("LoadNavigation() error = %v", err)
+	}
+
+	projectPath := "/path/to/shared-project"
+	activeFestivalPath := "/path/to/campaigns/festivals/active/fest-a-FA0009"
+
+	nav.SetLinkWithPath("fest-a-FA0009", projectPath, activeFestivalPath)
+
+	existing, existingFestivalPath, hasConflict := nav.ProjectConflict("fest-b-FA0010", projectPath)
+	if !hasConflict {
+		t.Fatal("ProjectConflict() should detect conflict when project is linked to a different festival")
+	}
+	if existing != "fest-a-FA0009" {
+		t.Errorf("ProjectConflict() existing = %q, want %q", existing, "fest-a-FA0009")
+	}
+	if existingFestivalPath != activeFestivalPath {
+		t.Errorf("ProjectConflict() existingFestivalPath = %q, want %q", existingFestivalPath, activeFestivalPath)
+	}
+
+	if nav.GetLinkedFestival(projectPath) != "fest-a-FA0009" {
+		t.Error("ProjectConflict() must not mutate state; active festival link should still be intact")
+	}
+}
+
+func TestNavigation_ProjectConflict_PlanningFestivalAllowed(t *testing.T) {
+	setupTestCampaign(t)
+
+	nav, err := LoadNavigation()
+	if err != nil {
+		t.Fatalf("LoadNavigation() error = %v", err)
+	}
+
+	projectPath := "/path/to/shared-project"
+	planningFestivalPath := "/path/to/campaigns/festivals/planning/fest-b-FA0010"
+
+	nav.SetLinkWithPath("fest-b-FA0010", projectPath, planningFestivalPath)
+
+	existing, _, hasConflict := nav.ProjectConflict("fest-c-FA0011", projectPath)
+	if !hasConflict {
+		t.Fatal("ProjectConflict() should detect conflict for any different festival (caller decides to block or allow)")
+	}
+	if existing != "fest-b-FA0010" {
+		t.Errorf("ProjectConflict() existing = %q, want %q", existing, "fest-b-FA0010")
+	}
+}
+
+func TestNavigation_ProjectConflict_LegacyLinkTreatedAsActive(t *testing.T) {
+	setupTestCampaign(t)
+
+	nav, err := LoadNavigation()
+	if err != nil {
+		t.Fatalf("LoadNavigation() error = %v", err)
+	}
+
+	projectPath := "/path/to/shared-project"
+
+	nav.SetLink("legacy-festival", projectPath)
+
+	_, existingFestivalPath, hasConflict := nav.ProjectConflict("new-festival", projectPath)
+	if !hasConflict {
+		t.Fatal("ProjectConflict() should detect conflict for legacy link")
+	}
+	if existingFestivalPath != "" {
+		t.Errorf("ProjectConflict() existingFestivalPath should be empty for legacy link (no festival path stored), got %q", existingFestivalPath)
+	}
+}


### PR DESCRIPTION
## Summary

- `fest link` from a planning festival silently overwrote the project->festival mapping for projects already linked to an active festival, causing `fest commit` to tag commits with the wrong festival ID
- Added `Navigation.ProjectConflict()` in `internal/navigation/state.go` to detect existing conflicts without mutating state
- Both `fest link` and `fgo link` now reject the link with a clear error when the project is already linked to an active festival, unless `--force` is passed to `fest link`
- Legacy links with no stored festival path are treated as active (safe default)

## What changed

**`internal/navigation/state.go`**: Added `ProjectConflict(festivalName, projectPath string)` method that returns the existing festival name, its stored festival path, and whether a conflict exists -- without touching state.

**`internal/commands/navigation/link.go`**: Added `--force` flag; added pre-link conflict check calling `ProjectConflict` + `isActiveFestivalPath`; returns `errors.Validation` with a `--force` hint when blocked.

**`internal/commands/navigation/go_link.go`**: Same guard in `linkFestivalToProject` (the `fgo link` path); returns the same error with the `fest link --force` hint.

**`internal/navigation/state_test.go`**: 4 regression tests covering no-conflict, active-blocked (verifies state is not mutated), planning-festival-conflict-detected (caller decides), and legacy-link-treated-as-active.

## Gate result

`just lint vet` -- clean  
`just lint all` -- 0 issues  
`go test -short ./...` -- all pass (including 4 new tests)

## Scope notes

- The `fgo link` TUI path blocks with an error rather than a confirmation prompt, matching the same safety contract as `fest link`. A follow-on could add an interactive "override?" prompt to the TUI flow, but that is out of scope here.
- `SetLinkWithPath` itself is unchanged; the guard is in the command layer so internal callers (unit tests, chaining) can still force-link without a flag.

Fixes: `fest-link-from-a-planning-20260603-020739`
