### PR TITLE
feat(picker): show festival progress bars in the interactive picker

### DIFF
--- a/internal/commands/shared/festival_picker.go
+++ b/internal/commands/shared/festival_picker.go
@@ -4,12 +4,17 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/navigation"
+	"github.com/Obedience-Corp/fest/internal/progress"
 	"github.com/Obedience-Corp/fest/internal/tui/picker"
+	"github.com/Obedience-Corp/fest/internal/ui"
 	"golang.org/x/term"
 )
+
+const progressDetailWorkers = 8
 
 // PickFestivalPath opens the shared festival picker and returns the selected path.
 func PickFestivalPath(ctx context.Context, festivalsDir string, opts FestivalPickerOptions) (string, error) {
@@ -28,6 +33,7 @@ func PickFestivalPath(ctx context.Context, festivalsDir string, opts FestivalPic
 	if len(items) == 0 {
 		return "", nil
 	}
+	attachProgressDetails(ctx, items)
 
 	selected, err := picker.Run(items, navigation.Score)
 	if err != nil {
@@ -67,4 +73,46 @@ func festivalPickerItemName(candidate FestivalPickCandidate) string {
 		return fmt.Sprintf("[%s]/", candidate.Status)
 	}
 	return fmt.Sprintf("[%s] %s", candidate.Status, candidate.Name)
+}
+
+// attachProgressDetails fills each item's Detail with a progress bar, computed
+// read-only and concurrently. Items without tasks (status directories, empty
+// festivals) get no bar.
+func attachProgressDetails(ctx context.Context, items []picker.Item) {
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, progressDetailWorkers)
+	for i := range items {
+		if items[i].Value == "" {
+			continue
+		}
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(i int) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			items[i].Detail = festivalProgressDetail(ctx, items[i].Value)
+		}(i)
+	}
+	wg.Wait()
+}
+
+func festivalProgressDetail(ctx context.Context, festivalPath string) string {
+	mgr, err := progress.NewManagerReadOnly(ctx, festivalPath)
+	if err != nil {
+		return ""
+	}
+	prog, err := mgr.GetFestivalProgress(ctx, festivalPath)
+	if err != nil || prog == nil || prog.Overall == nil || prog.Overall.Total == 0 {
+		return ""
+	}
+	return ui.RenderProgressBar(ui.ProgressBarOptions{
+		Current:        prog.Overall.Percentage,
+		Total:          100,
+		Width:          10,
+		FilledChar:     "█",
+		EmptyChar:      "░",
+		FilledColor:    ui.SuccessColor,
+		EmptyColor:     ui.BorderColor,
+		ShowPercentage: true,
+	})
 }

--- a/internal/commands/shared/festival_picker_test.go
+++ b/internal/commands/shared/festival_picker_test.go
@@ -1,6 +1,77 @@
 package shared
 
