### PR TITLE
feat(watch,status,progress): picker fallback + watch festival cycling

### DIFF
--- a/internal/commands/progress/picker_fallback_test.go
+++ b/internal/commands/progress/picker_fallback_test.go
@@ -1,0 +1,43 @@
+package progress
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestProgressPickerStatuses(t *testing.T) {
+	want := []string{"active", "ready", "planning"}
+	if len(progressPickerStatuses) != len(want) {
+		t.Fatalf("progressPickerStatuses length = %d, want %d", len(progressPickerStatuses), len(want))
+	}
+	for i, s := range want {
+		if progressPickerStatuses[i] != s {
+			t.Errorf("progressPickerStatuses[%d] = %q, want %q", i, progressPickerStatuses[i], s)
+		}
+	}
+}
+
+func TestPickFestivalForProgress_NoCampaign(t *testing.T) {
+	dir := t.TempDir()
+	path, err := pickFestivalForProgress(t.Context(), dir)
+	if err == nil {
+		t.Fatalf("expected error when no campaign workspace, got path %q", path)
+	}
+}
+
+func TestPickFestivalForProgress_EmptyFestivals(t *testing.T) {
+	dir := t.TempDir()
+	festivals := filepath.Join(dir, "festivals")
+	dotFestival := filepath.Join(festivals, ".festival")
+	if err := os.MkdirAll(dotFestival, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path, err := pickFestivalForProgress(t.Context(), dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != "" {
+		t.Errorf("expected empty path for empty festivals dir, got %q", path)
+	}
+}

--- a/internal/commands/progress/progress.go
+++ b/internal/commands/progress/progress.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/lifecycle"
 	"github.com/Obedience-Corp/fest/internal/progress"
 	"github.com/Obedience-Corp/fest/internal/scope"
+	"github.com/Obedience-Corp/fest/internal/workspace"
 	"github.com/spf13/cobra"
 )
 
@@ -121,12 +122,22 @@ func runProgress(ctx context.Context, opts *progressOptions) error {
 	}
 
 	// Use shared helper to resolve festival path (supports linked festivals)
-	resolvedFestivalPath, err := shared.ResolveFestivalPath(cwd, festivalPath)
-	if err != nil {
-		return errors.Wrap(err, "detecting festival location")
+	resolvedFestivalPath, resolveErr := shared.ResolveFestivalPath(cwd, festivalPath)
+	if resolveErr != nil {
+		if opts.festival != "" || opts.taskID != "" || opts.taskPath != "" {
+			return errors.Wrap(resolveErr, "detecting festival location")
+		}
+		picked, pickErr := pickFestivalForProgress(ctx, cwd)
+		if pickErr != nil {
+			return pickErr
+		}
+		if picked == "" {
+			return nil
+		}
+		resolvedFestivalPath = picked
 	}
 
-	targetPath := cwd // Use current directory for location detection
+	targetPath := resolvedFestivalPath
 	if opts.taskPath != "" {
 		resolvedTaskPath, err := resolveTaskPath(opts.taskPath, resolvedFestivalPath, cwd)
 		if err != nil {
@@ -172,4 +183,20 @@ func runProgress(ctx context.Context, opts *progressOptions) error {
 
 	// Show progress overview
 	return showProgressOverview(ctx, mgr, loc, opts)
+}
+
+var progressPickerStatuses = []string{"active", "ready", "planning"}
+
+func pickFestivalForProgress(ctx context.Context, cwd string) (string, error) {
+	festivalsDir, err := workspace.FindFestivals(cwd)
+	if err != nil || festivalsDir == "" {
+		return "", errors.NotFound("festival").
+			WithHint("navigate to a festival directory or a campaign workspace")
+	}
+	return shared.PickFestivalPath(ctx, festivalsDir, shared.FestivalPickerOptions{
+		IncludeStatusDirectories: false,
+		PreferredStatuses:        progressPickerStatuses,
+		FallbackStatuses:         progressPickerStatuses,
+		OrderByStatusThenRecency: true,
+	})
 }

--- a/internal/commands/show/show.go
+++ b/internal/commands/show/show.go
@@ -287,7 +287,7 @@ func runShowBySelector(ctx context.Context, selector string, opts *showOptions) 
 func emitShowFestival(ctx context.Context, festival *FestivalInfo, opts *showOptions, campaignRoot string) error {
 	// Watch mode - continuously refresh display
 	if opts.watch {
-		return runWatchMode(ctx, festival, opts)
+		return runWatchMode(ctx, festival, opts, false)
 	}
 
 	// Roadmap mode - full execution plan

--- a/internal/commands/show/standalone_watch.go
+++ b/internal/commands/show/standalone_watch.go
@@ -82,7 +82,7 @@ func (s *standaloneWatchSession) render(ctx context.Context, polling bool) error
 
 	clearScreen()
 	fmt.Print(formatStandaloneWorkflowProgress(info, standaloneRenderOptionsFromWatch(s.opts)))
-	printWatchFooter(polling)
+	printWatchFooter(polling, false)
 	s.addWatchPaths(info)
 	return nil
 }

--- a/internal/commands/show/watch.go
+++ b/internal/commands/show/watch.go
@@ -26,6 +26,7 @@ type WatchOptions struct {
 	Goals      bool
 	Collapsed  bool
 	InProgress bool
+	CycleHint  bool
 }
 
 // WatchFestival watches a festival using the existing show watch renderer.
@@ -39,34 +40,28 @@ func WatchFestival(ctx context.Context, festival *FestivalInfo, opts WatchOption
 		goals:      opts.Goals,
 		collapsed:  opts.Collapsed,
 		inProgress: opts.InProgress,
-	})
+	}, opts.CycleHint)
 }
 
 // runWatchMode watches for file changes and refreshes the festival display.
 // Falls back to polling if file watching is not available.
