### PR TITLE
fix(sync): dev channel resolves to the latest tag, never behind stable

### DIFF
--- a/internal/github/tags.go
+++ b/internal/github/tags.go
@@ -51,11 +51,14 @@ func semverGreater(a, b semver) bool {
 	if a.patch != b.patch {
 		return a.patch > b.patch
 	}
-	// For pre-release comparison (dev channel), compare numerically by pre suffix.
-	// e.g. "dev.10" > "dev.9"
-	aNum := preReleaseNum(a.pre)
-	bNum := preReleaseNum(b.pre)
-	return aNum > bNum
+	// Same base version: a release (no pre-release) outranks any pre-release of
+	// that version, e.g. v1.0.0 > v1.0.0-dev.5.
+	if (a.pre == "") != (b.pre == "") {
+		return a.pre == ""
+	}
+	// Two pre-releases of the same base: compare numerically by suffix, e.g.
+	// "dev.10" > "dev.9".
+	return preReleaseNum(a.pre) > preReleaseNum(b.pre)
 }
 
 // preReleaseNum extracts the numeric part from a pre-release string like "dev.3".
@@ -69,11 +72,13 @@ func preReleaseNum(pre string) int {
 }
 
 // ResolveLatestTag queries the remote repository for tags and returns the
-// highest semver tag matching the given channel.
+// highest-precedence tag for the given channel.
 //
 // Supported channels:
 //   - "stable": tags matching `^v\d+\.\d+\.\d+$`
