### PR TITLE
feat(promote): pick a festival from anywhere in a campaign

### DIFF
--- a/internal/commands/promote/promote.go
+++ b/internal/commands/promote/promote.go
@@ -2,6 +2,7 @@
 package promote
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"os"
@@ -42,7 +43,7 @@ type promoteOptions struct {
 func NewPromoteCommand() *cobra.Command {
 	opts := &promoteOptions{}
 	cmd := &cobra.Command{
-		Use:   "promote",
+		Use:   "promote [festival]",
 		Short: "Promote a festival to the next lifecycle status",
 		Long: `Promote moves a festival through the lifecycle: planning → ready → active → completed.
 
@@ -51,15 +52,26 @@ Each transition validates readiness:
   ready → active:      Festival is ready to begin execution
   active → completed:  All tasks must be completed
 
+By default, promotes the festival you are currently inside. From elsewhere in a
+campaign, pass a festival name or run promote interactively to pick one:
+  fest promote my-feature       Promote a festival by name (tab completion)
+  fest promote                  Pick a festival from a fuzzy picker (in a terminal)
+
 Use --dungeon to send a festival directly to a dungeon status:
   fest promote --dungeon someday     Shelve for later
   fest promote --dungeon archived    Archive the festival
   fest promote --dungeon completed   Mark as completed (skips task validation)`,
 		Annotations: map[string]string{
-			"scope": string(scope.Festival),
+			"scope": string(scope.Workspace),
 		},
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: completePromoteTarget,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runPromote(cmd.Context(), opts)
+			selector := ""
+			if len(args) > 0 {
+				selector = args[0]
+			}
+			return runPromote(cmd.Context(), opts, selector)
 		},
 	}
 
@@ -71,7 +83,81 @@ Use --dungeon to send a festival directly to a dungeon status:
 	return cmd
 }
 
