### PR TITLE
feat(extensions): load installer-managed marketplace extension path (feature-gated)

### DIFF
--- a/internal/extensions/loader.go
+++ b/internal/extensions/loader.go
@@ -5,8 +5,16 @@ import (
 	"path/filepath"
 
 	"github.com/Obedience-Corp/fest/internal/config"
+	"github.com/Obedience-Corp/fest/internal/features"
 	tpl "github.com/Obedience-Corp/fest/internal/template"
 )
+
+// MarketplaceExtensionsDir returns the obey-installer-managed extension path
+// (~/.obey/fest/marketplace/extensions). Extensions the installer activates
+// there are loaded when the marketplace_extension_source_v1 feature is on.
+func MarketplaceExtensionsDir() string {
+	return filepath.Join(config.ConfigDir(), "marketplace", ExtensionsDirName)
+}
 
 // ExtensionLoader handles loading extensions from multiple sources
 type ExtensionLoader struct {
@@ -23,13 +31,21 @@ func NewExtensionLoader() *ExtensionLoader {
 }
 
 // LoadAll loads extensions from all sources with proper precedence
+// (highest-priority last; whatever loads last wins):
 // 1. Project-local (.festival/extensions/)
 // 2. User config repo (festivals/.festival/extensions/)
-// 3. Built-in (~/.config/fest/festivals/.festival/extensions/)
+// 3. Installer-managed marketplace (~/.obey/fest/marketplace/extensions/), gated
+//    by the marketplace_extension_source_v1 feature
+// 4. Built-in (~/.obey/fest/festivals/.festival/extensions/)
 func (el *ExtensionLoader) LoadAll(festivalRoot string) error {
 	// Load built-in extensions first (lowest priority)
 	builtInPath := filepath.Join(config.ConfigDir(), "festivals", ".festival", ExtensionsDirName)
 	_ = el.loadFromDirectory(builtInPath, "built-in")
+
+	// Load installer-managed marketplace extensions (above built-in, below user)
+	if features.Enabled(features.MarketplaceExtensionSource) {
+		_ = el.loadFromDirectory(MarketplaceExtensionsDir(), "marketplace")
+	}
 
 	// Load user config repo extensions (medium priority)
 	if userFestPath := config.ActiveFestivalsPath(); userFestPath != "" {

--- a/internal/extensions/loader_test.go
+++ b/internal/extensions/loader_test.go
@@ -1,0 +1,88 @@
+package extensions
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/config"
+)
+
+func writeExtension(t *testing.T, dir, name string) {
+	t.Helper()
+	extDir := filepath.Join(dir, name)
+	if err := os.MkdirAll(extDir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", extDir, err)
+	}
+	manifest := "name: " + name + "\nversion: \"1.0.0\"\n"
+	if err := os.WriteFile(filepath.Join(extDir, ExtensionManifestFileName), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+}
+
+func TestLoadAll_MarketplaceFlagOn(t *testing.T) {
+	cfg := t.TempDir()
+	t.Setenv("FEST_CONFIG_DIR", cfg)
+	t.Setenv("FEST_FEATURE_MARKETPLACE_EXTENSION_SOURCE", "1")
+	writeExtension(t, MarketplaceExtensionsDir(), "demo")
+
+	l := NewExtensionLoader()
+	if err := l.LoadAll(""); err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	ext := l.Get("demo")
+	if ext == nil {
+		t.Fatal("expected demo to load from the marketplace path")
+	}
+	if ext.Source != "marketplace" {
+		t.Fatalf("source = %q, want marketplace", ext.Source)
+	}
+}
+
+func TestLoadAll_MarketplaceFlagOff(t *testing.T) {
+	cfg := t.TempDir()
+	t.Setenv("FEST_CONFIG_DIR", cfg)
+	t.Setenv("FEST_FEATURE_MARKETPLACE_EXTENSION_SOURCE", "0")
+	writeExtension(t, MarketplaceExtensionsDir(), "demo")
+
+	l := NewExtensionLoader()
+	if err := l.LoadAll(""); err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if l.Get("demo") != nil {
+		t.Fatal("expected the marketplace path to be ignored when the flag is off")
+	}
+}
+
+func TestLoadAll_UserOverridesMarketplace(t *testing.T) {
+	cfg := t.TempDir()
+	t.Setenv("FEST_CONFIG_DIR", cfg)
+	t.Setenv("FEST_FEATURE_MARKETPLACE_EXTENSION_SOURCE", "1")
+	writeExtension(t, MarketplaceExtensionsDir(), "demo")
+
+	userFest := filepath.Join(config.ActiveConfigPath(), "festivals", ".festival", ExtensionsDirName)
+	writeExtension(t, userFest, "demo")
+
+	l := NewExtensionLoader()
+	if err := l.LoadAll(""); err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	ext := l.Get("demo")
+	if ext == nil || ext.Source != "user" {
+		t.Fatalf("expected user override of marketplace, got %+v", ext)
+	}
+}
+
+func TestLoadAll_MissingMarketplaceDirBenign(t *testing.T) {
+	cfg := t.TempDir()
+	t.Setenv("FEST_CONFIG_DIR", cfg)
+	t.Setenv("FEST_FEATURE_MARKETPLACE_EXTENSION_SOURCE", "1")
+
+	l := NewExtensionLoader()
+	if err := l.LoadAll(""); err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(l.List()) != 0 {
+		t.Fatalf("expected no extensions, got %d", len(l.List()))
+	}
+}

--- a/internal/extensions/types.go
+++ b/internal/extensions/types.go
@@ -29,7 +29,7 @@ type Extension struct {
 
 	// Paths and metadata
 	Path   string `yaml:"-" json:"path"`   // Directory containing the extension
-	Source string `yaml:"-" json:"source"` // project, user, built-in
+	Source string `yaml:"-" json:"source"` // project, user, marketplace, built-in
 
 	// Extension contents
 	Files []ExtensionFile `yaml:"files,omitempty" json:"files,omitempty"`

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -1,0 +1,45 @@
+// Package features declares the runtime capabilities this fest build advertises
+// and lets callers query whether a capability is enabled.
+package features
+
+import (
+	"os"
+	"strings"
+)
+
+// MarketplaceExtensionSource is the capability of loading extensions from the
+// obey-installer-managed marketplace path (~/.obey/fest/marketplace/extensions).
+const MarketplaceExtensionSource = "marketplace_extension_source_v1"
+
+// Supported lists every capability this fest build advertises. The obey
+// installer reads this set (via fest version --json) to gate host-feature
+// requirements for extensions it activates.
+func Supported() []string {
+	return []string{MarketplaceExtensionSource}
+}
+
+// Enabled reports whether a capability is active. The marketplace extension
+// source defaults on (a missing marketplace dir is a harmless no-op for users
+// who never run the installer) and can be turned off with
+// FEST_FEATURE_MARKETPLACE_EXTENSION_SOURCE=0.
+func Enabled(name string) bool {
+	switch name {
+	case MarketplaceExtensionSource:
+		return envFlag("FEST_FEATURE_MARKETPLACE_EXTENSION_SOURCE", true)
+	default:
+		return false
+	}
+}
+
+func envFlag(key string, def bool) bool {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def
+	}
+	switch strings.ToLower(v) {
+	case "0", "false", "off", "no":
+		return false
+	default:
+		return true
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -5,6 +5,8 @@ package version
 import (
 	"runtime"
 	"strings"
+
+	"github.com/Obedience-Corp/fest/internal/features"
 )
 
 var (
@@ -20,11 +22,12 @@ var (
 
 // Info contains all version information
 type Info struct {
-	Version   string `json:"version"`
-	Commit    string `json:"commit"`
-	BuildDate string `json:"buildDate"`
-	GoVersion string `json:"goVersion"`
-	Platform  string `json:"platform"`
+	Version   string   `json:"version"`
+	Commit    string   `json:"commit"`
+	BuildDate string   `json:"buildDate"`
+	GoVersion string   `json:"goVersion"`
+	Platform  string   `json:"platform"`
+	Features  []string `json:"features"`
 }
 
 // IsDevBuild reports whether this is a development build.
@@ -50,5 +53,6 @@ func Get() Info {
 		BuildDate: BuildDate,
 		GoVersion: runtime.Version(),
 		Platform:  runtime.GOOS + "/" + runtime.GOARCH,
+		Features:  features.Supported(),
 	}
 }


### PR DESCRIPTION
Part of festival **OI0006** (obey-installer extensions support). Adds fest-side support for loading extensions that **obey-installer** activates into `~/.obey/fest/marketplace/extensions/`, behind the `marketplace_extension_source_v1` capability.

## What

- **`internal/features`** (new leaf package) — fest's capability set: the `marketplace_extension_source_v1` constant, `Supported()` (what `version --json` advertises so the installer's host-feature contract can read it), and `Enabled()`.
- **`internal/extensions/loader.go`** — `MarketplaceExtensionsDir()` (= `~/.obey/fest/marketplace/extensions`, mirroring `config.ConfigDir()`), plus a feature-gated load inserted **above built-in and below user/project**. Because `loadFromDirectory` is last-wins, a `marketplace` extension overrides `built-in` and is overridden by `user`/`project` — matching the spec's precedence. Doc comment updated to the four tiers.
- **`internal/version/version.go`** — additive `features` field in `version --json`.
- **`internal/extensions/types.go`** — `marketplace` added to the `Source` enumeration comment.

## Production safety

- **Flag off** (`FEST_FEATURE_MARKETPLACE_EXTENSION_SOURCE=0`) → byte-for-byte the current behavior (path not scanned).
- **Flag on (default)** → a missing `~/.obey/fest/marketplace/extensions` is a harmless no-op, so users who never run obey-installer see **zero behavior change**. Users who do get installer-activated extensions loaded automatically (no init friction).
- No change to camp/fest plugin discovery — only this new extension tier.

## Verification

`just lint all` → 0 issues; `just test unit-raw` → 91 packages pass, no failures. `fest version --json` now includes `"features": ["marketplace_extension_source_v1"]`.

Tests (host temp dirs, `FEST_CONFIG_DIR`): flag-on loads with `Source==marketplace`; flag-off ignores; a same-named user-config extension overrides the marketplace one; a missing dir is benign.

## Default-on rationale (call out for review)

I defaulted the capability **on** (opt-out via env) rather than off, because the gated path is empty/missing for everyone who hasn't used obey-installer, so there's no behavior change for them, and it avoids requiring users to flip a flag to make installer-activated extensions load. Happy to flip to default-off if you'd rather gate it explicitly.