-func runWatchMode(ctx context.Context, festival *FestivalInfo, opts *showOptions) error {
-	// Ensure .fest state directory exists so fsnotify has something to watch
+func runWatchMode(ctx context.Context, festival *FestivalInfo, opts *showOptions, cycleHint bool) error {
 	stateDir := filepath.Join(festival.Path, ".fest")
 	if err := os.MkdirAll(stateDir, 0755); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not create state directory: %v\n", err)
 	}
 
-	// Watch paths include the festival root directory to detect structural changes
-	// (new phases, fest.yaml modifications) in addition to state directory changes.
-	// This ensures `fest show --watch` reflects the full festival state.
 	watchPaths := []string{
-		festival.Path, // Festival root — detects structural changes
-		stateDir,      // State directory — detects progress/state changes
+		festival.Path,
+		stateDir,
 	}
 
-	// Initial render
 	clearScreen()
 	if err := renderFestivalView(ctx, festival, opts); err != nil {
 		return err
 	}
-	printWatchFooter(false)
+	printWatchFooter(false, cycleHint)
 
-	// Attempt file watching with fallback to polling
 	w, err := watch.New(watch.Config{
 		Paths:    watchPaths,
 		Debounce: 100 * time.Millisecond,
@@ -75,21 +70,19 @@ func runWatchMode(ctx context.Context, festival *FestivalInfo, opts *showOptions
 		},
 	}, func() {
 		clearScreen()
-		// Refresh festival info to get latest data
 		refreshed, err := DetectCurrentFestival(ctx, festival.Path, "")
 		if err == nil && refreshed != nil {
 			festival = refreshed
 		}
 		if err := renderFestivalView(ctx, festival, opts); err != nil {
-			// Log error but don't fail - just show stale data
 			fmt.Fprintf(os.Stderr, "%s could not refresh festival view: %v\n", ui.Warning("Warning:"), err)
 		}
-		printWatchFooter(false)
+		printWatchFooter(false, cycleHint)
 	})
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "File watching unavailable (%v), using polling fallback\n", err)
-		return runPollingMode(ctx, festival, opts)
+		return runPollingMode(ctx, festival, opts, cycleHint)
 	}
 	defer func() { _ = w.Close() }()
 
