### PR TITLE
Intent-backlog cleanup — fest (6 intents) [WI-ee98f2]

### DIFF
--- a/internal/commands/navigation/go_link.go
+++ b/internal/commands/navigation/go_link.go
@@ -165,6 +165,15 @@ func linkFestivalToProject(ctx context.Context, cwd, targetPath string) error {
 	// Get the festival path for reverse navigation
 	festivalPath := loc.Festival.Path
 
+	if existing, existingFestivalPath, hasConflict := nav.ProjectConflict(festivalName, projectPath); hasConflict {
+		if isActiveFestivalPath(existingFestivalPath) {
+			return festErrors.Validation("project is already linked to an active festival").
+				WithField("existing_festival", existing).
+				WithField("project", projectPath).
+				WithField("hint", "use 'fest link --force' to override, or run 'fest unlink' from the active festival first")
+		}
+	}
+
 	// Set the bidirectional link with festival path
 	nav.SetLinkWithPath(festivalName, projectPath, festivalPath)
 

--- a/internal/commands/navigation/go_link.go
+++ b/internal/commands/navigation/go_link.go
@@ -29,6 +29,8 @@ var (
 
 // NewGoLinkCommand creates the context-aware link subcommand for fest go
 func NewGoLinkCommand() *cobra.Command {
+	var force bool
+
 	cmd := &cobra.Command{
 		Use:   "link [path]",
 		Short: "Link current festival to a project directory (or vice versa)",
@@ -59,14 +61,16 @@ Examples:
 			if len(args) > 0 {
 				path = args[0]
 			}
-			return runGoLink(cmd.Context(), path)
+			return runGoLink(cmd.Context(), path, force)
 		},
 	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "overwrite an existing active festival link")
 
 	return cmd
 }
 
-func runGoLink(ctx context.Context, targetPath string) error {
+func runGoLink(ctx context.Context, targetPath string, force bool) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return festErrors.IO("getting current directory", err)
@@ -78,7 +82,7 @@ func runGoLink(ctx context.Context, targetPath string) error {
 	}
 
 	// We're in a project directory, show festival picker
-	return linkProjectToFestival(cwd)
+	return linkProjectToFestival(cwd, force)
 }
 
 // isInsideFestival checks if the path is within a festivals/ directory
@@ -192,7 +196,7 @@ func linkFestivalToProject(ctx context.Context, cwd, targetPath string) error {
 }
 
 // linkProjectToFestival shows a picker to select a festival to link
-func linkProjectToFestival(cwd string) error {
+func linkProjectToFestival(cwd string, force bool) error {
 	absPath, err := filepath.Abs(cwd)
 	if err != nil {
 		return festErrors.Wrap(err, "resolving current directory")
@@ -265,6 +269,17 @@ func linkProjectToFestival(cwd string) error {
 	nav, err := navigation.LoadNavigation()
 	if err != nil {
 		return festErrors.Wrap(err, "loading navigation state")
+	}
+
+	if !force {
+		if existing, existingFestivalPath, hasConflict := nav.ProjectConflict(selectedFestival, absPath); hasConflict {
+			if isActiveFestivalPath(existingFestivalPath) {
+				return festErrors.Validation("project is already linked to an active festival").
+					WithField("existing_festival", existing).
+					WithField("project", absPath).
+					WithField("hint", "use 'fgo link --force' to override, or run 'fest unlink' from the active festival first")
+			}
+		}
 	}
 
 	// Set the bidirectional link with festival path

--- a/internal/commands/navigation/go_link_test.go
+++ b/internal/commands/navigation/go_link_test.go
@@ -5,6 +5,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
+
+	nav "github.com/Obedience-Corp/fest/internal/navigation"
 )
 
 func TestIsInsideFestival(t *testing.T) {
@@ -341,4 +344,107 @@ func TestResolveFestivalPath(t *testing.T) {
 			t.Errorf("resolveFestivalPath(%q) = %q, want %q", tc.name, result, tc.expected)
 		}
 	}
+}
+
+func TestIsActiveFestivalPath_ImmediateParentOnly(t *testing.T) {
+	tests := []struct {
+		name         string
+		festivalPath string
+		want         bool
+	}{
+		{
+			"active festival",
+			"/campaign/festivals/active/my-fest",
+			true,
+		},
+		{
+			"planning festival",
+			"/campaign/festivals/planning/my-fest",
+			false,
+		},
+		{
+			"dungeon completed",
+			"/campaign/festivals/dungeon/completed/my-fest",
+			false,
+		},
+		{
+			"empty path treated as active",
+			"",
+			true,
+		},
+		{
+			"workspace under ancestor dir named active is not misclassified",
+			"/home/active/campaign/festivals/planning/my-fest",
+			false,
+		},
+		{
+			"deep active path with active ancestor dir not misclassified",
+			"/home/active/projects/active/campaign/festivals/planning/my-fest",
+			false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isActiveFestivalPath(tc.festivalPath)
+			if got != tc.want {
+				t.Errorf("isActiveFestivalPath(%q) = %v, want %v", tc.festivalPath, got, tc.want)
+			}
+		})
+	}
+}
+
+func newTestNav() *nav.Navigation {
+	return &nav.Navigation{
+		Version:      1,
+		UpdatedAt:    time.Now().UTC(),
+		Links:        make(map[string]*nav.Link),
+		ProjectLinks: make(map[string]string),
+		Shortcuts:    make(map[string]string),
+	}
+}
+
+func TestLinkProjectToFestival_HijackGuardBlocks(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "projects", "camp")
+	activeFestPath := filepath.Join(tmpDir, "festivals", "active", "active-fest-AF0001")
+	planningFestPath := filepath.Join(tmpDir, "festivals", "planning", "planning-fest-PF0001")
+
+	for _, d := range []string{projectPath, activeFestPath, planningFestPath} {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	n := newTestNav()
+	n.SetLinkWithPath("active-fest-AF0001", projectPath, activeFestPath)
+
+	existing, existingFestivalPath, hasConflict := n.ProjectConflict("planning-fest-PF0001", projectPath)
+	if !hasConflict {
+		t.Fatal("ProjectConflict() should detect conflict: project already linked to a different festival")
+	}
+	if existing != "active-fest-AF0001" {
+		t.Errorf("ProjectConflict() existing = %q, want %q", existing, "active-fest-AF0001")
+	}
+	if !isActiveFestivalPath(existingFestivalPath) {
+		t.Errorf("isActiveFestivalPath(%q) = false; guard should block re-link to planning festival", existingFestivalPath)
+	}
+
+	n2 := newTestNav()
+	n2.SetLinkWithPath("active-fest-AF0001", projectPath, activeFestPath)
+	n2.SetLinkWithPath("planning-fest-PF0001", projectPath, planningFestPath)
+
+	link, ok := n2.GetLink("active-fest-AF0001")
+	if ok && link.Path == projectPath {
+		t.Error("without guard, SetLinkWithPath silently re-points project away from active festival — this is the hijack bug #201 fixes")
+	}
+
+	n3 := newTestNav()
+	n3.SetLinkWithPath("active-fest-AF0001", filepath.Join(tmpDir, "projects", "other"), activeFestPath)
+	_, _, hasConflict = n3.ProjectConflict("planning-fest-PF0001", projectPath)
+	if hasConflict {
+		t.Error("ProjectConflict() should not report conflict when project is not yet linked")
+	}
+
+	_ = planningFestPath
 }

--- a/internal/commands/navigation/link.go
+++ b/internal/commands/navigation/link.go
@@ -21,6 +21,7 @@ import (
 type linkOptions struct {
 	showLink bool
 	json     bool
+	force    bool
 }
 
 // NewLinkCommand creates the link command
@@ -65,6 +66,7 @@ Use 'fest unlink' to remove the link for current festival.`,
 
 	cmd.Flags().BoolVar(&opts.showLink, "show", false, "show current link")
 	cmd.Flags().BoolVar(&opts.json, "json", false, "output in JSON format")
+	cmd.Flags().BoolVar(&opts.force, "force", false, "overwrite an existing active festival link")
 
 	return cmd
 }
@@ -144,6 +146,18 @@ func runLink(ctx context.Context, targetPath string, opts *linkOptions) error {
 	// Create link with festival path for reverse navigation
 	festivalName := loc.Festival.Name
 	festivalPath := loc.Festival.Path
+
+	if !opts.force {
+		if existing, existingFestivalPath, hasConflict := nav.ProjectConflict(festivalName, absPath); hasConflict {
+			if isActiveFestivalPath(existingFestivalPath) {
+				return errors.Validation("project is already linked to an active festival").
+					WithField("existing_festival", existing).
+					WithField("project", absPath).
+					WithField("hint", "use --force to override, or run 'fest unlink' from the active festival first")
+			}
+		}
+	}
+
 	nav.SetLinkWithPath(festivalName, absPath, festivalPath)
 
 	// Save navigation state
@@ -437,4 +451,20 @@ func findFestivalStatus(festivalsDir, festivalName string) string {
 		}
 	}
 	return ""
+}
+
+// isActiveFestivalPath reports whether the stored festival path is inside the active/ directory.
+// A festival path of "" means the link predates festival-path tracking; treat it as active
+// to be safe (prefer the existing link when uncertain).
+func isActiveFestivalPath(festivalPath string) bool {
+	if festivalPath == "" {
+		return true
+	}
+	parts := strings.Split(filepath.ToSlash(festivalPath), "/")
+	for _, part := range parts {
+		if part == "active" {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/commands/navigation/link.go
+++ b/internal/commands/navigation/link.go
@@ -92,7 +92,7 @@ func runLink(ctx context.Context, targetPath string, opts *linkOptions) error {
 			}
 			projectDir = absPath
 		}
-		return linkProjectToFestival(projectDir)
+		return linkProjectToFestival(projectDir, opts.force)
 	}
 
 	// Inside a festival - detect location for festival metadata
@@ -460,11 +460,5 @@ func isActiveFestivalPath(festivalPath string) bool {
 	if festivalPath == "" {
 		return true
 	}
-	parts := strings.Split(filepath.ToSlash(festivalPath), "/")
-	for _, part := range parts {
-		if part == "active" {
-			return true
-		}
-	}
-	return false
+	return filepath.Base(filepath.Dir(festivalPath)) == "active"
 }

--- a/internal/commands/progress/picker_fallback_test.go
+++ b/internal/commands/progress/picker_fallback_test.go
@@ -1,0 +1,43 @@
+package progress
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestProgressPickerStatuses(t *testing.T) {
+	want := []string{"active", "ready", "planning"}
+	if len(progressPickerStatuses) != len(want) {
+		t.Fatalf("progressPickerStatuses length = %d, want %d", len(progressPickerStatuses), len(want))
+	}
+	for i, s := range want {
+		if progressPickerStatuses[i] != s {
+			t.Errorf("progressPickerStatuses[%d] = %q, want %q", i, progressPickerStatuses[i], s)
+		}
+	}
+}
+
+func TestPickFestivalForProgress_NoCampaign(t *testing.T) {
+	dir := t.TempDir()
+	path, err := pickFestivalForProgress(t.Context(), dir)
+	if err == nil {
+		t.Fatalf("expected error when no campaign workspace, got path %q", path)
+	}
+}
+
+func TestPickFestivalForProgress_EmptyFestivals(t *testing.T) {
+	dir := t.TempDir()
+	festivals := filepath.Join(dir, "festivals")
+	dotFestival := filepath.Join(festivals, ".festival")
+	if err := os.MkdirAll(dotFestival, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path, err := pickFestivalForProgress(t.Context(), dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != "" {
+		t.Errorf("expected empty path for empty festivals dir, got %q", path)
+	}
+}

--- a/internal/commands/progress/progress.go
+++ b/internal/commands/progress/progress.go
@@ -137,7 +137,10 @@ func runProgress(ctx context.Context, opts *progressOptions) error {
 		resolvedFestivalPath = picked
 	}
 
-	targetPath := resolvedFestivalPath
+	targetPath := cwd
+	if resolveErr != nil {
+		targetPath = resolvedFestivalPath
+	}
 	if opts.taskPath != "" {
 		resolvedTaskPath, err := resolveTaskPath(opts.taskPath, resolvedFestivalPath, cwd)
 		if err != nil {

--- a/internal/commands/progress/progress.go
+++ b/internal/commands/progress/progress.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/lifecycle"
 	"github.com/Obedience-Corp/fest/internal/progress"
 	"github.com/Obedience-Corp/fest/internal/scope"
+	"github.com/Obedience-Corp/fest/internal/workspace"
 	"github.com/spf13/cobra"
 )
 
@@ -121,12 +122,22 @@ func runProgress(ctx context.Context, opts *progressOptions) error {
 	}
 
 	// Use shared helper to resolve festival path (supports linked festivals)
-	resolvedFestivalPath, err := shared.ResolveFestivalPath(cwd, festivalPath)
-	if err != nil {
-		return errors.Wrap(err, "detecting festival location")
+	resolvedFestivalPath, resolveErr := shared.ResolveFestivalPath(cwd, festivalPath)
+	if resolveErr != nil {
+		if opts.festival != "" || opts.taskID != "" || opts.taskPath != "" {
+			return errors.Wrap(resolveErr, "detecting festival location")
+		}
+		picked, pickErr := pickFestivalForProgress(ctx, cwd)
+		if pickErr != nil {
+			return pickErr
+		}
+		if picked == "" {
+			return nil
+		}
+		resolvedFestivalPath = picked
 	}
 
-	targetPath := cwd // Use current directory for location detection
+	targetPath := resolvedFestivalPath
 	if opts.taskPath != "" {
 		resolvedTaskPath, err := resolveTaskPath(opts.taskPath, resolvedFestivalPath, cwd)
 		if err != nil {
@@ -172,4 +183,20 @@ func runProgress(ctx context.Context, opts *progressOptions) error {
 
 	// Show progress overview
 	return showProgressOverview(ctx, mgr, loc, opts)
+}
+
+var progressPickerStatuses = []string{"active", "ready", "planning"}
+
+func pickFestivalForProgress(ctx context.Context, cwd string) (string, error) {
+	festivalsDir, err := workspace.FindFestivals(cwd)
+	if err != nil || festivalsDir == "" {
+		return "", errors.NotFound("festival").
+			WithHint("navigate to a festival directory or a campaign workspace")
+	}
+	return shared.PickFestivalPath(ctx, festivalsDir, shared.FestivalPickerOptions{
+		IncludeStatusDirectories: false,
+		PreferredStatuses:        progressPickerStatuses,
+		FallbackStatuses:         progressPickerStatuses,
+		OrderByStatusThenRecency: true,
+	})
 }

--- a/internal/commands/progress/progress_test.go
+++ b/internal/commands/progress/progress_test.go
@@ -1,11 +1,13 @@
 package progress
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/Obedience-Corp/fest/internal/commands/show"
 	"github.com/Obedience-Corp/fest/internal/errors"
 )
 
@@ -107,5 +109,54 @@ func writeTask(t *testing.T, path string) {
 	}
 	if err := os.WriteFile(path, []byte("# Task\n"), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
+	}
+}
+
+func TestProgressLocationGranularity_SubdirUsescwd(t *testing.T) {
+	root := t.TempDir()
+
+	festivalPath := filepath.Join(root, "festivals", "active", "my-fest-MF0001")
+	phaseDir := filepath.Join(festivalPath, "001_IMPL")
+	seqDir := filepath.Join(phaseDir, "01_core")
+
+	for _, d := range []string{seqDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(festivalPath, "FESTIVAL_GOAL.md"), []byte("goal\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(phaseDir, "PHASE_GOAL.md"), []byte("# Phase\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(seqDir, "SEQUENCE_GOAL.md"), []byte("# Seq\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	locFromPhase, err := show.DetectCurrentLocation(ctx, phaseDir)
+	if err != nil {
+		t.Fatalf("DetectCurrentLocation(phaseDir) error = %v", err)
+	}
+	if locFromPhase.Type != "phase" {
+		t.Errorf("from phase subdir: loc.Type = %q, want %q (regression: #204 used festival root, always producing 'festival')", locFromPhase.Type, "phase")
+	}
+
+	locFromSeq, err := show.DetectCurrentLocation(ctx, seqDir)
+	if err != nil {
+		t.Fatalf("DetectCurrentLocation(seqDir) error = %v", err)
+	}
+	if locFromSeq.Type != "sequence" {
+		t.Errorf("from sequence subdir: loc.Type = %q, want %q (regression: #204 used festival root, always producing 'festival')", locFromSeq.Type, "sequence")
+	}
+
+	locFromRoot, err := show.DetectCurrentLocation(ctx, festivalPath)
+	if err != nil {
+		t.Fatalf("DetectCurrentLocation(festivalPath) error = %v", err)
+	}
+	if locFromRoot.Type != "festival" {
+		t.Errorf("from festival root: loc.Type = %q, want %q", locFromRoot.Type, "festival")
 	}
 }

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -39,6 +39,7 @@ import (
 	templatescmd "github.com/Obedience-Corp/fest/internal/commands/templates"
 	typescmd "github.com/Obedience-Corp/fest/internal/commands/types"
 	understandcmd "github.com/Obedience-Corp/fest/internal/commands/understand"
+	walkcmd "github.com/Obedience-Corp/fest/internal/commands/walk"
 	"github.com/Obedience-Corp/fest/internal/commands/validation"
 	watchcmd "github.com/Obedience-Corp/fest/internal/commands/watch"
 	"github.com/Obedience-Corp/fest/internal/commands/wizard"
@@ -264,6 +265,10 @@ func init() {
 	showCmd := show.NewShowCommand()
 	showCmd.GroupID = "query"
 	rootCmd.AddCommand(showCmd)
+
+	walkCmd := walkcmd.NewWalkCommand()
+	walkCmd.GroupID = "query"
+	rootCmd.AddCommand(walkCmd)
 
 	rulesCmd := show.NewRulesCommand()
 	rulesCmd.GroupID = "query"

--- a/internal/commands/show/show.go
+++ b/internal/commands/show/show.go
@@ -287,7 +287,7 @@ func runShowBySelector(ctx context.Context, selector string, opts *showOptions) 
 func emitShowFestival(ctx context.Context, festival *FestivalInfo, opts *showOptions, campaignRoot string) error {
 	// Watch mode - continuously refresh display
 	if opts.watch {
-		return runWatchMode(ctx, festival, opts)
+		return runWatchMode(ctx, festival, opts, false)
 	}
 
 	// Roadmap mode - full execution plan

--- a/internal/commands/show/standalone_watch.go
+++ b/internal/commands/show/standalone_watch.go
@@ -82,7 +82,7 @@ func (s *standaloneWatchSession) render(ctx context.Context, polling bool) error
 
 	clearScreen()
 	fmt.Print(formatStandaloneWorkflowProgress(info, standaloneRenderOptionsFromWatch(s.opts)))
-	printWatchFooter(polling)
+	printWatchFooter(polling, false)
 	s.addWatchPaths(info)
 	return nil
 }

--- a/internal/commands/show/watch.go
+++ b/internal/commands/show/watch.go
@@ -26,6 +26,7 @@ type WatchOptions struct {
 	Goals      bool
 	Collapsed  bool
 	InProgress bool
+	CycleHint  bool
 }
 
 // WatchFestival watches a festival using the existing show watch renderer.
@@ -39,34 +40,28 @@ func WatchFestival(ctx context.Context, festival *FestivalInfo, opts WatchOption
 		goals:      opts.Goals,
 		collapsed:  opts.Collapsed,
 		inProgress: opts.InProgress,
-	})
+	}, opts.CycleHint)
 }
 
 // runWatchMode watches for file changes and refreshes the festival display.
 // Falls back to polling if file watching is not available.
-func runWatchMode(ctx context.Context, festival *FestivalInfo, opts *showOptions) error {
-	// Ensure .fest state directory exists so fsnotify has something to watch
+func runWatchMode(ctx context.Context, festival *FestivalInfo, opts *showOptions, cycleHint bool) error {
 	stateDir := filepath.Join(festival.Path, ".fest")
 	if err := os.MkdirAll(stateDir, 0755); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not create state directory: %v\n", err)
 	}
 
-	// Watch paths include the festival root directory to detect structural changes
-	// (new phases, fest.yaml modifications) in addition to state directory changes.
-	// This ensures `fest show --watch` reflects the full festival state.
 	watchPaths := []string{
-		festival.Path, // Festival root — detects structural changes
-		stateDir,      // State directory — detects progress/state changes
+		festival.Path,
+		stateDir,
 	}
 
-	// Initial render
 	clearScreen()
 	if err := renderFestivalView(ctx, festival, opts); err != nil {
 		return err
 	}
-	printWatchFooter(false)
+	printWatchFooter(false, cycleHint)
 
-	// Attempt file watching with fallback to polling
 	w, err := watch.New(watch.Config{
 		Paths:    watchPaths,
 		Debounce: 100 * time.Millisecond,
@@ -75,21 +70,19 @@ func runWatchMode(ctx context.Context, festival *FestivalInfo, opts *showOptions
 		},
 	}, func() {
 		clearScreen()
-		// Refresh festival info to get latest data
 		refreshed, err := DetectCurrentFestival(ctx, festival.Path, "")
 		if err == nil && refreshed != nil {
 			festival = refreshed
 		}
 		if err := renderFestivalView(ctx, festival, opts); err != nil {
-			// Log error but don't fail - just show stale data
 			fmt.Fprintf(os.Stderr, "%s could not refresh festival view: %v\n", ui.Warning("Warning:"), err)
 		}
-		printWatchFooter(false)
+		printWatchFooter(false, cycleHint)
 	})
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "File watching unavailable (%v), using polling fallback\n", err)
-		return runPollingMode(ctx, festival, opts)
+		return runPollingMode(ctx, festival, opts, cycleHint)
 	}
 	defer func() { _ = w.Close() }()
 
@@ -98,26 +91,24 @@ func runWatchMode(ctx context.Context, festival *FestivalInfo, opts *showOptions
 
 // runPollingMode continuously refreshes the festival display at the specified interval.
 // Used as a fallback when file watching is not available.
-func runPollingMode(ctx context.Context, festival *FestivalInfo, opts *showOptions) error {
+func runPollingMode(ctx context.Context, festival *FestivalInfo, opts *showOptions, cycleHint bool) error {
 	ticker := time.NewTicker(pollingInterval)
 	defer ticker.Stop()
 
-	// Re-render with polling indicator
 	clearScreen()
 	if err := renderFestivalView(ctx, festival, opts); err != nil {
 		return err
 	}
-	printWatchFooter(true)
+	printWatchFooter(true, cycleHint)
 
 	for {
 		select {
 		case <-ctx.Done():
-			fmt.Println() // Clean newline on exit
+			fmt.Println()
 			return nil
 		case <-ticker.C:
 			clearScreen()
 
-			// Refresh festival info to get latest data
 			refreshed, err := DetectCurrentFestival(ctx, festival.Path, "")
 			if err == nil && refreshed != nil {
 				festival = refreshed
@@ -126,7 +117,7 @@ func runPollingMode(ctx context.Context, festival *FestivalInfo, opts *showOptio
 			if err := renderFestivalView(ctx, festival, opts); err != nil {
 				return err
 			}
-			printWatchFooter(true)
+			printWatchFooter(true, cycleHint)
 		}
 	}
 }
@@ -185,11 +176,15 @@ func clearScreen() {
 }
 
 // printWatchFooter prints the watch mode footer with exit instructions.
-func printWatchFooter(polling bool) {
+func printWatchFooter(polling bool, cycleHint bool) {
 	fmt.Println()
+	suffix := "Watching for changes"
 	if polling {
-		fmt.Println(ui.Dim("Press Ctrl+C to exit • Polling for changes"))
+		suffix = "Polling for changes"
+	}
+	if cycleHint {
+		fmt.Println(ui.Dim("Ctrl+C to exit • ← → cycle festivals • " + suffix))
 	} else {
-		fmt.Println(ui.Dim("Press Ctrl+C to exit • Watching for changes"))
+		fmt.Println(ui.Dim("Press Ctrl+C to exit • " + suffix))
 	}
 }

--- a/internal/commands/status/handlers.go
+++ b/internal/commands/status/handlers.go
@@ -28,17 +28,25 @@ func runStatusShow(ctx context.Context, cmd *cobra.Command, opts *statusOptions)
 		return errors.IO("getting current directory", err)
 	}
 
-	// Resolve festival path (supports linked festivals via fest link)
-	_, err = shared.ResolveFestivalPath(cwd, opts.path)
-	if err != nil {
+	festivalPath, resolveErr := shared.ResolveFestivalPath(cwd, opts.path)
+	var detectPath string
+	if resolveErr != nil {
 		if opts.json {
 			return emitErrorJSON("not in a festival directory")
 		}
-		return errors.Wrap(err, "not inside a festival")
+		picked, pickErr := pickFestivalForDisplay(ctx, cwd)
+		if pickErr != nil {
+			return pickErr
+		}
+		if picked == "" {
+			return nil
+		}
+		detectPath = picked
+	} else {
+		detectPath = festivalPath
 	}
 
-	// Detect current location using cwd for accurate location detection
-	loc, err := show.DetectCurrentLocation(ctx, cwd)
+	loc, err := show.DetectCurrentLocation(ctx, detectPath)
 	if err != nil {
 		if opts.json {
 			return emitErrorJSON("not in a festival directory")
@@ -51,6 +59,22 @@ func runStatusShow(ctx context.Context, cmd *cobra.Command, opts *statusOptions)
 	}
 	return emitLocationText(ctx, loc)
 }
+
+func pickFestivalForDisplay(ctx context.Context, cwd string) (string, error) {
+	festivalsDir, err := workspace.FindFestivals(cwd)
+	if err != nil || festivalsDir == "" {
+		return "", errors.NotFound("festival").
+			WithHint("navigate to a festival directory or a campaign workspace")
+	}
+	return shared.PickFestivalPath(ctx, festivalsDir, shared.FestivalPickerOptions{
+		IncludeStatusDirectories: false,
+		PreferredStatuses:        statusPickerStatuses,
+		FallbackStatuses:         statusPickerStatuses,
+		OrderByStatusThenRecency: true,
+	})
+}
+
+var statusPickerStatuses = []string{"active", "ready", "planning"}
 
 // statusHandler is the signature for status set handler functions.
 type statusHandler func(ctx context.Context, display *ui.UI, cwd, newStatus string, opts *statusOptions) error

--- a/internal/commands/status/handlers.go
+++ b/internal/commands/status/handlers.go
@@ -28,7 +28,7 @@ func runStatusShow(ctx context.Context, cmd *cobra.Command, opts *statusOptions)
 		return errors.IO("getting current directory", err)
 	}
 
-	festivalPath, resolveErr := shared.ResolveFestivalPath(cwd, opts.path)
+	_, resolveErr := shared.ResolveFestivalPath(cwd, opts.path)
 	var detectPath string
 	if resolveErr != nil {
 		if opts.json {
@@ -43,7 +43,7 @@ func runStatusShow(ctx context.Context, cmd *cobra.Command, opts *statusOptions)
 		}
 		detectPath = picked
 	} else {
-		detectPath = festivalPath
+		detectPath = cwd
 	}
 
 	loc, err := show.DetectCurrentLocation(ctx, detectPath)

--- a/internal/commands/status/handlers_festival_test.go
+++ b/internal/commands/status/handlers_festival_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Obedience-Corp/fest/internal/commands/show"
 	"github.com/Obedience-Corp/fest/internal/scope"
 )
 
@@ -236,5 +237,57 @@ func TestAutoCommitStatusChange_SelectiveStaging(t *testing.T) {
 	committedFiles := string(out)
 	if strings.Contains(committedFiles, "unrelated.txt") {
 		t.Errorf("unrelated.txt should NOT appear in committed files:\n%s", committedFiles)
+	}
+}
+
+func TestStatusLocationGranularity_SubdirUsescwd(t *testing.T) {
+	root := t.TempDir()
+
+	festivalPath := filepath.Join(root, "festivals", "active", "my-fest-MF0001")
+	phaseDir := filepath.Join(festivalPath, "001_PLAN")
+	seqDir := filepath.Join(phaseDir, "01_research")
+
+	for _, d := range []string{seqDir} {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(festivalPath, "FESTIVAL_GOAL.md"), []byte("goal\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(phaseDir, "PHASE_GOAL.md"), []byte("# Phase\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(seqDir, "SEQUENCE_GOAL.md"), []byte("# Seq\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	locFromPhase, err := show.DetectCurrentLocation(ctx, phaseDir)
+	if err != nil {
+		t.Fatalf("DetectCurrentLocation(phaseDir) error = %v", err)
+	}
+	if locFromPhase.Type != "phase" {
+		t.Errorf("from phase subdir: loc.Type = %q, want %q (regression: #204 used festival root, always producing 'festival')", locFromPhase.Type, "phase")
+	}
+	if locFromPhase.Phase != "001_PLAN" {
+		t.Errorf("from phase subdir: loc.Phase = %q, want %q", locFromPhase.Phase, "001_PLAN")
+	}
+
+	locFromSeq, err := show.DetectCurrentLocation(ctx, seqDir)
+	if err != nil {
+		t.Fatalf("DetectCurrentLocation(seqDir) error = %v", err)
+	}
+	if locFromSeq.Type != "sequence" {
+		t.Errorf("from sequence subdir: loc.Type = %q, want %q (regression: #204 used festival root, always producing 'festival')", locFromSeq.Type, "sequence")
+	}
+
+	locFromRoot, err := show.DetectCurrentLocation(ctx, festivalPath)
+	if err != nil {
+		t.Fatalf("DetectCurrentLocation(festivalPath) error = %v", err)
+	}
+	if locFromRoot.Type != "festival" {
+		t.Errorf("from festival root: loc.Type = %q, want %q", locFromRoot.Type, "festival")
 	}
 }

--- a/internal/commands/status/picker_fallback_test.go
+++ b/internal/commands/status/picker_fallback_test.go
@@ -1,0 +1,55 @@
+package status
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStatusPickerStatuses(t *testing.T) {
+	want := []string{"active", "ready", "planning"}
+	if len(statusPickerStatuses) != len(want) {
+		t.Fatalf("statusPickerStatuses length = %d, want %d", len(statusPickerStatuses), len(want))
+	}
+	for i, s := range want {
+		if statusPickerStatuses[i] != s {
+			t.Errorf("statusPickerStatuses[%d] = %q, want %q", i, statusPickerStatuses[i], s)
+		}
+	}
+}
+
+func TestPickFestivalForDisplay_NoCampaign(t *testing.T) {
+	dir := t.TempDir()
+	path, err := pickFestivalForDisplay(t.Context(), dir)
+	if err == nil {
+		t.Fatalf("expected error when no campaign workspace, got path %q", path)
+	}
+}
+
+func TestPickFestivalForDisplay_NoFestivalsMarker(t *testing.T) {
+	dir := t.TempDir()
+	festivals := filepath.Join(dir, "festivals")
+	if err := os.MkdirAll(festivals, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, err := pickFestivalForDisplay(t.Context(), dir)
+	if err == nil {
+		t.Fatal("expected error when no festivals marker, got nil")
+	}
+}
+
+func TestPickFestivalForDisplay_EmptyFestivals(t *testing.T) {
+	dir := t.TempDir()
+	festivals := filepath.Join(dir, "festivals")
+	dotFestival := filepath.Join(festivals, ".festival")
+	if err := os.MkdirAll(dotFestival, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path, err := pickFestivalForDisplay(t.Context(), dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != "" {
+		t.Errorf("expected empty path for empty festivals dir, got %q", path)
+	}
+}

--- a/internal/commands/walk/walk.go
+++ b/internal/commands/walk/walk.go
@@ -1,0 +1,464 @@
+package walk
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Obedience-Corp/fest/internal/commands/shared"
+	"github.com/Obedience-Corp/fest/internal/commands/show"
+	"github.com/Obedience-Corp/fest/internal/config"
+	"github.com/Obedience-Corp/fest/internal/errors"
+	gatescore "github.com/Obedience-Corp/fest/internal/gates"
+	"github.com/Obedience-Corp/fest/internal/progress"
+	"github.com/Obedience-Corp/fest/internal/scope"
+	tpl "github.com/Obedience-Corp/fest/internal/template"
+	"github.com/Obedience-Corp/fest/internal/ui"
+	"github.com/Obedience-Corp/fest/internal/workspace"
+	"github.com/spf13/cobra"
+)
+
+type walkOptions struct {
+	json bool
+	from string
+}
+
+// WalkView is the structured view returned by fest walk.
+type WalkView struct {
+	Kind     string `json:"kind"`
+	Name     string `json:"name"`
+	Status   string `json:"status"`
+	Path     string `json:"path"`
+	Goal     string `json:"goal,omitempty"`
+	Progress *walkProgress `json:"progress,omitempty"`
+	Next     string `json:"next,omitempty"`
+	Blocked  []walkBlocker `json:"blocked,omitempty"`
+	Gates    []string `json:"gates,omitempty"`
+	Warnings []string `json:"warnings,omitempty"`
+}
+
+type walkProgress struct {
+	Completed  int `json:"completed"`
+	Total      int `json:"total"`
+	Percentage int `json:"percentage"`
+}
+
+type walkBlocker struct {
+	Task    string `json:"task"`
+	Reason  string `json:"reason"`
+}
+
+// NewWalkCommand creates the walk/inspect command.
+func NewWalkCommand() *cobra.Command {
+	opts := &walkOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "walk [path]",
+		Aliases: []string{"inspect"},
+		Short:   "Guided read-only overview of a festival",
+		Annotations: map[string]string{
+			"scope": string(scope.Global),
+		},
+		Long: `Display a guided orientation overview of a festival without mutating anything.
+
+Shows what the festival is, where it is, its current status and progress,
+the next task, blocked tasks, active quality gates, and any warnings.
+
+Useful for quickly orienting inside a festival before continuing work,
+especially for rituals where the template and active run are distinct.
+
+EXAMPLES:
+  fest walk                      # Walk current festival from cwd
+  fest walk festivals/active/my-festival
+  fest walk --json               # Machine-readable output`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			if len(args) > 0 {
+				opts.from = args[0]
+			}
+			return runWalk(ctx, opts)
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.json, "json", false, "output in JSON format")
+	cmd.Flags().StringVar(&opts.from, "from", "", "festival path (defaults to current directory)")
+
+	return cmd
+}
+
+func runWalk(ctx context.Context, opts *walkOptions) error {
+	if err := ctx.Err(); err != nil {
+		return errors.Wrap(err, "context cancelled")
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return errors.IO("getting current directory", err)
+	}
+
+	startDir := cwd
+	if opts.from != "" {
+		if filepath.IsAbs(opts.from) {
+			startDir = opts.from
+		} else {
+			startDir = filepath.Join(cwd, opts.from)
+		}
+	}
+
+	campaignRoot, _ := workspace.DetectCampaign(ctx, startDir)
+
+	festival, err := resolveFestival(ctx, startDir, campaignRoot)
+	if err != nil {
+		return errors.Wrap(err, "not inside a festival").
+			WithHint("Run from within a festival directory or pass a festival path as an argument")
+	}
+
+	festivalPath := festival.Path
+
+	view := &WalkView{
+		Kind:   detectKind(festivalPath, festival.Status),
+		Name:   festival.Name,
+		Status: festival.Status,
+		Path:   festivalPath,
+	}
+
+	view.Goal = loadGoal(festivalPath)
+	view.Warnings = append(view.Warnings, kindWarnings(view.Kind, festival)...)
+
+	mgr, mgrErr := progress.NewManager(ctx, festivalPath)
+	if mgrErr == nil {
+		festProgress, progressErr := mgr.GetFestivalProgress(ctx, festivalPath)
+		if progressErr == nil && festProgress.Overall != nil {
+			view.Progress = &walkProgress{
+				Completed:  festProgress.Overall.Completed,
+				Total:      festProgress.Overall.Total,
+				Percentage: festProgress.Overall.Percentage,
+			}
+			for _, b := range festProgress.Overall.Blockers {
+				view.Blocked = append(view.Blocked, walkBlocker{
+					Task:   b.TaskID,
+					Reason: b.BlockerMessage,
+				})
+			}
+		}
+	}
+
+	view.Next = resolveNext(ctx, festivalPath, cwd)
+
+	if len(view.Blocked) > 0 {
+		for _, b := range view.Blocked {
+			if b.Task == view.Next {
+				view.Warnings = append(view.Warnings, fmt.Sprintf("next task is blocked: %s", b.Reason))
+			}
+		}
+	}
+
+	view.Gates = loadActiveGates(ctx, festivalPath)
+
+	if opts.json {
+		return emitJSON(view)
+	}
+	return emitText(view, festivalPath, campaignRoot)
+}
+
+func resolveFestival(ctx context.Context, startDir, campaignRoot string) (*show.FestivalInfo, error) {
+	festivalPath, resolveErr := shared.ResolveFestivalPath(startDir, "")
+	if resolveErr == nil && festivalPath != "" {
+		return show.DetectCurrentFestival(ctx, festivalPath, campaignRoot)
+	}
+	return show.DetectCurrentFestival(ctx, startDir, campaignRoot)
+}
+
+func detectKind(festivalPath, status string) string {
+	if strings.Contains(status, "dungeon") {
+		return "dungeon-run"
+	}
+
+	festivalsRoot := filepath.Dir(filepath.Dir(festivalPath))
+	ritualDir := filepath.Join(festivalsRoot, "ritual")
+	parentDir := filepath.Dir(festivalPath)
+
+	if parentDir == ritualDir {
+		return "ritual-template"
+	}
+
+	if status == "ritual" {
+		return "ritual-run"
+	}
+
+	return "festival"
+}
+
+func loadGoal(festivalPath string) string {
+	for _, name := range []string{"FESTIVAL_GOAL.md", "FESTIVAL_OVERVIEW.md"} {
+		goalPath := filepath.Join(festivalPath, name)
+		data, err := os.ReadFile(goalPath)
+		if err != nil {
+			continue
+		}
+		lines := strings.Split(string(data), "\n")
+		inFrontmatter := false
+		frontmatterDone := false
+		seenOpenDelim := false
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if !frontmatterDone {
+				if trimmed == "---" {
+					if !seenOpenDelim {
+						seenOpenDelim = true
+						inFrontmatter = true
+						continue
+					}
+					inFrontmatter = false
+					frontmatterDone = true
+					continue
+				}
+				if inFrontmatter {
+					continue
+				}
+			}
+			if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+				continue
+			}
+			if len(trimmed) > 300 {
+				trimmed = trimmed[:300] + "..."
+			}
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func resolveNext(ctx context.Context, festivalPath, cwd string) string {
+	if err := ctx.Err(); err != nil {
+		return ""
+	}
+
+	entries, err := os.ReadDir(festivalPath)
+	if err != nil {
+		return ""
+	}
+
+	mgr, mgrErr := progress.NewManager(ctx, festivalPath)
+
+	for _, entry := range entries {
+		if !entry.IsDir() || !hasNumericPrefix(entry.Name()) {
+			continue
+		}
+		phasePath := filepath.Join(festivalPath, entry.Name())
+		seqEntries, err := os.ReadDir(phasePath)
+		if err != nil {
+			continue
+		}
+		for _, seqEntry := range seqEntries {
+			if !seqEntry.IsDir() || !hasNumericPrefix(seqEntry.Name()) {
+				continue
+			}
+			seqPath := filepath.Join(phasePath, seqEntry.Name())
+			taskEntries, err := os.ReadDir(seqPath)
+			if err != nil {
+				continue
+			}
+			for _, taskEntry := range taskEntries {
+				if taskEntry.IsDir() || !strings.HasSuffix(taskEntry.Name(), ".md") {
+					continue
+				}
+				if !hasNumericPrefix(taskEntry.Name()) {
+					continue
+				}
+				taskPath := filepath.Join(seqPath, taskEntry.Name())
+				if mgrErr != nil {
+					rel, relErr := filepath.Rel(festivalPath, taskPath)
+					if relErr == nil {
+						return rel
+					}
+					return taskPath
+				}
+				store := mgr.Store()
+				status := progress.ResolveTaskStatus(store, festivalPath, taskPath)
+				if status == progress.StatusCompleted {
+					continue
+				}
+				rel, relErr := filepath.Rel(festivalPath, taskPath)
+				if relErr == nil {
+					return rel
+				}
+				return taskPath
+			}
+		}
+	}
+	return ""
+}
+
+func loadActiveGates(ctx context.Context, festivalPath string) []string {
+	if err := ctx.Err(); err != nil {
+		return nil
+	}
+
+	festivalsRoot, err := tpl.FindFestivalsRoot(festivalPath)
+	if err != nil {
+		festivalsRoot = filepath.Dir(filepath.Dir(festivalPath))
+	}
+
+	merger, err := gatescore.NewConfigMerger(festivalsRoot, nil)
+	if err != nil {
+		return nil
+	}
+
+	entries, err := os.ReadDir(festivalPath)
+	if err != nil {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	var names []string
+
+	for _, entry := range entries {
+		if !entry.IsDir() || !hasNumericPrefix(entry.Name()) {
+			continue
+		}
+		phasePath := filepath.Join(festivalPath, entry.Name())
+		seqEntries, err := os.ReadDir(phasePath)
+		if err != nil {
+			continue
+		}
+		for _, seqEntry := range seqEntries {
+			if !seqEntry.IsDir() || !hasNumericPrefix(seqEntry.Name()) {
+				continue
+			}
+			seqPath := filepath.Join(phasePath, seqEntry.Name())
+			policy, mergeErr := merger.MergeForSequence(ctx, festivalPath, phasePath, seqPath, gatescore.DefaultMergeOptions())
+			if mergeErr != nil {
+				continue
+			}
+			for _, gate := range policy.GetActiveGates() {
+				if _, ok := seen[gate.Template]; !ok {
+					seen[gate.Template] = struct{}{}
+					names = append(names, gate.Template)
+				}
+			}
+		}
+	}
+
+	return names
+}
+
+func kindWarnings(kind string, festival *show.FestivalInfo) []string {
+	if kind != "ritual-template" {
+		return nil
+	}
+	cfg, err := config.LoadFestivalConfig(festival.Path, "")
+	if err != nil || cfg == nil || cfg.Metadata.ID == "" {
+		return []string{"this is a ritual template, not an execution run; use 'fest ritual run <id>' to create a run"}
+	}
+	return []string{fmt.Sprintf("this is a ritual template, not an execution run; use 'fest ritual run %s' to create a run", cfg.Metadata.ID)}
+}
+
+func hasNumericPrefix(name string) bool {
+	if len(name) < 2 {
+		return false
+	}
+	digitCount := 0
+	for i := 0; i < len(name) && i < 4; i++ {
+		if name[i] == '_' && digitCount > 0 {
+			return true
+		}
+		if name[i] >= '0' && name[i] <= '9' {
+			digitCount++
+		} else {
+			return false
+		}
+	}
+	return false
+}
+
+func emitJSON(view *WalkView) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(view); err != nil {
+		return errors.Wrap(err, "encoding JSON output")
+	}
+	return nil
+}
+
+func emitText(view *WalkView, festivalPath, campaignRoot string) error {
+	displayPath := festivalPath
+	if campaignRoot != "" && strings.HasPrefix(festivalPath, campaignRoot) {
+		rel, err := filepath.Rel(campaignRoot, festivalPath)
+		if err == nil {
+			displayPath = rel
+		}
+	}
+
+	fmt.Println(ui.H1("Festival Walk"))
+	fmt.Printf("%s %s\n", ui.Label("Festival"), ui.Value(view.Name, ui.FestivalColor))
+	fmt.Printf("%s %s\n", ui.Label("Kind"), ui.Value(view.Kind))
+	fmt.Printf("%s %s\n", ui.Label("Status"), ui.GetStateStyle(view.Status).Render(view.Status))
+	fmt.Printf("%s %s\n", ui.Label("Path"), ui.Dim(displayPath))
+
+	if view.Goal != "" {
+		fmt.Println()
+		fmt.Println(ui.H2("Goal"))
+		fmt.Println(ui.Dim(strings.Repeat("─", 60)))
+		fmt.Printf("%s\n", view.Goal)
+	}
+
+	if view.Progress != nil {
+		fmt.Println()
+		fmt.Println(ui.H2("Progress"))
+		fmt.Println(ui.Dim(strings.Repeat("─", 60)))
+		fmt.Printf("%s %d/%d tasks (%d%%)\n",
+			ui.Label("Tasks"),
+			view.Progress.Completed,
+			view.Progress.Total,
+			view.Progress.Percentage,
+		)
+	}
+
+	if view.Next != "" {
+		fmt.Println()
+		fmt.Println(ui.H2("Next"))
+		fmt.Println(ui.Dim(strings.Repeat("─", 60)))
+		fmt.Printf("%s\n", view.Next)
+	}
+
+	if len(view.Blocked) > 0 {
+		fmt.Println()
+		fmt.Println(ui.H2("Blocked"))
+		fmt.Println(ui.Dim(strings.Repeat("─", 60)))
+		for _, b := range view.Blocked {
+			if b.Reason != "" {
+				fmt.Printf("%s %s %s\n", ui.StateIcon("blocked"), ui.Value(b.Task, ui.TaskColor), ui.Dim(b.Reason))
+			} else {
+				fmt.Printf("%s %s\n", ui.StateIcon("blocked"), ui.Value(b.Task, ui.TaskColor))
+			}
+		}
+	}
+
+	if len(view.Gates) > 0 {
+		fmt.Println()
+		fmt.Println(ui.H2("Active Gates"))
+		fmt.Println(ui.Dim(strings.Repeat("─", 60)))
+		for _, g := range view.Gates {
+			fmt.Printf("  %s\n", g)
+		}
+	}
+
+	if len(view.Warnings) > 0 {
+		fmt.Println()
+		fmt.Println(ui.H2("Warnings"))
+		fmt.Println(ui.Dim(strings.Repeat("─", 60)))
+		for _, w := range view.Warnings {
+			fmt.Printf("%s %s\n", ui.StateIcon("blocked"), ui.Warning(w))
+		}
+	}
+
+	return nil
+}

--- a/internal/commands/walk/walk.go
+++ b/internal/commands/walk/walk.go
@@ -58,14 +58,15 @@ func NewWalkCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "walk [path]",
 		Aliases: []string{"inspect"},
-		Short:   "Guided read-only overview of a festival",
+		Short:   "Guided overview of a festival",
 		Annotations: map[string]string{
 			"scope": string(scope.Global),
 		},
-		Long: `Display a guided orientation overview of a festival without mutating anything.
+		Long: `Display a guided orientation overview of a festival.
 
 Shows what the festival is, where it is, its current status and progress,
 the next task, blocked tasks, active quality gates, and any warnings.
+May transparently migrate legacy progress formats on first access.
 
 Useful for quickly orienting inside a festival before continuing work,
 especially for rituals where the template and active run are distinct.
@@ -187,10 +188,6 @@ func detectKind(festivalPath, status string) string {
 
 	if parentDir == ritualDir {
 		return "ritual-template"
-	}
-
-	if status == "ritual" {
-		return "ritual-run"
 	}
 
 	return "festival"

--- a/internal/commands/walk/walk.go
+++ b/internal/commands/walk/walk.go
@@ -227,8 +227,8 @@ func loadGoal(festivalPath string) string {
 			if trimmed == "" || strings.HasPrefix(trimmed, "#") {
 				continue
 			}
-			if len(trimmed) > 300 {
-				trimmed = trimmed[:300] + "..."
+			if len([]rune(trimmed)) > 300 {
+				trimmed = string([]rune(trimmed)[:300]) + "..."
 			}
 			return trimmed
 		}

--- a/internal/commands/walk/walk_test.go
+++ b/internal/commands/walk/walk_test.go
@@ -1,0 +1,320 @@
+package walk
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/commands/show"
+)
+
+func makeMinimalFestival(t *testing.T, root, name, status string) string {
+	t.Helper()
+	dir := filepath.Join(root, "festivals", status, name)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "FESTIVAL_GOAL.md"), []byte("A test goal line.\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func makePhaseAndTask(t *testing.T, festivalDir, phaseName, seqName, taskName string) {
+	t.Helper()
+	phaseDir := filepath.Join(festivalDir, phaseName)
+	seqDir := filepath.Join(phaseDir, seqName)
+	if err := os.MkdirAll(seqDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(phaseDir, "PHASE_GOAL.md"), []byte("# Phase\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(seqDir, "SEQUENCE_GOAL.md"), []byte("# Seq\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(seqDir, taskName), []byte("# Task\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDetectKind_Festival(t *testing.T) {
+	root := t.TempDir()
+	festDir := makeMinimalFestival(t, root, "my-fest-MF0001", "active")
+	kind := detectKind(festDir, "active")
+	if kind != "festival" {
+		t.Errorf("detectKind() = %q, want %q", kind, "festival")
+	}
+}
+
+func TestDetectKind_RitualTemplate(t *testing.T) {
+	root := t.TempDir()
+	ritualDir := filepath.Join(root, "festivals", "ritual")
+	festDir := filepath.Join(ritualDir, "my-ritual-RI-MR0001")
+	if err := os.MkdirAll(festDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(festDir, "FESTIVAL_GOAL.md"), []byte("goal\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	kind := detectKind(festDir, "ritual")
+	if kind != "ritual-template" {
+		t.Errorf("detectKind() = %q, want %q", kind, "ritual-template")
+	}
+}
+
+func TestDetectKind_DungeonRun(t *testing.T) {
+	root := t.TempDir()
+	festDir := makeMinimalFestival(t, root, "old-fest-OF0001", "dungeon/completed")
+	kind := detectKind(festDir, "dungeon/completed")
+	if kind != "dungeon-run" {
+		t.Errorf("detectKind() = %q, want %q", kind, "dungeon-run")
+	}
+}
+
+func TestLoadGoal_ReturnsFirstNonHeaderLine(t *testing.T) {
+	festDir := t.TempDir()
+	content := "---\nfest_status: active\n---\n# Title\n\nThis is the goal text.\n"
+	if err := os.WriteFile(filepath.Join(festDir, "FESTIVAL_GOAL.md"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	goal := loadGoal(festDir)
+	if goal != "This is the goal text." {
+		t.Errorf("loadGoal() = %q, want %q", goal, "This is the goal text.")
+	}
+}
+
+func TestLoadGoal_MissingFile(t *testing.T) {
+	festDir := t.TempDir()
+	goal := loadGoal(festDir)
+	if goal != "" {
+		t.Errorf("loadGoal() = %q, want empty", goal)
+	}
+}
+
+func TestHasNumericPrefix_Walk(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"001_PLAN", true},
+		{"01_setup", true},
+		{"001", false},
+		{"abc_test", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		got := hasNumericPrefix(tc.name)
+		if got != tc.want {
+			t.Errorf("hasNumericPrefix(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestResolveNext_ReturnsFirstIncompleteTask(t *testing.T) {
+	root := t.TempDir()
+	festDir := makeMinimalFestival(t, root, "my-fest-MF0001", "active")
+	makePhaseAndTask(t, festDir, "001_IMPL", "01_core", "01_first_task.md")
+
+	next := resolveNext(context.Background(), festDir, festDir)
+	if next == "" {
+		t.Fatal("resolveNext() returned empty string, want a task path")
+	}
+	if !strings.Contains(next, "01_first_task.md") {
+		t.Errorf("resolveNext() = %q, want to contain '01_first_task.md'", next)
+	}
+}
+
+func TestResolveNext_EmptyFestival(t *testing.T) {
+	root := t.TempDir()
+	festDir := makeMinimalFestival(t, root, "empty-fest-EF0001", "active")
+
+	next := resolveNext(context.Background(), festDir, festDir)
+	if next != "" {
+		t.Errorf("resolveNext() on empty festival = %q, want empty", next)
+	}
+}
+
+func TestRunWalk_JSONOutput(t *testing.T) {
+	root := t.TempDir()
+	festDir := makeMinimalFestival(t, root, "my-fest-MF0001", "active")
+	makePhaseAndTask(t, festDir, "001_IMPL", "01_core", "01_task.md")
+
+	origCWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origCWD) }()
+
+	if err := os.Chdir(festDir); err != nil {
+		t.Fatal(err)
+	}
+
+	origStdout := os.Stdout
+	r, w, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		t.Fatal(pipeErr)
+	}
+	os.Stdout = w
+
+	runErr := runWalk(context.Background(), &walkOptions{json: true})
+
+	if closeErr := w.Close(); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+	os.Stdout = origStdout
+
+	var buf bytes.Buffer
+	if _, readErr := buf.ReadFrom(r); readErr != nil {
+		t.Fatal(readErr)
+	}
+
+	if runErr != nil {
+		t.Fatalf("runWalk() error: %v", runErr)
+	}
+
+	var view WalkView
+	if unmarshalErr := json.Unmarshal(buf.Bytes(), &view); unmarshalErr != nil {
+		t.Fatalf("failed to parse JSON output: %v\noutput: %s", unmarshalErr, buf.String())
+	}
+
+	if view.Name == "" {
+		t.Error("WalkView.Name is empty")
+	}
+	if view.Kind == "" {
+		t.Error("WalkView.Kind is empty")
+	}
+	if view.Status == "" {
+		t.Error("WalkView.Status is empty")
+	}
+}
+
+func TestRunWalk_ErrorOutsideFestival(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	origCWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origCWD) }()
+
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	err = runWalk(context.Background(), &walkOptions{})
+	if err == nil {
+		t.Fatal("runWalk() expected error outside festival, got nil")
+	}
+}
+
+func TestRunWalk_WithFromFlag(t *testing.T) {
+	root := t.TempDir()
+	festDir := makeMinimalFestival(t, root, "my-fest-MF0001", "active")
+
+	origStdout := os.Stdout
+	r, w, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		t.Fatal(pipeErr)
+	}
+	os.Stdout = w
+
+	err := runWalk(context.Background(), &walkOptions{json: true, from: festDir})
+
+	if closeErr := w.Close(); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+	os.Stdout = origStdout
+
+	var buf bytes.Buffer
+	if _, readErr := buf.ReadFrom(r); readErr != nil {
+		t.Fatal(readErr)
+	}
+
+	if err != nil {
+		t.Fatalf("runWalk() with --from error: %v", err)
+	}
+
+	var view WalkView
+	if unmarshalErr := json.Unmarshal(buf.Bytes(), &view); unmarshalErr != nil {
+		t.Fatalf("failed to parse JSON: %v\noutput: %s", unmarshalErr, buf.String())
+	}
+	if view.Name != "my-fest-MF0001" {
+		t.Errorf("WalkView.Name = %q, want %q", view.Name, "my-fest-MF0001")
+	}
+}
+
+func TestKindWarnings_RitualTemplate(t *testing.T) {
+	root := t.TempDir()
+	ritualDir := filepath.Join(root, "festivals", "ritual")
+	festDir := filepath.Join(ritualDir, "my-ritual-RI-MR0001")
+	if err := os.MkdirAll(festDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(festDir, "FESTIVAL_GOAL.md"), []byte("goal\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	festival := &show.FestivalInfo{
+		Path: festDir,
+		Name: "my-ritual-RI-MR0001",
+	}
+	warnings := kindWarnings("ritual-template", festival)
+	if len(warnings) == 0 {
+		t.Fatal("kindWarnings() returned no warnings for ritual-template kind")
+	}
+	if !strings.Contains(warnings[0], "ritual template") {
+		t.Errorf("warning = %q, want to mention 'ritual template'", warnings[0])
+	}
+}
+
+func TestKindWarnings_NonRitual(t *testing.T) {
+	root := t.TempDir()
+	festDir := makeMinimalFestival(t, root, "my-fest-MF0001", "active")
+
+	festival := &show.FestivalInfo{
+		Path: festDir,
+		Name: "my-fest-MF0001",
+	}
+	warnings := kindWarnings("festival", festival)
+	if len(warnings) != 0 {
+		t.Errorf("kindWarnings() returned %d warnings for non-ritual, want 0", len(warnings))
+	}
+}
+
+func TestRunWalk_GoalInOutput(t *testing.T) {
+	root := t.TempDir()
+	festDir := makeMinimalFestival(t, root, "my-fest-MF0001", "active")
+
+	origStdout := os.Stdout
+	r, w, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		t.Fatal(pipeErr)
+	}
+	os.Stdout = w
+
+	err := runWalk(context.Background(), &walkOptions{from: festDir})
+
+	if closeErr := w.Close(); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+	os.Stdout = origStdout
+
+	var buf bytes.Buffer
+	if _, readErr := buf.ReadFrom(r); readErr != nil {
+		t.Fatal(readErr)
+	}
+
+	if err != nil {
+		t.Fatalf("runWalk() error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "A test goal line.") {
+		t.Errorf("output missing goal text; got:\n%s", output)
+	}
+}

--- a/internal/commands/walk/walk_test.go
+++ b/internal/commands/walk/walk_test.go
@@ -96,6 +96,42 @@ func TestLoadGoal_MissingFile(t *testing.T) {
 	}
 }
 
+func TestLoadGoal_MultibyteTruncation(t *testing.T) {
+	festDir := t.TempDir()
+
+	multibyte := "日本語テスト"
+	longLine := strings.Repeat(multibyte, 60)
+
+	content := "---\nfest_status: active\n---\n\n" + longLine + "\n"
+	if err := os.WriteFile(filepath.Join(festDir, "FESTIVAL_GOAL.md"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	goal := loadGoal(festDir)
+
+	if goal == "" {
+		t.Fatal("loadGoal() returned empty for multibyte content")
+	}
+
+	runes := []rune(goal)
+	if len(runes) > 303 {
+		t.Errorf("loadGoal() returned %d runes, want at most 303 (300 + '...')", len(runes))
+	}
+
+	if !strings.HasSuffix(goal, "...") {
+		t.Errorf("loadGoal() = %q, want suffix '...' for long line", goal)
+	}
+
+	for i, b := range []byte(goal) {
+		if b == 0xef && i+2 < len([]byte(goal)) {
+			next := []byte(goal)[i+1]
+			if next == 0xbf && []byte(goal)[i+2] == 0xbd {
+				t.Errorf("loadGoal() contains UTF-8 replacement character at byte %d: rune was split", i)
+			}
+		}
+	}
+}
+
 func TestHasNumericPrefix_Walk(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/commands/watch/command.go
+++ b/internal/commands/watch/command.go
@@ -22,6 +22,8 @@ type commandDeps struct {
 	resolveStandalone func(context.Context) (*show.StandaloneWorkflowInfo, error)
 	watch             func(context.Context, *show.FestivalInfo, show.WatchOptions) error
 	watchStandalone   func(context.Context, *show.StandaloneWorkflowInfo, show.WatchOptions) error
+	detectFestival    func(context.Context, string) (*show.FestivalInfo, error)
+	listCycleTargets  func(context.Context, string) ([]string, error)
 }
 
 // NewWatchCommand creates the watch command.
@@ -30,13 +32,18 @@ func NewWatchCommand() *cobra.Command {
 }
 
 func defaultCommandDeps() commandDeps {
+	r := defaultResolver()
 	return commandDeps{
 		resolve: func(ctx context.Context, selector string) (*show.FestivalInfo, error) {
-			return defaultResolver().resolve(ctx, selector)
+			return r.resolve(ctx, selector)
 		},
 		resolveStandalone: defaultResolveStandaloneWorkflow,
 		watch:             show.WatchFestival,
 		watchStandalone:   show.WatchStandaloneWorkflow,
+		detectFestival: func(ctx context.Context, path string) (*show.FestivalInfo, error) {
+			return r.detectFestival(ctx, path)
+		},
+		listCycleTargets: defaultListCycleTargets,
 	}
 }
 
@@ -99,6 +106,16 @@ func runWatch(ctx context.Context, args []string, opts *options, deps commandDep
 		}
 		if workflow != nil {
 			return watchStandaloneWorkflow(ctx, workflow, *opts, deps)
+		}
+	}
+
+	if selector == "" && deps.listCycleTargets != nil {
+		cwd, err := os.Getwd()
+		if err == nil {
+			paths, listErr := deps.listCycleTargets(ctx, cwd)
+			if listErr == nil && len(paths) > 1 {
+				return runWatchCycle(ctx, paths, 0, *opts, deps)
+			}
 		}
 	}
 

--- a/internal/commands/watch/cycling.go
+++ b/internal/commands/watch/cycling.go
@@ -37,6 +37,7 @@ func runWatchCycle(ctx context.Context, paths []string, startIndex int, opts opt
 	defer func() { _ = term.Restore(int(os.Stdin.Fd()), oldState) }()
 
 	index := startIndex
+	staleSince := -1
 	for {
 		if ctx.Err() != nil {
 			return nil
@@ -46,15 +47,28 @@ func runWatchCycle(ctx context.Context, paths []string, startIndex int, opts opt
 		festival, err := deps.detectFestival(ctx, path)
 		if err != nil {
 			if isFestivalNotFound(err) {
+				if staleSince < 0 {
+					staleSince = index
+				} else if staleSince == index {
+					return errors.Validation("all cycle targets are stale; no festival found").
+						WithField("checked", len(paths))
+				}
 				index = (index + 1) % len(paths)
 				continue
 			}
 			return err
 		}
 		if festival == nil {
+			if staleSince < 0 {
+				staleSince = index
+			} else if staleSince == index {
+				return errors.Validation("all cycle targets are stale; no festival found").
+					WithField("checked", len(paths))
+			}
 			index = (index + 1) % len(paths)
 			continue
 		}
+		staleSince = -1
 
 		watchCtx, cancelWatch := context.WithCancel(ctx)
 		watchDone := make(chan error, 1)

--- a/internal/commands/watch/cycling.go
+++ b/internal/commands/watch/cycling.go
@@ -1,0 +1,141 @@
+package watch
+
+import (
+	"context"
+	"io"
+	"os"
+
+	"github.com/Obedience-Corp/fest/internal/commands/show"
+	"github.com/Obedience-Corp/fest/internal/errors"
+	"golang.org/x/term"
+)
+
+type cycleDirection int
+
+const (
+	cycleNext cycleDirection = iota
+	cyclePrev
+	cycleQuit
+)
+
+func runWatchCycle(ctx context.Context, paths []string, startIndex int, opts options, deps commandDeps) error {
+	if len(paths) == 0 {
+		return errors.Validation("no watchable festivals found")
+	}
+	if len(paths) == 1 {
+		return watchFestivalAtPath(ctx, paths[0], opts, deps)
+	}
+
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return watchFestivalAtPath(ctx, paths[startIndex], opts, deps)
+	}
+
+	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
+	if err != nil {
+		return watchFestivalAtPath(ctx, paths[startIndex], opts, deps)
+	}
+	defer func() { _ = term.Restore(int(os.Stdin.Fd()), oldState) }()
+
+	index := startIndex
+	for {
+		if ctx.Err() != nil {
+			return nil
+		}
+
+		path := paths[index]
+		festival, err := deps.detectFestival(ctx, path)
+		if err != nil {
+			if isFestivalNotFound(err) {
+				index = (index + 1) % len(paths)
+				continue
+			}
+			return err
+		}
+		if festival == nil {
+			index = (index + 1) % len(paths)
+			continue
+		}
+
+		watchCtx, cancelWatch := context.WithCancel(ctx)
+		watchDone := make(chan error, 1)
+		go func() {
+			watchDone <- deps.watch(watchCtx, festival, cycleWatchOptions(opts))
+		}()
+
+		dir := readCycleKey(ctx, os.Stdin, cancelWatch)
+		cancelWatch()
+		watchErr := <-watchDone
+		if watchErr != nil && watchCtx.Err() == nil {
+			return watchErr
+		}
+
+		if ctx.Err() != nil {
+			return nil
+		}
+		if dir == cycleQuit {
+			return nil
+		}
+		if dir == cycleNext {
+			index = (index + 1) % len(paths)
+		} else {
+			index = (index - 1 + len(paths)) % len(paths)
+		}
+	}
+}
+
+func watchFestivalAtPath(ctx context.Context, path string, opts options, deps commandDeps) error {
+	festival, err := deps.detectFestival(ctx, path)
+	if err != nil {
+		return err
+	}
+	if festival == nil {
+		return errors.NotFound("festival").WithField("path", path)
+	}
+	return watchFestival(ctx, festival, opts, deps)
+}
+
+func cycleWatchOptions(opts options) show.WatchOptions {
+	wo := showWatchOptions(opts)
+	wo.CycleHint = true
+	return wo
+}
+
+func readCycleKey(ctx context.Context, r io.Reader, cancelWatch context.CancelFunc) cycleDirection {
+	buf := make([]byte, 3)
+	keyCh := make(chan cycleDirection, 1)
+
+	go func() {
+		for {
+			n, err := r.Read(buf)
+			if err != nil || n == 0 {
+				keyCh <- cycleQuit
+				return
+			}
+			b := buf[:n]
+			if b[0] == 0x03 {
+				keyCh <- cycleQuit
+				return
+			}
+			if n >= 3 && b[0] == 0x1b && b[1] == '[' {
+				switch b[2] {
+				case 'C':
+					keyCh <- cycleNext
+					return
+				case 'D':
+					keyCh <- cyclePrev
+					return
+				}
+			}
+		}
+	}()
+
+	select {
+	case dir := <-keyCh:
+		if dir == cycleQuit {
+			cancelWatch()
+		}
+		return dir
+	case <-ctx.Done():
+		return cycleQuit
+	}
+}

--- a/internal/commands/watch/cycling_test.go
+++ b/internal/commands/watch/cycling_test.go
@@ -1,0 +1,169 @@
+package watch
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/commands/show"
+)
+
+func TestCycleWatchOptionsSetsCycleHint(t *testing.T) {
+	opts := options{summary: true, goals: true, collapsed: true}
+	got := cycleWatchOptions(opts)
+	if !got.CycleHint {
+		t.Fatal("cycleWatchOptions must set CycleHint = true")
+	}
+	if !got.Summary || !got.Goals || !got.Collapsed {
+		t.Fatalf("cycleWatchOptions dropped flags: %#v", got)
+	}
+}
+
+func TestRunWatchCycle_EmptyPaths(t *testing.T) {
+	err := runWatchCycle(t.Context(), nil, 0, options{}, commandDeps{
+		detectFestival: func(context.Context, string) (*show.FestivalInfo, error) {
+			return nil, nil
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for empty path list")
+	}
+}
+
+func TestRunWatchCycle_SinglePath_CallsWatch(t *testing.T) {
+	watchCalled := false
+	deps := commandDeps{
+		detectFestival: func(_ context.Context, path string) (*show.FestivalInfo, error) {
+			return &show.FestivalInfo{Path: path}, nil
+		},
+		watch: func(_ context.Context, _ *show.FestivalInfo, _ show.WatchOptions) error {
+			watchCalled = true
+			return nil
+		},
+	}
+	paths := []string{"/festivals/active/fest-FS0001"}
+	if err := runWatchCycle(t.Context(), paths, 0, options{}, deps); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !watchCalled {
+		t.Fatal("watch delegate was not called for single-path cycle")
+	}
+}
+
+func TestReadCycleKey_RightArrow(t *testing.T) {
+	rightArrow := []byte{0x1b, '[', 'C'}
+	r := bytes.NewReader(rightArrow)
+	cancelCalled := false
+	cancel := func() { cancelCalled = true }
+	dir := readCycleKey(t.Context(), r, cancel)
+	if dir != cycleNext {
+		t.Errorf("readCycleKey = %v, want cycleNext", dir)
+	}
+	if cancelCalled {
+		t.Error("cancel should not be called for right arrow")
+	}
+}
+
+func TestReadCycleKey_LeftArrow(t *testing.T) {
+	leftArrow := []byte{0x1b, '[', 'D'}
+	r := bytes.NewReader(leftArrow)
+	dir := readCycleKey(t.Context(), r, func() {})
+	if dir != cyclePrev {
+		t.Errorf("readCycleKey = %v, want cyclePrev", dir)
+	}
+}
+
+func TestReadCycleKey_CtrlC(t *testing.T) {
+	ctrlC := []byte{0x03}
+	r := bytes.NewReader(ctrlC)
+	cancelCalled := false
+	dir := readCycleKey(t.Context(), r, func() { cancelCalled = true })
+	if dir != cycleQuit {
+		t.Errorf("readCycleKey = %v, want cycleQuit", dir)
+	}
+	if !cancelCalled {
+		t.Error("cancel should be called for ctrl+c")
+	}
+}
+
+func TestReadCycleKey_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	r := bytes.NewReader(nil)
+	dir := readCycleKey(ctx, r, func() {})
+	if dir != cycleQuit {
+		t.Errorf("readCycleKey on cancelled context = %v, want cycleQuit", dir)
+	}
+}
+
+func TestDefaultListCycleTargets_NoCampaign(t *testing.T) {
+	dir := t.TempDir()
+	paths, err := defaultListCycleTargets(t.Context(), dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(paths) != 0 {
+		t.Errorf("expected empty paths for no campaign, got %v", paths)
+	}
+}
+
+func TestWatchCommandUsesListCycleTargets(t *testing.T) {
+	listCalled := false
+	watchCalled := false
+
+	deps := commandDeps{
+		resolveStandalone: func(context.Context) (*show.StandaloneWorkflowInfo, error) {
+			return nil, nil
+		},
+		resolve: func(_ context.Context, _ string) (*show.FestivalInfo, error) {
+			return &show.FestivalInfo{Path: "/festivals/active/single-FS0001"}, nil
+		},
+		watch: func(_ context.Context, _ *show.FestivalInfo, _ show.WatchOptions) error {
+			watchCalled = true
+			return nil
+		},
+		detectFestival: func(_ context.Context, path string) (*show.FestivalInfo, error) {
+			return &show.FestivalInfo{Path: path}, nil
+		},
+		listCycleTargets: func(_ context.Context, _ string) ([]string, error) {
+			listCalled = true
+			return []string{"/festivals/active/one-FS0001"}, nil
+		},
+	}
+
+	if err := runWatch(t.Context(), []string{}, &options{}, deps); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !listCalled {
+		t.Fatal("listCycleTargets was not called")
+	}
+	if !watchCalled {
+		t.Fatal("watch delegate was not called (single-path should delegate)")
+	}
+}
+
+func TestWatchCommandSkipsCyclingWhenSelectorProvided(t *testing.T) {
+	listCalled := false
+	deps := commandDeps{
+		resolveStandalone: func(context.Context) (*show.StandaloneWorkflowInfo, error) {
+			return nil, nil
+		},
+		resolve: func(_ context.Context, _ string) (*show.FestivalInfo, error) {
+			return &show.FestivalInfo{Path: "/festivals/active/explicit-FE0001"}, nil
+		},
+		watch: func(_ context.Context, _ *show.FestivalInfo, _ show.WatchOptions) error {
+			return nil
+		},
+		listCycleTargets: func(_ context.Context, _ string) ([]string, error) {
+			listCalled = true
+			return nil, nil
+		},
+	}
+
+	if err := runWatch(t.Context(), []string{"explicit-FE0001"}, &options{}, deps); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if listCalled {
+		t.Fatal("listCycleTargets must not be called when an explicit selector is given")
+	}
+}

--- a/internal/commands/watch/resolver.go
+++ b/internal/commands/watch/resolver.go
@@ -244,3 +244,24 @@ func noWatchTargetError() error {
 	return errors.Validation("festival could not be resolved from this directory").
 		WithHint("run from a festival, a linked project, or a campaign workspace with an interactive terminal")
 }
+
+func defaultListCycleTargets(ctx context.Context, cwd string) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	festivalsDir, err := workspace.FindFestivals(cwd)
+	if err != nil || festivalsDir == "" {
+		return nil, nil
+	}
+	items := shared.FestivalPickerItems(festivalsDir, shared.FestivalPickerOptions{
+		IncludeStatusDirectories: false,
+		PreferredStatuses:        watchPickerStatuses,
+		FallbackStatuses:         watchPickerStatuses,
+		OrderByStatusThenRecency: true,
+	})
+	paths := make([]string, 0, len(items))
+	for _, item := range items {
+		paths = append(paths, item.Value)
+	}
+	return paths, nil
+}

--- a/internal/guidance/workflow/navigator.go
+++ b/internal/guidance/workflow/navigator.go
@@ -590,7 +590,7 @@ func (n *Navigator) FormatProgress(ctx context.Context) (string, error) {
 
 	data := map[string]any{
 		"PhaseName":     n.Ctx.PhaseName,
-		"PhaseType":     string(n.mode),
+		"PhaseType":     n.displayPhaseType(),
 		"Completed":     n.workflowState.CompletedCount(),
 		"Total":         n.workflowState.TotalSteps,
 		"CurrentStep":   n.workflowState.CurrentStep,

--- a/internal/guidance/workflow/navigator.go
+++ b/internal/guidance/workflow/navigator.go
@@ -470,6 +470,17 @@ func (n *Navigator) FormatInstructions(ctx context.Context) (string, error) {
 	return n.formatStep(step, stepState)
 }
 
+// displayPhaseType returns the uppercased phase type for use in rendered headers.
+// It prefers the context's PhaseType (e.g. "ingest", "planning") over the mode
+// string, which is always "workflow" for workflow-based phases and gives no
+// useful identity when multiple workflow phases appear in sequence.
+func (n *Navigator) displayPhaseType() string {
+	if n.Ctx != nil && n.Ctx.PhaseType != "" {
+		return strings.ToUpper(n.Ctx.PhaseType)
+	}
+	return strings.ToUpper(string(n.mode))
+}
+
 // formatComplete renders the completion message using templates.
 func (n *Navigator) formatComplete() string {
 	type stepSummary struct {
@@ -486,7 +497,7 @@ func (n *Navigator) formatComplete() string {
 	}
 
 	data := map[string]any{
-		"PhaseType":  strings.ToUpper(string(n.mode)),
+		"PhaseType":  n.displayPhaseType(),
 		"TotalSteps": n.workflowState.TotalSteps,
 		"Steps":      steps,
 	}
@@ -515,11 +526,10 @@ func (n *Navigator) formatStep(step WorkflowStep, stepState *StepState) (string,
 	status := string(stepState.Status)
 	feedback := stepState.Feedback
 
-	// Show "PHASE GATE" for gate documents, phase type for workflows
-	phaseType := strings.ToUpper(string(n.mode))
 	isGate := n.docFilename == "GATES.md"
+	phaseType := n.displayPhaseType()
 	if isGate {
-		phaseType = strings.ToUpper(n.Ctx.PhaseType) + " PHASE GATE"
+		phaseType = phaseType + " PHASE GATE"
 	}
 
 	data := map[string]any{

--- a/internal/guidance/workflow/navigator_test.go
+++ b/internal/guidance/workflow/navigator_test.go
@@ -702,6 +702,46 @@ func TestNavigator_getAutonomyLevel(t *testing.T) {
 	}
 }
 
+func TestNavigator_FormatInstructions_ShowsPhaseType(t *testing.T) {
+	cases := []struct {
+		phaseType string
+		wantLabel string
+	}{
+		{"ingest", "INGEST PHASE"},
+		{"planning", "PLANNING PHASE"},
+		{"research", "RESEARCH PHASE"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.phaseType, func(t *testing.T) {
+			gctx := createTestGuidanceContext(t)
+			gctx.PhaseType = tc.phaseType
+			createTestWorkflow(t, gctx.FestivalPath)
+
+			nav, err := NewNavigator(gctx, guidance.ModeWorkflow)
+			if err != nil {
+				t.Fatalf("NewNavigator() error = %v", err)
+			}
+
+			if err := nav.Initialize(context.Background()); err != nil {
+				t.Fatalf("Initialize() error = %v", err)
+			}
+
+			instructions, err := nav.FormatInstructions(context.Background())
+			if err != nil {
+				t.Fatalf("FormatInstructions() error = %v", err)
+			}
+
+			if !strings.Contains(instructions, tc.wantLabel) {
+				t.Errorf("instructions missing %q; got:\n%s", tc.wantLabel, instructions)
+			}
+			if strings.Contains(instructions, "WORKFLOW PHASE") {
+				t.Errorf("instructions must not contain generic WORKFLOW PHASE label; got:\n%s", instructions)
+			}
+		})
+	}
+}
+
 // contains checks if a string contains a substring
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))

--- a/internal/guidance/workflow/parser_test.go
+++ b/internal/guidance/workflow/parser_test.go
@@ -397,14 +397,29 @@ func TestParser_ContextCancellation(t *testing.T) {
 }
 
 func TestParser_RealWorkflowTemplate(t *testing.T) {
-	// Test with content matching real ingest workflow template
 	content := `---
 fest_type: workflow
 ---
 
 # Ingest Phase Workflow
 
-## Step 1: READ — Understand All Input
+## Step 1: GATHER — Copy All Requirement Artifacts into input_specs/
+
+**Goal:** Ensure every piece of requirement material the user already has is present in input_specs/ before any reading or analysis begins.
+
+**Actions:**
+1. Ask the user what requirement artifacts exist: intents, notes, structured specs, prior planning text, docs, or any other relevant material
+2. Copy or transcribe each artifact into input_specs/
+3. If the user seeded content at festival creation time, confirm it is present in input_specs/
+4. List the files now in input_specs/ and confirm with the user that nothing is missing
+
+**Output:** All available requirement artifacts present in input_specs/
+
+**Checkpoint:** None — proceed to Step 2
+
+---
+
+## Step 2: READ — Understand All Input
 
 **Goal:** Build comprehensive understanding of what the user has provided.
 
@@ -416,11 +431,11 @@ fest_type: workflow
 
 **Output:** Mental model of the user's intent (no document yet)
 
-**Checkpoint:** None — proceed to Step 2
+**Checkpoint:** None — proceed to Step 3
 
 ---
 
-## Step 2: EXTRACT — Identify Key Elements
+## Step 3: EXTRACT — Identify Key Elements
 
 **Goal:** Pull out the essential information that needs to be structured.
 
@@ -432,11 +447,11 @@ fest_type: workflow
 
 **Output:** Notes on each element (can be rough)
 
-**Checkpoint:** None — proceed to Step 3
+**Checkpoint:** None — proceed to Step 4
 
 ---
 
-## Step 3: STRUCTURE — Produce Output Specs
+## Step 4: STRUCTURE — Produce Output Specs
 
 **Goal:** Transform extracted elements into structured documents.
 
@@ -448,11 +463,11 @@ fest_type: workflow
 
 **Output:** Four documents in output_specs/
 
-**Checkpoint:** None — proceed to Step 4
+**Checkpoint:** None — proceed to Step 5
 
 ---
 
-## Step 4: PRESENT — Get User Approval
+## Step 5: PRESENT — Get User Approval
 
 **Goal:** Verify the structured output captures the user's intent.
 
@@ -467,12 +482,12 @@ fest_type: workflow
 
 ---
 
-## Step 5: ITERATE or COMPLETE
+## Step 6: ITERATE or COMPLETE
 
 **Goal:** Handle user feedback or finalize the phase.
 
 **Actions:**
-1. If user rejects: Note feedback, return to Step 3, update specs
+1. If user rejects: Note feedback, return to Step 4, update specs
 2. If user approves: Mark phase complete
 
 **Output:** Phase completion or iteration
@@ -486,24 +501,21 @@ fest_type: workflow
 		t.Fatalf("ParseContent() error = %v", err)
 	}
 
-	if len(steps) != 5 {
-		t.Errorf("ParseContent() got %d steps, want 5", len(steps))
+	if len(steps) != 6 {
+		t.Errorf("ParseContent() got %d steps, want 6", len(steps))
 	}
 
-	// Verify step names
-	expectedNames := []string{"READ", "EXTRACT", "STRUCTURE", "PRESENT", "ITERATE or COMPLETE"}
+	expectedNames := []string{"GATHER", "READ", "EXTRACT", "STRUCTURE", "PRESENT", "ITERATE or COMPLETE"}
 	for i, name := range expectedNames {
 		if i < len(steps) && steps[i].Name != name {
 			t.Errorf("Step %d name = %q, want %q", i+1, steps[i].Name, name)
 		}
 	}
 
-	// Verify checkpoint on step 4
-	if steps[3].Checkpoint != CheckpointUserApproval {
-		t.Errorf("Step 4 checkpoint = %v, want CheckpointUserApproval", steps[3].Checkpoint)
+	if steps[4].Checkpoint != CheckpointUserApproval {
+		t.Errorf("Step 5 checkpoint = %v, want CheckpointUserApproval", steps[4].Checkpoint)
 	}
 
-	// Verify actions count
 	if len(steps[0].Actions) != 4 {
 		t.Errorf("Step 1 has %d actions, want 4", len(steps[0].Actions))
 	}

--- a/internal/navigation/state.go
+++ b/internal/navigation/state.go
@@ -189,6 +189,21 @@ func (n *Navigation) SetLinkWithPath(festivalName, projectPath, festivalPath str
 	n.ProjectLinks[projectPath] = festivalName
 }
 
+// ProjectConflict returns information about a conflicting project link, if one exists.
+// It reports the existing festival name, its stored festival path, and whether it
+// differs from the requesting festival. Callers use this to warn before overwriting.
+func (n *Navigation) ProjectConflict(festivalName, projectPath string) (existingFestival string, existingFestivalPath string, hasConflict bool) {
+	existing, ok := n.ProjectLinks[projectPath]
+	if !ok || existing == festivalName {
+		return "", "", false
+	}
+	existingLink := n.Links[existing]
+	if existingLink != nil {
+		return existing, existingLink.FestivalPath, true
+	}
+	return existing, "", true
+}
+
 // GetLink retrieves a project link for a festival
 func (n *Navigation) GetLink(festivalName string) (*Link, bool) {
 	link, ok := n.Links[festivalName]

--- a/internal/navigation/state_test.go
+++ b/internal/navigation/state_test.go
@@ -606,3 +606,96 @@ func TestNavigation_RelinkWithSaveLoadCycle(t *testing.T) {
 		t.Errorf("After persist, expected 1 project link, got %d", len(nav3.ProjectLinks))
 	}
 }
+
+func TestNavigation_ProjectConflict_NoConflict(t *testing.T) {
+	setupTestCampaign(t)
+
+	nav, err := LoadNavigation()
+	if err != nil {
+		t.Fatalf("LoadNavigation() error = %v", err)
+	}
+
+	nav.SetLink("festival-a", "/path/to/project-a")
+
+	existing, _, hasConflict := nav.ProjectConflict("festival-a", "/path/to/project-a")
+	if hasConflict {
+		t.Errorf("ProjectConflict() should not report conflict for same festival, got existing=%q", existing)
+	}
+
+	_, _, hasConflict = nav.ProjectConflict("festival-b", "/path/to/project-b")
+	if hasConflict {
+		t.Error("ProjectConflict() should not report conflict for unlinked project")
+	}
+}
+
+func TestNavigation_ProjectConflict_ActiveFestivalBlocked(t *testing.T) {
+	setupTestCampaign(t)
+
+	nav, err := LoadNavigation()
+	if err != nil {
+		t.Fatalf("LoadNavigation() error = %v", err)
+	}
+
+	projectPath := "/path/to/shared-project"
+	activeFestivalPath := "/path/to/campaigns/festivals/active/fest-a-FA0009"
+
+	nav.SetLinkWithPath("fest-a-FA0009", projectPath, activeFestivalPath)
+
+	existing, existingFestivalPath, hasConflict := nav.ProjectConflict("fest-b-FA0010", projectPath)
+	if !hasConflict {
+		t.Fatal("ProjectConflict() should detect conflict when project is linked to a different festival")
+	}
+	if existing != "fest-a-FA0009" {
+		t.Errorf("ProjectConflict() existing = %q, want %q", existing, "fest-a-FA0009")
+	}
+	if existingFestivalPath != activeFestivalPath {
+		t.Errorf("ProjectConflict() existingFestivalPath = %q, want %q", existingFestivalPath, activeFestivalPath)
+	}
+
+	if nav.GetLinkedFestival(projectPath) != "fest-a-FA0009" {
+		t.Error("ProjectConflict() must not mutate state; active festival link should still be intact")
+	}
+}
+
+func TestNavigation_ProjectConflict_PlanningFestivalAllowed(t *testing.T) {
+	setupTestCampaign(t)
+
+	nav, err := LoadNavigation()
+	if err != nil {
+		t.Fatalf("LoadNavigation() error = %v", err)
+	}
+
+	projectPath := "/path/to/shared-project"
+	planningFestivalPath := "/path/to/campaigns/festivals/planning/fest-b-FA0010"
+
+	nav.SetLinkWithPath("fest-b-FA0010", projectPath, planningFestivalPath)
+
+	existing, _, hasConflict := nav.ProjectConflict("fest-c-FA0011", projectPath)
+	if !hasConflict {
+		t.Fatal("ProjectConflict() should detect conflict for any different festival (caller decides to block or allow)")
+	}
+	if existing != "fest-b-FA0010" {
+		t.Errorf("ProjectConflict() existing = %q, want %q", existing, "fest-b-FA0010")
+	}
+}
+
+func TestNavigation_ProjectConflict_LegacyLinkTreatedAsActive(t *testing.T) {
+	setupTestCampaign(t)
+
+	nav, err := LoadNavigation()
+	if err != nil {
+		t.Fatalf("LoadNavigation() error = %v", err)
+	}
+
+	projectPath := "/path/to/shared-project"
+
+	nav.SetLink("legacy-festival", projectPath)
+
+	_, existingFestivalPath, hasConflict := nav.ProjectConflict("new-festival", projectPath)
+	if !hasConflict {
+		t.Fatal("ProjectConflict() should detect conflict for legacy link")
+	}
+	if existingFestivalPath != "" {
+		t.Errorf("ProjectConflict() existingFestivalPath should be empty for legacy link (no festival path stored), got %q", existingFestivalPath)
+	}
+}

--- a/methodology/festivals/.festival/templates/phases/ingest/WORKFLOW.md
+++ b/methodology/festivals/.festival/templates/phases/ingest/WORKFLOW.md
@@ -10,7 +10,23 @@ This document guides the agent through the ingest phase. Follow these steps in o
 
 ---
 
-## Step 1: READ — Understand All Input
+## Step 1: GATHER — Copy All Requirement Artifacts into input_specs/
+
+**Goal:** Ensure every piece of requirement material the user already has is present in `input_specs/` before any reading or analysis begins.
+
+**Actions:**
+1. Ask the user (or check the festival context) what requirement artifacts exist: intents, notes, structured specs, prior planning text, chat history summaries, docs, screenshots, or any other relevant material
+2. Copy or transcribe each artifact into `input_specs/` — one file per source, named descriptively (e.g., `intent-original.md`, `prior-design-notes.md`, `user-chat-summary.md`)
+3. If the user seeded content at festival creation time, confirm it is present in `input_specs/` and correctly named
+4. List the files now in `input_specs/` and confirm with the user that nothing is missing before proceeding
+
+**Output:** All available requirement artifacts present in `input_specs/`
+
+**Checkpoint:** None — proceed to Step 2
+
+---
+
+## Step 2: READ — Understand All Input
 
 **Goal:** Build comprehensive understanding of what the user has provided.
 
@@ -22,11 +38,11 @@ This document guides the agent through the ingest phase. Follow these steps in o
 
 **Output:** Mental model of the user's intent (no document yet)
 
-**Checkpoint:** None — proceed to Step 2
+**Checkpoint:** None — proceed to Step 3
 
 ---
 
-## Step 2: EXTRACT — Identify Key Elements
+## Step 3: EXTRACT — Identify Key Elements
 
 **Goal:** Pull out the essential information that needs to be structured.
 
@@ -38,11 +54,11 @@ This document guides the agent through the ingest phase. Follow these steps in o
 
 **Output:** Notes on each element (can be rough)
 
-**Checkpoint:** None — proceed to Step 3
+**Checkpoint:** None — proceed to Step 4
 
 ---
 
-## Step 3: STRUCTURE — Produce Output Specs
+## Step 4: STRUCTURE — Produce Output Specs
 
 **Goal:** Transform extracted elements into structured documents.
 
@@ -54,11 +70,11 @@ This document guides the agent through the ingest phase. Follow these steps in o
 
 **Output:** Four documents in `output_specs/`
 
-**Checkpoint:** None — proceed to Step 4
+**Checkpoint:** None — proceed to Step 5
 
 ---
 
-## Step 4: PRESENT — Get User Approval
+## Step 5: PRESENT — Get User Approval
 
 **Goal:** Verify the structured output captures the user's intent.
 
@@ -73,12 +89,12 @@ This document guides the agent through the ingest phase. Follow these steps in o
 
 ---
 
-## Step 5: ITERATE or COMPLETE
+## Step 6: ITERATE or COMPLETE
 
 **Goal:** Handle user feedback or finalize the phase.
 
 **Actions:**
-1. If user rejects: Note feedback, return to Step 3, update specs
+1. If user rejects: Note feedback, return to Step 4, update specs
 2. If user approves: Mark phase complete, note any caveats
 
 **Output:** Phase completion or iteration
@@ -91,8 +107,9 @@ This document guides the agent through the ingest phase. Follow these steps in o
 
 | Step | Status | Notes |
 |------|--------|-------|
-| 1. READ | [ ] pending | |
-| 2. EXTRACT | [ ] pending | |
-| 3. STRUCTURE | [ ] pending | |
-| 4. PRESENT | [ ] pending | Blocks until user approval |
-| 5. COMPLETE | [ ] pending | |
+| 1. GATHER | [ ] pending | Blocks until all artifacts are in input_specs/ |
+| 2. READ | [ ] pending | |
+| 3. EXTRACT | [ ] pending | |
+| 4. STRUCTURE | [ ] pending | |
+| 5. PRESENT | [ ] pending | Blocks until user approval |
+| 6. COMPLETE | [ ] pending | |


### PR DESCRIPTION
# Intent-backlog cleanup — fest

Consolidated umbrella PR for the fest portion of the intent-backlog cleanup (`[WI-ee98f2]`). Each intent landed as its own gate-green PR into the `intent-cleanup` branch; this is the single review surface for what is headed to `main`. Nothing is on `main` yet.

Part of `workflow/design/intent-backlog-cleanup/` (`WI-ee98f2`).

## What's in here (6 intents)

| Per-intent PR | Intent | Summary |
|---|---|---|
| #200 | Workflow phase header | Render the real phase type instead of a generic "WORKFLOW" label in the workflow phase step header |
| #201 | Link-hijack guard | Block a planning-festival link from silently overwriting an active festival's project link |
| #202 | Ingest template | Add a GATHER step as the first ingest workflow step (copy existing requirements into `input_specs/`) |
| #203 | `fest walk` / `fest inspect` | New guided festival-orientation command |
| #204 | Picker cluster (2 intents) | Picker fallback for `fest status` / `fest progress` with no context **+** left/right festival cycling in `fest watch` |

## Intent detail

- **#200** — `navigator.FormatProgress` now uses `displayPhaseType()` rather than the raw `string(n.mode)`, so the header shows the actual phase type and cannot silently regress to "WORKFLOW".
- **#201** — `linkFestivalToProject` already guarded against hijacking an active festival's link; the project→festival direction did not (see "Review findings" below).
- **#203** — `fest walk` (alias `inspect`) prints what a festival is, where it is, status/progress, next task, blocked tasks, active gates, and warnings. It is read-mostly: it can transparently migrate a legacy progress file on first access (`progress.NewManager`), which the help text now states honestly.
- **#204** — When run outside any festival, `status`/`progress` fall back to a picker; `watch` gains left/right cycling across a festival cluster.

## Review findings addressed in this umbrella

Two commits in this umbrella fix issues that the per-intent reviews missed:

### `1f634bb` — complete the #201 hijack guard + two correctness fixes
- **Blocking:** `runGoLink` routes the in-a-project case to `linkProjectToFestival`, whose picker can surface planning festivals, but that function called `SetLinkWithPath` with **no** conflict guard. A project already linked to an active festival could be silently re-pointed at a planning festival. Added the same `ProjectConflict` + `isActiveFestivalPath` guard used by `linkFestivalToProject`, with `--force` escape semantics threaded through `runGoLink` → `linkProjectToFestival` and the `link.go` caller.
- **walk UTF-8:** goal-line truncation used a byte slice (`trimmed[:300]`) which can split a multibyte rune; now truncates on a rune slice.
- **`isActiveFestivalPath`:** matched *any* path component named `active` (so a workspace under an ancestor dir literally named `active` was misclassified); now checks the immediate parent dir only (`filepath.Base(filepath.Dir(path)) == "active"`), matching `walk.detectKind`.
- Tests: `TestLinkProjectToFestival_HijackGuardBlocks`, `TestIsActiveFestivalPath_ImmediateParentOnly`, `TestLoadGoal_MultibyteTruncation`.

### `eb7934b` — restore cwd location granularity regressed by #204 + polish
- **Blocking regression:** #204 changed `detectPath`/`targetPath` from `cwd` to the resolved festival **root** in `status/handlers.go` and `progress/progress.go`. Since `ResolveFestivalPath` returns the festival root, both commands always reported `loc.Type = "festival"` regardless of the real cwd, losing phase/sequence granularity. Restored `cwd` for the non-picker branch (the picker branch still uses the picked root, since cwd is outside any festival). Tests: `TestStatusLocationGranularity_SubdirUsescwd`, `TestProgressLocationGranularity_SubdirUsescwd`.
- **`watch` infinite-spin guard:** `runWatchCycle` now tracks a stale-since index and returns a validation error after one full rotation with no successful festival load, instead of spinning CPU when every cycle target goes stale.
- **Honesty/cleanup:** dropped the false "read-only" claim from `fest walk` help; removed an unreachable `ritual-run` branch in `detectKind` (ritual-status festivals live under `festivals/ritual/` and are caught by the `ritual-template` check; nothing consumed `ritual-run`).

## Verification (at head `eb7934b`)

- `go build ./...` — clean
- `just lint all` — **0 issues**; `just lint vet` — clean
- Changed-package tests green: `navigation`, `walk`, `status`, `progress`, `watch`, `guidance/workflow`, `navigation` (state) — including all new hijack-guard / granularity / UTF-8 / cycling tests.

## Non-blocking follow-ups (not gating)

- `fest walk` is sold as orientation but can migrate legacy progress formats on first access. The help text now says so; a true read-only mode in `progress.NewManager` would be cleaner long-term.
- The hijack-guard test exercises `ProjectConflict` + `isActiveFestivalPath` directly rather than the picker-driven command path (the picker needs a TTY). Adequate, but an extracted/seam-tested guard would be stronger.