-import "testing"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/progress"
+	"github.com/Obedience-Corp/fest/internal/tui/picker"
+)
+
+func writeProgressFestival(t *testing.T, total, completed int) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "fest.yaml"), []byte("name: test\nid: TEST-001\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	seq := filepath.Join(dir, "001_PHASE", "01_sequence")
+	if err := os.MkdirAll(seq, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < total; i++ {
+		content := fmt.Sprintf("---\nfest_type: task\nfest_status: pending\n---\n# Task %d\n", i+1)
+		if err := os.WriteFile(filepath.Join(seq, fmt.Sprintf("%02d_task.md", i+1)), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mgr, err := progress.NewManager(t.Context(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < completed; i++ {
+		if err := mgr.MarkComplete(t.Context(), fmt.Sprintf("001_PHASE/01_sequence/%02d_task.md", i+1)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func TestFestivalProgressDetail(t *testing.T) {
+	withTasks := writeProgressFestival(t, 4, 2)
+	detail := festivalProgressDetail(t.Context(), withTasks)
+	if detail == "" {
+		t.Fatal("expected a progress bar for a festival with tasks")
+	}
+	if !strings.Contains(detail, "50%") {
+		t.Fatalf("expected 50%% in progress detail, got %q", detail)
+	}
+
+	empty := t.TempDir()
+	if err := os.WriteFile(filepath.Join(empty, "fest.yaml"), []byte("name: empty\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if d := festivalProgressDetail(t.Context(), empty); d != "" {
+		t.Fatalf("expected no bar for a festival with no tasks, got %q", d)
+	}
+}
+
+func TestAttachProgressDetails(t *testing.T) {
+	withTasks := writeProgressFestival(t, 2, 1)
+	items := []picker.Item{
+		{Name: "[active] has-tasks", Value: withTasks},
+		{Name: "[active]/", Value: ""},
+	}
+	attachProgressDetails(t.Context(), items)
+	if !strings.Contains(items[0].Detail, "%") {
+		t.Fatalf("expected a progress bar for the festival item, got %q", items[0].Detail)
+	}
+	if items[1].Detail != "" {
+		t.Fatalf("expected no detail for an item without a path, got %q", items[1].Detail)
+	}
+}
 
 func TestFestivalPickCandidatesForGoIncludeStatusDirectories(t *testing.T) {
 	candidates := filterFestivalPickCandidates(pureCandidateFixture(), FestivalPickerOptions{

--- a/internal/tui/picker/picker.go
+++ b/internal/tui/picker/picker.go
@@ -16,9 +16,10 @@ import (
 
 // Item represents a pickable item with a display name and value.
 type Item struct {
-	Name  string // Display name (used for matching)
-	Value string // Return value (e.g., path)
-	Score int    // Match score for sorting
+	Name   string // Display name (used for matching)
+	Value  string // Return value (e.g., path)
+	Detail string // Optional trailing text shown after the name (not matched)
+	Score  int    // Match score for sorting
 }
 
 // Scorer is a function that scores a query against a target string.
@@ -262,18 +263,34 @@ func (m Model) View() string {
 		endIdx = len(m.filtered)
 	}
 
+	// Align trailing detail (e.g. progress bars) into a column when present.
+	nameWidth, showDetail := 0, false
+	for _, it := range m.filtered {
+		if it.Detail != "" {
+			showDetail = true
+		}
+		if w := lipgloss.Width(it.Name); w > nameWidth {
+			nameWidth = w
+		}
+	}
+
 	for i := m.scrollStart; i < endIdx; i++ {
 		item := m.filtered[i]
+		name := item.Name
+		if showDetail {
+			name = padRight(name, nameWidth)
+		}
 
 		// Cursor and item name
 		if i == m.selected {
-			cursor := m.cursorStyle.Render("▶ ")
-			name := m.selectedStyle.Render(item.Name)
-			b.WriteString(cursor + name + "\n")
+			b.WriteString(m.cursorStyle.Render("▶ ") + m.selectedStyle.Render(name))
 		} else {
-			name := m.normalStyle.Render(item.Name)
-			b.WriteString("  " + name + "\n")
+			b.WriteString("  " + m.normalStyle.Render(name))
 		}
+		if showDetail && item.Detail != "" {
+			b.WriteString("  " + item.Detail)
+		}
+		b.WriteString("\n")
 	}
 
 	// Padding for empty space (only if we have fewer items than maxVisible)
@@ -287,6 +304,13 @@ func (m Model) View() string {
 	b.WriteString(help)
 
 	return b.String()
+}
+
+func padRight(s string, width int) string {
+	if w := lipgloss.Width(s); w < width {
+		return s + strings.Repeat(" ", width-w)
+	}
+	return s
 }
 
 // Selected returns the selected item, or nil if cancelled.

--- a/internal/tui/picker/picker_test.go
+++ b/internal/tui/picker/picker_test.go
@@ -2,11 +2,35 @@ package picker
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
+
+func TestPadRight(t *testing.T) {
+	if got := padRight("abc", 6); got != "abc   " {
+		t.Fatalf("padRight(\"abc\", 6) = %q, want %q", got, "abc   ")
+	}
+	if got := padRight("abcdef", 3); got != "abcdef" {
+		t.Fatalf("padRight must not truncate, got %q", got)
+	}
+}
+
+func TestViewRendersDetailColumn(t *testing.T) {
+	items := []Item{
+		{Name: "alpha", Value: "/a", Detail: "BAR-50%"},
+		{Name: "bravo-longer", Value: "/b"},
+	}
+	out := New(items, dummyScorer, testRenderer).View()
+	if !strings.Contains(out, "BAR-50%") {
+		t.Fatalf("View should render item Detail, got:\n%s", out)
+	}
+	if !strings.Contains(out, "alpha") || !strings.Contains(out, "bravo-longer") {
+		t.Fatalf("View should render item names, got:\n%s", out)
+	}
+}
 
 func dummyScorer(q, target string) (int, []int) {
 	return 1, nil


### PR DESCRIPTION
## Summary

The shared interactive festival picker now shows a progress bar and percentage after each festival, so you can see status while selecting. The picker is shared, so this lands in every festival picker: `fest go`, `fest promote`, `fest watch`, `fest status`, and `fest progress`.

```
─ 4/4 ──────────────────────────────────────────────────
> Type to filter...
▶ [active] daemon-chat-DC0001    ██████████ 100%
  [ready] launch-prep-LP0003     █████░░░░░ 50%
  [planning] my-feature-FE0007   ░░░░░░░░░░ 0%
  [active]/
```

## How it works

- `picker.Item` gains a display-only `Detail` field, rendered in an aligned trailing column. It is **not** used for fuzzy matching, so typing still filters on the festival name only. When no item has a `Detail`, rendering is byte-identical to before, so non-festival pickers are unaffected.
- `PickFestivalPath` fills each item's `Detail` with a compact bar via `progress.NewManagerReadOnly` + `GetFestivalProgress` (reusing `ui.RenderProgressBar`, the same helper `fest list` uses). This is the same orientation-only read pattern `fest stats` already uses.
- Items with no tasks (status directories like `[active]/`, empty festivals) report `Total == 0` and get no bar, so the column stays clean without needing per-item type flags.
- Progress is computed **concurrently** (bounded worker pool) so picker-open stays snappy even in large workspaces, and only after the TTY check, so non-interactive callers (scripts, agents) pay nothing.

Read-only note: for modern festivals this performs no disk writes. The only possible write is the same one-time legacy time-data backfill that `fest list`/`fest stats` already trigger via `GetFestivalProgress`.

## Testing

- `just build quick`, `just test unit` (2301/2301 pass), `just lint all` (0 issues). The new concurrent path is clean under `go test -race`.
- New unit tests:
  - `shared`: `TestFestivalProgressDetail` (real 4-task/2-complete fixture marked via the progress Manager → bar contains `50%`; empty festival → no bar) and `TestAttachProgressDetails` (festival item gets a bar, path-less item does not).
  - `picker`: `TestPadRight` and `TestViewRendersDetailColumn` (View renders the Detail column and the names).
- Rendered the real composed frame (shown above) through the actual `attachProgressDetails` + `picker.View` code paths against real progress fixtures.
