### PR TITLE
feat(watch): show festival status and add p promote shortcut

### DIFF
--- a/internal/commands/promote/promote.go
+++ b/internal/commands/promote/promote.go
@@ -182,6 +182,18 @@ func runPromote(ctx context.Context, opts *promoteOptions, selector string) erro
 		}
 		return err
 	}
+
+	_, err = promoteCore(ctx, festival, fromPicker, opts)
+	return err
+}
+
+// PromoteResolved promotes an already-resolved festival through the fest promote
+// flow, asking for confirmation, and returns the post-move path (empty if nothing moved).
+func PromoteResolved(ctx context.Context, festival *show.FestivalInfo) (string, error) {
+	return promoteCore(ctx, festival, true, &promoteOptions{})
+}
+
+func promoteCore(ctx context.Context, festival *show.FestivalInfo, confirm bool, opts *promoteOptions) (string, error) {
 	currentStatus := festival.Status
 
 	var nextStatus string
@@ -190,7 +202,7 @@ func runPromote(ctx context.Context, opts *promoteOptions, selector string) erro
 		// Dungeon override: resolve the dungeon status
 		resolved := id.ResolveStatusPath(opts.dungeon)
 		if !strings.HasPrefix(resolved, "dungeon/") {
-			return errors.Validation("invalid dungeon status").
+			return "", errors.Validation("invalid dungeon status").
 				WithField("value", opts.dungeon).
 				WithField("hint", "valid values: completed, archived, someday")
 		}
@@ -201,13 +213,13 @@ func runPromote(ctx context.Context, opts *promoteOptions, selector string) erro
 		nextStatus, ok = validTransitions[currentStatus]
 		if !ok {
 			if opts.json {
-				return shared.EncodeJSON(os.Stdout, map[string]any{
+				return "", shared.EncodeJSON(os.Stdout, map[string]any{
 					"success": false,
 					"error":   fmt.Sprintf("cannot promote festival with status %q", currentStatus),
 					"status":  currentStatus,
 				})
 			}
-			return errors.Validation("cannot promote festival").
+			return "", errors.Validation("cannot promote festival").
 				WithField("status", currentStatus).
 				WithField("hint", "only planning, ready, and active festivals can be promoted")
 		}
@@ -216,7 +228,7 @@ func runPromote(ctx context.Context, opts *promoteOptions, selector string) erro
 		if !opts.force {
 			if err := validateReadiness(ctx, festival, currentStatus, nextStatus); err != nil {
 				if opts.json {
-					return shared.EncodeJSON(os.Stdout, map[string]any{
+					return "", shared.EncodeJSON(os.Stdout, map[string]any{
 						"success": false,
 						"error":   err.Error(),
 						"from":    currentStatus,
@@ -226,7 +238,7 @@ func runPromote(ctx context.Context, opts *promoteOptions, selector string) erro
 				}
 				fmt.Printf("%s %s\n", ui.Warning("Promotion blocked"), ui.Dim(err.Error()))
 				fmt.Printf("\n  %s\n", ui.Dim("Use --force to skip validation"))
-				return nil
+				return "", nil
 			}
 		}
 	}
@@ -235,7 +247,7 @@ func runPromote(ctx context.Context, opts *promoteOptions, selector string) erro
 	if nextStatus == "active" && !opts.force && opts.dungeon == "" {
 		if blocked, blockMsg := checkChainDependencies(ctx, festival); blocked {
 			if opts.json {
-				return shared.EncodeJSON(os.Stdout, map[string]any{
+				return "", shared.EncodeJSON(os.Stdout, map[string]any{
 					"success": false,
 					"error":   "chain dependencies not met",
 					"details": blockMsg,
@@ -244,19 +256,19 @@ func runPromote(ctx context.Context, opts *promoteOptions, selector string) erro
 			}
 			fmt.Printf("%s %s\n", ui.Warning("Chain dependency gate:"), blockMsg)
 			fmt.Printf("\n  %s\n", ui.Dim("Use --force to skip chain dependency check"))
-			return nil
+			return "", nil
 		}
 	}
 
-	if fromPicker && !confirmPromotion(festival.Name, currentStatus, nextStatus) {
+	if confirm && !confirmPromotion(festival.Name, currentStatus, nextStatus) {
 		fmt.Println(ui.Dim("Promotion cancelled"))
-		return nil
+		return "", nil
 	}
 
 	// Execute the move using existing atomic status change
 	newPath, err := status.AtomicStatusChange(ctx, festival.Path, currentStatus, nextStatus)
 	if err != nil {
-		return errors.Wrap(err, "promoting festival")
+		return "", errors.Wrap(err, "promoting festival")
 	}
 
 	// Update FESTIVAL_GOAL.md frontmatter with the new status
@@ -310,7 +322,7 @@ func runPromote(ctx context.Context, opts *promoteOptions, selector string) erro
 		if commitHash != "" {
 			result["commit"] = commitHash
 		}
-		return shared.EncodeJSON(os.Stdout, result)
+		return newPath, shared.EncodeJSON(os.Stdout, result)
 	}
 
 	fmt.Println(ui.H2("Festival Promoted"))
@@ -324,7 +336,7 @@ func runPromote(ctx context.Context, opts *promoteOptions, selector string) erro
 		fmt.Printf("%s %s\n", ui.Label("Commit"), ui.Dim(commitHash))
 	}
 
-	return nil
+	return newPath, nil
 }
 
 // validateReadiness checks if a festival is ready for the next lifecycle status.

--- a/internal/commands/promote/promote_test.go
+++ b/internal/commands/promote/promote_test.go
@@ -381,3 +381,68 @@ func TestRunPromote_SelectorPromotesPlanningToReady(t *testing.T) {
 		t.Fatalf("expected planning copy removed, stat err=%v", err)
 	}
 }
+
+func feedStdin(t *testing.T, input string) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = old
+		_ = r.Close()
+	})
+	if _, err := w.WriteString(input); err != nil {
+		t.Fatal(err)
+	}
+	_ = w.Close()
+}
+
+func TestPromoteResolved_ConfirmedSharesTheCLIFlow(t *testing.T) {
+	_, festivalsDir := setupPromoteCampaign(t)
+
+	festival, _, err := resolveFestivalForPromote(t.Context(), "", filepath.Dir(festivalsDir), "alpha-feature-FE0001", false)
+	if err != nil {
+		t.Fatalf("resolveFestivalForPromote: %v", err)
+	}
+
+	feedStdin(t, "y\n")
+	newPath, err := PromoteResolved(t.Context(), festival)
+	if err != nil {
+		t.Fatalf("PromoteResolved: %v", err)
+	}
+	if newPath == "" {
+		t.Fatal("confirmed promotion should return the post-move path")
+	}
+
+	movedPath := filepath.Join(festivalsDir, "ready", "alpha-feature-FE0001")
+	if _, err := os.Stat(movedPath); err != nil {
+		t.Fatalf("expected festival moved to %s: %v", movedPath, err)
+	}
+	if _, err := os.Stat(filepath.Join(festivalsDir, "planning", "alpha-feature-FE0001")); !os.IsNotExist(err) {
+		t.Fatalf("expected planning copy removed, stat err=%v", err)
+	}
+}
+
+func TestPromoteResolved_DeclinedDoesNotMove(t *testing.T) {
+	_, festivalsDir := setupPromoteCampaign(t)
+
+	festival, _, err := resolveFestivalForPromote(t.Context(), "", filepath.Dir(festivalsDir), "alpha-feature-FE0001", false)
+	if err != nil {
+		t.Fatalf("resolveFestivalForPromote: %v", err)
+	}
+
+	feedStdin(t, "n\n")
+	newPath, err := PromoteResolved(t.Context(), festival)
+	if err != nil {
+		t.Fatalf("PromoteResolved: %v", err)
+	}
+	if newPath != "" {
+		t.Fatalf("declined promotion must not return a path, got %q", newPath)
+	}
+	if _, err := os.Stat(filepath.Join(festivalsDir, "planning", "alpha-feature-FE0001")); err != nil {
+		t.Fatalf("festival must remain in planning after decline: %v", err)
+	}
+}

--- a/internal/commands/show/show.go
+++ b/internal/commands/show/show.go
@@ -287,7 +287,7 @@ func runShowBySelector(ctx context.Context, selector string, opts *showOptions) 
 func emitShowFestival(ctx context.Context, festival *FestivalInfo, opts *showOptions, campaignRoot string) error {
 	// Watch mode - continuously refresh display
 	if opts.watch {
-		return runWatchMode(ctx, festival, opts, false)
+		return runWatchMode(ctx, festival, opts, false, false)
 	}
 
 	// Roadmap mode - full execution plan

--- a/internal/commands/show/standalone_watch.go
+++ b/internal/commands/show/standalone_watch.go
@@ -82,7 +82,7 @@ func (s *standaloneWatchSession) render(ctx context.Context, polling bool) error
 
 	clearScreen(os.Stdout)
 	fmt.Print(formatStandaloneWorkflowProgress(info, standaloneRenderOptionsFromWatch(s.opts)))
-	printWatchFooter(os.Stdout, polling, false)
+	printWatchFooter(os.Stdout, polling, false, false)
 	s.addWatchPaths(info)
 	return nil
 }

--- a/internal/commands/show/watch.go
+++ b/internal/commands/show/watch.go
@@ -91,6 +91,7 @@ type WatchOptions struct {
 	Collapsed  bool
 	InProgress bool
 	CycleHint  bool
+	Cycling    bool
 }
 
 // WatchFestival watches a festival using the existing show watch renderer.
@@ -104,12 +105,12 @@ func WatchFestival(ctx context.Context, festival *FestivalInfo, opts WatchOption
 		goals:      opts.Goals,
 		collapsed:  opts.Collapsed,
 		inProgress: opts.InProgress,
-	}, opts.CycleHint)
+	}, opts.CycleHint, opts.Cycling)
 }
 
 // runWatchMode watches for file changes and refreshes the festival display.
 // Falls back to polling if file watching is not available.