-//   - "dev":    tags matching `^v\d+\.\d+\.\d+-dev\.\d+$`
+//   - "dev":    dev pre-release tags (`^v\d+\.\d+\.\d+-dev\.\d+$`) AND stable
+//     releases, so the dev channel never resolves to a tag older than the
+//     latest stable. A newer dev pre-release still wins when one exists.
 func ResolveLatestTag(repoURL, channel string) (string, error) {
 	if !IsGitAvailable() {
 		return "", errors.Validation("git command not found")
@@ -85,57 +90,71 @@ func ResolveLatestTag(repoURL, channel string) (string, error) {
 		return "", errors.IO("listing remote tags", err).WithField("url", repoURL)
 	}
 
-	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	tag, err := selectLatestTag(parseLsRemoteTags(string(output)), channel)
+	if err != nil {
+		return "", err
+	}
+	return tag, nil
+}
 
-	var candidates []semver
-	for _, line := range lines {
+// parseLsRemoteTags extracts plain tag names from `git ls-remote --tags` output,
+// skipping annotated tag pointer entries (refs ending in "^{}").
+func parseLsRemoteTags(output string) []string {
+	var tags []string
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
 		if line == "" {
 			continue
 		}
-
-		// Each line is "<sha>\trefs/tags/<name>"
+		// Each line is "<sha>\trefs/tags/<name>".
 		parts := strings.Fields(line)
 		if len(parts) < 2 {
 			continue
 		}
-
 		ref := parts[1]
-
-		// Skip annotated tag pointer entries (end with ^{})
 		if strings.HasSuffix(ref, "^{}") {
 			continue
 		}
+		tags = append(tags, strings.TrimPrefix(ref, "refs/tags/"))
+	}
+	return tags
+}
 
-		tagName := strings.TrimPrefix(ref, "refs/tags/")
-
+// selectLatestTag returns the highest-precedence tag for the channel from the
+// given tag names. See ResolveLatestTag for channel semantics.
+func selectLatestTag(tags []string, channel string) (string, error) {
+	matchesChannel := func(tag string) bool {
 		switch channel {
 		case "stable":
-			if !stableTagRe.MatchString(tagName) {
-				continue
-			}
+			return stableTagRe.MatchString(tag)
 		case "dev":
-			if !devTagRe.MatchString(tagName) {
-				continue
-			}
+			return devTagRe.MatchString(tag) || stableTagRe.MatchString(tag)
 		default:
-			return "", errors.Validation("unknown channel: " + channel)
+			return false
 		}
+	}
 
-		sv, ok := parseSemver(tagName)
-		if !ok {
+	switch channel {
+	case "stable", "dev":
+	default:
+		return "", errors.Validation("unknown channel: " + channel)
+	}
+
+	var candidates []semver
+	for _, tag := range tags {
+		if !matchesChannel(tag) {
 			continue
 		}
-		candidates = append(candidates, sv)
+		if sv, ok := parseSemver(tag); ok {
+			candidates = append(candidates, sv)
+		}
 	}
 
 	if len(candidates) == 0 {
-		return "", errors.NotFound("tags matching channel "+channel).WithField("url", repoURL)
+		return "", errors.NotFound("tags matching channel " + channel)
 	}
 
-	// Sort descending and return the first element.
 	sort.Slice(candidates, func(i, j int) bool {
 		return semverGreater(candidates[i], candidates[j])
 	})
-
 	return candidates[0].raw, nil
 }

--- a/internal/github/tags_test.go
+++ b/internal/github/tags_test.go
@@ -63,6 +63,13 @@ func TestSemverGreater(t *testing.T) {
 		{"v1.2.3-dev.5", "v1.2.3-dev.4", true},
 		{"v1.2.3-dev.10", "v1.2.3-dev.9", true},
 		{"v1.2.3-dev.3", "v1.2.3-dev.10", false},
+		// A release outranks any pre-release of the same base version.
+		{"v1.2.3", "v1.2.3-dev.5", true},
+		{"v1.2.3-dev.5", "v1.2.3", false},
+		// A higher base beats a lower-base pre-release (and vice versa).
+		{"v1.0.1", "v1.0.0-dev.10", true},
+		{"v0.4.3", "v0.1.0-dev.2", true},
+		{"v0.5.0-dev.1", "v0.4.3", true},
 	}
 
 	for _, tc := range tests {
@@ -91,68 +98,8 @@ func buildLsRemoteOutput(tags []string) string {
 	return sb.String()
 }
 
-// resolveFromOutput mirrors the filtering/parsing logic in ResolveLatestTag so
-// we can test it without executing real git commands.
-func resolveFromOutput(output, channel string) (string, error) {
-	lines := strings.Split(output, "\n")
-	var candidates []semver
-	for _, line := range lines {
-		if line == "" {
-			continue
-		}
-		parts := strings.Fields(line)
-		if len(parts) < 2 {
-			continue
-		}
-		ref := parts[1]
-		if strings.HasSuffix(ref, "^{}") {
-			continue
-		}
-		tagName := strings.TrimPrefix(ref, "refs/tags/")
-
-		switch channel {
-		case "stable":
-			if !stableTagRe.MatchString(tagName) {
-				continue
-			}
-		case "dev":
-			if !devTagRe.MatchString(tagName) {
-				continue
-			}
-		default:
-			return "", &parseError{msg: "unknown channel: " + channel}
-		}
-
-		sv, ok := parseSemver(tagName)
-		if !ok {
-			continue
-		}
-		candidates = append(candidates, sv)
-	}
-
-	if len(candidates) == 0 {
-		return "", &notFoundError{channel: channel}
-	}
-
-	best := candidates[0]
-	for _, c := range candidates[1:] {
-		if semverGreater(c, best) {
-			best = c
-		}
-	}
-	return best.raw, nil
-}
-
-type parseError struct{ msg string }
-
-func (e *parseError) Error() string { return e.msg }
-
-type notFoundError struct{ channel string }
-
-func (e *notFoundError) Error() string { return "no tags found for channel " + e.channel }
-
-// TestResolveLatestTagFiltering tests the filtering logic with mock data.
-func TestResolveLatestTagFiltering(t *testing.T) {
+// TestSelectLatestTag tests channel filtering and selection with mock tags.
+func TestSelectLatestTag(t *testing.T) {
 	allTags := []string{
 		"v0.1.0",
 		"v0.1.0-dev.1",
@@ -164,18 +111,14 @@ func TestResolveLatestTagFiltering(t *testing.T) {
 		"v1.0.0-dev.10",
 		"v1.0.0-dev.9",
 		"v1.0.1",
-		// Should be ignored by both channels:
+		// Never selected by either channel:
 		"v1.0.0-rc.1",
 		"v1.0.0-alpha.2",
 		"latest",
 	}
 
-	output := buildLsRemoteOutput(allTags)
-	// Also add an annotated tag pointer that should be filtered out.
-	output += "deadbeef\trefs/tags/v1.0.1^{}\n"
-
 	t.Run("stable channel", func(t *testing.T) {
-		got, err := resolveFromOutput(output, "stable")
+		got, err := selectLatestTag(allTags, "stable")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -184,53 +127,99 @@ func TestResolveLatestTagFiltering(t *testing.T) {
 		}
 	})
 
-	t.Run("dev channel", func(t *testing.T) {
-		got, err := resolveFromOutput(output, "dev")
+	t.Run("dev channel includes stable releases", func(t *testing.T) {
+		got, err := selectLatestTag(allTags, "dev")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if got != "v1.0.0-dev.10" {
-			t.Errorf("dev: got %q, want %q", got, "v1.0.0-dev.10")
+		// v1.0.1 (stable) > v1.0.0-dev.10, so dev resolves to the stable release.
+		if got != "v1.0.1" {
+			t.Errorf("dev: got %q, want %q", got, "v1.0.1")
 		}
 	})
 
 	t.Run("unknown channel", func(t *testing.T) {
-		_, err := resolveFromOutput(output, "nightly")
-		if err == nil {
+		if _, err := selectLatestTag(allTags, "nightly"); err == nil {
 			t.Fatal("expected error for unknown channel")
 		}
 	})
 }
 
-// TestResolveLatestTagNoMatches tests that a clear error is returned when no
-// tags match the requested channel.
-func TestResolveLatestTagNoMatches(t *testing.T) {
-	output := buildLsRemoteOutput([]string{
-		"v1.0.0-dev.1",
-		"v1.0.0-dev.2",
-	})
+// TestSelectLatestTag_DevNeverBehindStable verifies the dev channel resolves to
+// the newest tag overall: it falls back to stable when dev tags are stale, and
+// a newer dev pre-release leads when one exists.
+func TestSelectLatestTag_DevNeverBehindStable(t *testing.T) {
+	tests := []struct {
+		name string
+		tags []string
+		want string
+	}{
+		{
+			name: "falls back to stable when dev tags are stale",
+			tags: []string{"v0.1.0-dev.1", "v0.1.0-dev.2", "v0.2.0", "v0.3.1", "v0.4.3"},
+			want: "v0.4.3",
+		},
+		{
+			name: "newer dev pre-release leads stable",
+			tags: []string{"v0.4.3", "v0.5.0-dev.1"},
+			want: "v0.5.0-dev.1",
+		},
+		{
+			name: "release outranks its own pre-releases",
+			tags: []string{"v0.5.0-dev.1", "v0.5.0-dev.3", "v0.5.0"},
+			want: "v0.5.0",
+		},
+		{
+			name: "dev tags only still resolves to the highest dev",
+			tags: []string{"v0.1.0-dev.1", "v0.1.0-dev.2"},
+			want: "v0.1.0-dev.2",
+		},
+	}
 
-	_, err := resolveFromOutput(output, "stable")
-	if err == nil {
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := selectLatestTag(tc.tags, "dev")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSelectLatestTag_NoMatches verifies a clear error when no tags match.
+func TestSelectLatestTag_NoMatches(t *testing.T) {
+	if _, err := selectLatestTag([]string{"v1.0.0-dev.1", "v1.0.0-dev.2"}, "stable"); err == nil {
 		t.Fatal("expected error when no stable tags exist")
 	}
-}
-
-// TestResolveLatestTagAnnotatedTagsFiltered verifies that ^{} entries are skipped.
-func TestResolveLatestTagAnnotatedTagsFiltered(t *testing.T) {
-	// Only annotated pointer entry — no plain ref should result in no match.
-	output := "abc123\trefs/tags/v2.0.0^{}\n"
-
-	_, err := resolveFromOutput(output, "stable")
-	if err == nil {
-		t.Fatal("expected not-found error when only annotated pointers are present")
+	if _, err := selectLatestTag(nil, "dev"); err == nil {
+		t.Fatal("expected error when no tags exist")
 	}
 }
 
-// TestResolveLatestTagEmptyOutput verifies that empty output returns an error.
-func TestResolveLatestTagEmptyOutput(t *testing.T) {
-	_, err := resolveFromOutput("", "stable")
-	if err == nil {
-		t.Fatal("expected error for empty output")
+// TestParseLsRemoteTags verifies tag-name extraction and annotated-pointer filtering.
+func TestParseLsRemoteTags(t *testing.T) {
+	output := buildLsRemoteOutput([]string{"v1.0.0", "v1.0.1"})
+	// Annotated tag pointer entries (ending in ^{}) must be skipped.
+	output += "deadbeef\trefs/tags/v1.0.1^{}\n"
+
+	got := parseLsRemoteTags(output)
+	want := []string{"v1.0.0", "v1.0.1"}
+	if len(got) != len(want) {
+		t.Fatalf("parseLsRemoteTags returned %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("tag[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+
+	if tags := parseLsRemoteTags(""); len(tags) != 0 {
+		t.Errorf("parseLsRemoteTags(\"\") = %v, want empty", tags)
+	}
+	if tags := parseLsRemoteTags("abc123\trefs/tags/v2.0.0^{}\n"); len(tags) != 0 {
+		t.Errorf("parseLsRemoteTags with only annotated pointers = %v, want empty", tags)
 	}
 }


### PR DESCRIPTION
## Summary

`fest system sync` on a dev build was syncing months-old templates. The dev channel only ever matched `-dev` tags (`internal/github/tags.go`), so once dev tagging lapsed (the last dev tag, `v0.1.0-dev.2`, is from April) it silently froze there while stable advanced to `v0.4.x`. Dev and festival-app users got stale templates with no signal that anything was wrong.

This was a release-process gap, not a parse bug, but the resolver had no fallback, so it stranded dev users by design. This makes the dev channel self-healing.

## Change

- **Dev channel now resolves to the newest tag overall.** Its candidate set is dev pre-releases **plus** stable releases, so it can never fall behind stable. A newer dev pre-release still wins when one exists; once a stable release of the same base ships, dev follows it.
- **Comparator fix.** `semverGreater` now ranks a release above its own pre-release (`v1.0.0 > v1.0.0-dev.5`), which is required now that dev and stable tags are compared together. This is backward-compatible for the stable-only and dev-only paths.
- **Removed a parallel implementation.** The test file previously reimplemented the resolver (`resolveFromOutput`) and had already diverged in spirit. Extracted pure `selectLatestTag` and `parseLsRemoteTags` helpers so production and tests share one code path.

`ResolveLatestTag` has a single production caller (`fest system sync`), so the behavior change is scoped to template sync; nothing else (e.g. self-update) depends on it.

Note: this is the durable fix. Cutting fresh dev tags is still fine and will make dev lead again, but it's no longer required to keep dev users current.

## Testing

- `just build quick`, `just test unit` (2301/2301 pass), `just lint all` (0 issues).
- New/updated unit tests in `internal/github/tags_test.go`:
  - `TestSelectLatestTag_DevNeverBehindStable`: dev falls back to latest stable when dev tags are stale (the exact bug: stale `v0.1.0-dev.2` + stable up to `v0.4.3` → `v0.4.3`); a newer dev pre-release leads stable; a release outranks its own pre-releases; dev-only sets still pick the highest dev.
  - `TestSemverGreater`: added release-vs-pre-release and cross-base cases.
  - `TestParseLsRemoteTags`: tag extraction and annotated-pointer (`^{}`) filtering.
- Verified against the real repo with the built binary: `fest system sync --channel dev --dry-run` now prints `Resolved dev channel to tag v0.4.4` (was `v0.1.0-dev.2`), matching the stable channel.