-func runPromote(ctx context.Context, opts *promoteOptions) error {
+// promotePickerOptions limits the picker and completion to promotable festivals.
+func promotePickerOptions() shared.FestivalPickerOptions {
+	return shared.FestivalPickerOptions{
+		PreferredStatuses: []string{"planning", "ready", "active"},
+	}
+}
+
+// completePromoteTarget provides shell completion for the festival selector.
+func completePromoteTarget(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	completions, err := shared.CompleteFestivalPickSelectors(cmd.Context(), cwd, toComplete, promotePickerOptions())
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}
+
+// resolveFestivalForPromote resolves the festival to promote from an explicit
+// selector, the current directory, or an interactive picker. The returned bool
+// reports whether the festival was chosen from the picker.
+func resolveFestivalForPromote(ctx context.Context, festivalsDir, cwd, selector string, allowPicker bool) (*show.FestivalInfo, bool, error) {
+	if strings.TrimSpace(selector) != "" {
+		path, err := shared.ResolveFestivalSelector(ctx, cwd, selector)
+		if err != nil {
+			return nil, false, err
+		}
+		festival, err := show.DetectCurrentFestival(ctx, path, "")
+		return festival, false, err
+	}
+
+	if loc, err := show.DetectCurrentLocation(ctx, cwd); err == nil && loc.Festival != nil {
+		return loc.Festival, false, nil
+	}
+
+	if allowPicker && festivalsDir != "" {
+		picked, err := shared.PickFestivalPath(ctx, festivalsDir, promotePickerOptions())
+		if err != nil {
+			return nil, false, err
+		}
+		if picked != "" {
+			festival, err := show.DetectCurrentFestival(ctx, picked, "")
+			return festival, true, err
+		}
+	}
+
+	return nil, false, errors.NotFound("festival").
+		WithHint("Run inside a festival, pass a name (fest promote <festival>), or run 'fest promote' in a terminal to pick one")
+}
+
+// confirmPromotion asks the operator to confirm a picker-selected promotion.
+func confirmPromotion(name, from, to string) bool {
+	fmt.Printf("Promote %s: %s → %s? [y/N] ",
+		ui.Value(name, ui.FestivalColor),
+		ui.GetStateStyle(from).Render(from),
+		ui.GetStateStyle(to).Render(to))
+
+	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	if err != nil {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
+func runPromote(ctx context.Context, opts *promoteOptions, selector string) error {
 	if err := ctx.Err(); err != nil {
 		return errors.Wrap(err, "context cancelled")
 	}
@@ -81,16 +167,21 @@ func runPromote(ctx context.Context, opts *promoteOptions) error {
 		return errors.IO("getting current directory", err)
 	}
 
-	// Detect current location
-	loc, err := show.DetectCurrentLocation(ctx, cwd)
-	if err != nil {
-		return errors.Wrap(err, "detecting location")
-	}
-	if loc.Festival == nil {
-		return errors.NotFound("festival")
+	festivalsDir := ""
+	if ws, ok := scope.WorkspaceFrom(ctx); ok && ws != nil {
+		festivalsDir = ws.FestivalsPath
 	}
 
-	festival := loc.Festival
+	festival, fromPicker, err := resolveFestivalForPromote(ctx, festivalsDir, cwd, selector, !opts.json)
+	if err != nil {
+		if opts.json {
+			return shared.EncodeJSON(os.Stdout, map[string]any{
+				"success": false,
+				"error":   err.Error(),
+			})
+		}
+		return err
+	}
 	currentStatus := festival.Status
 
 	var nextStatus string
@@ -155,6 +246,11 @@ func runPromote(ctx context.Context, opts *promoteOptions) error {
 			fmt.Printf("\n  %s\n", ui.Dim("Use --force to skip chain dependency check"))
 			return nil
 		}
+	}
+
+	if fromPicker && !confirmPromotion(festival.Name, currentStatus, nextStatus) {
+		fmt.Println(ui.Dim("Promotion cancelled"))
+		return nil
 	}
 
 	// Execute the move using existing atomic status change

--- a/internal/commands/promote/promote.go
+++ b/internal/commands/promote/promote.go
@@ -394,12 +394,9 @@ func checkChainDependencies(ctx context.Context, festival *show.FestivalInfo) (b
 	}
 	festivalID := festCfg.Metadata.ID
 
-	// Find festivals root.
-	cwd, err := os.Getwd()
-	if err != nil {
-		return false, ""
-	}
-	root, err := tpl.FindFestivalsRoot(cwd)
+	// Anchor the festivals root on the festival being promoted, not process cwd:
+	// selector and picker resolution can promote from outside festivals/.
+	root, err := tpl.FindFestivalsRoot(festival.Path)
 	if err != nil {
 		return false, ""
 	}

--- a/internal/commands/promote/promote_test.go
+++ b/internal/commands/promote/promote_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Obedience-Corp/fest/internal/commands/shared"
 	"github.com/Obedience-Corp/fest/internal/commands/show"
 	"github.com/Obedience-Corp/fest/internal/id"
 )
@@ -89,8 +90,11 @@ func TestValidateActiveToCompleted(t *testing.T) {
 
 func TestNewPromoteCommand(t *testing.T) {
 	cmd := NewPromoteCommand()
-	if cmd.Use != "promote" {
-		t.Errorf("expected Use=%q, got %q", "promote", cmd.Use)
+	if cmd.Use != "promote [festival]" {
+		t.Errorf("expected Use=%q, got %q", "promote [festival]", cmd.Use)
+	}
+	if cmd.ValidArgsFunction == nil {
+		t.Error("expected ValidArgsFunction to be set for festival completion")
 	}
 
 	// Check flags exist
@@ -208,5 +212,125 @@ func TestCheckChainDependencies_IncompleteUpstreamStillBlocks(t *testing.T) {
 	}
 	if !strings.Contains(msg, "FA0009") {
 		t.Fatalf("block message should name the incomplete upstream, got: %s", msg)
+	}
+}
+
+func writePromoteFestival(t *testing.T, dir, festivalID, status string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "version: \"1.0\"\nmetadata:\n  id: " + festivalID +
+		"\n  status_history:\n    - status: " + status + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "fest.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "FESTIVAL_GOAL.md"), []byte("# Goal\nTest goal\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func setupPromoteCampaign(t *testing.T) (root, festivalsDir string) {
+	t.Helper()
+	root = t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".campaign"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	festivalsDir = filepath.Join(root, "festivals")
+	for _, status := range []string{"planning", "ready", "active", "ritual"} {
+		if err := os.MkdirAll(filepath.Join(festivalsDir, status), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writePromoteFestival(t, filepath.Join(festivalsDir, "planning", "alpha-feature-FE0001"), "FE0001", "planning")
+	writePromoteFestival(t, filepath.Join(festivalsDir, "ready", "beta-feature-FE0002"), "FE0002", "ready")
+	writePromoteFestival(t, filepath.Join(festivalsDir, "active", "gamma-feature-FE0003"), "FE0003", "active")
+	writePromoteFestival(t, filepath.Join(festivalsDir, "ritual", "delta-ritual"), "", "ritual")
+	t.Setenv("CAMP_ROOT", root)
+	return root, festivalsDir
+}
+
+func TestResolveFestivalForPromote_Selector(t *testing.T) {
+	root, _ := setupPromoteCampaign(t)
+
+	festival, fromPicker, err := resolveFestivalForPromote(t.Context(), "", root, "alpha-feature-FE0001", false)
+	if err != nil {
+		t.Fatalf("resolveFestivalForPromote: %v", err)
+	}
+	if fromPicker {
+		t.Error("explicit selector must not be reported as a picker selection")
+	}
+	if festival.Name != "alpha-feature-FE0001" {
+		t.Errorf("got festival %q, want alpha-feature-FE0001", festival.Name)
+	}
+	if festival.Status != "planning" {
+		t.Errorf("got status %q, want planning", festival.Status)
+	}
+}
+
+func TestResolveFestivalForPromote_CwdContext(t *testing.T) {
+	_, festivalsDir := setupPromoteCampaign(t)
+	activeDir := filepath.Join(festivalsDir, "active", "gamma-feature-FE0003")
+
+	festival, fromPicker, err := resolveFestivalForPromote(t.Context(), festivalsDir, activeDir, "", false)
+	if err != nil {
+		t.Fatalf("resolveFestivalForPromote: %v", err)
+	}
+	if fromPicker {
+		t.Error("cwd context must not be reported as a picker selection")
+	}
+	if festival.Name != "gamma-feature-FE0003" || festival.Status != "active" {
+		t.Errorf("got %q/%q, want gamma-feature-FE0003/active", festival.Name, festival.Status)
+	}
+}
+
+func TestResolveFestivalForPromote_NoContextNonInteractive(t *testing.T) {
+	root, festivalsDir := setupPromoteCampaign(t)
+
+	_, fromPicker, err := resolveFestivalForPromote(t.Context(), festivalsDir, root, "", false)
+	if err == nil {
+		t.Fatal("expected an error when no festival context is available and the picker is disabled")
+	}
+	if fromPicker {
+		t.Error("no festival should be reported as a picker selection")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "festival") {
+		t.Errorf("error should mention festival, got: %v", err)
+	}
+}
+
+func TestCompletePromoteTargetExcludesRitual(t *testing.T) {
+	root, _ := setupPromoteCampaign(t)
+
+	completions, err := shared.CompleteFestivalPickSelectors(t.Context(), root, "", promotePickerOptions())
+	if err != nil {
+		t.Fatalf("CompleteFestivalPickSelectors: %v", err)
+	}
+
+	joined := strings.Join(completions, " ")
+	for _, want := range []string{"alpha-feature-FE0001", "beta-feature-FE0002", "gamma-feature-FE0003"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("expected completion to include %q, got %v", want, completions)
+		}
+	}
+	if strings.Contains(joined, "delta-ritual") {
+		t.Errorf("ritual festival must not appear in promote completions, got %v", completions)
+	}
+}
+
+func TestRunPromote_SelectorPromotesPlanningToReady(t *testing.T) {
+	_, festivalsDir := setupPromoteCampaign(t)
+
+	if err := runPromote(t.Context(), &promoteOptions{noCommit: true}, "alpha-feature-FE0001"); err != nil {
+		t.Fatalf("runPromote: %v", err)
+	}
+
+	movedPath := filepath.Join(festivalsDir, "ready", "alpha-feature-FE0001")
+	if _, err := os.Stat(movedPath); err != nil {
+		t.Fatalf("expected festival at %s after promotion: %v", movedPath, err)
+	}
+	oldPath := filepath.Join(festivalsDir, "planning", "alpha-feature-FE0001")
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Fatalf("expected planning copy removed, stat err=%v", err)
 	}
 }

--- a/internal/commands/promote/promote_test.go
+++ b/internal/commands/promote/promote_test.go
@@ -215,6 +215,53 @@ func TestCheckChainDependencies_IncompleteUpstreamStillBlocks(t *testing.T) {
 	}
 }
 
+func TestCheckChainDependencies_AnchorsOnFestivalNotCwd(t *testing.T) {
+	fa10 := setupChainGateCampaign(t, "active", "active")
+	root := filepath.Dir(filepath.Dir(filepath.Dir(fa10)))
+	t.Chdir(root)
+
+	festival := &show.FestivalInfo{Name: "onboarding-parity", Path: fa10, Status: "ready"}
+	blocked, msg := checkChainDependencies(t.Context(), festival)
+	if !blocked {
+		t.Fatal("expected chain gate to block when checked from outside festivals/")
+	}
+	if !strings.Contains(msg, "FA0009") {
+		t.Fatalf("block message should name the incomplete upstream, got: %s", msg)
+	}
+}
+
+func TestRunPromote_SelectorReadyToActiveBlockedByChainFromCampaignRoot(t *testing.T) {
+	root := t.TempDir()
+	festivals := filepath.Join(root, "festivals")
+	for _, dir := range []string{
+		filepath.Join(root, ".campaign"),
+		filepath.Join(festivals, ".festival"),
+		filepath.Join(festivals, "chains"),
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeGateChain(t, filepath.Join(festivals, "chains", "onboarding-readiness-CH0001.yaml"))
+	fa10 := filepath.Join(festivals, "ready", "onboarding-parity-FA0010")
+	writeGateFestival(t, fa10, "FA0010", "ready")
+	writeGateFestival(t, filepath.Join(festivals, "active", "audit-remediation-FA0009"), "FA0009", "active")
+	t.Setenv("CAMP_ROOT", root)
+	t.Chdir(root)
+
+	if err := runPromote(t.Context(), &promoteOptions{noCommit: true}, "FA0010"); err != nil {
+		t.Fatalf("runPromote: %v", err)
+	}
+
+	if _, err := os.Stat(fa10); err != nil {
+		t.Fatalf("FA0010 should remain in ready (chain gate must block), got stat err: %v", err)
+	}
+	promoted := filepath.Join(festivals, "active", "onboarding-parity-FA0010")
+	if _, err := os.Stat(promoted); !os.IsNotExist(err) {
+		t.Fatal("FA0010 must not be promoted to active while hard upstream FA0009 is incomplete")
+	}
+}
+
 func writePromoteFestival(t *testing.T, dir, festivalID, status string) {
 	t.Helper()
 	if err := os.MkdirAll(dir, 0o755); err != nil {


### PR DESCRIPTION
## Summary

`fest promote` was Festival-scoped: it hard-errored with "not inside a festival" unless run from inside (or linked to) a specific festival directory. You could only promote a festival while physically standing in it.

This makes promotion easy from anywhere in a campaign, mirroring how `fest go` lets you jump to any festival:

- **Scope relaxed `Festival` → `Workspace`.** The festivals root now resolves from the campaign root, a sibling festival, or a project submodule (via `workspace.FindWorkspace`, which honors `.campaign/` and `CAMP_ROOT`). `runPromote` already resolved the festival itself, so it never relied on the injected festival context.
- **Positional selector + tab completion.** `fest promote <festival>` resolves by ID, exact name, or fuzzy match (reuses `shared.ResolveFestivalSelector`); `fest promote <TAB>` completes promotable festival names.
- **Interactive picker fallback.** When no festival context is available and the terminal is interactive, `fest promote` opens the same Bubble Tea fuzzy picker `fest go` uses (`shared.PickFestivalPath`).
- **Confirmation on the picker path.** A picker selection prompts `Promote <name>: <from> → <to>? [y/N]` (default No) before the directory move and auto-commit. Running inside a festival stays immediate, so existing muscle memory is unchanged.
- **Promotable-only list.** The picker and completion show only festivals in `planning`/`ready`/`active` (festivals that have a valid lifecycle transition); ritual and dungeon are excluded.
- **JSON mode** returns a structured `{ "success": false, "error": ... }` instead of launching a TUI.

## Resolution order

1. Explicit selector argument (`fest promote <festival>`)
2. Current-directory festival context (today's behavior)
3. Interactive picker (TTY only)
4. Otherwise, an actionable `NotFound` error

## Testing

- `just build quick`, `just test unit` (2293/2293 pass), `just lint all` (0 issues).
- New unit tests cover selector resolution, cwd-context resolution, the non-interactive no-context error, completion scoping (excludes ritual), and an end-to-end `runPromote` selector promotion (planning → ready).
- Manually verified against a throwaway campaign: `fest promote <TAB>` completion, `fest promote <name>` from the campaign root, cwd-context promote, and the `--json` error path.

The interactive picker and confirmation prompt require a real TTY, so they are exercised manually rather than in unit tests; the surrounding plumbing is unit-tested.