-func runWatchMode(ctx context.Context, festival *FestivalInfo, opts *showOptions, cycleHint bool) error {
+func runWatchMode(ctx context.Context, festival *FestivalInfo, opts *showOptions, cycleHint bool, cycling bool) error {
 	out := watchWriter(cycleHint)
 	errOut := watchErrWriter(cycleHint)
 
@@ -127,7 +128,7 @@ func runWatchMode(ctx context.Context, festival *FestivalInfo, opts *showOptions
 	if err := renderFestivalView(ctx, festival, opts, out); err != nil {
 		return err
 	}
-	printWatchFooter(out, false, cycleHint)
+	printWatchFooter(out, false, cycleHint, cycling)
 
 	w, err := watch.New(watch.Config{
 		Paths:    watchPaths,
@@ -144,12 +145,12 @@ func runWatchMode(ctx context.Context, festival *FestivalInfo, opts *showOptions
 		if err := renderFestivalView(ctx, festival, opts, out); err != nil {
 			_, _ = fmt.Fprintf(errOut, "%s could not refresh festival view: %v\n", ui.Warning("Warning:"), err)
 		}
-		printWatchFooter(out, false, cycleHint)
+		printWatchFooter(out, false, cycleHint, cycling)
 	})
 
 	if err != nil {
 		_, _ = fmt.Fprintf(errOut, "File watching unavailable (%v), using polling fallback\n", err)
-		return runPollingMode(ctx, festival, opts, cycleHint)
+		return runPollingMode(ctx, festival, opts, cycleHint, cycling)
 	}
 	defer func() { _ = w.Close() }()
 
@@ -158,7 +159,7 @@ func runWatchMode(ctx context.Context, festival *FestivalInfo, opts *showOptions
 
 // runPollingMode continuously refreshes the festival display at the specified interval.
 // Used as a fallback when file watching is not available.
-func runPollingMode(ctx context.Context, festival *FestivalInfo, opts *showOptions, cycleHint bool) error {
+func runPollingMode(ctx context.Context, festival *FestivalInfo, opts *showOptions, cycleHint bool, cycling bool) error {
 	ticker := time.NewTicker(pollingInterval)
 	defer ticker.Stop()
 
@@ -167,7 +168,7 @@ func runPollingMode(ctx context.Context, festival *FestivalInfo, opts *showOptio
 	if err := renderFestivalView(ctx, festival, opts, out); err != nil {
 		return err
 	}
-	printWatchFooter(out, true, cycleHint)
+	printWatchFooter(out, true, cycleHint, cycling)
 
 	for {
 		select {
@@ -185,7 +186,7 @@ func runPollingMode(ctx context.Context, festival *FestivalInfo, opts *showOptio
 			if err := renderFestivalView(ctx, festival, opts, out); err != nil {
 				return err
 			}
-			printWatchFooter(out, true, cycleHint)
+			printWatchFooter(out, true, cycleHint, cycling)
 		}
 	}
 }
@@ -206,6 +207,14 @@ func renderFestivalView(ctx context.Context, festival *FestivalInfo, opts *showO
 		// Fall back to summary view on error
 		_, _ = fmt.Fprintln(out, FormatFestivalDetails(festival, verbose, ""))
 		return nil
+	}
+
+	if festival.Status != "" {
+		statusValue := ui.GetStatusStyle(festival.Status).Render(festival.Status)
+		if festival.StatusDate != "" {
+			statusValue += " " + ui.Dim("("+festival.StatusDate+")")
+		}
+		_, _ = fmt.Fprintf(out, "%s %s\n", ui.Label("Status"), statusValue)
 	}
 
 	// Render progress bar at the top
@@ -244,15 +253,20 @@ func clearScreen(out io.Writer) {
 }
 
 // printWatchFooter prints the watch mode footer with exit instructions.
-func printWatchFooter(out io.Writer, polling bool, cycleHint bool) {
+func printWatchFooter(out io.Writer, polling bool, cycleHint bool, cycling bool) {
 	_, _ = fmt.Fprintln(out)
 	suffix := "Watching for changes"
 	if polling {
 		suffix = "Polling for changes"
 	}
-	if cycleHint {
-		_, _ = fmt.Fprintln(out, ui.Dim("Ctrl+C to exit • ← → cycle festivals • "+suffix))
-	} else {
+	if !cycleHint {
 		_, _ = fmt.Fprintln(out, ui.Dim("Press Ctrl+C to exit • "+suffix))
+		return
 	}
+	hint := "Ctrl+C exit • "
+	if cycling {
+		hint += "← → cycle • "
+	}
+	hint += "p promote • " + suffix
+	_, _ = fmt.Fprintln(out, ui.Dim(hint))
 }

--- a/internal/commands/show/watch_test.go
+++ b/internal/commands/show/watch_test.go
@@ -117,7 +117,7 @@ func TestCRLFWriter_PreservesPartialWriteCount(t *testing.T) {
 
 func TestPrintWatchFooter_CycleModeEmitsCRLF(t *testing.T) {
 	var buf bytes.Buffer
-	printWatchFooter(crlfWriter{w: &buf}, false, true)
+	printWatchFooter(crlfWriter{w: &buf}, false, true, true)
 
 	out := buf.String()
 	if !strings.Contains(out, "\r\n") {
@@ -125,5 +125,52 @@ func TestPrintWatchFooter_CycleModeEmitsCRLF(t *testing.T) {
 	}
 	if strings.Contains(strings.ReplaceAll(out, "\r\n", ""), "\n") {
 		t.Errorf("cycle-mode footer has a bare \\n (cursor would not return to column 0): %q", out)
+	}
+}
+
+func TestPrintWatchFooter_PromoteHint(t *testing.T) {
+	cases := []struct {
+		name        string
+		cycleHint   bool
+		cycling     bool
+		wantPromote bool
+		wantCycle   bool
+	}{
+		{"raw_single", true, false, true, false},
+		{"raw_multi", true, true, true, true},
+		{"non_raw", false, false, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			printWatchFooter(&buf, false, tc.cycleHint, tc.cycling)
+			out := buf.String()
+			if got := strings.Contains(out, "p promote"); got != tc.wantPromote {
+				t.Errorf("promote hint present = %v, want %v (footer %q)", got, tc.wantPromote, out)
+			}
+			if got := strings.Contains(out, "cycle"); got != tc.wantCycle {
+				t.Errorf("cycle hint present = %v, want %v (footer %q)", got, tc.wantCycle, out)
+			}
+			if !tc.cycleHint && !strings.Contains(out, "Press Ctrl+C to exit") {
+				t.Errorf("non-raw footer should keep the plain exit hint, got %q", out)
+			}
+		})
+	}
+}
+
+func TestRenderFestivalView_TreeShowsLifecycleStatus(t *testing.T) {
+	festDir := setupTempFestival(t)
+	festival := &FestivalInfo{Name: "test-fest", Status: "active", Path: festDir}
+
+	var buf bytes.Buffer
+	if err := renderFestivalView(t.Context(), festival, &showOptions{}, &buf); err != nil {
+		t.Fatalf("renderFestivalView: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Status") || !strings.Contains(out, "active") {
+		t.Errorf("tree watch view should surface the lifecycle status, got %q", out)
+	}
+	if strings.Contains(out, "Path") {
+		t.Errorf("expected tree view, but summary fallback rendered: %q", out)
 	}
 }

--- a/internal/commands/watch/command.go
+++ b/internal/commands/watch/command.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 type options struct {
@@ -125,6 +126,9 @@ func runWatch(ctx context.Context, args []string, opts *options, deps commandDep
 			return nil
 		}
 		return err
+	}
+	if term.IsTerminal(int(os.Stdin.Fd())) {
+		return runWatchCycle(ctx, []string{festival.Path}, 0, *opts, deps)
 	}
 	return watchFestival(ctx, festival, *opts, deps)
 }

--- a/internal/commands/watch/cycling.go
+++ b/internal/commands/watch/cycling.go
@@ -1,11 +1,15 @@
 package watch
 
 import (
+	"bufio"
 	"context"
+	"fmt"
 	"os"
 
+	"github.com/Obedience-Corp/fest/internal/commands/promote"
 	"github.com/Obedience-Corp/fest/internal/commands/show"
 	"github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/ui"
 	"golang.org/x/term"
 )
 
@@ -15,15 +19,13 @@ const (
 	cycleNone cycleDirection = iota
 	cycleNext
 	cyclePrev
+	cyclePromote
 	cycleQuit
 )
 
 func runWatchCycle(ctx context.Context, paths []string, startIndex int, opts options, deps commandDeps) error {
 	if len(paths) == 0 {
 		return errors.Validation("no watchable festivals found")
-	}
-	if len(paths) == 1 {
-		return watchFestivalAtPath(ctx, paths[0], opts, deps)
 	}
 
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
@@ -36,6 +38,7 @@ func runWatchCycle(ctx context.Context, paths []string, startIndex int, opts opt
 	}
 	defer func() { _ = term.Restore(int(os.Stdin.Fd()), oldState) }()
 
+	cycling := len(paths) > 1
 	index := startIndex
 	staleSince := -1
 	for {
@@ -73,7 +76,7 @@ func runWatchCycle(ctx context.Context, paths []string, startIndex int, opts opt
 		watchCtx, cancelWatch := context.WithCancel(ctx)
 		watchDone := make(chan error, 1)
 		go func() {
-			watchDone <- deps.watch(watchCtx, festival, cycleWatchOptions(opts))
+			watchDone <- deps.watch(watchCtx, festival, cycleWatchOptions(opts, cycling))
 		}()
 
 		dir := readCycleKey(ctx, os.Stdin)
@@ -89,12 +92,41 @@ func runWatchCycle(ctx context.Context, paths []string, startIndex int, opts opt
 		if dir == cycleQuit {
 			return nil
 		}
+		if dir == cyclePromote {
+			if newPath, ok := promoteFromWatch(ctx, festival, oldState); ok && newPath != "" {
+				paths[index] = newPath
+			} else if !ok {
+				return nil
+			}
+			continue
+		}
 		if dir == cycleNext {
 			index = (index + 1) % len(paths)
 		} else {
 			index = (index - 1 + len(paths)) % len(paths)
 		}
 	}
+}
+
+// promoteFromWatch runs the fest promote flow outside raw mode and returns the
+// post-move path (empty if nothing moved) and whether raw mode was restored.
+func promoteFromWatch(ctx context.Context, festival *show.FestivalInfo, rawState *term.State) (string, bool) {
+	fd := int(os.Stdin.Fd())
+	_ = term.Restore(fd, rawState)
+
+	newPath, err := promote.PromoteResolved(ctx, festival)
+	if err != nil {
+		fmt.Printf("%s %v\n", ui.Warning("Promote failed:"), err)
+	}
+	if newPath == "" {
+		fmt.Print("\nPress Enter to continue...")
+		_, _ = bufio.NewReader(os.Stdin).ReadString('\n')
+	}
+
+	if _, err := term.MakeRaw(fd); err != nil {
+		return newPath, false
+	}
+	return newPath, true
 }
 
 func watchFestivalAtPath(ctx context.Context, path string, opts options, deps commandDeps) error {
@@ -108,9 +140,10 @@ func watchFestivalAtPath(ctx context.Context, path string, opts options, deps co
 	return watchFestival(ctx, festival, opts, deps)
 }
 
-func cycleWatchOptions(opts options) show.WatchOptions {
+func cycleWatchOptions(opts options, cycling bool) show.WatchOptions {
 	wo := showWatchOptions(opts)
 	wo.CycleHint = true
+	wo.Cycling = cycling
 	return wo
 }
 
@@ -120,6 +153,9 @@ func classifyCycleKey(b []byte) (cycleDirection, bool) {
 	}
 	if b[0] == 0x03 {
 		return cycleQuit, true
+	}
+	if b[0] == 'p' || b[0] == 'P' {
+		return cyclePromote, true
 	}
 	if len(b) >= 3 && b[0] == 0x1b && b[1] == '[' {
 		switch b[2] {

--- a/internal/commands/watch/cycling_test.go
+++ b/internal/commands/watch/cycling_test.go
@@ -11,12 +11,18 @@ import (
 
 func TestCycleWatchOptionsSetsCycleHint(t *testing.T) {
 	opts := options{summary: true, goals: true, collapsed: true}
-	got := cycleWatchOptions(opts)
+	got := cycleWatchOptions(opts, true)
 	if !got.CycleHint {
 		t.Fatal("cycleWatchOptions must set CycleHint = true")
 	}
+	if !got.Cycling {
+		t.Fatal("cycleWatchOptions must propagate cycling = true")
+	}
 	if !got.Summary || !got.Goals || !got.Collapsed {
 		t.Fatalf("cycleWatchOptions dropped flags: %#v", got)
+	}
+	if single := cycleWatchOptions(opts, false); single.Cycling {
+		t.Fatal("cycleWatchOptions must leave Cycling = false for a single target")
 	}
 }
 
@@ -144,6 +150,8 @@ func TestClassifyCycleKey(t *testing.T) {
 		{"ctrl_c", []byte{0x03}, cycleQuit, true},
 		{"right_arrow", []byte{0x1b, '[', 'C'}, cycleNext, true},
 		{"left_arrow", []byte{0x1b, '[', 'D'}, cyclePrev, true},
+		{"lower_p_promotes", []byte{'p'}, cyclePromote, true},
+		{"upper_p_promotes", []byte{'P'}, cyclePromote, true},
 		{"up_arrow_ignored", []byte{0x1b, '[', 'A'}, cycleNone, false},
 		{"plain_char", []byte{'x'}, cycleNone, false},
 		{"short_escape", []byte{0x1b, '['}, cycleNone, false},


### PR DESCRIPTION
## Summary

Two changes to `fest watch`, both scoped to the festival watch view:

1. **Show lifecycle status.** The default tree watch view now renders the festival's lifecycle status (`planning` / `ready` / `active`) above the progress bar. Previously only `--summary` showed it; the tree view did not.
2. **Promote from watch with `p`.** In an interactive watch session, pressing `p` promotes the watched festival through its next lifecycle transition and refreshes in place at the festival's new on-disk location.

## Design

`workflow/design/fest-watch-status-and-promote-2026-06-22/` (design workitem `WI-831ebc`).

## Key decision: reuse the `fest promote` flow

This is a TUI/UX change, **not** a new promotion implementation. The `p` key triggers the same flow `fest promote` runs. The transition table, readiness + chain-dependency gates, directory move, frontmatter / `fest.yaml` / nav-link updates, and auto-commit all stay in `internal/commands/promote` and are reused via a new `PromoteResolved(ctx, festival) (newPath, err)` seam:

- `runPromote`'s post-resolution body was extracted into `promoteCore`; `runPromote` and `PromoteResolved` both call it. `fest promote` behavior (including `--json`, `--force`, `--dungeon`, picker confirm) is unchanged.
- The watch loop leaves raw mode before promoting so the shared confirmation and output behave exactly as on the CLI, then re-enters raw mode for the next frame. No new result/error taxonomy, no separate commit policy.

## Behavior

- **Every promote confirms** (`y/N`); `p` sits next to the `←`/`→` cycle keys and the action mutates on-disk state.
- A held readiness or chain gate prints the same message as `fest promote` and stays in watch. Forcing remains a deliberate `fest promote --force`, never a keystroke.
- After a successful promote the directory moves; the loop re-resolves to the new path and keeps watching.
- Single-festival watch now enters the raw-mode loop in a TTY so the shortcut works without cycling. The footer shows `p promote`, and `← → cycle` only when there is more than one target.
- Non-TTY / piped watch and standalone `WORKFLOW.md` watch are unchanged (no raw mode, no promote).

## Tests

- `promote`: `PromoteResolved` confirmed (moves planning→ready, shares the CLI flow) and declined (no move); existing `runPromote` tests unchanged.
- `watch`: `classifyCycleKey` maps `p`/`P` to the promote action; `cycleWatchOptions` propagates the cycling flag.
- `show`: tree watch view renders the lifecycle status line; footer advertises `p promote` (and `← → cycle` only with multiple targets).
- Gates green at HEAD: `just build quick-stable` + `quick-dev`, `just test unit` (2317 passed), `just lint all` (0 issues), `go vet`, `gofmt`.

## Note on coverage

The interactive raw-mode keystroke path (`promoteFromWatch` + the TTY loop wiring) is covered at the component level (key classification, footer, `PromoteResolved` core) plus manual acceptance; a full PTY-driven integration test in the container harness is a reasonable follow-up.
