### PR TITLE
feat(workflow): add 'fest workflow create' alias for 'fest create workflow'

### DIFF
--- a/internal/commands/festival/create_workflow.go
+++ b/internal/commands/festival/create_workflow.go
@@ -56,13 +56,9 @@ type createWorkflowResult struct {
 	Suggestions []string         `json:"suggestions,omitempty"`
 }
 
-// NewCreateWorkflowCommand creates the 'create workflow' subcommand.
-func NewCreateWorkflowCommand() *cobra.Command {
-	opts := &CreateWorkflowOptions{}
-	cmd := &cobra.Command{
-		Use:   "workflow",
-		Short: "Create a standalone or phase WORKFLOW.md from structured step definitions",
-		Long: `Generate a parseable WORKFLOW.md from prompts, inline JSON, or a steps file.
+// createWorkflowLong is the shared help text for `fest create workflow` and its
+// `fest workflow create` alias so the two never drift.
+const createWorkflowLong = `Generate a parseable WORKFLOW.md from prompts, inline JSON, or a steps file.
 
 Outside a festival phase, this creates WORKFLOW.md in the current directory,
 initializes .workflow/ runtime state, and starts a tracked run so fest next works
@@ -82,7 +78,15 @@ Examples:
   fest create workflow --steps-file steps.json --position after
 
   # Explicit phase path
-  fest create workflow --steps-file steps.json --path ./004_POLISH`,
+  fest create workflow --steps-file steps.json --path ./004_POLISH`
+
+// NewCreateWorkflowCommand creates the 'create workflow' subcommand.
+func NewCreateWorkflowCommand() *cobra.Command {
+	opts := &CreateWorkflowOptions{}
+	cmd := &cobra.Command{
+		Use:   "workflow",
+		Short: "Create a standalone or phase WORKFLOW.md from structured step definitions",
+		Long:  createWorkflowLong,
 		Annotations: map[string]string{
 			"scope": string(scope.Global),
 		},
@@ -95,6 +99,14 @@ Examples:
 		},
 	}
 
+	BindCreateWorkflowFlags(cmd, opts)
+	return cmd
+}
+
+// BindCreateWorkflowFlags binds the create-workflow flag set to opts on cmd.
+// Shared by `fest create workflow` and the `fest workflow create` alias so the
+// two surfaces expose an identical flag set.
+func BindCreateWorkflowFlags(cmd *cobra.Command, opts *CreateWorkflowOptions) {
 	cmd.Flags().StringVar(&opts.Steps, "steps", "", "Inline JSON with workflow definition")
 	cmd.Flags().StringVar(&opts.StepsFile, "steps-file", "", "Path to JSON file with workflow definition")
 	cmd.Flags().StringVar(&opts.Position, "position", "after", "Workflow position relative to sequences (before|after)")
@@ -104,7 +116,6 @@ Examples:
 	cmd.Flags().BoolVar(&opts.AgentMode, "agent", false, "Strict agent mode (implies --json)")
 	cmd.Flags().StringVar(&opts.Type, "type", "task", "workflow type (standalone mode only)")
 	cmd.Flags().BoolVar(&opts.NoInit, "no-init", false, "skip .workflow/ runtime init (advanced standalone mode)")
-	return cmd
 }
 
 // RunCreateWorkflow executes the create workflow command. Dispatches to

--- a/internal/commands/workflow/create.go
+++ b/internal/commands/workflow/create.go
@@ -1,0 +1,48 @@
+package workflow
+
+import (
+	"github.com/Obedience-Corp/fest/internal/commands/festival"
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/scope"
+	"github.com/spf13/cobra"
+)
+
+// newCreateCmd registers `fest workflow create`, an alias for `fest create
+// workflow` that delegates to the same festival.RunCreateWorkflow.
+func newCreateCmd() *cobra.Command {
+	opts := &festival.CreateWorkflowOptions{}
+	cmd := &cobra.Command{
+		Use:   "create [name]",
+		Short: "Scaffold a new standalone WORKFLOW.md (alias of 'fest create workflow')",
+		Long: `Alias of 'fest create workflow'.
+
+` + createAliasIntro + `
+
+Unlike the other 'fest workflow' subcommands (init, start, show, advance), which
+operate on an existing WORKFLOW.md, this one scaffolds a brand-new document.
+
+Examples:
+  fest workflow create demo
+  fest workflow create demo --steps '{"title":"Review","steps":[...]}'
+  fest workflow create demo --steps-file steps.json`,
+		Annotations: map[string]string{"scope": string(scope.Global)},
+		Args:        cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Reject the inherited --phase persistent flag rather than ignore it.
+			if phaseFlag != "" {
+				return festerrors.Validation("--phase is not supported by 'fest workflow create'").
+					WithHint("scaffold in the current directory, or use 'fest create workflow --path <phase>' for phase mode")
+			}
+			if len(args) == 1 {
+				opts.Name = args[0]
+			}
+			return festival.RunCreateWorkflow(cmd.Context(), opts)
+		},
+	}
+	festival.BindCreateWorkflowFlags(cmd, opts)
+	return cmd
+}
+
+const createAliasIntro = `Outside a festival phase, this creates WORKFLOW.md in the current directory,
+initializes .workflow/ runtime state, and starts a tracked run so 'fest next'
+works immediately.`

