### PR TITLE
fix(walk): make fest walk/inspect truly read-only (#206 item 3)

### DIFF
--- a/internal/commands/shared/workflow_render.go
+++ b/internal/commands/shared/workflow_render.go
@@ -130,9 +130,10 @@ func LoadWorkflowStepsForPhase(ctx context.Context, festivalPath, phasePath stri
 		return []WorkflowStepView{}, nil
 	}
 
-	// Load workflow state from Store (JSONL-backed)
+	// Load workflow state read-only: rendering steps for display must never
+	// migrate or rewrite the festival's .fest/ files as a side effect.
 	store := progress.NewStore(festivalPath)
-	if err := store.Load(ctx); err != nil {
+	if err := store.LoadReadOnly(ctx); err != nil {
 		return nil, fmt.Errorf("loading progress store: %w", err)
 	}
 	state, ok := store.WorkflowPhaseState(phaseName)
@@ -227,7 +228,7 @@ func LoadGateStepsForPhase(ctx context.Context, festivalPath, phasePath string) 
 	}
 
 	store := progress.NewStore(festivalPath)
-	if err := store.Load(ctx); err != nil {
+	if err := store.LoadReadOnly(ctx); err != nil {
 		return nil, fmt.Errorf("loading progress store: %w", err)
 	}
 	state, ok := store.GatePhaseState(phaseName)

--- a/internal/commands/show/stats.go
+++ b/internal/commands/show/stats.go
@@ -73,8 +73,9 @@ func CalculateFestivalStats(ctx context.Context, festivalDir string) (*FestivalS
 	festivalRoot := resolveFestivalRoot(festivalDir)
 
 	// Manager is the single source of truth for progress numbers.
-	// Keep a reference to delegate task totals after the structural walk.
-	mgr, mgrErr := progress.NewManager(ctx, festivalRoot)
+	// Stats are display-only, so load read-only: computing a festival's stats
+	// must never migrate or rewrite its .fest/ files as a side effect.
+	mgr, mgrErr := progress.NewManagerReadOnly(ctx, festivalRoot)
 	var store *progress.Store
 	if mgrErr == nil {
 		store = mgr.Store()

--- a/internal/commands/show/stats_readonly_test.go
+++ b/internal/commands/show/stats_readonly_test.go
@@ -1,0 +1,59 @@
+package show
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/progress"
+)
+
+func TestCalculateFestivalStats_DoesNotMutate(t *testing.T) {
+	festivalDir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(festivalDir, "fest.yaml"), []byte("name: stats-ro\nmetadata:\n  id: SR0001\n"), 0o644); err != nil {
+		t.Fatalf("write fest.yaml: %v", err)
+	}
+	taskDir := filepath.Join(festivalDir, "001_PLAN", "01_seq")
+	if err := os.MkdirAll(taskDir, 0o755); err != nil {
+		t.Fatalf("mkdir task dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(taskDir, "01_task.md"), []byte("# Task\n"), 0o644); err != nil {
+		t.Fatalf("write task: %v", err)
+	}
+
+	festDir := filepath.Join(festivalDir, progress.ProgressDir)
+	if err := os.MkdirAll(festDir, 0o755); err != nil {
+		t.Fatalf("mkdir .fest: %v", err)
+	}
+	legacyYAML := "festival: stats-ro\nupdated_at: 2026-01-15T10:00:00Z\ntasks:\n" +
+		"  001_PLAN/01_seq/01_task.md:\n" +
+		"    task_id: 001_PLAN/01_seq/01_task.md\n" +
+		"    status: completed\n" +
+		"    progress: 100\n" +
+		"    started_at: 2026-01-15T09:00:00Z\n" +
+		"    completed_at: 2026-01-15T09:30:00Z\n"
+	legacyPath := filepath.Join(festDir, progress.ProgressFileName)
+	if err := os.WriteFile(legacyPath, []byte(legacyYAML), 0o644); err != nil {
+		t.Fatalf("write legacy progress: %v", err)
+	}
+
+	stats, err := CalculateFestivalStats(context.Background(), festivalDir)
+	if err != nil {
+		t.Fatalf("CalculateFestivalStats: %v", err)
+	}
+	if stats == nil {
+		t.Fatal("stats is nil")
+	}
+
+	if _, err := os.Stat(legacyPath); err != nil {
+		t.Errorf("legacy progress.yaml was removed by stats calculation: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(festDir, progress.ProgressEventsFile)); !os.IsNotExist(err) {
+		t.Error("stats calculation wrote progress_events.jsonl; it must not mutate disk")
+	}
+	if stats.Tasks.Total < 1 {
+		t.Errorf("stats.Tasks.Total = %d, want >= 1 (read-only load must still report progress)", stats.Tasks.Total)
+	}
+}

--- a/internal/commands/show/stats_readonly_test.go
+++ b/internal/commands/show/stats_readonly_test.go
@@ -5,8 +5,11 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
 	"github.com/Obedience-Corp/fest/internal/progress"
+	"gopkg.in/yaml.v3"
 )
 
 func TestCalculateFestivalStats_DoesNotMutate(t *testing.T) {
@@ -55,5 +58,68 @@ func TestCalculateFestivalStats_DoesNotMutate(t *testing.T) {
 	}
 	if stats.Tasks.Total < 1 {
 		t.Errorf("stats.Tasks.Total = %d, want >= 1 (read-only load must still report progress)", stats.Tasks.Total)
+	}
+}
+
+func TestCalculateFestivalStats_WorkflowPhaseDoesNotMutate(t *testing.T) {
+	festivalDir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(festivalDir, "fest.yaml"), []byte("name: stats-wf-ro\nmetadata:\n  id: SR0002\n"), 0o644); err != nil {
+		t.Fatalf("write fest.yaml: %v", err)
+	}
+
+	phaseDir := filepath.Join(festivalDir, "001_INGEST")
+	if err := os.MkdirAll(phaseDir, 0o755); err != nil {
+		t.Fatalf("mkdir phase dir: %v", err)
+	}
+	workflowMD := "# Ingest Workflow\n\n" +
+		"## Step 1: Gather inputs\n\n**Goal:** collect specs\n\n" +
+		"## Step 2: Synthesize\n\n**Goal:** produce output\n"
+	if err := os.WriteFile(filepath.Join(phaseDir, "WORKFLOW.md"), []byte(workflowMD), 0o644); err != nil {
+		t.Fatalf("write WORKFLOW.md: %v", err)
+	}
+
+	festDir := filepath.Join(festivalDir, progress.ProgressDir)
+	if err := os.MkdirAll(festDir, 0o755); err != nil {
+		t.Fatalf("mkdir .fest: %v", err)
+	}
+
+	started := time.Date(2026, 1, 15, 9, 0, 0, 0, time.UTC)
+	completed := started.Add(30 * time.Minute)
+	state := &wf.FestivalWorkflowState{
+		Version:   1,
+		CreatedAt: started,
+		UpdatedAt: completed,
+		Phases: map[string]*wf.WorkflowState{
+			"001_INGEST": {
+				CurrentStep: 2,
+				TotalSteps:  2,
+				CreatedAt:   started,
+				UpdatedAt:   completed,
+				Steps: map[int]*wf.StepState{
+					1: {Number: 1, Status: wf.StepStatusCompleted, StartedAt: &started, CompletedAt: &completed},
+					2: {Number: 2, Status: wf.StepStatusInProgress, StartedAt: &completed},
+				},
+			},
+		},
+	}
+	data, err := yaml.Marshal(state)
+	if err != nil {
+		t.Fatalf("marshal workflow state: %v", err)
+	}
+	workflowYAML := filepath.Join(festDir, wf.StateFileName)
+	if err := os.WriteFile(workflowYAML, data, 0o644); err != nil {
+		t.Fatalf("write workflow_state.yaml: %v", err)
+	}
+
+	if _, err := CalculateFestivalStats(context.Background(), festivalDir); err != nil {
+		t.Fatalf("CalculateFestivalStats: %v", err)
+	}
+
+	if _, err := os.Stat(workflowYAML); err != nil {
+		t.Errorf("workflow_state.yaml was consumed by stats calculation: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(festDir, progress.ProgressEventsFile)); !os.IsNotExist(err) {
+		t.Error("stats calculation wrote progress_events.jsonl for a workflow phase; it must not mutate disk")
 	}
 }

--- a/internal/commands/walk/walk.go
+++ b/internal/commands/walk/walk.go
@@ -66,7 +66,7 @@ func NewWalkCommand() *cobra.Command {
 
 Shows what the festival is, where it is, its current status and progress,
 the next task, blocked tasks, active quality gates, and any warnings.
-May transparently migrate legacy progress formats on first access.
+This is a read-only orientation command; it never mutates festival state.
 
 Useful for quickly orienting inside a festival before continuing work,
 especially for rituals where the template and active run are distinct.
@@ -133,7 +133,7 @@ func runWalk(ctx context.Context, opts *walkOptions) error {
 	view.Goal = loadGoal(festivalPath)
 	view.Warnings = append(view.Warnings, kindWarnings(view.Kind, festival)...)
 
-	mgr, mgrErr := progress.NewManager(ctx, festivalPath)
+	mgr, mgrErr := progress.NewManagerReadOnly(ctx, festivalPath)
 	if mgrErr == nil {
 		festProgress, progressErr := mgr.GetFestivalProgress(ctx, festivalPath)
 		if progressErr == nil && festProgress.Overall != nil {
@@ -243,7 +243,7 @@ func resolveNext(ctx context.Context, festivalPath, cwd string) string {
 		return ""
 	}
 
-	mgr, mgrErr := progress.NewManager(ctx, festivalPath)
+	mgr, mgrErr := progress.NewManagerReadOnly(ctx, festivalPath)
 
 	for _, entry := range entries {
 		if !entry.IsDir() || !hasNumericPrefix(entry.Name()) {

--- a/internal/progress/events.go
+++ b/internal/progress/events.go
@@ -68,57 +68,59 @@ type ProgressEvent struct {
 
 // loadFromEvents reads the JSONL file and materializes current state.
 func (s *Store) loadFromEvents(ctx context.Context) error {
+	events, err := s.parseEventsFile(ctx)
+	if err != nil {
+		return err
+	}
+	s.materializeFrom(events)
+	return nil
+}
+
+func (s *Store) parseEventsFile(ctx context.Context) ([]ProgressEvent, error) {
 	if err := ctx.Err(); err != nil {
-		return errors.Wrap(err, "context cancelled")
+		return nil, errors.Wrap(err, "context cancelled")
 	}
 
 	eventsPath := s.eventsFilePath()
 
 	f, err := os.Open(eventsPath)
 	if err != nil {
-		return errors.IO("opening events file", err).
+		return nil, errors.IO("opening events file", err).
 			WithField("path", eventsPath)
 	}
 	defer func() { _ = f.Close() }()
 
 	var events []ProgressEvent
 	scanner := bufio.NewScanner(f)
-	lineNum := 0
 	for scanner.Scan() {
-		lineNum++
 		line := scanner.Bytes()
 		if len(line) == 0 {
-			continue // Skip empty lines
+			continue
 		}
 
 		var event ProgressEvent
 		if err := json.Unmarshal(line, &event); err != nil {
-			// Log warning but continue - don't fail on single bad line
-			// This makes the format resilient to partial writes
 			continue
 		}
 		events = append(events, event)
 	}
 
 	if err := scanner.Err(); err != nil {
-		return errors.IO("reading events file", err).
+		return nil, errors.IO("reading events file", err).
 			WithField("path", eventsPath)
 	}
 
-	// Materialize state from events
+	return events, nil
+}
+
+func (s *Store) materializeFrom(events []ProgressEvent) {
 	s.data = &FestivalProgressData{
 		Festival:  filepath.Base(s.festivalPath),
 		UpdatedAt: time.Now().UTC(),
 		Tasks:     materializeState(events),
 	}
-
-	// Initialize TimeMetrics from events
 	s.data.TimeMetrics = materializeTimeMetrics(events, s.data.Tasks)
-
-	// Materialize workflow state from events
 	s.workflowData = materializeWorkflowState(events)
-
-	return nil
 }
 
 // materializeState builds current task state from a sequence of events.

--- a/internal/progress/manager.go
+++ b/internal/progress/manager.go
@@ -44,6 +44,21 @@ func NewManagerWithGate(ctx context.Context, festivalPath string, gate Gate) (*M
 	return &Manager{store: store, gate: gate}, nil
 }
 
+// NewManagerReadOnly creates a progress manager that never mutates disk while
+// loading: legacy progress and workflow YAML are materialized in memory rather
+// than migrated. Use for orientation-only callers such as walk/inspect.
+func NewManagerReadOnly(ctx context.Context, festivalPath string) (*Manager, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, errors.Wrap(err, "context cancelled")
+	}
+
+	store := NewStore(festivalPath)
+	if err := store.LoadReadOnly(ctx); err != nil {
+		return nil, errors.Wrap(err, "loading progress data")
+	}
+	return &Manager{store: store, gate: NoopGate{}}, nil
+}
+
 // UpdateProgress updates the progress percentage for a task
 func (m *Manager) UpdateProgress(ctx context.Context, taskID string, progress int) error {
 	if err := ctx.Err(); err != nil {

--- a/internal/progress/store.go
+++ b/internal/progress/store.go
@@ -157,6 +157,54 @@ func (s *Store) Load(ctx context.Context) error {
 	return nil
 }
 
+// LoadReadOnly materializes progress state without mutating disk. Unlike Load,
+// it never converts legacy YAML to JSONL or removes workflow_state.yaml; legacy
+// formats are parsed into synthetic events in memory and materialized the same
+// way Load would after migration. Use for orientation-only callers (walk/inspect).
+func (s *Store) LoadReadOnly(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return errors.Wrap(err, "context cancelled")
+	}
+
+	var events []ProgressEvent
+
+	switch {
+	case fileExists(s.eventsFilePath()):
+		parsed, err := s.parseEventsFile(ctx)
+		if err != nil {
+			return err
+		}
+		events = parsed
+	case fileExists(s.legacyFilePath()):
+		if err := s.loadLegacyYAML(ctx); err != nil {
+			return errors.Wrap(err, "loading legacy progress format")
+		}
+		events = generateEventsFromState(s.data.Tasks)
+	}
+
+	if fileExists(s.workflowYAMLPath()) {
+		workflowEvents, err := s.readonlyWorkflowEvents(ctx)
+		if err != nil {
+			return err
+		}
+		events = append(events, workflowEvents...)
+	}
+
+	s.materializeFrom(events)
+	return nil
+}
+
+func (s *Store) readonlyWorkflowEvents(ctx context.Context) ([]ProgressEvent, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, errors.Wrap(err, "context cancelled")
+	}
+	festState, err := s.parseWorkflowYAML()
+	if err != nil {
+		return nil, err
+	}
+	return generateWorkflowEventsFromYAML(festState), nil
+}
+
 // fileExists checks if a file exists and is not a directory
 func fileExists(path string) bool {
 	info, err := os.Stat(path)
@@ -592,34 +640,14 @@ func (s *Store) migrateWorkflowYAML(ctx context.Context) error {
 		return nil
 	}
 
-	// Read and parse the YAML file
-	data, err := os.ReadFile(yamlPath)
+	festState, err := s.parseWorkflowYAML()
 	if err != nil {
-		return errors.IO("reading workflow state YAML", err).
-			WithField("path", yamlPath)
+		return err
 	}
 
-	var festState wf.FestivalWorkflowState
-	if err := yaml.Unmarshal(data, &festState); err != nil {
-		return errors.Parse("parsing workflow state YAML", err).
-			WithField("path", yamlPath)
-	}
-
-	// Ensure maps are initialized
-	if festState.Phases == nil {
-		festState.Phases = make(map[string]*wf.WorkflowState)
-	}
-	for _, phaseState := range festState.Phases {
-		if phaseState.Steps == nil {
-			phaseState.Steps = make(map[int]*wf.StepState)
-		}
-	}
-
-	// Generate synthetic events from the YAML state
-	syntheticEvents := generateWorkflowEventsFromYAML(&festState)
+	syntheticEvents := generateWorkflowEventsFromYAML(festState)
 
 	if len(syntheticEvents) > 0 {
-		// Append synthetic events to JSONL
 		ptrs := make([]*ProgressEvent, len(syntheticEvents))
 		for i := range syntheticEvents {
 			ptrs[i] = &syntheticEvents[i]
@@ -638,4 +666,31 @@ func (s *Store) migrateWorkflowYAML(ctx context.Context) error {
 	_ = os.Remove(yamlPath)
 
 	return nil
+}
+
+func (s *Store) parseWorkflowYAML() (*wf.FestivalWorkflowState, error) {
+	yamlPath := s.workflowYAMLPath()
+
+	data, err := os.ReadFile(yamlPath)
+	if err != nil {
+		return nil, errors.IO("reading workflow state YAML", err).
+			WithField("path", yamlPath)
+	}
+
+	var festState wf.FestivalWorkflowState
+	if err := yaml.Unmarshal(data, &festState); err != nil {
+		return nil, errors.Parse("parsing workflow state YAML", err).
+			WithField("path", yamlPath)
+	}
+
+	if festState.Phases == nil {
+		festState.Phases = make(map[string]*wf.WorkflowState)
+	}
+	for _, phaseState := range festState.Phases {
+		if phaseState.Steps == nil {
+			phaseState.Steps = make(map[int]*wf.StepState)
+		}
+	}
+
+	return &festState, nil
 }

--- a/internal/progress/store.go
+++ b/internal/progress/store.go
@@ -157,40 +157,53 @@ func (s *Store) Load(ctx context.Context) error {
 	return nil
 }
 
-// LoadReadOnly materializes progress state without mutating disk. Unlike Load,
-// it never converts legacy YAML to JSONL or removes workflow_state.yaml; legacy
-// formats are parsed into synthetic events in memory and materialized the same
-// way Load would after migration. Use for orientation-only callers (walk/inspect).
+// LoadReadOnly materializes progress state without mutating disk: it never
+// converts legacy YAML to JSONL or removes workflow_state.yaml. JSONL, when
+// present, is authoritative and is materialized from events (layering any
+// workflow_state.yaml on top). Legacy progress.yaml is loaded directly rather
+// than round-tripped through synthetic events, because accepted legacy entries
+// may omit started_at/completed_at and the synthetic-event path emits nothing
+// for those, which would silently drop completed/in-progress tasks. Use for
+// orientation-only callers (walk/inspect/stats).
 func (s *Store) LoadReadOnly(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return errors.Wrap(err, "context cancelled")
 	}
 
-	var events []ProgressEvent
-
-	switch {
-	case fileExists(s.eventsFilePath()):
-		parsed, err := s.parseEventsFile(ctx)
+	if fileExists(s.eventsFilePath()) {
+		events, err := s.parseEventsFile(ctx)
 		if err != nil {
 			return err
 		}
-		events = parsed
-	case fileExists(s.legacyFilePath()):
+		if fileExists(s.workflowYAMLPath()) {
+			workflowEvents, err := s.readonlyWorkflowEvents(ctx)
+			if err != nil {
+				return err
+			}
+			events = append(events, workflowEvents...)
+		}
+		s.materializeFrom(events)
+		return nil
+	}
+
+	if fileExists(s.legacyFilePath()) {
 		if err := s.loadLegacyYAML(ctx); err != nil {
 			return errors.Wrap(err, "loading legacy progress format")
 		}
-		events = generateEventsFromState(s.data.Tasks)
+	} else {
+		s.initializeEmptyState()
 	}
 
 	if fileExists(s.workflowYAMLPath()) {
-		workflowEvents, err := s.readonlyWorkflowEvents(ctx)
+		festState, err := s.parseWorkflowYAML()
 		if err != nil {
 			return err
 		}
-		events = append(events, workflowEvents...)
+		s.workflowData = festState
+	} else if s.workflowData == nil {
+		s.workflowData = wf.NewFestivalWorkflowState()
 	}
 
-	s.materializeFrom(events)
 	return nil
 }
 

--- a/internal/progress/store_readonly_test.go
+++ b/internal/progress/store_readonly_test.go
@@ -149,3 +149,37 @@ func TestLoadReadOnly_MatchesMigratingLoad(t *testing.T) {
 		t.Error("read-only load must preserve workflow_state.yaml")
 	}
 }
+
+func TestLoadReadOnly_PreservesTimestampFreeLegacyTasks(t *testing.T) {
+	dir := t.TempDir()
+	festDir := filepath.Join(dir, ProgressDir)
+	if err := os.MkdirAll(festDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	legacy := "festival: legacy-no-ts\nupdated_at: 2026-01-15T10:00:00Z\ntasks:\n" +
+		"  001_PHASE/01_seq/01_task.md:\n" +
+		"    task_id: 001_PHASE/01_seq/01_task.md\n" +
+		"    status: completed\n" +
+		"    progress: 100\n" +
+		"  001_PHASE/01_seq/02_task.md:\n" +
+		"    task_id: 001_PHASE/01_seq/02_task.md\n" +
+		"    status: in_progress\n" +
+		"    progress: 50\n"
+	if err := os.WriteFile(filepath.Join(festDir, ProgressFileName), []byte(legacy), 0o644); err != nil {
+		t.Fatalf("write legacy: %v", err)
+	}
+
+	store := NewStore(dir)
+	if err := store.LoadReadOnly(context.Background()); err != nil {
+		t.Fatalf("LoadReadOnly: %v", err)
+	}
+
+	completed, ok := store.GetTask("001_PHASE/01_seq/01_task.md")
+	if !ok || completed.Status != StatusCompleted {
+		t.Errorf("completed timestamp-free task lost: ok=%v task=%+v", ok, completed)
+	}
+	inProgress, ok := store.GetTask("001_PHASE/01_seq/02_task.md")
+	if !ok || inProgress.Status != StatusInProgress {
+		t.Errorf("in-progress timestamp-free task lost: ok=%v task=%+v", ok, inProgress)
+	}
+}

--- a/internal/progress/store_readonly_test.go
+++ b/internal/progress/store_readonly_test.go
@@ -1,0 +1,151 @@
+package progress
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+	"gopkg.in/yaml.v3"
+)
+
+const readonlyLegacyYAML = `festival: test-festival
+updated_at: 2026-01-15T10:00:00Z
+tasks:
+  001_PHASE/01_seq/01_task.md:
+    task_id: 001_PHASE/01_seq/01_task.md
+    status: completed
+    progress: 100
+    started_at: 2026-01-15T09:00:00Z
+    completed_at: 2026-01-15T09:30:00Z
+    time_spent_minutes: 30
+  001_PHASE/01_seq/02_task.md:
+    task_id: 001_PHASE/01_seq/02_task.md
+    status: in_progress
+    progress: 40
+    started_at: 2026-01-15T09:45:00Z
+`
+
+func writeReadonlyFixture(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	festDir := filepath.Join(dir, ProgressDir)
+	if err := os.MkdirAll(festDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(festDir, ProgressFileName), []byte(readonlyLegacyYAML), 0o644); err != nil {
+		t.Fatalf("write legacy yaml: %v", err)
+	}
+
+	started := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+	completed := started.Add(time.Hour)
+	state := &wf.FestivalWorkflowState{
+		Version:   1,
+		CreatedAt: started,
+		UpdatedAt: completed,
+		Phases: map[string]*wf.WorkflowState{
+			"001_PHASE": {
+				CurrentStep: 2,
+				TotalSteps:  2,
+				CreatedAt:   started,
+				UpdatedAt:   completed,
+				Steps: map[int]*wf.StepState{
+					1: {Number: 1, Status: wf.StepStatusCompleted, StartedAt: &started, CompletedAt: &completed},
+					2: {Number: 2, Status: wf.StepStatusInProgress, StartedAt: &completed},
+				},
+			},
+		},
+	}
+	data, err := yaml.Marshal(state)
+	if err != nil {
+		t.Fatalf("marshal workflow state: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(festDir, wf.StateFileName), data, 0o644); err != nil {
+		t.Fatalf("write workflow yaml: %v", err)
+	}
+
+	return dir
+}
+
+func TestLoadReadOnly_DoesNotMutateLegacyFiles(t *testing.T) {
+	dir := writeReadonlyFixture(t)
+	festDir := filepath.Join(dir, ProgressDir)
+
+	store := NewStore(dir)
+	if err := store.LoadReadOnly(context.Background()); err != nil {
+		t.Fatalf("LoadReadOnly: %v", err)
+	}
+
+	if !fileExists(filepath.Join(festDir, ProgressFileName)) {
+		t.Error("legacy progress.yaml was removed by LoadReadOnly")
+	}
+	if !fileExists(filepath.Join(festDir, wf.StateFileName)) {
+		t.Error("workflow_state.yaml was removed by LoadReadOnly")
+	}
+	if fileExists(filepath.Join(festDir, ProgressEventsFile)) {
+		t.Error("LoadReadOnly wrote progress_events.jsonl; it must not mutate disk")
+	}
+
+	task, ok := store.GetTask("001_PHASE/01_seq/01_task.md")
+	if !ok || task.Status != StatusCompleted {
+		t.Errorf("task status = %+v, want completed", task)
+	}
+}
+
+func TestLoadReadOnly_MatchesMigratingLoad(t *testing.T) {
+	roDir := writeReadonlyFixture(t)
+	migDir := writeReadonlyFixture(t)
+
+	roStore := NewStore(roDir)
+	if err := roStore.LoadReadOnly(context.Background()); err != nil {
+		t.Fatalf("LoadReadOnly: %v", err)
+	}
+
+	migStore := NewStore(migDir)
+	if err := migStore.Load(context.Background()); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	for _, id := range []string{"001_PHASE/01_seq/01_task.md", "001_PHASE/01_seq/02_task.md"} {
+		ro, okRO := roStore.GetTask(id)
+		mig, okMig := migStore.GetTask(id)
+		if okRO != okMig {
+			t.Fatalf("task %s presence: read-only=%v migrating=%v", id, okRO, okMig)
+		}
+		if ro.Status != mig.Status || ro.Progress != mig.Progress {
+			t.Errorf("task %s: read-only (%s,%d) != migrating (%s,%d)", id, ro.Status, ro.Progress, mig.Status, mig.Progress)
+		}
+	}
+
+	roPhase, okRO := roStore.WorkflowPhaseState("001_PHASE")
+	migPhase, okMig := migStore.WorkflowPhaseState("001_PHASE")
+	if okRO != okMig {
+		t.Fatalf("workflow phase presence: read-only=%v migrating=%v", okRO, okMig)
+	}
+	if okRO {
+		if roPhase.TotalSteps != migPhase.TotalSteps {
+			t.Errorf("workflow TotalSteps: read-only=%d migrating=%d", roPhase.TotalSteps, migPhase.TotalSteps)
+		}
+		for i := 1; i <= migPhase.TotalSteps; i++ {
+			rss := roPhase.GetStepState(i)
+			mss := migPhase.GetStepState(i)
+			if (rss == nil) != (mss == nil) {
+				t.Errorf("step %d presence: read-only=%v migrating=%v", i, rss != nil, mss != nil)
+				continue
+			}
+			if rss != nil && rss.Status != mss.Status {
+				t.Errorf("step %d status: read-only=%s migrating=%s", i, rss.Status, mss.Status)
+			}
+		}
+	}
+
+	if fileExists(filepath.Join(migDir, ProgressDir, wf.StateFileName)) {
+		t.Error("migrating Load should have consumed workflow_state.yaml")
+	}
+	if !fileExists(filepath.Join(roDir, ProgressDir, wf.StateFileName)) {
+		t.Error("read-only load must preserve workflow_state.yaml")
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up item **3 of #206** (non-blocking findings from the intent-cleanup review of #205).

`fest walk` / `fest inspect` advertises read-only orientation, but on first access to a **legacy** festival it mutated disk: it converted `.fest/progress.yaml` to JSONL and consumed `.fest/workflow_state.yaml`. PR #205 had only made the help text honest about this; this PR makes the command genuinely read-only.

## Root cause (found via a real-binary smoke, not just unit tests)

Walk's own progress loads were not the whole story. The mutation came from the **shared detection path**:

```
walk -> show.DetectCurrentFestival -> parseFestivalInfo -> CalculateFestivalStats -> progress.NewManager -> Store.Load (migrates)
```

`CalculateFestivalStats` is display-only but used the migrating `Load`, so *any* festival detection rewrote a legacy festival's `.fest/`. Unit tests that called the new read-only path directly passed while the binary still mutated — caught by a real `fest walk` smoke.

## Change

- **`Store.LoadReadOnly`** — materializes task/time/workflow state in memory from the same synthetic-event stream `Load` produces *after* migration, but never writes JSONL or removes YAML. Factored `parseEventsFile`/`materializeFrom` out of `loadFromEvents`, and `parseWorkflowYAML` out of `migrateWorkflowYAML`, to share materialization (no behavior change to `Load`).
- **`NewManagerReadOnly`** wraps it.
- **`walk`** uses `NewManagerReadOnly` for its own loads; help text now states it never mutates.
- **`CalculateFestivalStats`** loads read-only — computing a festival's stats must never rewrite its `.fest/`. This also makes the detection path read-only for `show`/`status`/`list` (a strict improvement; genuine migration still happens when a mutation command loads progress in its own body).

## Verification

Real binary against a legacy festival (`progress.yaml` + `workflow_state.yaml`, no JSONL):
- `fest walk` and `fest walk --json` -> both YAMLs unchanged (checksums equal), **no** `progress_events.jsonl` written, progress still reported correctly (`1/1 tasks (100%)`).

Tests:
- `TestLoadReadOnly_DoesNotMutateLegacyFiles` / `TestLoadReadOnly_MatchesMigratingLoad` — read-only view equals the migrating `Load`'s, while the migrating `Load` consumes the YAML and read-only preserves it.
- `TestCalculateFestivalStats_DoesNotMutate` — the precise regression guard; **fails** against the old migrating load, passes now.

## Gates
- `just lint all` -> 0 issues
- `just test unit-raw` -> 91 packages pass

Refs #206 (item 3).