### PR TITLE
fix(link): unify active-festival link --force hint (#206 item 4)

### DIFF
--- a/internal/commands/navigation/go_link.go
+++ b/internal/commands/navigation/go_link.go
@@ -27,6 +27,8 @@ var (
 	pathStyle     = lipgloss.NewStyle().Foreground(ui.MetadataColor)
 )
 
+const linkForceHint = "use 'fest link --force' to override, or run 'fest unlink' from the active festival first"
+
 // NewGoLinkCommand creates the context-aware link subcommand for fest go
 func NewGoLinkCommand() *cobra.Command {
 	var force bool
@@ -174,7 +176,7 @@ func linkFestivalToProject(ctx context.Context, cwd, targetPath string) error {
 			return festErrors.Validation("project is already linked to an active festival").
 				WithField("existing_festival", existing).
 				WithField("project", projectPath).
-				WithField("hint", "use 'fest link --force' to override, or run 'fest unlink' from the active festival first")
+				WithField("hint", linkForceHint)
 		}
 	}
 
@@ -277,7 +279,7 @@ func linkProjectToFestival(cwd string, force bool) error {
 				return festErrors.Validation("project is already linked to an active festival").
 					WithField("existing_festival", existing).
 					WithField("project", absPath).
-					WithField("hint", "use 'fgo link --force' to override, or run 'fest unlink' from the active festival first")
+					WithField("hint", linkForceHint)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Follow-up item **4 of #206** (non-blocking findings from the intent-cleanup review of #205).

`linkProjectToFestival` (`go_link.go:280`) hinted `'fgo link --force'` while the sibling guard in `linkFestivalToProject` (`go_link.go:177`) hinted `'fest link --force'`. The user-facing subcommand is `fest link`, so the `fgo` variant was wrong.

## Change

Extract the shared remediation hint into a single `linkForceHint` constant used by both guard sites, so the two can't drift again. No behavior change beyond the corrected hint text.

Scope note: line 172's guard intentionally differs from line 274's `if !force` wrapper — that's separate logic and is left untouched here.

## Gates

- `just lint all` -> 0 issues
- `just test unit-raw` -> all packages pass

Refs #206 (item 4).