--- a/internal/commands/workflow/create_test.go
+++ b/internal/commands/workflow/create_test.go
@@ -1,0 +1,91 @@
+package workflow
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func findSubcommand(parent *cobra.Command, name string) *cobra.Command {
+	for _, c := range parent.Commands() {
+		if c.Name() == name {
+			return c
+		}
+	}
+	return nil
+}
+
+func TestWorkflowCreateRegistered(t *testing.T) {
+	create := findSubcommand(NewWorkflowCommand(), "create")
+	if create == nil {
+		t.Fatal("`fest workflow create` is not registered under the workflow command")
+	}
+	for _, f := range []string{"steps", "steps-file", "type", "json", "agent", "no-init", "path", "position", "festival"} {
+		if create.Flags().Lookup(f) == nil {
+			t.Errorf("create alias is missing flag --%s", f)
+		}
+	}
+}
+
+func TestWorkflowCreateHelpMentionsAlias(t *testing.T) {
+	cmd := NewWorkflowCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"create", "--help"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("help: %v", err)
+	}
+	help := strings.ToLower(out.String())
+	for _, want := range []string{"alias of 'fest create workflow'", "current directory", "fest next"} {
+		if !strings.Contains(help, strings.ToLower(want)) {
+			t.Fatalf("create help missing %q:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestWorkflowCreateRejectsPhaseFlag(t *testing.T) {
+	defer func() { phaseFlag = "" }()
+	cmd := NewWorkflowCommand()
+	cmd.SetArgs([]string{"create", "demo", "--phase", "001_X", "--steps", `{"title":"x","steps":[{"name":"A","goal":"g"}]}`})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected --phase to be rejected")
+	}
+	if !strings.Contains(err.Error(), "--phase is not supported") {
+		t.Errorf("error = %v, want it to mention --phase is not supported", err)
+	}
+}
+
+func TestWorkflowCreateScaffoldsStandalone(t *testing.T) {
+	defer func() { phaseFlag = "" }()
+	dir := t.TempDir()
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	cmd := NewWorkflowCommand()
+	cmd.SetArgs([]string{
+		"create", "demo", "--json",
+		"--steps", `{"title":"Demo","steps":[{"name":"SCAN","goal":"Scan items"},{"name":"DECIDE","goal":"Decide fate"}]}`,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "WORKFLOW.md")); err != nil {
+		t.Errorf("WORKFLOW.md not created: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".workflow", "workflow.yaml")); err != nil {
+		t.Errorf(".workflow/workflow.yaml not created: %v", err)
+	}
+}

--- a/internal/commands/workflow/init.go
+++ b/internal/commands/workflow/init.go
@@ -29,6 +29,10 @@ Run from the directory containing WORKFLOW.md. The command refuses to run
 inside a festival phase. Use --force to overwrite an existing
 .workflow/workflow.yaml.
 
+To scaffold a new WORKFLOW.md and initialize its runtime in one step, use
+'fest workflow create <name>' (alias of 'fest create workflow'). init is for a
+WORKFLOW.md you have already authored.
+
 This command does not create .workitem; that file is owned by camp
 (see 'camp workitem create' and 'camp workitem adopt').`,
 		Annotations: map[string]string{"scope": string(scope.Global)},

--- a/internal/commands/workflow/workflow.go
+++ b/internal/commands/workflow/workflow.go
@@ -23,6 +23,13 @@ These commands work with WORKFLOW.md files (step-by-step guidance for workflow p
 and GATES.md files (phase-level quality gates for all phase types). Use 'fest next'
 to see the current step, then these commands to advance.
 
+Creating a Workflow:
+  Use 'fest workflow create <name>' (an alias of 'fest create workflow') to
+  scaffold a brand-new standalone WORKFLOW.md outside a festival. It writes the
+  document, initializes .workflow/ runtime state, and starts a tracked run so
+  'fest next' works immediately. The init/start subcommands below operate on a
+  WORKFLOW.md that already exists.
+
 Workflow Steps:
   Workflows are defined in WORKFLOW.md files within phase directories.
   Each step has a goal, actions to complete, expected output, and an optional checkpoint.
@@ -51,6 +58,7 @@ Auto-Routing:
   - GATES.md if workflow is complete/absent and phase work is done
 
 Examples:
+  fest workflow create my-review    # Scaffold a new standalone WORKFLOW.md
   fest workflow status              # Show workflow or gate progress
   fest workflow status --phase 001_INGEST  # Show specific phase
   fest workflow advance             # Complete current step and move to next
@@ -74,6 +82,7 @@ Examples:
 		newResetCmd(),
 		newShowCmd(),
 		// Standalone workflow lifecycle (introduced in WW0001/004.01).
+		newCreateCmd(),
 		newInitCmd(),
 		newStartCmd(),
 		newRunsCmd(),

--- a/tests/integration/create_workflow_standalone_test.go
+++ b/tests/integration/create_workflow_standalone_test.go
@@ -164,4 +164,38 @@ func TestCreateWorkflowStandalone(t *testing.T) {
 		require.Error(t, err, "--position non-default in standalone mode must error")
 		require.Contains(t, out, "--position is not valid", "error should mention --position: %s", out)
 	})
+
+	t.Run("WorkflowCreateAliasMatchesCreateWorkflow", func(t *testing.T) {
+		const dir = "/tmp/cw-standalone-alias"
+		_, _ = container.Exec("rm", "-rf", dir)
+		_, err := container.Exec("mkdir", "-p", dir)
+		require.NoError(t, err)
+
+		require.NoError(t, container.WriteFile(dir+"/steps.json", standaloneStepsJSON))
+		out, err := container.RunFestInDir(dir, "workflow", "create", "demo", "--steps-file", dir+"/steps.json")
+		require.NoError(t, err, "fest workflow create: %s", out)
+		require.Contains(t, out, "initialized .workflow/workflow.yaml")
+		require.Contains(t, out, "workflow_id=wf-demo")
+
+		exists, _ := container.CheckFileExists(dir + "/WORKFLOW.md")
+		require.True(t, exists, "WORKFLOW.md should exist")
+		exists, _ = container.CheckFileExists(dir + "/.workflow/workflow.yaml")
+		require.True(t, exists, ".workflow/workflow.yaml should exist")
+
+		out, err = container.RunFestInDir(dir, "next", "--json")
+		require.NoError(t, err, "fest next should work after workflow create: %s", out)
+		require.Contains(t, out, `"mode": "standalone-tracked"`)
+	})
+
+	t.Run("WorkflowCreateAliasRejectsPhaseFlag", func(t *testing.T) {
+		const dir = "/tmp/cw-standalone-alias-phase"
+		_, _ = container.Exec("rm", "-rf", dir)
+		_, err := container.Exec("mkdir", "-p", dir)
+		require.NoError(t, err)
+
+		require.NoError(t, container.WriteFile(dir+"/steps.json", standaloneStepsJSON))
+		out, err := container.RunFestInDir(dir, "workflow", "create", "demo", "--steps-file", dir+"/steps.json", "--phase", "001_X")
+		require.Error(t, err, "--phase must be rejected by the alias")
+		require.Contains(t, out, "--phase is not supported", "error should mention --phase: %s", out)
+	})
 }


### PR DESCRIPTION
## Problem

Creating a standalone `WORKFLOW.md` outside a festival is supported via `fest create workflow <name>` (it writes the doc, initializes `.workflow/`, and starts a tracked run so `fest next` works immediately). But the entrypoint is hard to discover: agents and humans look under the `workflow` noun first, and `fest workflow ...` only exposes `init`, `start`, `show`, `advance`, etc. Those operate on a WORKFLOW.md that already exists (`fest workflow init` literally requires one). There was no command under `fest workflow` to scaffold a new one, so the scaffolding command was effectively invisible from that namespace.

This actually tripped up an agent session: asked to "create a WORKFLOW.md with the fest CLI," it went down the `fest workflow init`/`start` path and stalled instead of finding `fest create workflow`.

## Change

Add `fest workflow create` as a discoverability alias for `fest create workflow`:

- It delegates to the same `festival.RunCreateWorkflow`, so both surfaces behave identically.
- The flag set is shared via a new exported `BindCreateWorkflowFlags`, so the two commands cannot drift.
- The inherited `--phase` persistent flag (from the parent `workflow` command, used by the navigation subcommands) is rejected explicitly rather than silently ignored. This matches the existing `rejectFestivalOnlyFlags` contract, which the codebase added specifically to avoid confusing silent flag drops.
- Help text now points to the scaffolding command from both the `fest workflow` group description and `fest workflow init`.

No behavior change to `fest create workflow` itself; the help text was extracted to a shared const but is byte-identical.

## Testing

- Unit (`internal/commands/workflow/create_test.go`): alias is registered, flag parity with `create workflow`, `--phase` is rejected, and an end-to-end standalone scaffold produces `WORKFLOW.md` + `.workflow/workflow.yaml`.
- Integration (`tests/integration/create_workflow_standalone_test.go`): `fest workflow create` produces the same artifacts as `fest create workflow` and `fest next` works immediately after; `--phase` is rejected.
- Gates: `just lint all` (0 issues), `just lint vet`, `go vet -tags integration`, and `just test unit` (2305/2305 passing).

## Notes for reviewers

The alias is intentionally an alias, not a relocation: `fest create workflow` stays canonical alongside its `create festival/phase/sequence/task` siblings, and `fest workflow create` is the discoverability shortcut under the noun agents reach for first.

This is the CLI half of a broader follow-up captured as a campaign intent (skill docs for standalone WORKFLOW.md creation, then propagation to the festival plugin skill copies for claude/codex/opencode/cursor). Those docs intentionally follow once this command lands, so they describe shipped behavior.
