### PR TITLE
fix(watch): open the festival detected from cwd, not the first in the cycle

### DIFF
--- a/internal/commands/watch/command.go
+++ b/internal/commands/watch/command.go
@@ -114,7 +114,7 @@ func runWatch(ctx context.Context, args []string, opts *options, deps commandDep
 		if err == nil {
 			paths, listErr := deps.listCycleTargets(ctx, cwd)
 			if listErr == nil && len(paths) > 1 {
-				return runWatchCycle(ctx, paths, 0, *opts, deps)
+				return runWatchCycle(ctx, paths, currentFestivalIndex(ctx, cwd, paths, deps), *opts, deps)
 			}
 		}
 	}
@@ -127,6 +127,26 @@ func runWatch(ctx context.Context, args []string, opts *options, deps commandDep
 		return err
 	}
 	return watchFestival(ctx, festival, *opts, deps)
+}
+
+func currentFestivalIndex(ctx context.Context, cwd string, paths []string, deps commandDeps) int {
+	if deps.detectFestival == nil {
+		return 0
+	}
+	festival, err := deps.detectFestival(ctx, cwd)
+	if err != nil || festival == nil {
+		return 0
+	}
+	target := canonicalWatchPath(festival.Path)
+	if target == "" {
+		return 0
+	}
+	for i, path := range paths {
+		if canonicalWatchPath(path) == target {
+			return i
+		}
+	}
+	return 0
 }
 
 func watchFestival(ctx context.Context, festival *show.FestivalInfo, opts options, deps commandDeps) error {

--- a/internal/commands/watch/cycling_test.go
+++ b/internal/commands/watch/cycling_test.go
@@ -2,9 +2,11 @@ package watch
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/Obedience-Corp/fest/internal/commands/show"
+	"github.com/Obedience-Corp/fest/internal/errors"
 )
 
 func TestCycleWatchOptionsSetsCycleHint(t *testing.T) {
@@ -46,6 +48,89 @@ func TestRunWatchCycle_SinglePath_CallsWatch(t *testing.T) {
 	}
 	if !watchCalled {
 		t.Fatal("watch delegate was not called for single-path cycle")
+	}
+}
+
+func TestCurrentFestivalIndex(t *testing.T) {
+	paths := []string{
+		"/festivals/active/a-FS0001",
+		"/festivals/ready/b-FS0002",
+		"/festivals/planning/c-FS0003",
+	}
+	tests := []struct {
+		name           string
+		detectFestival func(context.Context, string) (*show.FestivalInfo, error)
+		want           int
+	}{
+		{
+			name: "detected festival selects its index",
+			detectFestival: func(context.Context, string) (*show.FestivalInfo, error) {
+				return &show.FestivalInfo{Path: paths[2]}, nil
+			},
+			want: 2,
+		},
+		{
+			name: "not in a festival falls back to zero",
+			detectFestival: func(context.Context, string) (*show.FestivalInfo, error) {
+				return nil, errors.NotFound("festival")
+			},
+			want: 0,
+		},
+		{
+			name: "detected festival outside the cycle falls back to zero",
+			detectFestival: func(context.Context, string) (*show.FestivalInfo, error) {
+				return &show.FestivalInfo{Path: "/festivals/active/unlisted-FS0009"}, nil
+			},
+			want: 0,
+		},
+		{
+			name:           "missing detector falls back to zero",
+			detectFestival: nil,
+			want:           0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deps := commandDeps{detectFestival: tt.detectFestival}
+			if got := currentFestivalIndex(t.Context(), "/some/cwd", paths, deps); got != tt.want {
+				t.Fatalf("currentFestivalIndex = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWatchCommandCycleStartsAtCurrentFestival(t *testing.T) {
+	paths := []string{
+		"/festivals/active/first-FS0001",
+		"/festivals/ready/current-FS0002",
+		"/festivals/planning/third-FS0003",
+	}
+	var watched string
+	deps := commandDeps{
+		resolveStandalone: func(context.Context) (*show.StandaloneWorkflowInfo, error) {
+			return nil, nil
+		},
+		listCycleTargets: func(_ context.Context, _ string) ([]string, error) {
+			return paths, nil
+		},
+		detectFestival: func(_ context.Context, p string) (*show.FestivalInfo, error) {
+			if strings.HasPrefix(p, "/festivals/") {
+				return &show.FestivalInfo{Path: p}, nil
+			}
+			return &show.FestivalInfo{Path: paths[1]}, nil
+		},
+		watch: func(_ context.Context, festival *show.FestivalInfo, _ show.WatchOptions) error {
+			watched = festival.Path
+			return nil
+		},
+	}
+
+	if err := runWatch(t.Context(), nil, &options{}, deps); err != nil {
+		t.Fatalf("runWatch: %v", err)
+	}
+	if watched != paths[1] {
+		t.Fatalf("watch started at %q, want current festival %q", watched, paths[1])
 	}
 }
 

--- a/internal/commands/watch/resolver.go
+++ b/internal/commands/watch/resolver.go
@@ -202,6 +202,19 @@ func defaultCanPickFestival() bool {
 	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stderr.Fd()))
 }
 
+func canonicalWatchPath(p string) string {
+	if p == "" {
+		return ""
+	}
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		return resolved
+	}
+	if abs, err := filepath.Abs(p); err == nil {
+		return abs
+	}
+	return filepath.Clean(p)
+}
+
 func isWatchPickerCancelled(err error) bool {
 	return stderrors.Is(err, errWatchPickerCancelled)
 }


### PR DESCRIPTION
## Summary

`fest watch`, run from inside a festival, opened the wrong festival. When the workspace had more than one watchable festival, `runWatch` built the watch cycle and always started it at index 0 (the newest active festival, then ready, then planning by `OrderByStatusThenRecency`), ignoring the festival detected from the current directory.

Now `fest watch` opens the festival in context:

- `runWatch` detects the current festival from cwd via `deps.detectFestival` (`show.DetectCurrentFestival`, which walks up for festival markers and also follows project links) and starts the cycle at that festival's index in the cycle list.
- Matching is by canonical, symlink-resolved path (`filepath.EvalSymlinks` with `Abs`/`Clean` fallback), so the detected festival root and the cycle entry resolve to the same on-disk directory regardless of how each path was constructed.
- Falls back to index 0 when cwd is not inside a watchable festival, preserving today's behavior. The cycle navigation (arrow keys to browse other festivals) is unchanged; only the starting position is fixed.

Root cause was a single line in `runWatch` (`internal/commands/watch/command.go`): `runWatchCycle(ctx, paths, 0, ...)`.

## Testing

- `just build quick`, `just test unit` (2297/2297 pass), `just lint all` (0 issues).
- New unit tests:
  - `TestCurrentFestivalIndex` (table): detected festival selects its index; not-in-a-festival, detected-festival-outside-the-cycle, and missing-detector all fall back to 0.
  - `TestWatchCommandCycleStartsAtCurrentFestival`: end-to-end through `runWatch` (non-TTY), asserting the watch delegate receives the current festival, not the first in the cycle. Verified this test fails on the old `startIndex=0` code and passes with the fix.
- Manual repro with the built binary against a temp campaign: two active festivals where `older-feature-FS0001` is index 1 by recency. Running `fest watch` from inside `older-feature-FS0001` now opens `older-feature-FS0001` (confirmed in rendered output), where before it opened the newest festival.