@@ -98,26 +91,24 @@ func runWatchMode(ctx context.Context, festival *FestivalInfo, opts *showOptions
 
 // runPollingMode continuously refreshes the festival display at the specified interval.
 // Used as a fallback when file watching is not available.
-func runPollingMode(ctx context.Context, festival *FestivalInfo, opts *showOptions) error {
+func runPollingMode(ctx context.Context, festival *FestivalInfo, opts *showOptions, cycleHint bool) error {
 	ticker := time.NewTicker(pollingInterval)
 	defer ticker.Stop()
 
-	// Re-render with polling indicator
 	clearScreen()
 	if err := renderFestivalView(ctx, festival, opts); err != nil {
 		return err
 	}
-	printWatchFooter(true)
+	printWatchFooter(true, cycleHint)
 
 	for {
 		select {
 		case <-ctx.Done():
-			fmt.Println() // Clean newline on exit
+			fmt.Println()
 			return nil
 		case <-ticker.C:
 			clearScreen()
 
-			// Refresh festival info to get latest data
 			refreshed, err := DetectCurrentFestival(ctx, festival.Path, "")
 			if err == nil && refreshed != nil {
 				festival = refreshed
@@ -126,7 +117,7 @@ func runPollingMode(ctx context.Context, festival *FestivalInfo, opts *showOptio
 			if err := renderFestivalView(ctx, festival, opts); err != nil {
 				return err
 			}
-			printWatchFooter(true)
+			printWatchFooter(true, cycleHint)
 		}
 	}
 }
@@ -185,11 +176,15 @@ func clearScreen() {
 }
 
 // printWatchFooter prints the watch mode footer with exit instructions.
-func printWatchFooter(polling bool) {
+func printWatchFooter(polling bool, cycleHint bool) {
 	fmt.Println()
+	suffix := "Watching for changes"
 	if polling {
-		fmt.Println(ui.Dim("Press Ctrl+C to exit • Polling for changes"))
+		suffix = "Polling for changes"
+	}
+	if cycleHint {
+		fmt.Println(ui.Dim("Ctrl+C to exit • ← → cycle festivals • " + suffix))
 	} else {
-		fmt.Println(ui.Dim("Press Ctrl+C to exit • Watching for changes"))
+		fmt.Println(ui.Dim("Press Ctrl+C to exit • " + suffix))
 	}
 }

--- a/internal/commands/status/handlers.go
+++ b/internal/commands/status/handlers.go
@@ -28,17 +28,25 @@ func runStatusShow(ctx context.Context, cmd *cobra.Command, opts *statusOptions)
 		return errors.IO("getting current directory", err)
 	}
 
-	// Resolve festival path (supports linked festivals via fest link)
-	_, err = shared.ResolveFestivalPath(cwd, opts.path)
-	if err != nil {
+	festivalPath, resolveErr := shared.ResolveFestivalPath(cwd, opts.path)
+	var detectPath string
+	if resolveErr != nil {
 		if opts.json {
 			return emitErrorJSON("not in a festival directory")
 		}
-		return errors.Wrap(err, "not inside a festival")
+		picked, pickErr := pickFestivalForDisplay(ctx, cwd)
+		if pickErr != nil {
+			return pickErr
+		}
+		if picked == "" {
+			return nil
+		}
+		detectPath = picked
+	} else {
+		detectPath = festivalPath
 	}
 
-	// Detect current location using cwd for accurate location detection
-	loc, err := show.DetectCurrentLocation(ctx, cwd)
+	loc, err := show.DetectCurrentLocation(ctx, detectPath)
 	if err != nil {
 		if opts.json {
 			return emitErrorJSON("not in a festival directory")
@@ -51,6 +59,22 @@ func runStatusShow(ctx context.Context, cmd *cobra.Command, opts *statusOptions)
 	}
 	return emitLocationText(ctx, loc)
 }
+
+func pickFestivalForDisplay(ctx context.Context, cwd string) (string, error) {
+	festivalsDir, err := workspace.FindFestivals(cwd)
+	if err != nil || festivalsDir == "" {
+		return "", errors.NotFound("festival").
+			WithHint("navigate to a festival directory or a campaign workspace")
+	}
+	return shared.PickFestivalPath(ctx, festivalsDir, shared.FestivalPickerOptions{
+		IncludeStatusDirectories: false,
+		PreferredStatuses:        statusPickerStatuses,
+		FallbackStatuses:         statusPickerStatuses,
+		OrderByStatusThenRecency: true,
+	})
+}
+
+var statusPickerStatuses = []string{"active", "ready", "planning"}
 
 // statusHandler is the signature for status set handler functions.
 type statusHandler func(ctx context.Context, display *ui.UI, cwd, newStatus string, opts *statusOptions) error

--- a/internal/commands/status/picker_fallback_test.go
+++ b/internal/commands/status/picker_fallback_test.go
@@ -1,0 +1,55 @@
+package status
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStatusPickerStatuses(t *testing.T) {
+	want := []string{"active", "ready", "planning"}
+	if len(statusPickerStatuses) != len(want) {
+		t.Fatalf("statusPickerStatuses length = %d, want %d", len(statusPickerStatuses), len(want))
+	}
+	for i, s := range want {
+		if statusPickerStatuses[i] != s {
+			t.Errorf("statusPickerStatuses[%d] = %q, want %q", i, statusPickerStatuses[i], s)
+		}
+	}
+}
+
+func TestPickFestivalForDisplay_NoCampaign(t *testing.T) {
+	dir := t.TempDir()
+	path, err := pickFestivalForDisplay(t.Context(), dir)
+	if err == nil {
+		t.Fatalf("expected error when no campaign workspace, got path %q", path)
+	}
+}
+
+func TestPickFestivalForDisplay_NoFestivalsMarker(t *testing.T) {
+	dir := t.TempDir()
+	festivals := filepath.Join(dir, "festivals")
+	if err := os.MkdirAll(festivals, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, err := pickFestivalForDisplay(t.Context(), dir)
+	if err == nil {
+		t.Fatal("expected error when no festivals marker, got nil")
+	}
+}
+
+func TestPickFestivalForDisplay_EmptyFestivals(t *testing.T) {
+	dir := t.TempDir()
+	festivals := filepath.Join(dir, "festivals")
+	dotFestival := filepath.Join(festivals, ".festival")
+	if err := os.MkdirAll(dotFestival, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path, err := pickFestivalForDisplay(t.Context(), dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != "" {
+		t.Errorf("expected empty path for empty festivals dir, got %q", path)
+	}
+}

--- a/internal/commands/watch/command.go
+++ b/internal/commands/watch/command.go
@@ -22,6 +22,8 @@ type commandDeps struct {
 	resolveStandalone func(context.Context) (*show.StandaloneWorkflowInfo, error)
 	watch             func(context.Context, *show.FestivalInfo, show.WatchOptions) error
 	watchStandalone   func(context.Context, *show.StandaloneWorkflowInfo, show.WatchOptions) error
+	detectFestival    func(context.Context, string) (*show.FestivalInfo, error)
+	listCycleTargets  func(context.Context, string) ([]string, error)
 }
 
 // NewWatchCommand creates the watch command.
@@ -30,13 +32,18 @@ func NewWatchCommand() *cobra.Command {
 }
 
 func defaultCommandDeps() commandDeps {
+	r := defaultResolver()
 	return commandDeps{
 		resolve: func(ctx context.Context, selector string) (*show.FestivalInfo, error) {
-			return defaultResolver().resolve(ctx, selector)
+			return r.resolve(ctx, selector)
 		},
 		resolveStandalone: defaultResolveStandaloneWorkflow,
 		watch:             show.WatchFestival,
 		watchStandalone:   show.WatchStandaloneWorkflow,
+		detectFestival: func(ctx context.Context, path string) (*show.FestivalInfo, error) {
+			return r.detectFestival(ctx, path)
+		},
+		listCycleTargets: defaultListCycleTargets,
 	}
 }
 
@@ -99,6 +106,16 @@ func runWatch(ctx context.Context, args []string, opts *options, deps commandDep
 		}
 		if workflow != nil {
 			return watchStandaloneWorkflow(ctx, workflow, *opts, deps)
+		}
+	}
+
+	if selector == "" && deps.listCycleTargets != nil {
+		cwd, err := os.Getwd()
+		if err == nil {
+			paths, listErr := deps.listCycleTargets(ctx, cwd)
+			if listErr == nil && len(paths) > 1 {
+				return runWatchCycle(ctx, paths, 0, *opts, deps)
+			}
 		}
 	}
 

--- a/internal/commands/watch/cycling.go
+++ b/internal/commands/watch/cycling.go
@@ -1,0 +1,141 @@
+package watch
+
+import (
+	"context"
+	"io"
+	"os"
+
+	"github.com/Obedience-Corp/fest/internal/commands/show"
+	"github.com/Obedience-Corp/fest/internal/errors"
+	"golang.org/x/term"
+)
+
+type cycleDirection int
+
+const (
+	cycleNext cycleDirection = iota
+	cyclePrev
+	cycleQuit
+)
+
+func runWatchCycle(ctx context.Context, paths []string, startIndex int, opts options, deps commandDeps) error {
+	if len(paths) == 0 {
+		return errors.Validation("no watchable festivals found")
+	}
+	if len(paths) == 1 {
+		return watchFestivalAtPath(ctx, paths[0], opts, deps)
+	}
+
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return watchFestivalAtPath(ctx, paths[startIndex], opts, deps)
+	}
+
+	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
+	if err != nil {
+		return watchFestivalAtPath(ctx, paths[startIndex], opts, deps)
+	}
+	defer func() { _ = term.Restore(int(os.Stdin.Fd()), oldState) }()
+
+	index := startIndex
+	for {
+		if ctx.Err() != nil {
+			return nil
+		}
+
+		path := paths[index]
+		festival, err := deps.detectFestival(ctx, path)
+		if err != nil {
+			if isFestivalNotFound(err) {
+				index = (index + 1) % len(paths)
+				continue
+			}
+			return err
+		}
+		if festival == nil {
+			index = (index + 1) % len(paths)
+			continue
+		}
+
+		watchCtx, cancelWatch := context.WithCancel(ctx)
+		watchDone := make(chan error, 1)
+		go func() {
+			watchDone <- deps.watch(watchCtx, festival, cycleWatchOptions(opts))
+		}()
+
+		dir := readCycleKey(ctx, os.Stdin, cancelWatch)
+		cancelWatch()
+		watchErr := <-watchDone
+		if watchErr != nil && watchCtx.Err() == nil {
+			return watchErr
+		}
+
+		if ctx.Err() != nil {
+			return nil
+		}
+		if dir == cycleQuit {
+			return nil
+		}
+		if dir == cycleNext {
+			index = (index + 1) % len(paths)
+		} else {
+			index = (index - 1 + len(paths)) % len(paths)
+		}
+	}
+}
+
+func watchFestivalAtPath(ctx context.Context, path string, opts options, deps commandDeps) error {
+	festival, err := deps.detectFestival(ctx, path)
+	if err != nil {
+		return err
+	}
+	if festival == nil {
+		return errors.NotFound("festival").WithField("path", path)
+	}
+	return watchFestival(ctx, festival, opts, deps)
+}
+
+func cycleWatchOptions(opts options) show.WatchOptions {
+	wo := showWatchOptions(opts)
+	wo.CycleHint = true
+	return wo
+}
+
+func readCycleKey(ctx context.Context, r io.Reader, cancelWatch context.CancelFunc) cycleDirection {
+	buf := make([]byte, 3)
+	keyCh := make(chan cycleDirection, 1)
+
+	go func() {
+		for {
+			n, err := r.Read(buf)
+			if err != nil || n == 0 {
+				keyCh <- cycleQuit
+				return
+			}
+			b := buf[:n]
+			if b[0] == 0x03 {
+				keyCh <- cycleQuit
+				return
+			}
+			if n >= 3 && b[0] == 0x1b && b[1] == '[' {
+				switch b[2] {
+				case 'C':
+					keyCh <- cycleNext
+					return
+				case 'D':
+					keyCh <- cyclePrev
+					return
+				}
+			}
+		}
+	}()
+
+	select {
+	case dir := <-keyCh:
+		if dir == cycleQuit {
+			cancelWatch()
+		}
+		return dir
+	case <-ctx.Done():
+		return cycleQuit
+	}
+}

--- a/internal/commands/watch/cycling_test.go
+++ b/internal/commands/watch/cycling_test.go
@@ -1,0 +1,169 @@
+package watch
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/commands/show"
+)
+
+func TestCycleWatchOptionsSetsCycleHint(t *testing.T) {
+	opts := options{summary: true, goals: true, collapsed: true}
+	got := cycleWatchOptions(opts)
+	if !got.CycleHint {
+		t.Fatal("cycleWatchOptions must set CycleHint = true")
+	}
+	if !got.Summary || !got.Goals || !got.Collapsed {
+		t.Fatalf("cycleWatchOptions dropped flags: %#v", got)
+	}
+}
+
+func TestRunWatchCycle_EmptyPaths(t *testing.T) {
+	err := runWatchCycle(t.Context(), nil, 0, options{}, commandDeps{
+		detectFestival: func(context.Context, string) (*show.FestivalInfo, error) {
+			return nil, nil
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for empty path list")
+	}
+}
+
+func TestRunWatchCycle_SinglePath_CallsWatch(t *testing.T) {
+	watchCalled := false
+	deps := commandDeps{
+		detectFestival: func(_ context.Context, path string) (*show.FestivalInfo, error) {
+			return &show.FestivalInfo{Path: path}, nil
+		},
+		watch: func(_ context.Context, _ *show.FestivalInfo, _ show.WatchOptions) error {
+			watchCalled = true
+			return nil
+		},
+	}
+	paths := []string{"/festivals/active/fest-FS0001"}
+	if err := runWatchCycle(t.Context(), paths, 0, options{}, deps); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !watchCalled {
+		t.Fatal("watch delegate was not called for single-path cycle")
+	}
+}
+
+func TestReadCycleKey_RightArrow(t *testing.T) {
+	rightArrow := []byte{0x1b, '[', 'C'}
+	r := bytes.NewReader(rightArrow)
+	cancelCalled := false
+	cancel := func() { cancelCalled = true }
+	dir := readCycleKey(t.Context(), r, cancel)
+	if dir != cycleNext {
+		t.Errorf("readCycleKey = %v, want cycleNext", dir)
+	}
+	if cancelCalled {
+		t.Error("cancel should not be called for right arrow")
+	}
+}
+
+func TestReadCycleKey_LeftArrow(t *testing.T) {
+	leftArrow := []byte{0x1b, '[', 'D'}
+	r := bytes.NewReader(leftArrow)
+	dir := readCycleKey(t.Context(), r, func() {})
+	if dir != cyclePrev {
+		t.Errorf("readCycleKey = %v, want cyclePrev", dir)
+	}
+}
+
+func TestReadCycleKey_CtrlC(t *testing.T) {
+	ctrlC := []byte{0x03}
+	r := bytes.NewReader(ctrlC)
+	cancelCalled := false
+	dir := readCycleKey(t.Context(), r, func() { cancelCalled = true })
+	if dir != cycleQuit {
+		t.Errorf("readCycleKey = %v, want cycleQuit", dir)
+	}
+	if !cancelCalled {
+		t.Error("cancel should be called for ctrl+c")
+	}
+}
+
+func TestReadCycleKey_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	r := bytes.NewReader(nil)
+	dir := readCycleKey(ctx, r, func() {})
+	if dir != cycleQuit {
+		t.Errorf("readCycleKey on cancelled context = %v, want cycleQuit", dir)
+	}
+}
+
+func TestDefaultListCycleTargets_NoCampaign(t *testing.T) {
+	dir := t.TempDir()
+	paths, err := defaultListCycleTargets(t.Context(), dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(paths) != 0 {
+		t.Errorf("expected empty paths for no campaign, got %v", paths)
+	}
+}
+
+func TestWatchCommandUsesListCycleTargets(t *testing.T) {
+	listCalled := false
+	watchCalled := false
+
+	deps := commandDeps{
+		resolveStandalone: func(context.Context) (*show.StandaloneWorkflowInfo, error) {
+			return nil, nil
+		},
+		resolve: func(_ context.Context, _ string) (*show.FestivalInfo, error) {
+			return &show.FestivalInfo{Path: "/festivals/active/single-FS0001"}, nil
+		},
+		watch: func(_ context.Context, _ *show.FestivalInfo, _ show.WatchOptions) error {
+			watchCalled = true
+			return nil
+		},
+		detectFestival: func(_ context.Context, path string) (*show.FestivalInfo, error) {
+			return &show.FestivalInfo{Path: path}, nil
+		},
+		listCycleTargets: func(_ context.Context, _ string) ([]string, error) {
+			listCalled = true
+			return []string{"/festivals/active/one-FS0001"}, nil
+		},
+	}
+
+	if err := runWatch(t.Context(), []string{}, &options{}, deps); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !listCalled {
+		t.Fatal("listCycleTargets was not called")
+	}
+	if !watchCalled {
+		t.Fatal("watch delegate was not called (single-path should delegate)")
+	}
+}
+
+func TestWatchCommandSkipsCyclingWhenSelectorProvided(t *testing.T) {
+	listCalled := false
+	deps := commandDeps{
+		resolveStandalone: func(context.Context) (*show.StandaloneWorkflowInfo, error) {
+			return nil, nil
+		},
+		resolve: func(_ context.Context, _ string) (*show.FestivalInfo, error) {
+			return &show.FestivalInfo{Path: "/festivals/active/explicit-FE0001"}, nil
+		},
+		watch: func(_ context.Context, _ *show.FestivalInfo, _ show.WatchOptions) error {
+			return nil
+		},
+		listCycleTargets: func(_ context.Context, _ string) ([]string, error) {
+			listCalled = true
+			return nil, nil
+		},
+	}
+
+	if err := runWatch(t.Context(), []string{"explicit-FE0001"}, &options{}, deps); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if listCalled {
+		t.Fatal("listCycleTargets must not be called when an explicit selector is given")
+	}
+}

--- a/internal/commands/watch/resolver.go
+++ b/internal/commands/watch/resolver.go
@@ -244,3 +244,24 @@ func noWatchTargetError() error {
 	return errors.Validation("festival could not be resolved from this directory").
 		WithHint("run from a festival, a linked project, or a campaign workspace with an interactive terminal")
 }
+
+func defaultListCycleTargets(ctx context.Context, cwd string) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	festivalsDir, err := workspace.FindFestivals(cwd)
+	if err != nil || festivalsDir == "" {
+		return nil, nil
+	}
+	items := shared.FestivalPickerItems(festivalsDir, shared.FestivalPickerOptions{
+		IncludeStatusDirectories: false,
+		PreferredStatuses:        watchPickerStatuses,
+		FallbackStatuses:         watchPickerStatuses,
+		OrderByStatusThenRecency: true,
+	})
+	paths := make([]string, 0, len(items))
+	for _, item := range items {
+		paths = append(paths, item.Value)
+	}
+	return paths, nil
+}


### PR DESCRIPTION
## Summary

Lands two related intents that both touch the picker/watch surface:

- **fest-tab-completion-when-no-20260612-100848**: `fest status` and `fest progress` fall back to the shared festival picker when run outside a festival directory, instead of erroring. Uses the same active/ready/planning priority order (most-recently-modified within group) that `fest watch` already uses.
- **fest-watch-cycle-when-no-20260516-134452**: In `fest watch` with no explicit selector, left/right arrow keys cycle through all watchable festivals in picker order. The footer shows `← → cycle festivals` when cycling is available. A single-festival watch session is unaffected.

## Changes

**Intent A (picker fallback for status and progress):**
- `internal/commands/status/handlers.go`: `runStatusShow` falls back to `pickFestivalForDisplay` when `ResolveFestivalPath` fails and the terminal is interactive. JSON mode still errors immediately.
- `internal/commands/progress/progress.go`: `runProgress` falls back to `pickFestivalForProgress` when not in festival context and no explicit `--festival`/`--task`/`--path` flags are set.
- Both pickers use the same `active/ready/planning` ordered set as the watch picker.

**Intent B (left/right cycling in fest watch):**
- `internal/commands/watch/cycling.go`: New file. `runWatchCycle` collects all watchable festival paths, runs a watch-cancel-advance loop, reads raw stdin for arrow key escape sequences, and cycles the index on `← →`. Falls back gracefully when stdin is not a TTY or raw mode fails.
- `internal/commands/watch/command.go`: `commandDeps` gains `detectFestival` and `listCycleTargets` fields. `runWatch` calls `runWatchCycle` when no selector is provided and multiple targets are available.
- `internal/commands/watch/resolver.go`: `defaultListCycleTargets` collects ordered festival paths using the shared picker items infrastructure.
- `internal/commands/show/watch.go`: `WatchOptions` gains `CycleHint bool`. `printWatchFooter` shows `← → cycle festivals` when set. `runWatchMode` and `runPollingMode` signatures updated to pass the hint through.

## Test plan

- [ ] `go test ./internal/commands/status/ -run TestStatusPicker` and `TestPickFestivalForDisplay`
- [ ] `go test ./internal/commands/progress/ -run TestProgressPicker` and `TestPickFestivalForProgress`
- [ ] `go test ./internal/commands/watch/ -run "TestCycle|TestReadCycle|TestRunWatchCycle|TestWatchCommand|TestDefaultList"`
- [ ] `just lint all` clean (0 issues)
- [ ] `go test -short ./...` all green

Intent IDs: fest-tab-completion-when-no-20260612-100848, fest-watch-cycle-when-no-20260516-134452
