### PR TITLE
Extend fest walk to standalone workflows

### DIFF
--- a/internal/commands/show/standalone.go
+++ b/internal/commands/show/standalone.go
@@ -322,21 +322,23 @@ func currentStandaloneStep(info *StandaloneWorkflowInfo) *shared.WorkflowStepVie
 	return nil
 }
 
-type standaloneWorkflowJSON struct {
-	Mode           string                   `json:"mode"`
-	WorkflowDoc    string                   `json:"workflow_doc"`
-	RuntimeDir     string                   `json:"runtime_dir,omitempty"`
-	RunID          string                   `json:"run_id,omitempty"`
-	RunStatus      string                   `json:"run_status"`
-	CurrentStep    int                      `json:"current_step"`
-	TotalSteps     int                      `json:"total_steps"`
-	CompletedSteps int                      `json:"completed_steps"`
-	Blocked        bool                     `json:"blocked,omitempty"`
-	DocHashChanged bool                     `json:"doc_hash_changed,omitempty"`
-	Steps          []standaloneWorkflowStep `json:"steps"`
+// StandaloneWorkflowJSON is the machine-readable view of a standalone WORKFLOW.md.
+type StandaloneWorkflowJSON struct {
+	Mode           string                       `json:"mode"`
+	WorkflowDoc    string                       `json:"workflow_doc"`
+	RuntimeDir     string                       `json:"runtime_dir,omitempty"`
+	RunID          string                       `json:"run_id,omitempty"`
+	RunStatus      string                       `json:"run_status"`
+	CurrentStep    int                          `json:"current_step"`
+	TotalSteps     int                          `json:"total_steps"`
+	CompletedSteps int                          `json:"completed_steps"`
+	Blocked        bool                         `json:"blocked,omitempty"`
+	DocHashChanged bool                         `json:"doc_hash_changed,omitempty"`
+	Steps          []StandaloneWorkflowStepJSON `json:"steps"`
 }
 
-type standaloneWorkflowStep struct {
+// StandaloneWorkflowStepJSON is a single step in a standalone workflow view.
+type StandaloneWorkflowStepJSON struct {
 	Number        int    `json:"number"`
 	Name          string `json:"name"`
 	Status        string `json:"status"`
@@ -345,8 +347,9 @@ type standaloneWorkflowStep struct {
 	Goal          string `json:"goal,omitempty"`
 }
 
-func emitStandaloneWorkflowJSON(info *StandaloneWorkflowInfo) error {
-	out := standaloneWorkflowJSON{
+// NewStandaloneWorkflowJSON projects resolved info into the JSON view.
+func NewStandaloneWorkflowJSON(info *StandaloneWorkflowInfo) StandaloneWorkflowJSON {
+	out := StandaloneWorkflowJSON{
 		Mode:           info.Mode,
 		WorkflowDoc:    info.WorkflowDoc,
 		RuntimeDir:     info.RuntimeDir,
@@ -357,10 +360,10 @@ func emitStandaloneWorkflowJSON(info *StandaloneWorkflowInfo) error {
 		CompletedSteps: info.CompletedSteps,
 		Blocked:        info.Blocked,
 		DocHashChanged: info.DocHashChanged,
-		Steps:          make([]standaloneWorkflowStep, 0, len(info.Steps)),
+		Steps:          make([]StandaloneWorkflowStepJSON, 0, len(info.Steps)),
 	}
 	for _, step := range info.Steps {
-		out.Steps = append(out.Steps, standaloneWorkflowStep{
+		out.Steps = append(out.Steps, StandaloneWorkflowStepJSON{
 			Number:        step.Number,
 			Name:          step.Name,
 			Status:        string(step.Status),
@@ -369,7 +372,11 @@ func emitStandaloneWorkflowJSON(info *StandaloneWorkflowInfo) error {
 			Goal:          step.Goal,
 		})
 	}
-	if err := shared.EncodeJSON(os.Stdout, out); err != nil {
+	return out
+}
+
+func emitStandaloneWorkflowJSON(info *StandaloneWorkflowInfo) error {
+	if err := shared.EncodeJSON(os.Stdout, NewStandaloneWorkflowJSON(info)); err != nil {
 		return errors.Wrap(err, "encoding JSON output")
 	}
 	return nil

--- a/internal/commands/walk/walk.go
+++ b/internal/commands/walk/walk.go
@@ -28,16 +28,17 @@ type walkOptions struct {
 
 // WalkView is the structured view returned by fest walk.
 type WalkView struct {
-	Kind     string `json:"kind"`
-	Name     string `json:"name"`
-	Status   string `json:"status"`
-	Path     string `json:"path"`
-	Goal     string `json:"goal,omitempty"`
+	Kind     string        `json:"kind"`
+	Name     string        `json:"name"`
+	Status   string        `json:"status"`
+	Path     string        `json:"path"`
+	Goal     string        `json:"goal,omitempty"`
 	Progress *walkProgress `json:"progress,omitempty"`
-	Next     string `json:"next,omitempty"`
+	Next     string        `json:"next,omitempty"`
 	Blocked  []walkBlocker `json:"blocked,omitempty"`
-	Gates    []string `json:"gates,omitempty"`
-	Warnings []string `json:"warnings,omitempty"`
+	Gates    []string      `json:"gates,omitempty"`
+	Warnings []string      `json:"warnings,omitempty"`
+	Workflow *walkWorkflow `json:"workflow,omitempty"`
 }
 
 type walkProgress struct {
@@ -47,8 +48,31 @@ type walkProgress struct {
 }
 
 type walkBlocker struct {
-	Task    string `json:"task"`
-	Reason  string `json:"reason"`
+	Task   string `json:"task"`
+	Reason string `json:"reason"`
+}
+
+type walkWorkflow struct {
+	Mode           string             `json:"mode"`
+	WorkflowDoc    string             `json:"workflow_doc"`
+	RuntimeDir     string             `json:"runtime_dir,omitempty"`
+	RunID          string             `json:"run_id,omitempty"`
+	RunStatus      string             `json:"run_status"`
+	CurrentStep    int                `json:"current_step"`
+	TotalSteps     int                `json:"total_steps"`
+	CompletedSteps int                `json:"completed_steps"`
+	Blocked        bool               `json:"blocked,omitempty"`
+	DocHashChanged bool               `json:"doc_hash_changed,omitempty"`
+	Steps          []walkWorkflowStep `json:"steps"`
+}
+
+type walkWorkflowStep struct {
+	Number        int    `json:"number"`
+	Name          string `json:"name"`
+	Status        string `json:"status"`
+	Current       bool   `json:"current,omitempty"`
+	HasCheckpoint bool   `json:"has_checkpoint,omitempty"`
+	Goal          string `json:"goal,omitempty"`
 }
 
 // NewWalkCommand creates the walk/inspect command.
@@ -58,22 +82,26 @@ func NewWalkCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "walk [path]",
 		Aliases: []string{"inspect"},
-		Short:   "Guided overview of a festival",
+		Short:   "Guided overview of a festival or workflow",
 		Annotations: map[string]string{
 			"scope": string(scope.Global),
 		},
-		Long: `Display a guided orientation overview of a festival.
+		Long: `Display a guided orientation overview of a festival or workflow.
 
-Shows what the festival is, where it is, its current status and progress,
-the next task, blocked tasks, active quality gates, and any warnings.
-This is a read-only orientation command; it never mutates festival state.
+For festivals, shows what the festival is, where it is, its current status
+and progress, the next task, blocked tasks, active quality gates, and any
+warnings. For standalone WORKFLOW.md files, shows workflow mode, run status,
+step progress, and the current step. This is a read-only orientation command;
+it never mutates festival or workflow state.
 
-Useful for quickly orienting inside a festival before continuing work,
-especially for rituals where the template and active run are distinct.
+Useful for quickly orienting inside a festival or standalone workflow before
+continuing work, especially for rituals where the template and active run are
+distinct.
 
 EXAMPLES:
-  fest walk                      # Walk current festival from cwd
+  fest walk                      # Walk current festival or WORKFLOW.md from cwd
   fest walk festivals/active/my-festival
+  fest walk path/to/workflow-dir
   fest walk --json               # Machine-readable output`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -115,10 +143,22 @@ func runWalk(ctx context.Context, opts *walkOptions) error {
 
 	campaignRoot, _ := workspace.DetectCampaign(ctx, startDir)
 
+	standaloneWorkflow, err := show.ResolveStandaloneWorkflow(ctx, startDir)
+	if err != nil {
+		return errors.Wrap(err, "resolving standalone workflow")
+	}
+	if standaloneWorkflow != nil {
+		view := buildStandaloneWalkView(standaloneWorkflow)
+		if opts.json {
+			return emitJSON(view)
+		}
+		return emitStandaloneText(view, standaloneWorkflow, campaignRoot)
+	}
+
 	festival, err := resolveFestival(ctx, startDir, campaignRoot)
 	if err != nil {
-		return errors.Wrap(err, "not inside a festival").
-			WithHint("Run from within a festival directory or pass a festival path as an argument")
+		return errors.Wrap(err, "not inside a festival or standalone workflow").
+			WithHint("Run from within a festival directory, a directory containing WORKFLOW.md, or pass a path as an argument")
 	}
 
 	festivalPath := festival.Path
@@ -175,6 +215,71 @@ func resolveFestival(ctx context.Context, startDir, campaignRoot string) (*show.
 		return show.DetectCurrentFestival(ctx, festivalPath, campaignRoot)
 	}
 	return show.DetectCurrentFestival(ctx, startDir, campaignRoot)
+}
+
+func buildStandaloneWalkView(info *show.StandaloneWorkflowInfo) *WalkView {
+	view := &WalkView{
+		Kind:   "workflow",
+		Name:   filepath.Base(info.StartDir),
+		Status: info.RunStatus,
+		Path:   info.WorkflowDoc,
+		Progress: &walkProgress{
+			Completed:  info.CompletedSteps,
+			Total:      info.TotalSteps,
+			Percentage: progressPercentage(info.CompletedSteps, info.TotalSteps),
+		},
+		Workflow: &walkWorkflow{
+			Mode:           info.Mode,
+			WorkflowDoc:    info.WorkflowDoc,
+			RuntimeDir:     info.RuntimeDir,
+			RunID:          info.RunID,
+			RunStatus:      info.RunStatus,
+			CurrentStep:    info.CurrentStep,
+			TotalSteps:     info.TotalSteps,
+			CompletedSteps: info.CompletedSteps,
+			Blocked:        info.Blocked,
+			DocHashChanged: info.DocHashChanged,
+			Steps:          make([]walkWorkflowStep, 0, len(info.Steps)),
+		},
+	}
+
+	for _, step := range info.Steps {
+		if step.IsCurrent {
+			view.Next = fmt.Sprintf("Step %d: %s", step.Number, step.Name)
+		}
+		view.Workflow.Steps = append(view.Workflow.Steps, walkWorkflowStep{
+			Number:        step.Number,
+			Name:          step.Name,
+			Status:        string(step.Status),
+			Current:       step.IsCurrent,
+			HasCheckpoint: step.HasCheckpoint,
+			Goal:          step.Goal,
+		})
+	}
+
+	if info.Blocked && view.Next != "" {
+		view.Blocked = append(view.Blocked, walkBlocker{
+			Task:   view.Next,
+			Reason: "workflow run is blocked",
+		})
+	}
+	if info.DocHashChanged {
+		view.Warnings = append(view.Warnings, "WORKFLOW.md has changed since this run started")
+	}
+	return view
+}
+
+func progressPercentage(completed, total int) int {
+	if total <= 0 {
+		return 0
+	}
+	if completed < 0 {
+		completed = 0
+	}
+	if completed > total {
+		completed = total
+	}
+	return completed * 100 / total
 }
 
 func detectKind(festivalPath, status string) string {
@@ -382,6 +487,69 @@ func emitJSON(view *WalkView) error {
 	if err := enc.Encode(view); err != nil {
 		return errors.Wrap(err, "encoding JSON output")
 	}
+	return nil
+}
+
+func emitStandaloneText(view *WalkView, info *show.StandaloneWorkflowInfo, campaignRoot string) error {
+	displayPath := view.Path
+	if campaignRoot != "" && strings.HasPrefix(view.Path, campaignRoot) {
+		rel, err := filepath.Rel(campaignRoot, view.Path)
+		if err == nil {
+			displayPath = rel
+		}
+	}
+
+	fmt.Println(ui.H1("Workflow Walk"))
+	fmt.Printf("%s %s\n", ui.Label("Workflow"), ui.Value(view.Name, ui.FestivalColor))
+	fmt.Printf("%s %s\n", ui.Label("Kind"), ui.Value(view.Kind))
+	fmt.Printf("%s %s\n", ui.Label("Mode"), ui.Value(strings.TrimPrefix(info.Mode, "standalone-")))
+	fmt.Printf("%s %s\n", ui.Label("Status"), ui.GetStateStyle(view.Status).Render(view.Status))
+	fmt.Printf("%s %s\n", ui.Label("Path"), ui.Dim(displayPath))
+	if info.RunID != "" {
+		fmt.Printf("%s %s\n", ui.Label("Run"), ui.Value(info.RunID))
+	}
+
+	if view.Progress != nil {
+		fmt.Println()
+		fmt.Println(ui.H2("Progress"))
+		fmt.Println(ui.Dim(strings.Repeat("─", 60)))
+		fmt.Printf("%s %d/%d steps (%d%%)\n",
+			ui.Label("Steps"),
+			view.Progress.Completed,
+			view.Progress.Total,
+			view.Progress.Percentage,
+		)
+	}
+
+	if view.Next != "" {
+		fmt.Println()
+		fmt.Println(ui.H2("Current"))
+		fmt.Println(ui.Dim(strings.Repeat("─", 60)))
+		fmt.Printf("%s\n", view.Next)
+	}
+
+	if len(view.Blocked) > 0 {
+		fmt.Println()
+		fmt.Println(ui.H2("Blocked"))
+		fmt.Println(ui.Dim(strings.Repeat("─", 60)))
+		for _, b := range view.Blocked {
+			if b.Reason != "" {
+				fmt.Printf("%s %s %s\n", ui.StateIcon("blocked"), ui.Value(b.Task, ui.TaskColor), ui.Dim(b.Reason))
+			} else {
+				fmt.Printf("%s %s\n", ui.StateIcon("blocked"), ui.Value(b.Task, ui.TaskColor))
+			}
+		}
+	}
+
+	if len(view.Warnings) > 0 {
+		fmt.Println()
+		fmt.Println(ui.H2("Warnings"))
+		fmt.Println(ui.Dim(strings.Repeat("─", 60)))
+		for _, w := range view.Warnings {
+			fmt.Printf("%s %s\n", ui.StateIcon("blocked"), ui.Warning(w))
+		}
+	}
+
 	return nil
 }
 

--- a/internal/commands/walk/walk.go
+++ b/internal/commands/walk/walk.go
@@ -28,17 +28,17 @@ type walkOptions struct {
 
 // WalkView is the structured view returned by fest walk.
 type WalkView struct {
-	Kind     string        `json:"kind"`
-	Name     string        `json:"name"`
-	Status   string        `json:"status"`
-	Path     string        `json:"path"`
-	Goal     string        `json:"goal,omitempty"`
-	Progress *walkProgress `json:"progress,omitempty"`
-	Next     string        `json:"next,omitempty"`
-	Blocked  []walkBlocker `json:"blocked,omitempty"`
-	Gates    []string      `json:"gates,omitempty"`
-	Warnings []string      `json:"warnings,omitempty"`
-	Workflow *walkWorkflow `json:"workflow,omitempty"`
+	Kind     string                       `json:"kind"`
+	Name     string                       `json:"name"`
+	Status   string                       `json:"status"`
+	Path     string                       `json:"path"`
+	Goal     string                       `json:"goal,omitempty"`
+	Progress *walkProgress                `json:"progress,omitempty"`
+	Next     string                       `json:"next,omitempty"`
+	Blocked  []walkBlocker                `json:"blocked,omitempty"`
+	Gates    []string                     `json:"gates,omitempty"`
+	Warnings []string                     `json:"warnings,omitempty"`
+	Workflow *show.StandaloneWorkflowJSON `json:"workflow,omitempty"`
 }
 
 type walkProgress struct {
@@ -50,29 +50,6 @@ type walkProgress struct {
 type walkBlocker struct {
 	Task   string `json:"task"`
 	Reason string `json:"reason"`
-}
-
-type walkWorkflow struct {
-	Mode           string             `json:"mode"`
-	WorkflowDoc    string             `json:"workflow_doc"`
-	RuntimeDir     string             `json:"runtime_dir,omitempty"`
-	RunID          string             `json:"run_id,omitempty"`
-	RunStatus      string             `json:"run_status"`
-	CurrentStep    int                `json:"current_step"`
-	TotalSteps     int                `json:"total_steps"`
-	CompletedSteps int                `json:"completed_steps"`
-	Blocked        bool               `json:"blocked,omitempty"`
-	DocHashChanged bool               `json:"doc_hash_changed,omitempty"`
-	Steps          []walkWorkflowStep `json:"steps"`
-}
-
-type walkWorkflowStep struct {
-	Number        int    `json:"number"`
-	Name          string `json:"name"`
-	Status        string `json:"status"`
-	Current       bool   `json:"current,omitempty"`
-	HasCheckpoint bool   `json:"has_checkpoint,omitempty"`
-	Goal          string `json:"goal,omitempty"`
 }
 
 // NewWalkCommand creates the walk/inspect command.
@@ -218,6 +195,7 @@ func resolveFestival(ctx context.Context, startDir, campaignRoot string) (*show.
 }
 
 func buildStandaloneWalkView(info *show.StandaloneWorkflowInfo) *WalkView {
+	workflow := show.NewStandaloneWorkflowJSON(info)
 	view := &WalkView{
 		Kind:   "workflow",
 		Name:   filepath.Base(info.StartDir),
@@ -228,33 +206,13 @@ func buildStandaloneWalkView(info *show.StandaloneWorkflowInfo) *WalkView {
 			Total:      info.TotalSteps,
 			Percentage: progressPercentage(info.CompletedSteps, info.TotalSteps),
 		},
-		Workflow: &walkWorkflow{
-			Mode:           info.Mode,
-			WorkflowDoc:    info.WorkflowDoc,
-			RuntimeDir:     info.RuntimeDir,
-			RunID:          info.RunID,
-			RunStatus:      info.RunStatus,
-			CurrentStep:    info.CurrentStep,
-			TotalSteps:     info.TotalSteps,
-			CompletedSteps: info.CompletedSteps,
-			Blocked:        info.Blocked,
-			DocHashChanged: info.DocHashChanged,
-			Steps:          make([]walkWorkflowStep, 0, len(info.Steps)),
-		},
+		Workflow: &workflow,
 	}
 
 	for _, step := range info.Steps {
 		if step.IsCurrent {
 			view.Next = fmt.Sprintf("Step %d: %s", step.Number, step.Name)
 		}
-		view.Workflow.Steps = append(view.Workflow.Steps, walkWorkflowStep{
-			Number:        step.Number,
-			Name:          step.Name,
-			Status:        string(step.Status),
-			Current:       step.IsCurrent,
-			HasCheckpoint: step.HasCheckpoint,
-			Goal:          step.Goal,
-		})
 	}
 
 	if info.Blocked && view.Next != "" {

--- a/internal/commands/walk/walk_test.go
+++ b/internal/commands/walk/walk_test.go
@@ -9,7 +9,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Obedience-Corp/fest/internal/commands/shared"
 	"github.com/Obedience-Corp/fest/internal/commands/show"
+	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
 )
 
 func makeMinimalFestival(t *testing.T, root, name, status string) string {
@@ -357,6 +359,51 @@ func TestRunWalk_StandaloneWorkflowTextOutput(t *testing.T) {
 		if !strings.Contains(output, want) {
 			t.Fatalf("output missing %q:\n%s", want, output)
 		}
+	}
+}
+
+func TestBuildStandaloneWalkView_BlockedAndStale(t *testing.T) {
+	info := &show.StandaloneWorkflowInfo{
+		Mode:           "standalone-tracked",
+		StartDir:       "/tmp/demo",
+		WorkflowDoc:    "/tmp/demo/WORKFLOW.md",
+		RunID:          "run-1",
+		RunStatus:      "blocked",
+		CurrentStep:    1,
+		TotalSteps:     2,
+		CompletedSteps: 0,
+		Blocked:        true,
+		DocHashChanged: true,
+		Steps: []shared.WorkflowStepView{
+			{Number: 1, Name: "First", Status: wf.StepStatusBlocked, IsCurrent: true},
+			{Number: 2, Name: "Second", Status: wf.StepStatusPending},
+		},
+	}
+
+	view := buildStandaloneWalkView(info)
+
+	if view.Next != "Step 1: First" {
+		t.Fatalf("Next = %q, want Step 1: First", view.Next)
+	}
+	if len(view.Blocked) != 1 {
+		t.Fatalf("Blocked = %#v, want exactly one blocker", view.Blocked)
+	}
+	if view.Blocked[0].Task != "Step 1: First" || view.Blocked[0].Reason != "workflow run is blocked" {
+		t.Fatalf("Blocked[0] = %#v", view.Blocked[0])
+	}
+
+	foundWarning := false
+	for _, warning := range view.Warnings {
+		if strings.Contains(warning, "WORKFLOW.md has changed") {
+			foundWarning = true
+		}
+	}
+	if !foundWarning {
+		t.Fatalf("Warnings = %#v, want a doc-hash-changed warning", view.Warnings)
+	}
+
+	if view.Workflow == nil || !view.Workflow.Blocked || !view.Workflow.DocHashChanged {
+		t.Fatalf("Workflow = %#v, want blocked and doc-hash-changed", view.Workflow)
 	}
 }
 

--- a/internal/commands/walk/walk_test.go
+++ b/internal/commands/walk/walk_test.go
@@ -42,6 +42,27 @@ func makePhaseAndTask(t *testing.T, festivalDir, phaseName, seqName, taskName st
 	}
 }
 
+func makeStandaloneWorkflow(t *testing.T, root string) string {
+	t.Helper()
+	if err := os.MkdirAll(root, 0755); err != nil {
+		t.Fatal(err)
+	}
+	content := `# Workflow
+
+## Step 1: First
+
+**Goal:** Start work.
+
+## Step 2: Second
+
+**Goal:** Finish work.
+`
+	if err := os.WriteFile(filepath.Join(root, "WORKFLOW.md"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
 func TestDetectKind_Festival(t *testing.T) {
 	root := t.TempDir()
 	festDir := makeMinimalFestival(t, root, "my-fest-MF0001", "active")
@@ -245,6 +266,97 @@ func TestRunWalk_ErrorOutsideFestival(t *testing.T) {
 	err = runWalk(context.Background(), &walkOptions{})
 	if err == nil {
 		t.Fatal("runWalk() expected error outside festival, got nil")
+	}
+}
+
+func TestRunWalk_StandaloneWorkflowJSONOutput(t *testing.T) {
+	workflowDir := makeStandaloneWorkflow(t, filepath.Join(t.TempDir(), "standalone-work"))
+
+	origStdout := os.Stdout
+	r, w, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		t.Fatal(pipeErr)
+	}
+	os.Stdout = w
+
+	runErr := runWalk(context.Background(), &walkOptions{json: true, from: workflowDir})
+
+	if closeErr := w.Close(); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+	os.Stdout = origStdout
+
+	var buf bytes.Buffer
+	if _, readErr := buf.ReadFrom(r); readErr != nil {
+		t.Fatal(readErr)
+	}
+
+	if runErr != nil {
+		t.Fatalf("runWalk() error: %v", runErr)
+	}
+
+	var view WalkView
+	if unmarshalErr := json.Unmarshal(buf.Bytes(), &view); unmarshalErr != nil {
+		t.Fatalf("failed to parse JSON output: %v\noutput: %s", unmarshalErr, buf.String())
+	}
+
+	if view.Kind != "workflow" {
+		t.Fatalf("WalkView.Kind = %q, want workflow", view.Kind)
+	}
+	if view.Workflow == nil {
+		t.Fatal("WalkView.Workflow is nil")
+	}
+	if view.Workflow.Mode != "standalone-anonymous" {
+		t.Fatalf("Workflow.Mode = %q, want standalone-anonymous", view.Workflow.Mode)
+	}
+	if view.Workflow.TotalSteps != 2 {
+		t.Fatalf("Workflow.TotalSteps = %d, want 2", view.Workflow.TotalSteps)
+	}
+	if view.Next != "Step 1: First" {
+		t.Fatalf("WalkView.Next = %q, want Step 1: First", view.Next)
+	}
+	if view.Progress == nil || view.Progress.Total != 2 || view.Progress.Completed != 0 {
+		t.Fatalf("WalkView.Progress = %#v, want 0/2", view.Progress)
+	}
+}
+
+func TestRunWalk_StandaloneWorkflowTextOutput(t *testing.T) {
+	workflowDir := makeStandaloneWorkflow(t, filepath.Join(t.TempDir(), "standalone-work"))
+
+	origStdout := os.Stdout
+	r, w, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		t.Fatal(pipeErr)
+	}
+	os.Stdout = w
+
+	err := runWalk(context.Background(), &walkOptions{from: workflowDir})
+
+	if closeErr := w.Close(); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+	os.Stdout = origStdout
+
+	var buf bytes.Buffer
+	if _, readErr := buf.ReadFrom(r); readErr != nil {
+		t.Fatal(readErr)
+	}
+
+	if err != nil {
+		t.Fatalf("runWalk() error: %v", err)
+	}
+
+	output := buf.String()
+	for _, want := range []string{
+		"WORKFLOW WALK",
+		"Mode",
+		"anonymous",
+		"0/2 steps",
+		"Step 1: First",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Extend `fest walk` / `fest inspect` to resolve standalone `WORKFLOW.md` contexts in addition to festivals.
- Add workflow-shaped JSON output and text orientation for standalone workflows, including mode, run status, progress, current step, blocked state, and stale-document warnings.
- Reuse the existing standalone workflow resolver/display model so festival context still wins when both signals are present.
- Add walk command tests for anonymous standalone workflow JSON and text output.

## Validation

- `go test ./internal/commands/walk`
- `just test unit`
- Manual: `go run ./cmd/fest walk --json <tmp-workflow-dir>`
