### PR TITLE
feat(walk): add fest walk read-only festival orientation command

### DIFF
--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -39,6 +39,7 @@ import (
 	templatescmd "github.com/Obedience-Corp/fest/internal/commands/templates"
 	typescmd "github.com/Obedience-Corp/fest/internal/commands/types"
 	understandcmd "github.com/Obedience-Corp/fest/internal/commands/understand"
+	walkcmd "github.com/Obedience-Corp/fest/internal/commands/walk"
 	"github.com/Obedience-Corp/fest/internal/commands/validation"
 	watchcmd "github.com/Obedience-Corp/fest/internal/commands/watch"
 	"github.com/Obedience-Corp/fest/internal/commands/wizard"
@@ -264,6 +265,10 @@ func init() {
 	showCmd := show.NewShowCommand()
 	showCmd.GroupID = "query"
 	rootCmd.AddCommand(showCmd)
+
+	walkCmd := walkcmd.NewWalkCommand()
+	walkCmd.GroupID = "query"
+	rootCmd.AddCommand(walkCmd)
 
 	rulesCmd := show.NewRulesCommand()
 	rulesCmd.GroupID = "query"

--- a/internal/commands/walk/walk.go
+++ b/internal/commands/walk/walk.go
@@ -1,0 +1,464 @@
+package walk
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Obedience-Corp/fest/internal/commands/shared"
+	"github.com/Obedience-Corp/fest/internal/commands/show"
+	"github.com/Obedience-Corp/fest/internal/config"
+	"github.com/Obedience-Corp/fest/internal/errors"
+	gatescore "github.com/Obedience-Corp/fest/internal/gates"
+	"github.com/Obedience-Corp/fest/internal/progress"
+	"github.com/Obedience-Corp/fest/internal/scope"
+	tpl "github.com/Obedience-Corp/fest/internal/template"
+	"github.com/Obedience-Corp/fest/internal/ui"
+	"github.com/Obedience-Corp/fest/internal/workspace"
+	"github.com/spf13/cobra"
+)
+
+type walkOptions struct {
+	json bool
+	from string
+}
+
+// WalkView is the structured view returned by fest walk.
+type WalkView struct {
+	Kind     string `json:"kind"`
+	Name     string `json:"name"`
+	Status   string `json:"status"`
+	Path     string `json:"path"`
+	Goal     string `json:"goal,omitempty"`
+	Progress *walkProgress `json:"progress,omitempty"`
+	Next     string `json:"next,omitempty"`
+	Blocked  []walkBlocker `json:"blocked,omitempty"`
+	Gates    []string `json:"gates,omitempty"`
+	Warnings []string `json:"warnings,omitempty"`
+}
+
+type walkProgress struct {
+	Completed  int `json:"completed"`
+	Total      int `json:"total"`
+	Percentage int `json:"percentage"`
+}
+
+type walkBlocker struct {
+	Task    string `json:"task"`
+	Reason  string `json:"reason"`
+}
+
+// NewWalkCommand creates the walk/inspect command.
+func NewWalkCommand() *cobra.Command {
+	opts := &walkOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "walk [path]",
+		Aliases: []string{"inspect"},
+		Short:   "Guided read-only overview of a festival",
+		Annotations: map[string]string{
+			"scope": string(scope.Global),
+		},
+		Long: `Display a guided orientation overview of a festival without mutating anything.
+
+Shows what the festival is, where it is, its current status and progress,
+the next task, blocked tasks, active quality gates, and any warnings.
+
+Useful for quickly orienting inside a festival before continuing work,
+especially for rituals where the template and active run are distinct.
+
+EXAMPLES:
+  fest walk                      # Walk current festival from cwd
+  fest walk festivals/active/my-festival
+  fest walk --json               # Machine-readable output`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			if len(args) > 0 {
+				opts.from = args[0]
+			}
+			return runWalk(ctx, opts)
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.json, "json", false, "output in JSON format")
+	cmd.Flags().StringVar(&opts.from, "from", "", "festival path (defaults to current directory)")
+
+	return cmd
+}
+
+func runWalk(ctx context.Context, opts *walkOptions) error {
+	if err := ctx.Err(); err != nil {
+		return errors.Wrap(err, "context cancelled")
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return errors.IO("getting current directory", err)
+	}
+
+	startDir := cwd
+	if opts.from != "" {
+		if filepath.IsAbs(opts.from) {
+			startDir = opts.from
+		} else {
+			startDir = filepath.Join(cwd, opts.from)
+		}
+	}
+
+	campaignRoot, _ := workspace.DetectCampaign(ctx, startDir)
+
+	festival, err := resolveFestival(ctx, startDir, campaignRoot)
+	if err != nil {
+		return errors.Wrap(err, "not inside a festival").
+			WithHint("Run from within a festival directory or pass a festival path as an argument")
+	}
+
+	festivalPath := festival.Path
+
+	view := &WalkView{
+		Kind:   detectKind(festivalPath, festival.Status),
+		Name:   festival.Name,
+		Status: festival.Status,
+		Path:   festivalPath,
+	}
+
+	view.Goal = loadGoal(festivalPath)
+	view.Warnings = append(view.Warnings, kindWarnings(view.Kind, festival)...)
+
+	mgr, mgrErr := progress.NewManager(ctx, festivalPath)
+	if mgrErr == nil {
+		festProgress, progressErr := mgr.GetFestivalProgress(ctx, festivalPath)
+		if progressErr == nil && festProgress.Overall != nil {
+			view.Progress = &walkProgress{
+				Completed:  festProgress.Overall.Completed,
+				Total:      festProgress.Overall.Total,
+				Percentage: festProgress.Overall.Percentage,
+			}
+			for _, b := range festProgress.Overall.Blockers {
+				view.Blocked = append(view.Blocked, walkBlocker{
+					Task:   b.TaskID,
+					Reason: b.BlockerMessage,
+				})
+			}
+		}
+	}
+
+	view.Next = resolveNext(ctx, festivalPath, cwd)
+
+	if len(view.Blocked) > 0 {
+		for _, b := range view.Blocked {
+			if b.Task == view.Next {
+				view.Warnings = append(view.Warnings, fmt.Sprintf("next task is blocked: %s", b.Reason))
+			}
+		}
+	}
+
+	view.Gates = loadActiveGates(ctx, festivalPath)
+
+	if opts.json {
+		return emitJSON(view)
+	}
+	return emitText(view, festivalPath, campaignRoot)
+}
+
+func resolveFestival(ctx context.Context, startDir, campaignRoot string) (*show.FestivalInfo, error) {
+	festivalPath, resolveErr := shared.ResolveFestivalPath(startDir, "")
+	if resolveErr == nil && festivalPath != "" {
+		return show.DetectCurrentFestival(ctx, festivalPath, campaignRoot)
+	}
+	return show.DetectCurrentFestival(ctx, startDir, campaignRoot)
+}
+
+func detectKind(festivalPath, status string) string {
+	if strings.Contains(status, "dungeon") {
+		return "dungeon-run"
+	}
+
+	festivalsRoot := filepath.Dir(filepath.Dir(festivalPath))
+	ritualDir := filepath.Join(festivalsRoot, "ritual")
+	parentDir := filepath.Dir(festivalPath)
+
+	if parentDir == ritualDir {
+		return "ritual-template"
+	}
+
+	if status == "ritual" {
+		return "ritual-run"
+	}
+
+	return "festival"
+}
+
+func loadGoal(festivalPath string) string {
+	for _, name := range []string{"FESTIVAL_GOAL.md", "FESTIVAL_OVERVIEW.md"} {
+		goalPath := filepath.Join(festivalPath, name)
+		data, err := os.ReadFile(goalPath)
+		if err != nil {
+			continue
+		}
+		lines := strings.Split(string(data), "\n")
+		inFrontmatter := false
+		frontmatterDone := false
+		seenOpenDelim := false
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if !frontmatterDone {
+				if trimmed == "---" {
+					if !seenOpenDelim {
+						seenOpenDelim = true
+						inFrontmatter = true
+						continue
+					}
+					inFrontmatter = false
+					frontmatterDone = true
+					continue
+				}
+				if inFrontmatter {
+					continue
+				}
+			}
+			if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+				continue
+			}
+			if len(trimmed) > 300 {
+				trimmed = trimmed[:300] + "..."
+			}
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func resolveNext(ctx context.Context, festivalPath, cwd string) string {
+	if err := ctx.Err(); err != nil {
+		return ""
+	}
+
+	entries, err := os.ReadDir(festivalPath)
+	if err != nil {
+		return ""
+	}
+
+	mgr, mgrErr := progress.NewManager(ctx, festivalPath)
+
+	for _, entry := range entries {
+		if !entry.IsDir() || !hasNumericPrefix(entry.Name()) {
+			continue
+		}
+		phasePath := filepath.Join(festivalPath, entry.Name())
+		seqEntries, err := os.ReadDir(phasePath)
+		if err != nil {
+			continue
+		}
+		for _, seqEntry := range seqEntries {
+			if !seqEntry.IsDir() || !hasNumericPrefix(seqEntry.Name()) {
+				continue
+			}
+			seqPath := filepath.Join(phasePath, seqEntry.Name())
+			taskEntries, err := os.ReadDir(seqPath)
+			if err != nil {
+				continue
+			}
+			for _, taskEntry := range taskEntries {
+				if taskEntry.IsDir() || !strings.HasSuffix(taskEntry.Name(), ".md") {
+					continue
+				}
+				if !hasNumericPrefix(taskEntry.Name()) {
+					continue
+				}
+				taskPath := filepath.Join(seqPath, taskEntry.Name())
+				if mgrErr != nil {
+					rel, relErr := filepath.Rel(festivalPath, taskPath)
+					if relErr == nil {
+						return rel
+					}
+					return taskPath
+				}
+				store := mgr.Store()
+				status := progress.ResolveTaskStatus(store, festivalPath, taskPath)
+				if status == progress.StatusCompleted {
+					continue
+				}
+				rel, relErr := filepath.Rel(festivalPath, taskPath)
+				if relErr == nil {
+					return rel
+				}
+				return taskPath
+			}
+		}
+	}
+	return ""
+}
+
+func loadActiveGates(ctx context.Context, festivalPath string) []string {
+	if err := ctx.Err(); err != nil {
+		return nil
+	}
+
+	festivalsRoot, err := tpl.FindFestivalsRoot(festivalPath)
+	if err != nil {
+		festivalsRoot = filepath.Dir(filepath.Dir(festivalPath))
+	}
+
+	merger, err := gatescore.NewConfigMerger(festivalsRoot, nil)
+	if err != nil {
+		return nil
+	}
+
+	entries, err := os.ReadDir(festivalPath)
+	if err != nil {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	var names []string
+
+	for _, entry := range entries {
+		if !entry.IsDir() || !hasNumericPrefix(entry.Name()) {
+			continue
+		}
+		phasePath := filepath.Join(festivalPath, entry.Name())
+		seqEntries, err := os.ReadDir(phasePath)
+		if err != nil {
+			continue
+		}
+		for _, seqEntry := range seqEntries {
+			if !seqEntry.IsDir() || !hasNumericPrefix(seqEntry.Name()) {
+				continue
+			}
+			seqPath := filepath.Join(phasePath, seqEntry.Name())
+			policy, mergeErr := merger.MergeForSequence(ctx, festivalPath, phasePath, seqPath, gatescore.DefaultMergeOptions())
+			if mergeErr != nil {
+				continue
+			}
+			for _, gate := range policy.GetActiveGates() {
+				if _, ok := seen[gate.Template]; !ok {
+					seen[gate.Template] = struct{}{}
+					names = append(names, gate.Template)
+				}
+			}
+		}
+	}
+
+	return names
+}
+
+func kindWarnings(kind string, festival *show.FestivalInfo) []string {
+	if kind != "ritual-template" {
+		return nil
+	}
+	cfg, err := config.LoadFestivalConfig(festival.Path, "")
+	if err != nil || cfg == nil || cfg.Metadata.ID == "" {
+		return []string{"this is a ritual template, not an execution run; use 'fest ritual run <id>' to create a run"}
+	}
+	return []string{fmt.Sprintf("this is a ritual template, not an execution run; use 'fest ritual run %s' to create a run", cfg.Metadata.ID)}
+}
+
+func hasNumericPrefix(name string) bool {
+	if len(name) < 2 {
+		return false
+	}
+	digitCount := 0
+	for i := 0; i < len(name) && i < 4; i++ {
+		if name[i] == '_' && digitCount > 0 {
+			return true
+		}
+		if name[i] >= '0' && name[i] <= '9' {
+			digitCount++
+		} else {
+			return false
+		}
+	}
+	return false
+}
+
+func emitJSON(view *WalkView) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(view); err != nil {
+		return errors.Wrap(err, "encoding JSON output")
+	}
+	return nil
+}
+
+func emitText(view *WalkView, festivalPath, campaignRoot string) error {
+	displayPath := festivalPath
+	if campaignRoot != "" && strings.HasPrefix(festivalPath, campaignRoot) {
+		rel, err := filepath.Rel(campaignRoot, festivalPath)
+		if err == nil {
+			displayPath = rel
+		}
+	}
+
+	fmt.Println(ui.H1("Festival Walk"))
+	fmt.Printf("%s %s\n", ui.Label("Festival"), ui.Value(view.Name, ui.FestivalColor))
+	fmt.Printf("%s %s\n", ui.Label("Kind"), ui.Value(view.Kind))
+	fmt.Printf("%s %s\n", ui.Label("Status"), ui.GetStateStyle(view.Status).Render(view.Status))
+	fmt.Printf("%s %s\n", ui.Label("Path"), ui.Dim(displayPath))
+
+	if view.Goal != "" {
+		fmt.Println()
+		fmt.Println(ui.H2("Goal"))
+		fmt.Println(ui.Dim(strings.Repeat("─", 60)))
+		fmt.Printf("%s\n", view.Goal)
+	}
+
+	if view.Progress != nil {
+		fmt.Println()
+		fmt.Println(ui.H2("Progress"))
+		fmt.Println(ui.Dim(strings.Repeat("─", 60)))
+		fmt.Printf("%s %d/%d tasks (%d%%)\n",
+			ui.Label("Tasks"),
+			view.Progress.Completed,
+			view.Progress.Total,
+			view.Progress.Percentage,
+		)
+	}
+
+	if view.Next != "" {
+		fmt.Println()
+		fmt.Println(ui.H2("Next"))
+		fmt.Println(ui.Dim(strings.Repeat("─", 60)))
+		fmt.Printf("%s\n", view.Next)
+	}
+
+	if len(view.Blocked) > 0 {
+		fmt.Println()
+		fmt.Println(ui.H2("Blocked"))
+		fmt.Println(ui.Dim(strings.Repeat("─", 60)))
+		for _, b := range view.Blocked {
+			if b.Reason != "" {
+				fmt.Printf("%s %s %s\n", ui.StateIcon("blocked"), ui.Value(b.Task, ui.TaskColor), ui.Dim(b.Reason))
+			} else {
+				fmt.Printf("%s %s\n", ui.StateIcon("blocked"), ui.Value(b.Task, ui.TaskColor))
+			}
+		}
+	}
+
+	if len(view.Gates) > 0 {
+		fmt.Println()
+		fmt.Println(ui.H2("Active Gates"))
+		fmt.Println(ui.Dim(strings.Repeat("─", 60)))
+		for _, g := range view.Gates {
+			fmt.Printf("  %s\n", g)
+		}
+	}
+
+	if len(view.Warnings) > 0 {
+		fmt.Println()
+		fmt.Println(ui.H2("Warnings"))
+		fmt.Println(ui.Dim(strings.Repeat("─", 60)))
+		for _, w := range view.Warnings {
+			fmt.Printf("%s %s\n", ui.StateIcon("blocked"), ui.Warning(w))
+		}
+	}
+
+	return nil
+}

--- a/internal/commands/walk/walk_test.go
+++ b/internal/commands/walk/walk_test.go
@@ -1,0 +1,320 @@
+package walk
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/commands/show"
+)
+
+func makeMinimalFestival(t *testing.T, root, name, status string) string {
+	t.Helper()
+	dir := filepath.Join(root, "festivals", status, name)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "FESTIVAL_GOAL.md"), []byte("A test goal line.\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func makePhaseAndTask(t *testing.T, festivalDir, phaseName, seqName, taskName string) {
+	t.Helper()
+	phaseDir := filepath.Join(festivalDir, phaseName)
+	seqDir := filepath.Join(phaseDir, seqName)
+	if err := os.MkdirAll(seqDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(phaseDir, "PHASE_GOAL.md"), []byte("# Phase\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(seqDir, "SEQUENCE_GOAL.md"), []byte("# Seq\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(seqDir, taskName), []byte("# Task\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDetectKind_Festival(t *testing.T) {
+	root := t.TempDir()
+	festDir := makeMinimalFestival(t, root, "my-fest-MF0001", "active")
+	kind := detectKind(festDir, "active")
+	if kind != "festival" {
+		t.Errorf("detectKind() = %q, want %q", kind, "festival")
+	}
+}
+
+func TestDetectKind_RitualTemplate(t *testing.T) {
+	root := t.TempDir()
+	ritualDir := filepath.Join(root, "festivals", "ritual")
+	festDir := filepath.Join(ritualDir, "my-ritual-RI-MR0001")
+	if err := os.MkdirAll(festDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(festDir, "FESTIVAL_GOAL.md"), []byte("goal\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	kind := detectKind(festDir, "ritual")
+	if kind != "ritual-template" {
+		t.Errorf("detectKind() = %q, want %q", kind, "ritual-template")
+	}
+}
+
+func TestDetectKind_DungeonRun(t *testing.T) {
+	root := t.TempDir()
+	festDir := makeMinimalFestival(t, root, "old-fest-OF0001", "dungeon/completed")
+	kind := detectKind(festDir, "dungeon/completed")
+	if kind != "dungeon-run" {
+		t.Errorf("detectKind() = %q, want %q", kind, "dungeon-run")
+	}
+}
+
+func TestLoadGoal_ReturnsFirstNonHeaderLine(t *testing.T) {
+	festDir := t.TempDir()
+	content := "---\nfest_status: active\n---\n# Title\n\nThis is the goal text.\n"
+	if err := os.WriteFile(filepath.Join(festDir, "FESTIVAL_GOAL.md"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	goal := loadGoal(festDir)
+	if goal != "This is the goal text." {
+		t.Errorf("loadGoal() = %q, want %q", goal, "This is the goal text.")
+	}
+}
+
+func TestLoadGoal_MissingFile(t *testing.T) {
+	festDir := t.TempDir()
+	goal := loadGoal(festDir)
+	if goal != "" {
+		t.Errorf("loadGoal() = %q, want empty", goal)
+	}
+}
+
+func TestHasNumericPrefix_Walk(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"001_PLAN", true},
+		{"01_setup", true},
+		{"001", false},
+		{"abc_test", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		got := hasNumericPrefix(tc.name)
+		if got != tc.want {
+			t.Errorf("hasNumericPrefix(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestResolveNext_ReturnsFirstIncompleteTask(t *testing.T) {
+	root := t.TempDir()
+	festDir := makeMinimalFestival(t, root, "my-fest-MF0001", "active")
+	makePhaseAndTask(t, festDir, "001_IMPL", "01_core", "01_first_task.md")
+
+	next := resolveNext(context.Background(), festDir, festDir)
+	if next == "" {
+		t.Fatal("resolveNext() returned empty string, want a task path")
+	}
+	if !strings.Contains(next, "01_first_task.md") {
+		t.Errorf("resolveNext() = %q, want to contain '01_first_task.md'", next)
+	}
+}
+
+func TestResolveNext_EmptyFestival(t *testing.T) {
+	root := t.TempDir()
+	festDir := makeMinimalFestival(t, root, "empty-fest-EF0001", "active")
+
+	next := resolveNext(context.Background(), festDir, festDir)
+	if next != "" {
+		t.Errorf("resolveNext() on empty festival = %q, want empty", next)
+	}
+}
+
+func TestRunWalk_JSONOutput(t *testing.T) {
+	root := t.TempDir()
+	festDir := makeMinimalFestival(t, root, "my-fest-MF0001", "active")
+	makePhaseAndTask(t, festDir, "001_IMPL", "01_core", "01_task.md")
+
+	origCWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origCWD) }()
+
+	if err := os.Chdir(festDir); err != nil {
+		t.Fatal(err)
+	}
+
+	origStdout := os.Stdout
+	r, w, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		t.Fatal(pipeErr)
+	}
+	os.Stdout = w
+
+	runErr := runWalk(context.Background(), &walkOptions{json: true})
+
+	if closeErr := w.Close(); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+	os.Stdout = origStdout
+
+	var buf bytes.Buffer
+	if _, readErr := buf.ReadFrom(r); readErr != nil {
+		t.Fatal(readErr)
+	}
+
+	if runErr != nil {
+		t.Fatalf("runWalk() error: %v", runErr)
+	}
+
+	var view WalkView
+	if unmarshalErr := json.Unmarshal(buf.Bytes(), &view); unmarshalErr != nil {
+		t.Fatalf("failed to parse JSON output: %v\noutput: %s", unmarshalErr, buf.String())
+	}
+
+	if view.Name == "" {
+		t.Error("WalkView.Name is empty")
+	}
+	if view.Kind == "" {
+		t.Error("WalkView.Kind is empty")
+	}
+	if view.Status == "" {
+		t.Error("WalkView.Status is empty")
+	}
+}
+
+func TestRunWalk_ErrorOutsideFestival(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	origCWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origCWD) }()
+
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	err = runWalk(context.Background(), &walkOptions{})
+	if err == nil {
+		t.Fatal("runWalk() expected error outside festival, got nil")
+	}
+}
+
+func TestRunWalk_WithFromFlag(t *testing.T) {
+	root := t.TempDir()
+	festDir := makeMinimalFestival(t, root, "my-fest-MF0001", "active")
+
+	origStdout := os.Stdout
+	r, w, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		t.Fatal(pipeErr)
+	}
+	os.Stdout = w
+
+	err := runWalk(context.Background(), &walkOptions{json: true, from: festDir})
+
+	if closeErr := w.Close(); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+	os.Stdout = origStdout
+
+	var buf bytes.Buffer
+	if _, readErr := buf.ReadFrom(r); readErr != nil {
+		t.Fatal(readErr)
+	}
+
+	if err != nil {
+		t.Fatalf("runWalk() with --from error: %v", err)
+	}
+
+	var view WalkView
+	if unmarshalErr := json.Unmarshal(buf.Bytes(), &view); unmarshalErr != nil {
+		t.Fatalf("failed to parse JSON: %v\noutput: %s", unmarshalErr, buf.String())
+	}
+	if view.Name != "my-fest-MF0001" {
+		t.Errorf("WalkView.Name = %q, want %q", view.Name, "my-fest-MF0001")
+	}
+}
+
+func TestKindWarnings_RitualTemplate(t *testing.T) {
+	root := t.TempDir()
+	ritualDir := filepath.Join(root, "festivals", "ritual")
+	festDir := filepath.Join(ritualDir, "my-ritual-RI-MR0001")
+	if err := os.MkdirAll(festDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(festDir, "FESTIVAL_GOAL.md"), []byte("goal\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	festival := &show.FestivalInfo{
+		Path: festDir,
+		Name: "my-ritual-RI-MR0001",
+	}
+	warnings := kindWarnings("ritual-template", festival)
+	if len(warnings) == 0 {
+		t.Fatal("kindWarnings() returned no warnings for ritual-template kind")
+	}
+	if !strings.Contains(warnings[0], "ritual template") {
+		t.Errorf("warning = %q, want to mention 'ritual template'", warnings[0])
+	}
+}
+
+func TestKindWarnings_NonRitual(t *testing.T) {
+	root := t.TempDir()
+	festDir := makeMinimalFestival(t, root, "my-fest-MF0001", "active")
+
+	festival := &show.FestivalInfo{
+		Path: festDir,
+		Name: "my-fest-MF0001",
+	}
+	warnings := kindWarnings("festival", festival)
+	if len(warnings) != 0 {
+		t.Errorf("kindWarnings() returned %d warnings for non-ritual, want 0", len(warnings))
+	}
+}
+
+func TestRunWalk_GoalInOutput(t *testing.T) {
+	root := t.TempDir()
+	festDir := makeMinimalFestival(t, root, "my-fest-MF0001", "active")
+
+	origStdout := os.Stdout
+	r, w, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		t.Fatal(pipeErr)
+	}
+	os.Stdout = w
+
+	err := runWalk(context.Background(), &walkOptions{from: festDir})
+
+	if closeErr := w.Close(); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+	os.Stdout = origStdout
+
+	var buf bytes.Buffer
+	if _, readErr := buf.ReadFrom(r); readErr != nil {
+		t.Fatal(readErr)
+	}
+
+	if err != nil {
+		t.Fatalf("runWalk() error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "A test goal line.") {
+		t.Errorf("output missing goal text; got:\n%s", output)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `fest walk` (aliased as `fest inspect`) as a read-only, guided orientation command that answers the most common questions a user or agent has before continuing work in a festival: what is this festival, where is it, what is its status, what comes next, what is blocked, and what gates are active.
- Composes existing `show.DetectCurrentFestival`, `progress.Manager`, and `gates.ConfigMerger` rather than adding new state or duplication.
- The command is strictly read-only; no file writes or state mutations occur in any code path.

## What the command outputs

```
Festival Walk
Festival  my-project-MP0001
Kind      festival
Status    active
Path      festivals/active/my-project-MP0001

Goal
────────────────────────────────────────────────────────────
Find high-signal monetizable problems ...

Progress
────────────────────────────────────────────────────────────
Tasks  12/45 tasks (27%)

Next
────────────────────────────────────────────────────────────
001_DISCOVER/01_buyer_and_signal_scan/02_mine_50_complaints.md

Active Gates
────────────────────────────────────────────────────────────
  testing
  review

Warnings
────────────────────────────────────────────────────────────
! next task is blocked: Waiting on external data
```

The `--json` flag produces a structured `WalkView` object covering all fields.

Ritual templates get an explicit warning with the exact `fest ritual run <id>` command to run.

## Relevant files

- `internal/commands/walk/walk.go` - command implementation (464 lines)
- `internal/commands/walk/walk_test.go` - 11 tests (320 lines)
- `internal/commands/root.go` - command registration in the query group

## Test plan

- [x] `just lint all` - 0 issues
- [x] `just test unit-raw` - all 101 packages pass (including new walk package)
- [x] `go build ./...` - clean
- [x] Tests cover: detectKind for all four festival kinds, loadGoal with frontmatter stripping, hasNumericPrefix, resolveNext returning first incomplete task, runWalk JSON output round-trip, error when run outside a festival, --from flag, kindWarnings for ritual-template and non-ritual, goal text in text output

## Scope notes

- JSON schema for `WalkView` is minimal-correct per the intent (first implementation slice). Future flags named in the intent (`--artifacts`, `--gates`, `--blocked`, `--next`, `--strict`) are not included but the structure leaves room.
- Output-directory awareness (RUN_OUTPUT.md parsing) and artifact summaries are called out in the intent as nice-to-have for later slices; not included here.
- The command uses `scope.Global` (same as `fest next`) so scope middleware does not pre-require a festival; it resolves the festival itself and errors with a clear hint if not found.
