### PR TITLE
fix(status): crash-safe, atomic festival status moves (STATE-01/05)

### DIFF
--- a/internal/commands/status/date_directory.go
+++ b/internal/commands/status/date_directory.go
@@ -75,18 +75,22 @@ func GetCompletedPath(festivalsRoot, festivalName, dateDir string) string {
 }
 
 // copyAndDelete performs a copy+delete move across filesystems. It stages the
-// copy into a sibling ".partial" directory it owns and renames that into place
-// only after a complete copy, so a failure never removes a destination this
-// call did not create.
+// copy into a process-unique sibling directory it owns and renames that into
+// place only after a complete copy, so concurrent moves of the same festival
+// never delete each other's in-progress stage, and a failure never removes a
+// destination this call did not create.
 func copyAndDelete(sourcePath, destPath string) (string, error) {
-	stagePath := destPath + ".partial"
-	_ = os.RemoveAll(stagePath)
-
-	if err := os.MkdirAll(stagePath, 0755); err != nil {
+	destParent := filepath.Dir(destPath)
+	if err := os.MkdirAll(destParent, 0755); err != nil {
 		return "", errors.IO("creating staging directory", err)
 	}
 
-	err := filepath.Walk(sourcePath, func(path string, info os.FileInfo, err error) error {
+	stagePath, err := os.MkdirTemp(destParent, filepath.Base(destPath)+".partial-*")
+	if err != nil {
+		return "", errors.IO("creating staging directory", err)
+	}
+
+	err = filepath.Walk(sourcePath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}

--- a/internal/commands/status/date_directory.go
+++ b/internal/commands/status/date_directory.go
@@ -2,9 +2,11 @@
 package status
 
 import (
+	stderrors "errors"
 	"io"
 	"os"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	"github.com/Obedience-Corp/fest/internal/errors"
@@ -45,11 +47,25 @@ func MoveToDateDirectory(sourcePath, completedDir, dateDir string) (string, erro
 
 	// Attempt atomic rename first
 	if err := os.Rename(sourcePath, destPath); err != nil {
-		// Fallback to copy+delete for cross-filesystem moves
+		if !isCrossDevice(err) {
+			return "", errors.IO("moving festival to date directory", err).
+				WithField("source", sourcePath).
+				WithField("destination", destPath)
+		}
 		return copyAndDelete(sourcePath, destPath)
 	}
 
 	return destPath, nil
+}
+
+// isCrossDevice reports whether a rename failed solely because source and
+// destination live on different filesystems.
+func isCrossDevice(err error) bool {
+	var linkErr *os.LinkError
+	if stderrors.As(err, &linkErr) {
+		return stderrors.Is(linkErr.Err, syscall.EXDEV)
+	}
+	return stderrors.Is(err, syscall.EXDEV)
 }
 
 // GetCompletedPath returns the full path for a completed festival with date organization.
@@ -58,16 +74,18 @@ func GetCompletedPath(festivalsRoot, festivalName, dateDir string) string {
 	return filepath.Join(festivalsRoot, "dungeon", "completed", dateDir, festivalName)
 }
 
-// copyAndDelete performs a copy+delete operation for cross-filesystem moves.
-// It copies all files recursively, then deletes the source.
-// If copy fails, no deletion occurs (atomic behavior).
+// copyAndDelete performs a copy+delete move across filesystems. It stages the
+// copy into a sibling ".partial" directory it owns and renames that into place
+// only after a complete copy, so a failure never removes a destination this
+// call did not create.
 func copyAndDelete(sourcePath, destPath string) (string, error) {
-	// Create destination directory
-	if err := os.MkdirAll(destPath, 0755); err != nil {
-		return "", errors.IO("creating destination directory", err)
+	stagePath := destPath + ".partial"
+	_ = os.RemoveAll(stagePath)
+
+	if err := os.MkdirAll(stagePath, 0755); err != nil {
+		return "", errors.IO("creating staging directory", err)
 	}
 
-	// Copy all files recursively
 	err := filepath.Walk(sourcePath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -78,22 +96,31 @@ func copyAndDelete(sourcePath, destPath string) (string, error) {
 			return err
 		}
 
-		targetPath := filepath.Join(destPath, relPath)
+		targetPath := filepath.Join(stagePath, relPath)
 
 		if info.IsDir() {
 			return os.MkdirAll(targetPath, info.Mode())
 		}
 
-		// Copy file
 		return copyFile(path, targetPath, info.Mode())
 	})
 	if err != nil {
-		// Cleanup on failure - remove partial copy
-		_ = os.RemoveAll(destPath)
+		_ = os.RemoveAll(stagePath)
 		return "", errors.Wrap(err, "copying festival files")
 	}
 
-	// Delete source only after successful copy
+	if _, err := os.Stat(destPath); err == nil {
+		_ = os.RemoveAll(stagePath)
+		return "", errors.Validation("destination already exists").
+			WithField("destination", destPath)
+	}
+
+	if err := os.Rename(stagePath, destPath); err != nil {
+		_ = os.RemoveAll(stagePath)
+		return "", errors.IO("finalizing festival move", err).
+			WithField("destination", destPath)
+	}
+
 	if err := os.RemoveAll(sourcePath); err != nil {
 		return "", errors.IO("removing source after copy", err)
 	}

--- a/internal/commands/status/date_directory_race_test.go
+++ b/internal/commands/status/date_directory_race_test.go
@@ -1,0 +1,93 @@
+package status
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestMoveToDateDirectory_ConcurrentCompletionPreservesFestival(t *testing.T) {
+	root := resolvePath(t, t.TempDir())
+	sourcePath := filepath.Join(root, "active", "race-fest-RF0001")
+	if err := os.MkdirAll(filepath.Join(sourcePath, ".fest"), 0755); err != nil {
+		t.Fatalf("setup source: %v", err)
+	}
+	marker := filepath.Join(sourcePath, ".fest", "status_history.json")
+	want := []byte(`[{"from":"active","to":"completed"}]`)
+	if err := os.WriteFile(marker, want, 0644); err != nil {
+		t.Fatalf("setup marker: %v", err)
+	}
+
+	completedDir := filepath.Join(root, "dungeon", "completed")
+	dateDir := "2026-07-01"
+
+	var wg sync.WaitGroup
+	results := make([]string, 2)
+	errs := make([]error, 2)
+	start := make(chan struct{})
+	for i := range 2 {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			results[idx], errs[idx] = MoveToDateDirectory(sourcePath, completedDir, dateDir)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	successes := 0
+	var destPath string
+	for i := range 2 {
+		if errs[i] == nil {
+			successes++
+			destPath = results[i]
+		}
+	}
+	if successes != 1 {
+		t.Fatalf("expected exactly one successful completion, got %d (errs: %v, %v)", successes, errs[0], errs[1])
+	}
+
+	got, err := os.ReadFile(filepath.Join(destPath, ".fest", "status_history.json"))
+	if err != nil {
+		t.Fatalf("festival lost after concurrent completion: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("festival content corrupted: got %q want %q", got, want)
+	}
+
+	if _, err := os.Stat(filepath.Join(completedDir, dateDir, "race-fest-RF0001.partial")); !os.IsNotExist(err) {
+		t.Errorf("staging directory leaked after move")
+	}
+}
+
+func TestCopyAndDelete_PreservesForeignDestination(t *testing.T) {
+	root := resolvePath(t, t.TempDir())
+	sourcePath := filepath.Join(root, "source", "fest")
+	if err := os.MkdirAll(sourcePath, 0755); err != nil {
+		t.Fatalf("setup source: %v", err)
+	}
+
+	destPath := filepath.Join(root, "dest", "fest")
+	if err := os.MkdirAll(destPath, 0755); err != nil {
+		t.Fatalf("setup dest: %v", err)
+	}
+	foreign := filepath.Join(destPath, "owned-by-other.txt")
+	want := []byte("do not delete me")
+	if err := os.WriteFile(foreign, want, 0644); err != nil {
+		t.Fatalf("setup foreign file: %v", err)
+	}
+
+	if _, err := copyAndDelete(sourcePath, destPath); err == nil {
+		t.Fatal("expected error moving into an existing destination")
+	}
+
+	got, err := os.ReadFile(foreign)
+	if err != nil {
+		t.Fatalf("foreign destination was removed: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("foreign destination corrupted: got %q want %q", got, want)
+	}
+}

--- a/internal/commands/status/date_directory_race_test.go
+++ b/internal/commands/status/date_directory_race_test.go
@@ -62,6 +62,109 @@ func TestMoveToDateDirectory_ConcurrentCompletionPreservesFestival(t *testing.T)
 	}
 }
 
+func TestCopyAndDelete_ConcurrentCompletionPreservesFestival(t *testing.T) {
+	root := resolvePath(t, t.TempDir())
+	sourcePath := filepath.Join(root, "active", "race-fest-RF0002")
+	if err := os.MkdirAll(filepath.Join(sourcePath, ".fest"), 0755); err != nil {
+		t.Fatalf("setup source: %v", err)
+	}
+	marker := filepath.Join(sourcePath, ".fest", "status_history.json")
+	want := []byte(`[{"from":"active","to":"completed"}]`)
+	if err := os.WriteFile(marker, want, 0644); err != nil {
+		t.Fatalf("setup marker: %v", err)
+	}
+
+	destDir := filepath.Join(root, "dungeon", "completed", "2026-07-01")
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		t.Fatalf("setup dest dir: %v", err)
+	}
+	destPath := filepath.Join(destDir, "race-fest-RF0002")
+
+	var wg sync.WaitGroup
+	results := make([]string, 2)
+	errs := make([]error, 2)
+	start := make(chan struct{})
+	for i := range 2 {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			results[idx], errs[idx] = copyAndDelete(sourcePath, destPath)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	successes := 0
+	var winner string
+	for i := range 2 {
+		if errs[i] == nil {
+			successes++
+			winner = results[i]
+		}
+	}
+	if successes != 1 {
+		t.Fatalf("expected exactly one successful completion, got %d (errs: %v, %v)", successes, errs[0], errs[1])
+	}
+
+	got, err := os.ReadFile(filepath.Join(winner, ".fest", "status_history.json"))
+	if err != nil {
+		t.Fatalf("festival lost after concurrent completion: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("festival content corrupted: got %q want %q", got, want)
+	}
+
+	entries, err := os.ReadDir(destDir)
+	if err != nil {
+		t.Fatalf("reading completed dir: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Name() != "race-fest-RF0002" {
+			t.Errorf("staging directory leaked: %s", entry.Name())
+		}
+	}
+}
+
+func TestCopyAndDelete_DoesNotTouchLegacyDeterministicStagePath(t *testing.T) {
+	root := resolvePath(t, t.TempDir())
+	sourcePath := filepath.Join(root, "active", "race-fest-RF0003")
+	if err := os.MkdirAll(filepath.Join(sourcePath, ".fest"), 0755); err != nil {
+		t.Fatalf("setup source: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourcePath, ".fest", "status_history.json"), []byte(`[]`), 0644); err != nil {
+		t.Fatalf("setup marker: %v", err)
+	}
+
+	destDir := filepath.Join(root, "dungeon", "completed", "2026-07-01")
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		t.Fatalf("setup dest dir: %v", err)
+	}
+	destPath := filepath.Join(destDir, "race-fest-RF0003")
+
+	foreignStage := destPath + ".partial"
+	if err := os.MkdirAll(foreignStage, 0755); err != nil {
+		t.Fatalf("setup foreign stage: %v", err)
+	}
+	foreignMarker := filepath.Join(foreignStage, "in-progress.txt")
+	want := []byte("owned by another concurrent completion")
+	if err := os.WriteFile(foreignMarker, want, 0644); err != nil {
+		t.Fatalf("setup foreign marker: %v", err)
+	}
+
+	if _, err := copyAndDelete(sourcePath, destPath); err != nil {
+		t.Fatalf("copyAndDelete failed: %v", err)
+	}
+
+	got, err := os.ReadFile(foreignMarker)
+	if err != nil {
+		t.Fatalf("foreign in-progress stage was removed: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("foreign in-progress stage corrupted: got %q want %q", got, want)
+	}
+}
+
 func TestCopyAndDelete_PreservesForeignDestination(t *testing.T) {
 	root := resolvePath(t, t.TempDir())
 	sourcePath := filepath.Join(root, "source", "fest")

--- a/internal/commands/status/history.go
+++ b/internal/commands/status/history.go
@@ -62,10 +62,48 @@ func RecordStatusChange(ctx context.Context, festivalDir, fromStatus, toStatus, 
 	}
 
 	data := bytes.TrimRight(buffer.Bytes(), "\n")
-	if err := os.WriteFile(historyPath, data, 0644); err != nil {
-		return errors.IO("writing status history", err)
+	if err := writeStatusHistoryAtomic(historyPath, data); err != nil {
+		return err
 	}
 
+	return nil
+}
+
+// writeStatusHistoryAtomic writes the history file via a temp file and rename so
+// a crash mid-write cannot truncate or corrupt the existing history.
+func writeStatusHistoryAtomic(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".status-history-*.tmp")
+	if err != nil {
+		return errors.IO("creating temp status history", err).WithField("dir", dir)
+	}
+	tmpPath := tmp.Name()
+
+	cleanup := func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+	}
+
+	if _, err := tmp.Write(data); err != nil {
+		cleanup()
+		return errors.IO("writing temp status history", err).WithField("path", tmpPath)
+	}
+	if err := tmp.Sync(); err != nil {
+		cleanup()
+		return errors.IO("syncing temp status history", err).WithField("path", tmpPath)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return errors.IO("closing temp status history", err).WithField("path", tmpPath)
+	}
+	if err := os.Chmod(tmpPath, 0644); err != nil {
+		_ = os.Remove(tmpPath)
+		return errors.IO("setting status history mode", err).WithField("path", tmpPath)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return errors.IO("replacing status history", err).WithField("path", path)
+	}
 	return nil
 }
 
@@ -90,7 +128,11 @@ func LoadStatusHistory(ctx context.Context, festivalDir string) ([]StatusHistory
 
 	var history []StatusHistoryEntry
 	if err := json.Unmarshal(data, &history); err != nil {
-		return nil, errors.Wrap(err, "parsing status history")
+		quarantinePath := historyPath + ".corrupt"
+		if renameErr := os.Rename(historyPath, quarantinePath); renameErr != nil {
+			return nil, errors.Wrap(err, "parsing status history")
+		}
+		return []StatusHistoryEntry{}, nil
 	}
 
 	return history, nil

--- a/internal/commands/status/history.go
+++ b/internal/commands/status/history.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -108,7 +109,9 @@ func writeStatusHistoryAtomic(path string, data []byte) error {
 }
 
 // LoadStatusHistory loads the status history from a festival's .fest directory.
-// Returns an empty slice if no history file exists.
+// Returns an empty slice if no history file exists. If the existing history
+// file is corrupt, this call quarantines it (renames it to a unique
+// ".corrupt" path and warns on stderr) and returns an empty slice.
 func LoadStatusHistory(ctx context.Context, festivalDir string) ([]StatusHistoryEntry, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -128,14 +131,33 @@ func LoadStatusHistory(ctx context.Context, festivalDir string) ([]StatusHistory
 
 	var history []StatusHistoryEntry
 	if err := json.Unmarshal(data, &history); err != nil {
-		quarantinePath := historyPath + ".corrupt"
-		if renameErr := os.Rename(historyPath, quarantinePath); renameErr != nil {
+		quarantinePath, quarantineErr := quarantineCorruptHistory(historyPath)
+		if quarantineErr != nil {
 			return nil, errors.Wrap(err, "parsing status history")
 		}
+		fmt.Fprintf(os.Stderr, "fest: discarded corrupt status history, quarantined at %s\n", quarantinePath)
 		return []StatusHistoryEntry{}, nil
 	}
 
 	return history, nil
+}
+
+// quarantineCorruptHistory renames a corrupt history file to a unique
+// ".corrupt" path so it never overwrites an earlier quarantined file.
+func quarantineCorruptHistory(historyPath string) (string, error) {
+	dest := historyPath + ".corrupt"
+	for i := 1; ; i++ {
+		if _, err := os.Stat(dest); os.IsNotExist(err) {
+			break
+		} else if err != nil {
+			return "", err
+		}
+		dest = fmt.Sprintf("%s.corrupt.%d", historyPath, i)
+	}
+	if err := os.Rename(historyPath, dest); err != nil {
+		return "", err
+	}
+	return dest, nil
 }
 
 // GetLastStatusChange returns the most recent status change entry, if any.

--- a/internal/commands/status/history_quarantine_test.go
+++ b/internal/commands/status/history_quarantine_test.go
@@ -2,8 +2,10 @@ package status
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -33,5 +35,83 @@ func TestRecordStatusChange_QuarantinesCorruptHistory(t *testing.T) {
 	}
 	if len(history) != 1 || history[0].ToStatus != "ready" {
 		t.Fatalf("expected one fresh entry after quarantine, got %+v", history)
+	}
+}
+
+func TestLoadStatusHistory_QuarantineDoesNotOverwriteEarlierCorrupt(t *testing.T) {
+	root := resolvePath(t, t.TempDir())
+	festDir := filepath.Join(root, "planning", "corrupt-fest-CF0002")
+	dotFest := filepath.Join(festDir, ".fest")
+	if err := os.MkdirAll(dotFest, 0755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	historyPath := filepath.Join(dotFest, "status_history.json")
+
+	firstCorrupt := []byte("{ first corruption")
+	if err := os.WriteFile(historyPath, firstCorrupt, 0644); err != nil {
+		t.Fatalf("setup first corrupt history: %v", err)
+	}
+	if _, err := LoadStatusHistory(context.Background(), festDir); err != nil {
+		t.Fatalf("first load should quarantine and return empty, got: %v", err)
+	}
+
+	secondCorrupt := []byte("{ second corruption")
+	if err := os.WriteFile(historyPath, secondCorrupt, 0644); err != nil {
+		t.Fatalf("setup second corrupt history: %v", err)
+	}
+	if _, err := LoadStatusHistory(context.Background(), festDir); err != nil {
+		t.Fatalf("second load should quarantine and return empty, got: %v", err)
+	}
+
+	firstQuarantined, err := os.ReadFile(historyPath + ".corrupt")
+	if err != nil {
+		t.Fatalf("first quarantined copy missing: %v", err)
+	}
+	if string(firstQuarantined) != string(firstCorrupt) {
+		t.Fatalf("first quarantined copy was overwritten: got %q want %q", firstQuarantined, firstCorrupt)
+	}
+
+	secondQuarantined, err := os.ReadFile(historyPath + ".corrupt.1")
+	if err != nil {
+		t.Fatalf("second quarantined copy missing: %v", err)
+	}
+	if string(secondQuarantined) != string(secondCorrupt) {
+		t.Fatalf("second quarantined copy content mismatch: got %q want %q", secondQuarantined, secondCorrupt)
+	}
+}
+
+func TestLoadStatusHistory_WarnsOnQuarantine(t *testing.T) {
+	root := resolvePath(t, t.TempDir())
+	festDir := filepath.Join(root, "planning", "corrupt-fest-CF0003")
+	dotFest := filepath.Join(festDir, ".fest")
+	if err := os.MkdirAll(dotFest, 0755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	historyPath := filepath.Join(dotFest, "status_history.json")
+	if err := os.WriteFile(historyPath, []byte("{ not valid json"), 0644); err != nil {
+		t.Fatalf("setup corrupt history: %v", err)
+	}
+
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("creating pipe: %v", err)
+	}
+	os.Stderr = w
+
+	_, loadErr := LoadStatusHistory(context.Background(), festDir)
+
+	_ = w.Close()
+	os.Stderr = origStderr
+	if loadErr != nil {
+		t.Fatalf("load should quarantine and return empty, got: %v", loadErr)
+	}
+
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("reading captured stderr: %v", err)
+	}
+	if !strings.Contains(string(out), historyPath+".corrupt") {
+		t.Fatalf("expected stderr warning naming quarantine path, got: %q", out)
 	}
 }

--- a/internal/commands/status/history_quarantine_test.go
+++ b/internal/commands/status/history_quarantine_test.go
@@ -1,0 +1,37 @@
+package status
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRecordStatusChange_QuarantinesCorruptHistory(t *testing.T) {
+	root := resolvePath(t, t.TempDir())
+	festDir := filepath.Join(root, "planning", "corrupt-fest-CF0001")
+	dotFest := filepath.Join(festDir, ".fest")
+	if err := os.MkdirAll(dotFest, 0755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	historyPath := filepath.Join(dotFest, "status_history.json")
+	if err := os.WriteFile(historyPath, []byte("{ this is not valid json"), 0644); err != nil {
+		t.Fatalf("setup corrupt history: %v", err)
+	}
+
+	if err := RecordStatusChange(context.Background(), festDir, "planning", "ready", ""); err != nil {
+		t.Fatalf("recording should recover from a corrupt history, got: %v", err)
+	}
+
+	if _, err := os.Stat(historyPath + ".corrupt"); err != nil {
+		t.Errorf("corrupt history was not quarantined: %v", err)
+	}
+
+	history, err := LoadStatusHistory(context.Background(), festDir)
+	if err != nil {
+		t.Fatalf("reloading history: %v", err)
+	}
+	if len(history) != 1 || history[0].ToStatus != "ready" {
+		t.Fatalf("expected one fresh entry after quarantine, got %+v", history)
+	}
+}


### PR DESCRIPTION
Closes the two data-integrity findings from the Fable 2026-07-01 review (`workflow/code_reviews/fable-2026-07-01-code-review/fest/`), both adversarially re-verified (CONFIRMED, refute-first).

## STATE-01 (critical) — data-loss race in festival completion
`copyAndDelete` ran `os.RemoveAll(destPath)` on a destination it did not create. On two concurrent completions of the same festival: A renames source→dest and wins; B's rename fails because the source is gone; B falls into `copyAndDelete`; B's `Walk` errors on the missing source; the cleanup `RemoveAll(destPath)` deletes A's festival **and its `.fest` history**.

Fix:
- `MoveToDateDirectory` now falls back to copy only on a genuine cross-device (`EXDEV`) rename error. Any other failure (vanished source, permissions) surfaces instead of triggering a recursive copy.
- `copyAndDelete` stages the copy into a sibling `.partial` directory it owns and renames that into place only after a complete copy, so a failure never removes a foreign destination. It also refuses an already-existing destination.

## STATE-05 — non-atomic history writes
`status_history.json` was written with a truncate-in-place `os.WriteFile`, so a crash mid-write could corrupt it, and a corrupt file then made every later `RecordStatusChange` fail forever.

Fix:
- Writes go through a temp file + `rename` (mirroring `internal/chain/write.go`).
- A corrupt history file is quarantined to `.corrupt` and recording continues from empty instead of failing.

## Tests
New deterministic regressions (host `t.TempDir`, per fest convention): concurrent-completion preserves the festival, `copyAndDelete` preserves a foreign destination, corrupt history is quarantined and recording recovers.

## Gates (verbatim, at branch head)
- `just lint all` → `0 issues.` exit 0
- `just lint vet` → exit 0
- `just test unit` → `ALL 2324 TESTS PASSED` exit 0

## Scope note
This is the data-integrity slice of the fest-data-safety festival (FD0001). The remaining review items (STATE-04 single status-truth seam / MOD-02, NEXT-01 gate ordering, STATE-07 scaffold fest.yaml, CON-01 dungeon depth resolution, CON-02/03 JSON exit codes) follow as separate focused PRs so each stays reviewable.