### PR TITLE
fix(next): surface earlier phase gate before later phase workflow (#218)

### DIFF
--- a/internal/commands/next/next.go
+++ b/internal/commands/next/next.go
@@ -293,19 +293,22 @@ func runNext(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// If selector says festival is complete, check for remaining incomplete workflow phases
+	// If the selector says the festival is complete, workflow phases and/or
+	// phase gates may still remain. Surface whichever incomplete phase comes
+	// FIRST in numerical order. A completed workflow phase can still have an
+	// unsatisfied gate (GATES.md) that must be walked before a LATER phase's
+	// workflow; routing to the later workflow first would skip that gate and
+	// desync `fest next` from `fest workflow status` (which stays on the
+	// earlier phase's gate).
 	if result.FestivalComplete {
-		incompleteWorkflow, wErr := findFirstIncompleteWorkflowPhase(ctx, festivalPath)
-		if wErr == nil && incompleteWorkflow != "" {
-			return runWorkflowMode(ctx, festivalPath, incompleteWorkflow)
-		}
-	}
-
-	// If selector says festival is complete, check for remaining incomplete phase gates
-	if result.FestivalComplete {
-		incompleteGate, gErr := findFirstIncompletePhaseGate(ctx, festivalPath)
-		if gErr == nil && incompleteGate != "" {
-			return runPhaseGateMode(ctx, festivalPath, incompleteGate)
+		route, routePhase, routeErr := resolveCompletePhaseRoute(ctx, festivalPath)
+		if routeErr == nil {
+			switch route {
+			case routeGate:
+				return runPhaseGateMode(ctx, festivalPath, routePhase)
+			case routeWorkflow:
+				return runWorkflowMode(ctx, festivalPath, routePhase)
+			}
 		}
 	}
 

--- a/internal/commands/next/phase.go
+++ b/internal/commands/next/phase.go
@@ -210,3 +210,46 @@ func findFirstIncompletePhaseGate(ctx context.Context, festivalPath string) (str
 func isPhaseWorkAndWorkflowComplete(ctx context.Context, storeLoaded bool, store *progress.Store, phasePath, phaseName string) bool {
 	return shared.ArePhaseTasksAndWorkflowComplete(ctx, storeLoaded, store, phasePath, phaseName)
 }
+
+// completeRoute identifies what fest next should surface when the task selector
+// reports the festival complete but workflow or gate work still remains.
+type completeRoute int
+
+const (
+	routeNone completeRoute = iota
+	routeWorkflow
+	routeGate
+)
+
+// resolveCompletePhaseRoute decides, when the task selector reports the festival
+// complete, whether to surface an incomplete phase workflow or an incomplete
+// phase gate — choosing whichever phase comes first in numerical order. A later
+// phase's workflow must not mask an earlier phase's unsatisfied gate, which is
+// what makes fest next desync from fest workflow status. Returns routeNone when
+// nothing remains. Phase basenames are zero-padded numeric prefixes, so lexical
+// comparison matches numerical order (the same convention the phase scanners use
+// via sort.Strings).
+func resolveCompletePhaseRoute(ctx context.Context, festivalPath string) (completeRoute, string, error) {
+	incompleteWorkflow, wErr := findFirstIncompleteWorkflowPhase(ctx, festivalPath)
+	if wErr != nil {
+		return routeNone, "", wErr
+	}
+	incompleteGate, gErr := findFirstIncompletePhaseGate(ctx, festivalPath)
+	if gErr != nil {
+		return routeNone, "", gErr
+	}
+
+	switch {
+	case incompleteGate != "" && incompleteWorkflow != "":
+		if filepath.Base(incompleteGate) < filepath.Base(incompleteWorkflow) {
+			return routeGate, incompleteGate, nil
+		}
+		return routeWorkflow, incompleteWorkflow, nil
+	case incompleteGate != "":
+		return routeGate, incompleteGate, nil
+	case incompleteWorkflow != "":
+		return routeWorkflow, incompleteWorkflow, nil
+	default:
+		return routeNone, "", nil
+	}
+}

--- a/internal/commands/next/phase_gate_routing_test.go
+++ b/internal/commands/next/phase_gate_routing_test.go
@@ -1,0 +1,131 @@
+package next
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+	"github.com/Obedience-Corp/fest/internal/progress"
+)
+
+func scaffoldWorkflowGateFestival(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "fest.yaml"), []byte("name: wf-gate-test\nid: WGT-001\n"), 0o644); err != nil {
+		t.Fatalf("write fest.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "FESTIVAL_GOAL.md"), []byte("# WF Gate Test\n"), 0o644); err != nil {
+		t.Fatalf("write goal: %v", err)
+	}
+
+	workflowMD := "---\nfest_type: workflow\nfest_id: %s-WF\nfest_parent: %s\n---\n\n# WF\n\n## Step 1: ONE — First\n\n**Goal:** one.\n\n**Actions:**\n1. do\n\n**Output:** done\n\n**Checkpoint:** None\n\n## Step 2: TWO — Second\n\n**Goal:** two.\n\n**Actions:**\n1. do\n\n**Output:** done\n\n**Checkpoint:** None\n"
+	gatesMD := "---\nfest_type: phase_gate\nfest_id: %s-GATE\nfest_parent: %s\n---\n\n# Gate\n\n## Step 1: VERIFY — Verify\n\n**Question:** good?\n\n**Actions:**\n1. check\n\n**Checkpoint:** APPROVAL REQUIRED\n"
+
+	ingest := filepath.Join(dir, "001_INGEST")
+	if err := os.MkdirAll(ingest, 0o755); err != nil {
+		t.Fatalf("mkdir ingest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(ingest, "PHASE_GOAL.md"), []byte("---\nfest_type: phase\nfest_id: 001_INGEST\nfest_phase_type: ingest\n---\n\n# Ingest\n"), 0o644); err != nil {
+		t.Fatalf("write ingest goal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(ingest, "WORKFLOW.md"), fmt.Appendf(nil, workflowMD, "001_INGEST", "001_INGEST"), 0o644); err != nil {
+		t.Fatalf("write ingest WORKFLOW.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(ingest, "GATES.md"), fmt.Appendf(nil, gatesMD, "001_INGEST", "001_INGEST"), 0o644); err != nil {
+		t.Fatalf("write ingest GATES.md: %v", err)
+	}
+
+	plan := filepath.Join(dir, "002_PLAN")
+	if err := os.MkdirAll(plan, 0o755); err != nil {
+		t.Fatalf("mkdir plan: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(plan, "PHASE_GOAL.md"), []byte("---\nfest_type: phase\nfest_id: 002_PLAN\nfest_phase_type: planning\n---\n\n# Plan\n"), 0o644); err != nil {
+		t.Fatalf("write plan goal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(plan, "WORKFLOW.md"), fmt.Appendf(nil, workflowMD, "002_PLAN", "002_PLAN"), 0o644); err != nil {
+		t.Fatalf("write plan WORKFLOW.md: %v", err)
+	}
+
+	return dir
+}
+
+func completeWorkflow(t *testing.T, festDir, key string, steps int) {
+	t.Helper()
+	ctx := context.Background()
+	store := progress.NewStore(festDir)
+	if err := store.Load(ctx); err != nil {
+		t.Fatalf("store.Load: %v", err)
+	}
+	store.QueueWorkflowEvents(wf.EmitInitEvents(key, steps))
+	for i := 1; i <= steps; i++ {
+		store.QueueWorkflowEvents(wf.EmitStepDoneEvents(key, i))
+	}
+	if err := store.Save(ctx); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+}
+
+func TestResolveCompletePhaseRoute_SurfacesEarlierGateBeforeLaterWorkflow(t *testing.T) {
+	festDir := scaffoldWorkflowGateFestival(t)
+	ctx := context.Background()
+
+	completeWorkflow(t, festDir, "001_INGEST", 2)
+
+	if got, _ := findFirstIncompleteWorkflowPhase(ctx, festDir); filepath.Base(got) != "002_PLAN" {
+		t.Fatalf("findFirstIncompleteWorkflowPhase = %q, want 002_PLAN", got)
+	}
+	if got, _ := findFirstIncompletePhaseGate(ctx, festDir); filepath.Base(got) != "001_INGEST" {
+		t.Fatalf("findFirstIncompletePhaseGate = %q, want 001_INGEST", got)
+	}
+
+	route, phase, err := resolveCompletePhaseRoute(ctx, festDir)
+	if err != nil {
+		t.Fatalf("resolveCompletePhaseRoute: %v", err)
+	}
+	if route != routeGate {
+		t.Fatalf("route = %v, want routeGate", route)
+	}
+	if filepath.Base(phase) != "001_INGEST" {
+		t.Fatalf("phase = %q, want 001_INGEST", phase)
+	}
+}
+
+func TestResolveCompletePhaseRoute_AdvancesToNextWorkflowAfterGateDone(t *testing.T) {
+	festDir := scaffoldWorkflowGateFestival(t)
+	ctx := context.Background()
+
+	completeWorkflow(t, festDir, "001_INGEST", 2)
+	completeWorkflow(t, festDir, "gate:001_INGEST", 1)
+
+	route, phase, err := resolveCompletePhaseRoute(ctx, festDir)
+	if err != nil {
+		t.Fatalf("resolveCompletePhaseRoute: %v", err)
+	}
+	if route != routeWorkflow {
+		t.Fatalf("route = %v, want routeWorkflow", route)
+	}
+	if filepath.Base(phase) != "002_PLAN" {
+		t.Fatalf("phase = %q, want 002_PLAN", phase)
+	}
+}
+
+func TestResolveCompletePhaseRoute_NoneWhenAllComplete(t *testing.T) {
+	festDir := scaffoldWorkflowGateFestival(t)
+	ctx := context.Background()
+
+	completeWorkflow(t, festDir, "001_INGEST", 2)
+	completeWorkflow(t, festDir, "gate:001_INGEST", 1)
+	completeWorkflow(t, festDir, "002_PLAN", 2)
+
+	route, _, err := resolveCompletePhaseRoute(ctx, festDir)
+	if err != nil {
+		t.Fatalf("resolveCompletePhaseRoute: %v", err)
+	}
+	if route != routeNone {
+		t.Fatalf("route = %v, want routeNone", route)
+	}
+}


### PR DESCRIPTION
## Problem

Closes #218.

After a workflow-style phase (e.g. `INGEST`) finishes its step workflow, `fest next`
and `fest workflow status` disagreed about the current phase, and the just-completed
phase's **gate** (`GATES.md`: PHASE GOAL / COMPLETENESS / APPROVAL) was never surfaced
by `fest next`:

- `fest status`: INGEST complete, on to PLAN.
- `fest next`: PLAN workflow, step 1/8.
- `fest workflow status`: still parked on the INGEST gate, step 1/3, 0%.

An agent or human driving the documented `fest next` loop silently skipped the phase
gate, and `fest workflow advance` / `approve` operated on a different phase than
`fest next` displayed.

## Root cause

`lifecycle.FindFirstIncompletePhase` already detects the pending gate and returns
`(INGEST, isWorkflow=false)`. But in `runNext`, when the task selector reports the
festival complete, the two follow-up checks ran in the wrong precedence:

```go
if result.FestivalComplete {            // checked FIRST
    incompleteWorkflow := findFirstIncompleteWorkflowPhase(...)  // -> 002_PLAN
    return runWorkflowMode(...)          // routes to PLAN, returns
}
if result.FestivalComplete {            // never reached
    incompleteGate := findFirstIncompletePhaseGate(...)          // -> 001_INGEST
    return runPhaseGateMode(...)
}
```

An incomplete *workflow* phase was unconditionally preferred over an incomplete
*gate*, regardless of phase order, so a later phase's workflow (PLAN) masked an
earlier phase's unsatisfied gate (INGEST).

## Fix

Resolve both candidates and route to whichever phase comes **first in numerical
order** (`internal/commands/next/phase.go` `resolveCompletePhaseRoute`). A simple
reorder would be wrong (it would surface a later phase's gate before an earlier
phase's workflow); ordering by phase number is the correct rule. `runNext` now calls
the single resolver instead of the two order-blind blocks.

## Verification

New unit tests in `internal/commands/next/phase_gate_routing_test.go`:
- earlier incomplete gate is surfaced before a later incomplete workflow,
- after the gate completes, routing advances to the next phase's workflow,
- `routeNone` when everything is complete.

`just lint all` (0 issues), `just lint vet`, and the full `just test unit-raw` suite
pass.

End-to-end against a real standard festival, after the fix `fest next` and
`fest workflow status` agree:

```
$ fest next
                    BLOCKING CHECKPOINT
Step 1: PHASE GOAL
- Approve and continue: fest workflow approve

$ fest workflow status
Current Step: 1 of 3
→ ● Step 1: PHASE GOAL [checkpoint]
  ○ Step 2: COMPLETENESS [checkpoint]
  ○ Step 3: APPROVAL [checkpoint]
```

## Notes

This only changes routing when the selector reports the festival complete and both an
incomplete workflow phase and an incomplete phase gate exist; single-candidate cases
behave as before. The gate is a real approval checkpoint and is now walked rather than
skipped (no gate state is auto-completed or suppressed).
