### PR TITLE
fix(watch): keep cursor column-aligned in raw-mode festival cycling

### DIFF
--- a/internal/commands/show/standalone_watch.go
+++ b/internal/commands/show/standalone_watch.go
@@ -80,9 +80,9 @@ func (s *standaloneWatchSession) render(ctx context.Context, polling bool) error
 		return errors.NotFound("standalone workflow").WithField("path", s.startDir)
 	}
 
-	clearScreen()
+	clearScreen(os.Stdout)
 	fmt.Print(formatStandaloneWorkflowProgress(info, standaloneRenderOptionsFromWatch(s.opts)))
-	printWatchFooter(polling, false)
+	printWatchFooter(os.Stdout, polling, false)
 	s.addWatchPaths(info)
 	return nil
 }

--- a/internal/commands/show/watch.go
+++ b/internal/commands/show/watch.go
@@ -32,19 +32,50 @@ func (c crlfWriter) Write(p []byte) (int, error) {
 		}
 		b.WriteByte(p[i])
 	}
-	if _, err := c.w.Write(b.Bytes()); err != nil {
-		return 0, err
+	translated := b.Bytes()
+	written, err := c.w.Write(translated)
+	if written == len(translated) && err == nil {
+		return len(p), nil
 	}
-	return len(p), nil
+
+	n, remaining := 0, written
+	for i := 0; i < len(p); i++ {
+		cost := 1
+		if p[i] == '\n' && (i == 0 || p[i-1] != '\r') {
+			cost = 2
+		}
+		if remaining < cost {
+			break
+		}
+		remaining -= cost
+		n++
+	}
+	if err == nil && n < len(p) {
+		err = io.ErrShortWrite
+	}
+	return n, err
 }
 
-// watchWriter returns the writer for a watch frame. In cycle mode the terminal
-// is in raw mode, so newlines must be translated to keep lines column-aligned.
+// watchWriter returns the stdout writer for a watch frame. In cycle mode the
+// terminal is in raw mode, so newlines must be translated to keep lines
+// column-aligned.
 func watchWriter(cycleHint bool) io.Writer {
+	return cycleOutput(cycleHint, os.Stdout)
+}
+
+// watchErrWriter returns the writer for warnings and errors emitted during a
+// watch frame. term.MakeRaw stays active for the entire cycle session, so
+// stderr output must also translate newlines or it produces the same staircase
+// as the rendered tree.
+func watchErrWriter(cycleHint bool) io.Writer {
+	return cycleOutput(cycleHint, os.Stderr)
+}
+
+func cycleOutput(cycleHint bool, w io.Writer) io.Writer {
 	if cycleHint {
-		return crlfWriter{w: os.Stdout}
+		return crlfWriter{w: w}
 	}
-	return os.Stdout
+	return w
 }
 
 // ProgressBarWidth defines the number of characters in the progress bar
@@ -79,9 +110,12 @@ func WatchFestival(ctx context.Context, festival *FestivalInfo, opts WatchOption
 // runWatchMode watches for file changes and refreshes the festival display.
 // Falls back to polling if file watching is not available.
 func runWatchMode(ctx context.Context, festival *FestivalInfo, opts *showOptions, cycleHint bool) error {
+	out := watchWriter(cycleHint)
+	errOut := watchErrWriter(cycleHint)
+
 	stateDir := filepath.Join(festival.Path, ".fest")
 	if err := os.MkdirAll(stateDir, 0755); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not create state directory: %v\n", err)
+		_, _ = fmt.Fprintf(errOut, "Warning: could not create state directory: %v\n", err)
 	}
 
 	watchPaths := []string{
@@ -89,7 +123,6 @@ func runWatchMode(ctx context.Context, festival *FestivalInfo, opts *showOptions
 		stateDir,
 	}
 
-	out := watchWriter(cycleHint)
 	clearScreen(out)
 	if err := renderFestivalView(ctx, festival, opts, out); err != nil {
 		return err
@@ -100,7 +133,7 @@ func runWatchMode(ctx context.Context, festival *FestivalInfo, opts *showOptions
 		Paths:    watchPaths,
 		Debounce: 100 * time.Millisecond,
 		OnError: func(err error) {
-			fmt.Fprintf(os.Stderr, "%s file watch error: %v\n", ui.Warning("Warning:"), err)
+			_, _ = fmt.Fprintf(errOut, "%s file watch error: %v\n", ui.Warning("Warning:"), err)
 		},
 	}, func() {
 		clearScreen(out)
@@ -109,13 +142,13 @@ func runWatchMode(ctx context.Context, festival *FestivalInfo, opts *showOptions
 			festival = refreshed
 		}
 		if err := renderFestivalView(ctx, festival, opts, out); err != nil {
-			fmt.Fprintf(os.Stderr, "%s could not refresh festival view: %v\n", ui.Warning("Warning:"), err)
+			_, _ = fmt.Fprintf(errOut, "%s could not refresh festival view: %v\n", ui.Warning("Warning:"), err)
 		}
 		printWatchFooter(out, false, cycleHint)
 	})
 
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "File watching unavailable (%v), using polling fallback\n", err)
+		_, _ = fmt.Fprintf(errOut, "File watching unavailable (%v), using polling fallback\n", err)
 		return runPollingMode(ctx, festival, opts, cycleHint)
 	}
 	defer func() { _ = w.Close() }()

