### PR TITLE
Add renderable fest show JSON view

### DIFF
--- a/internal/commands/show/show.go
+++ b/internal/commands/show/show.go
@@ -299,7 +299,7 @@ func emitShowFestival(ctx context.Context, festival *FestivalInfo, opts *showOpt
 	}
 
 	if opts.json {
-		return emitFestivalJSON(festival, campaignRoot)
+		return emitFestivalJSON(ctx, festival, opts, campaignRoot)
 	}
 	return emitFestivalText(festival, opts, campaignRoot)
 }
@@ -406,15 +406,73 @@ func emitShowErrorJSON(message string) error {
 	return nil
 }
 
-func emitFestivalJSON(festival *FestivalInfo, campaignRoot string) error {
+type festivalShowJSON struct {
+	*FestivalInfo
+	View *festivalShowView `json:"view,omitempty"`
+}
+
+type festivalShowView struct {
+	Mode    string                  `json:"mode"`
+	Options festivalShowViewOptions `json:"options"`
+	Tree    *DisplayNode            `json:"tree,omitempty"`
+	Error   string                  `json:"error,omitempty"`
+}
+
+type festivalShowViewOptions struct {
+	Summary    bool `json:"summary"`
+	ShowGoals  bool `json:"show_goals"`
+	Collapsed  bool `json:"collapsed"`
+	InProgress bool `json:"in_progress"`
+}
+
+func emitFestivalJSON(ctx context.Context, festival *FestivalInfo, opts *showOptions, campaignRoot string) error {
 	output := festival
 	if campaignRoot != "" {
 		output = toDisplayFestival(festival, campaignRoot)
 	}
-	if err := shared.EncodeJSON(os.Stdout, output); err != nil {
+
+	result := &festivalShowJSON{
+		FestivalInfo: output,
+		View:         buildFestivalShowView(ctx, festival, opts),
+	}
+	if err := shared.EncodeJSON(os.Stdout, result); err != nil {
 		return errors.Wrap(err, "encoding JSON output")
 	}
 	return nil
+}
+
+func buildFestivalShowView(ctx context.Context, festival *FestivalInfo, opts *showOptions) *festivalShowView {
+	if opts == nil {
+		opts = &showOptions{}
+	}
+
+	view := &festivalShowView{
+		Mode: "tree",
+		Options: festivalShowViewOptions{
+			Summary:    opts.summary,
+			ShowGoals:  opts.goals,
+			Collapsed:  opts.collapsed,
+			InProgress: opts.inProgress,
+		},
+	}
+
+	if opts.summary {
+		view.Mode = "summary"
+		return view
+	}
+
+	tree, err := BuildFestivalTree(ctx, festival.Path)
+	if err != nil {
+		view.Mode = "summary"
+		view.Error = err.Error()
+		return view
+	}
+
+	if opts.inProgress {
+		markNextPending(tree)
+	}
+	view.Tree = tree
+	return view
 }
 
 func emitFestivalText(festival *FestivalInfo, showOpts *showOptions, campaignRoot string) error {

--- a/internal/commands/show/show_command_test.go
+++ b/internal/commands/show/show_command_test.go
@@ -1,7 +1,9 @@
 package show
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -75,4 +77,192 @@ func TestRunShowBySelector_RequiresCampaignWorkspace(t *testing.T) {
 	if !strings.Contains(strings.ToLower(err.Error()), "campaign workspace") {
 		t.Fatalf("unexpected error: %v", err)
 	}
+}
+
+func TestEmitShowFestivalJSONIncludesRenderableTreeView(t *testing.T) {
+	festivalDir := makeShowJSONFestival(t)
+	festival := &FestivalInfo{
+		ID:         "launch-readiness-LR0001",
+		MetadataID: "LR0001",
+		Name:       "launch-readiness",
+		Status:     "active",
+		Path:       festivalDir,
+		Stats: &FestivalStats{
+			Progress: 0,
+			Tasks:    StatusCounts{Total: 1, Pending: 1},
+		},
+	}
+
+	output := captureShowStdout(t, func() error {
+		return emitShowFestival(context.Background(), festival, &showOptions{json: true, goals: true}, "")
+	})
+
+	var got struct {
+		ID         string `json:"id"`
+		MetadataID string `json:"metadata_id"`
+		Name       string `json:"name"`
+		Status     string `json:"status"`
+		View       struct {
+			Mode    string `json:"mode"`
+			Options struct {
+				ShowGoals bool `json:"show_goals"`
+			} `json:"options"`
+			Tree struct {
+				Name     string `json:"name"`
+				NodeType string `json:"node_type"`
+				Goal     string `json:"goal"`
+				Children []struct {
+					Name     string `json:"name"`
+					NodeType string `json:"node_type"`
+					Goal     string `json:"goal"`
+					Children []struct {
+						Name     string `json:"name"`
+						NodeType string `json:"node_type"`
+						Children []struct {
+							Name     string `json:"name"`
+							NodeType string `json:"node_type"`
+							Status   string `json:"status"`
+						} `json:"children"`
+					} `json:"children"`
+				} `json:"children"`
+			} `json:"tree"`
+		} `json:"view"`
+	}
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("failed to decode JSON: %v\n%s", err, output)
+	}
+
+	if got.ID != "launch-readiness-LR0001" || got.MetadataID != "LR0001" {
+		t.Fatalf("top-level festival metadata missing: %#v", got)
+	}
+	if got.View.Mode != "tree" {
+		t.Fatalf("view.mode = %q, want tree", got.View.Mode)
+	}
+	if !got.View.Options.ShowGoals {
+		t.Fatal("view.options.show_goals = false, want true")
+	}
+	if got.View.Tree.Name != filepath.Base(festivalDir) || got.View.Tree.NodeType != "festival" {
+		t.Fatalf("unexpected root tree node: %#v", got.View.Tree)
+	}
+	if got.View.Tree.Goal != "Ship a useful show JSON view." {
+		t.Fatalf("tree goal = %q", got.View.Tree.Goal)
+	}
+	if len(got.View.Tree.Children) != 1 {
+		t.Fatalf("tree children = %d, want 1", len(got.View.Tree.Children))
+	}
+	phase := got.View.Tree.Children[0]
+	if phase.Name != "001_PLAN" || phase.NodeType != "phase" || phase.Goal != "Plan the implementation." {
+		t.Fatalf("unexpected phase node: %#v", phase)
+	}
+	if len(phase.Children) != 1 || len(phase.Children[0].Children) != 1 {
+		t.Fatalf("expected sequence with one task: %#v", phase.Children)
+	}
+	task := phase.Children[0].Children[0]
+	if task.Name != "01_define_view.md" || task.NodeType != "task" || task.Status != "pending" {
+		t.Fatalf("unexpected task node: %#v", task)
+	}
+}
+
+func TestEmitShowFestivalJSONSummaryModePreservesMetadata(t *testing.T) {
+	festivalDir := makeShowJSONFestival(t)
+	festival := &FestivalInfo{
+		ID:     "launch-readiness-LR0001",
+		Name:   "launch-readiness",
+		Status: "active",
+		Path:   festivalDir,
+	}
+
+	output := captureShowStdout(t, func() error {
+		return emitShowFestival(context.Background(), festival, &showOptions{json: true, summary: true}, "")
+	})
+
+	var got struct {
+		ID   string `json:"id"`
+		View struct {
+			Mode string `json:"mode"`
+			Tree *struct {
+				Name string `json:"name"`
+			} `json:"tree"`
+		} `json:"view"`
+	}
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("failed to decode JSON: %v\n%s", err, output)
+	}
+
+	if got.ID != "launch-readiness-LR0001" {
+		t.Fatalf("top-level id = %q, want launch-readiness-LR0001", got.ID)
+	}
+	if got.View.Mode != "summary" {
+		t.Fatalf("view.mode = %q, want summary", got.View.Mode)
+	}
+	if got.View.Tree != nil {
+		t.Fatalf("summary JSON should not include tree: %#v", got.View.Tree)
+	}
+}
+
+func makeShowJSONFestival(t *testing.T) string {
+	t.Helper()
+
+	festivalDir := filepath.Join(t.TempDir(), "launch-readiness-LR0001")
+	if err := os.MkdirAll(festivalDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(festivalDir, FestivalGoalFile), []byte("**Primary Goal:** Ship a useful show JSON view.\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	phaseDir := filepath.Join(festivalDir, "001_PLAN")
+	if err := os.MkdirAll(phaseDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(phaseDir, "PHASE_GOAL.md"), []byte("**Primary Goal:** Plan the implementation.\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	seqDir := filepath.Join(phaseDir, "01_design")
+	if err := os.MkdirAll(seqDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(seqDir, "SEQUENCE_GOAL.md"), []byte("**Primary Goal:** Design the schema.\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	task := `---
+fest_type: task
+fest_tracking: true
+---
+# Define view
+`
+	if err := os.WriteFile(filepath.Join(seqDir, "01_define_view.md"), []byte(task), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	return festivalDir
+}
+
+func captureShowStdout(t *testing.T, fn func() error) string {
+	t.Helper()
+
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	runErr := fn()
+
+	if closeErr := w.Close(); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+	os.Stdout = origStdout
+
+	var buf bytes.Buffer
+	if _, readErr := buf.ReadFrom(r); readErr != nil {
+		t.Fatal(readErr)
+	}
+	if runErr != nil {
+		t.Fatalf("function returned error: %v\noutput:\n%s", runErr, buf.String())
+	}
+	return buf.String()
 }

--- a/internal/commands/show/tree.go
+++ b/internal/commands/show/tree.go
@@ -19,13 +19,13 @@ import (
 
 // DisplayNode represents a node in the festival tree hierarchy.
 type DisplayNode struct {
-	Name          string       // Directory/file name
-	Goal          string       // Primary goal from *_GOAL.md
-	Status        string       // pending/in_progress/completed/blocked
-	Stats         StatusCounts // Task counts for this level
-	NodeType      string       // "festival", "phase", "sequence", "step", "task"
-	Children      []*DisplayNode
-	IsNextPending bool // First incomplete node at this level — expanded by --inprogress
+	Name          string         `json:"name"`                      // Directory/file name
+	Goal          string         `json:"goal,omitempty"`            // Primary goal from *_GOAL.md
+	Status        string         `json:"status"`                    // pending/in_progress/completed/blocked
+	Stats         StatusCounts   `json:"stats"`                     // Task counts for this level
+	NodeType      string         `json:"node_type"`                 // "festival", "phase", "sequence", "step", "task"
+	Children      []*DisplayNode `json:"children,omitempty"`        // Child phases, sequences, steps, or tasks
+	IsNextPending bool           `json:"is_next_pending,omitempty"` // First incomplete node at this level — expanded by --inprogress
 }
 
 // TreeOptions configures how the tree is rendered.


### PR DESCRIPTION
## Summary

- Preserve existing `fest show --json` festival metadata at the top level.
- Add a `view` object for single-festival JSON output with render mode, active show options, and the same tree model used by normal `fest show` text rendering.
- Add JSON tags to `DisplayNode` so apps can consume festival/phase/sequence/task nodes directly.
- Cover default tree JSON and summary-mode JSON with focused tests.

## Validation

- `go test ./internal/commands/show`
- `just test unit`
- Manual: built a temporary `fest` binary and ran `fest show --json` inside a temporary campaign festival to verify top-level metadata plus `view.tree`.