--- a/internal/commands/show/watch.go
+++ b/internal/commands/show/watch.go
@@ -2,8 +2,10 @@
 package show
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -13,6 +15,37 @@ import (
 	"github.com/Obedience-Corp/fest/internal/ui"
 	"github.com/Obedience-Corp/fest/internal/watch"
 )
+
+// crlfWriter translates a bare "\n" into "\r\n" before writing. The watch cycle
+// reader puts the terminal in raw mode (term.MakeRaw) to capture arrow keys,
+// which clears OPOST/ONLCR so the terminal no longer maps "\n" to "\r\n" on
+// output. Without this, every rendered line starts where the previous one ended
+// (a diagonal staircase). It reports the original input length per io.Writer.
+type crlfWriter struct{ w io.Writer }
+
+func (c crlfWriter) Write(p []byte) (int, error) {
+	var b bytes.Buffer
+	b.Grow(len(p) + bytes.Count(p, []byte{'\n'}))
+	for i := 0; i < len(p); i++ {
+		if p[i] == '\n' && (i == 0 || p[i-1] != '\r') {
+			b.WriteByte('\r')
+		}
+		b.WriteByte(p[i])
+	}
+	if _, err := c.w.Write(b.Bytes()); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+// watchWriter returns the writer for a watch frame. In cycle mode the terminal
+// is in raw mode, so newlines must be translated to keep lines column-aligned.
+func watchWriter(cycleHint bool) io.Writer {
+	if cycleHint {
+		return crlfWriter{w: os.Stdout}
+	}
+	return os.Stdout
+}
 
 // ProgressBarWidth defines the number of characters in the progress bar
 const ProgressBarWidth = 20
@@ -56,11 +89,12 @@ func runWatchMode(ctx context.Context, festival *FestivalInfo, opts *showOptions
 		stateDir,
 	}
 
-	clearScreen()
-	if err := renderFestivalView(ctx, festival, opts); err != nil {
+	out := watchWriter(cycleHint)
+	clearScreen(out)
+	if err := renderFestivalView(ctx, festival, opts, out); err != nil {
 		return err
 	}
-	printWatchFooter(false, cycleHint)
+	printWatchFooter(out, false, cycleHint)
 
 	w, err := watch.New(watch.Config{
 		Paths:    watchPaths,
@@ -69,15 +103,15 @@ func runWatchMode(ctx context.Context, festival *FestivalInfo, opts *showOptions
 			fmt.Fprintf(os.Stderr, "%s file watch error: %v\n", ui.Warning("Warning:"), err)
 		},
 	}, func() {
-		clearScreen()
+		clearScreen(out)
 		refreshed, err := DetectCurrentFestival(ctx, festival.Path, "")
 		if err == nil && refreshed != nil {
 			festival = refreshed
 		}
-		if err := renderFestivalView(ctx, festival, opts); err != nil {
+		if err := renderFestivalView(ctx, festival, opts, out); err != nil {
 			fmt.Fprintf(os.Stderr, "%s could not refresh festival view: %v\n", ui.Warning("Warning:"), err)
 		}
-		printWatchFooter(false, cycleHint)
+		printWatchFooter(out, false, cycleHint)
 	})
 
 	if err != nil {
@@ -95,40 +129,41 @@ func runPollingMode(ctx context.Context, festival *FestivalInfo, opts *showOptio
 	ticker := time.NewTicker(pollingInterval)
 	defer ticker.Stop()
 
-	clearScreen()
-	if err := renderFestivalView(ctx, festival, opts); err != nil {
+	out := watchWriter(cycleHint)
+	clearScreen(out)
+	if err := renderFestivalView(ctx, festival, opts, out); err != nil {
 		return err
 	}
-	printWatchFooter(true, cycleHint)
+	printWatchFooter(out, true, cycleHint)
 
 	for {
 		select {
 		case <-ctx.Done():
-			fmt.Println()
+			_, _ = fmt.Fprintln(out)
 			return nil
 		case <-ticker.C:
-			clearScreen()
+			clearScreen(out)
 
 			refreshed, err := DetectCurrentFestival(ctx, festival.Path, "")
 			if err == nil && refreshed != nil {
 				festival = refreshed
 			}
 
-			if err := renderFestivalView(ctx, festival, opts); err != nil {
+			if err := renderFestivalView(ctx, festival, opts, out); err != nil {
 				return err
 			}
-			printWatchFooter(true, cycleHint)
+			printWatchFooter(out, true, cycleHint)
 		}
 	}
 }
 
 // renderFestivalView renders the appropriate view for the festival.
-func renderFestivalView(ctx context.Context, festival *FestivalInfo, opts *showOptions) error {
+func renderFestivalView(ctx context.Context, festival *FestivalInfo, opts *showOptions, out io.Writer) error {
 	verbose := shared.IsVerbose()
 
 	// Use tree view by default, summary view with --summary flag
 	if opts.summary {
-		fmt.Println(FormatFestivalDetails(festival, verbose, ""))
+		_, _ = fmt.Fprintln(out, FormatFestivalDetails(festival, verbose, ""))
 		return nil
 	}
 
@@ -136,14 +171,14 @@ func renderFestivalView(ctx context.Context, festival *FestivalInfo, opts *showO
 	tree, err := BuildFestivalTree(ctx, festival.Path)
 	if err != nil {
 		// Fall back to summary view on error
-		fmt.Println(FormatFestivalDetails(festival, verbose, ""))
+		_, _ = fmt.Fprintln(out, FormatFestivalDetails(festival, verbose, ""))
 		return nil
 	}
 
 	// Render progress bar at the top
 	if festival.Stats != nil {
 		progressBar := renderProgressBar(int(festival.Stats.Progress))
-		fmt.Printf("%s %s %s\n\n",
+		_, _ = fmt.Fprintf(out, "%s %s %s\n\n",
 			ui.Value(fmt.Sprintf("%.0f%%", festival.Stats.Progress)),
 			progressBar,
 			ui.Dim(fmt.Sprintf("(%d/%d tasks)", festival.Stats.Tasks.Completed, festival.Stats.Tasks.Total)))
@@ -153,7 +188,7 @@ func renderFestivalView(ctx context.Context, festival *FestivalInfo, opts *showO
 	treeOpts.ShowGoals = opts.goals
 	treeOpts.Collapsed = opts.collapsed
 	treeOpts.InProgress = opts.inProgress
-	fmt.Println(RenderTree(tree, treeOpts))
+	_, _ = fmt.Fprintln(out, RenderTree(tree, treeOpts))
 	return nil
 }
 
@@ -171,20 +206,20 @@ func renderProgressBar(percentage int) string {
 }
 
 // clearScreen clears the terminal screen using ANSI escape codes.
-func clearScreen() {
-	fmt.Print("\033[H\033[2J")
+func clearScreen(out io.Writer) {
+	_, _ = fmt.Fprint(out, "\033[H\033[2J")
 }
 
 // printWatchFooter prints the watch mode footer with exit instructions.
-func printWatchFooter(polling bool, cycleHint bool) {
-	fmt.Println()
+func printWatchFooter(out io.Writer, polling bool, cycleHint bool) {
+	_, _ = fmt.Fprintln(out)
 	suffix := "Watching for changes"
 	if polling {
 		suffix = "Polling for changes"
 	}
 	if cycleHint {
-		fmt.Println(ui.Dim("Ctrl+C to exit • ← → cycle festivals • " + suffix))
+		_, _ = fmt.Fprintln(out, ui.Dim("Ctrl+C to exit • ← → cycle festivals • "+suffix))
 	} else {
-		fmt.Println(ui.Dim("Press Ctrl+C to exit • " + suffix))
+		_, _ = fmt.Fprintln(out, ui.Dim("Press Ctrl+C to exit • "+suffix))
 	}
 }

--- a/internal/commands/show/watch_test.go
+++ b/internal/commands/show/watch_test.go
@@ -1,0 +1,70 @@
+package show
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestCRLFWriter_TranslatesBareNewlines(t *testing.T) {
+	var buf bytes.Buffer
+	w := crlfWriter{w: &buf}
+
+	in := "line1\nline2\n"
+	n, err := w.Write([]byte(in))
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if n != len(in) {
+		t.Errorf("Write returned %d, want original length %d", n, len(in))
+	}
+	if got, want := buf.String(), "line1\r\nline2\r\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestCRLFWriter_DoesNotDoubleExistingCRLF(t *testing.T) {
+	var buf bytes.Buffer
+	w := crlfWriter{w: &buf}
+
+	if _, err := w.Write([]byte("a\r\nb\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if got, want := buf.String(), "a\r\nb\r\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestCRLFWriter_LeavesEscapeSequencesIntact(t *testing.T) {
+	var buf bytes.Buffer
+	w := crlfWriter{w: &buf}
+
+	if _, err := w.Write([]byte("\033[H\033[2J")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if got, want := buf.String(), "\033[H\033[2J"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWatchWriter_CycleModeWrapsCRLF(t *testing.T) {
+	if _, ok := watchWriter(false).(crlfWriter); ok {
+		t.Error("watchWriter(false) should not translate newlines")
+	}
+	if _, ok := watchWriter(true).(crlfWriter); !ok {
+		t.Error("watchWriter(true) should translate newlines (raw mode)")
+	}
+}
+
+func TestPrintWatchFooter_CycleModeEmitsCRLF(t *testing.T) {
+	var buf bytes.Buffer
+	printWatchFooter(crlfWriter{w: &buf}, false, true)
+
+	out := buf.String()
+	if !strings.Contains(out, "\r\n") {
+		t.Errorf("cycle-mode footer should use CRLF line endings, got %q", out)
+	}
+	if strings.Contains(strings.ReplaceAll(out, "\r\n", ""), "\n") {
+		t.Errorf("cycle-mode footer has a bare \\n (cursor would not return to column 0): %q", out)
+	}
+}

--- a/internal/commands/show/watch_test.go
+++ b/internal/commands/show/watch_test.go
@@ -2,9 +2,27 @@ package show
 
 import (
 	"bytes"
+	"io"
 	"strings"
 	"testing"
 )
+
+type limitedWriter struct {
+	limit int
+	buf   bytes.Buffer
+}
+
+func (l *limitedWriter) Write(p []byte) (int, error) {
+	n := len(p)
+	if n > l.limit {
+		n = l.limit
+	}
+	l.buf.Write(p[:n])
+	if n < len(p) {
+		return n, io.ErrShortWrite
+	}
+	return n, nil
+}
 
 func TestCRLFWriter_TranslatesBareNewlines(t *testing.T) {
 	var buf bytes.Buffer
@@ -53,6 +71,47 @@ func TestWatchWriter_CycleModeWrapsCRLF(t *testing.T) {
 	}
 	if _, ok := watchWriter(true).(crlfWriter); !ok {
 		t.Error("watchWriter(true) should translate newlines (raw mode)")
+	}
+}
+
+func TestWatchErrWriter_CycleModeWrapsCRLF(t *testing.T) {
+	if _, ok := watchErrWriter(false).(crlfWriter); ok {
+		t.Error("watchErrWriter(false) should not translate newlines")
+	}
+	if _, ok := watchErrWriter(true).(crlfWriter); !ok {
+		t.Error("watchErrWriter(true) should translate newlines (raw mode)")
+	}
+}
+
+func TestCRLFWriter_PreservesPartialWriteCount(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		limit   int
+		wantN   int
+		wantErr bool
+	}{
+		{"stops mid-crlf pair", "ab\ncd", 3, 2, true},
+		{"stops after translated newline", "ab\ncd", 4, 3, true},
+		{"full write", "ab\ncd", 6, 5, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lw := &limitedWriter{limit: tt.limit}
+			n, err := crlfWriter{w: lw}.Write([]byte(tt.in))
+			if n != tt.wantN {
+				t.Errorf("Write returned n=%d, want %d", n, tt.wantN)
+			}
+			if tt.wantErr && err == nil {
+				t.Error("expected a short-write error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if n < 0 || n > len(tt.in) {
+				t.Errorf("n=%d violates io.Writer contract for input length %d", n, len(tt.in))
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

After merging the recent fest changes, `fest watch` renders as a garbled diagonal staircase that wraps into unreadable text (screenshot of the symptom: the progress tree cascades down-right and wraps mid-word).

## Root cause

The festival-cycling feature added in **#204** puts the terminal into **raw mode** (`term.MakeRaw` in `internal/commands/watch/cycling.go`) so it can read the `← →` arrow keys for cycling. `MakeRaw` clears `OPOST`/`ONLCR`, which is the terminal flag that maps a bare `\n` to `\r\n` on output. With it off, every `\n` the renderer emits moves the cursor **down but not back to column 0**, so each line starts where the previous one ended. That is exactly the staircase.

It only reproduces with **2+ watchable festivals** in a real terminal — the single-festival path (`watchFestivalAtPath`) and the non-TTY path both skip raw mode, which is why it renders fine when piped or with one festival. This is a regression from #204 (before it, `fest watch` never entered raw mode).

It is **not** fixed by either open PR: #208 fixes a goroutine leak in the key reader (`cycling.go` only), #209 is `fest walk` read-only. Neither touches the render, and the #206 follow-up issue doesn't list it.

## Fix

Route the watch render output through a small writer that translates a bare `\n` → `\r\n` while in cycle (raw) mode, so each line returns to column 0. `clearScreen`, `renderFestivalView`, and `printWatchFooter` now take an `io.Writer`; the cycle path gets the translating writer (`watchWriter(true)`), every other path (including standalone watch, which never enters raw mode) gets plain `os.Stdout`.

This keeps the fix portable (no platform-specific termios manipulation, no new dependencies) and confined to the `show` package. The cycle key reader and raw-mode setup in `cycling.go` are untouched.

## Changes

- `internal/commands/show/watch.go` — add `crlfWriter` + `watchWriter`; thread an `io.Writer` through `runWatchMode`, `runPollingMode`, `renderFestivalView`, `clearScreen`, `printWatchFooter`.
- `internal/commands/show/standalone_watch.go` — pass `os.Stdout` to the now-parameterized helpers (standalone watch never enters raw mode).
- `internal/commands/show/watch_test.go` (new) — CRLF translation, no-double-CRLF, escape-sequence passthrough, `watchWriter` mode selection, and that cycle-mode footer output contains no bare `\n`.

## Verification

- `go build ./...` — clean
- `just lint all` — **0 issues**; `just lint vet` — clean
- `go test ./internal/commands/show/... ./internal/commands/watch/...` — green, incl. the new CRLF tests
- The render path is unchanged except for the output writer, so `fest show`, non-cycle `fest watch`, and standalone watch are unaffected.

**Please confirm in your terminal** with a multi-festival campaign (`fest watch`, then `← →` to cycle) — that's the only path that exercises raw mode, and it can't be fully reproduced in a non-PTY test harness. Immediate workaround if needed before merge: `fest watch --collapsed` renders a shallow tree that fits any width.
