### PR TITLE
fix(next,scaffold): earlier-gate ordering before cwd shortcut + scaffold writes fest.yaml (NEXT-01/STATE-07)

### DIFF
--- a/internal/commands/next/next.go
+++ b/internal/commands/next/next.go
@@ -159,7 +159,11 @@ func runNext(cmd *cobra.Command, args []string) error {
 	nextPhasePath := ""
 	nextPhaseType := ""
 	nextPhaseName := ""
-	if found, _, findErr := lifecycle.FindFirstIncompletePhase(ctx, festivalPath); findErr == nil && found != "" {
+	found, _, findErr := lifecycle.FindFirstIncompletePhase(ctx, festivalPath)
+	if findErr != nil {
+		return errors.Wrap(findErr, "resolving next incomplete phase")
+	}
+	if found != "" {
 		nextPhasePath = found
 		nextPhaseType = guidance.DetectPhaseType(found)
 		nextPhaseName = filepath.Base(found)
@@ -215,6 +219,9 @@ func runNext(cmd *cobra.Command, args []string) error {
 			if position == frontmatter.WorkflowPositionBefore {
 				// WORKFLOW.md exists with position=before - check if workflow is complete before routing
 				phaseName := filepath.Base(phasePath)
+				if handled, rerr := routeEarlierIncompleteWork(ctx, festivalPath, phaseName); handled {
+					return rerr
+				}
 				store := progress.NewStore(festivalPath)
 				if loadErr := store.Load(ctx); loadErr != nil {
 					return runWorkflowMode(ctx, festivalPath, phasePath)
@@ -275,21 +282,9 @@ func runNext(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Check if an earlier phase has incomplete after-workflow steps
-	// that should run before jumping to later phases
 	if result.Task != nil {
-		earlierWorkflow, ewErr := findEarlierIncompleteAfterWorkflow(ctx, festivalPath, result.Task.PhaseName)
-		if ewErr == nil && earlierWorkflow != "" {
-			return runWorkflowMode(ctx, festivalPath, earlierWorkflow)
-		}
-	}
-
-	// Check if an earlier phase has an incomplete phase gate (GATES.md)
-	// Phase gates run after all tasks and workflows in a phase are complete
-	if result.Task != nil {
-		earlierGate, egErr := findEarlierIncompletePhaseGate(ctx, festivalPath, result.Task.PhaseName)
-		if egErr == nil && earlierGate != "" {
-			return runPhaseGateMode(ctx, festivalPath, earlierGate)
+		if handled, rerr := routeEarlierIncompleteWork(ctx, festivalPath, result.Task.PhaseName); handled {
+			return rerr
 		}
 	}
 

--- a/internal/commands/next/next_ordering_test.go
+++ b/internal/commands/next/next_ordering_test.go
@@ -1,0 +1,55 @@
+package next
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func TestRouteEarlierIncompleteWork_HandlesEarlierGateFromLaterPhase(t *testing.T) {
+	festDir := scaffoldWorkflowGateFestival(t)
+	ctx := context.Background()
+
+	completeWorkflow(t, festDir, "001_INGEST", 2)
+
+	if got, _ := findEarlierIncompletePhaseGate(ctx, festDir, "002_PLAN"); filepath.Base(got) != "001_INGEST" {
+		t.Fatalf("findEarlierIncompletePhaseGate = %q, want 001_INGEST", got)
+	}
+
+	handled, err := routeEarlierIncompleteWork(ctx, festDir, "002_PLAN")
+	if err != nil {
+		t.Fatalf("routeEarlierIncompleteWork: %v", err)
+	}
+	if !handled {
+		t.Fatal("routeEarlierIncompleteWork handled = false, want true (earlier gate must run before a later phase)")
+	}
+}
+
+func TestRouteEarlierIncompleteWork_NotHandledWhenEarlierComplete(t *testing.T) {
+	festDir := scaffoldWorkflowGateFestival(t)
+	ctx := context.Background()
+
+	completeWorkflow(t, festDir, "001_INGEST", 2)
+	completeWorkflow(t, festDir, "gate:001_INGEST", 1)
+
+	handled, err := routeEarlierIncompleteWork(ctx, festDir, "002_PLAN")
+	if err != nil {
+		t.Fatalf("routeEarlierIncompleteWork: %v", err)
+	}
+	if handled {
+		t.Fatal("routeEarlierIncompleteWork handled = true, want false when the earlier phase is complete")
+	}
+}
+
+func TestRouteEarlierIncompleteWork_FailsClosedOnUnreadableFestival(t *testing.T) {
+	ctx := context.Background()
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+
+	handled, err := routeEarlierIncompleteWork(ctx, missing, "002_PLAN")
+	if !handled {
+		t.Fatal("routeEarlierIncompleteWork handled = false on a read error, want true (fail closed)")
+	}
+	if err == nil {
+		t.Fatal("routeEarlierIncompleteWork err = nil on a read error, want a propagated error")
+	}
+}

--- a/internal/commands/next/phase.go
+++ b/internal/commands/next/phase.go
@@ -8,10 +8,29 @@ import (
 	"sort"
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
+	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/frontmatter"
 	"github.com/Obedience-Corp/fest/internal/lifecycle"
 	"github.com/Obedience-Corp/fest/internal/progress"
 )
+
+func routeEarlierIncompleteWork(ctx context.Context, festivalPath, phaseName string) (bool, error) {
+	earlierWorkflow, ewErr := findEarlierIncompleteAfterWorkflow(ctx, festivalPath, phaseName)
+	if ewErr != nil {
+		return true, errors.Wrap(ewErr, "checking earlier incomplete after-workflow")
+	}
+	if earlierWorkflow != "" {
+		return true, runWorkflowMode(ctx, festivalPath, earlierWorkflow)
+	}
+	earlierGate, egErr := findEarlierIncompletePhaseGate(ctx, festivalPath, phaseName)
+	if egErr != nil {
+		return true, errors.Wrap(egErr, "checking earlier incomplete phase gate")
+	}
+	if earlierGate != "" {
+		return true, runPhaseGateMode(ctx, festivalPath, earlierGate)
+	}
+	return false, nil
+}
 
 // findSequencePath finds the sequence path from current directory
 func findSequencePath(cwd, festivalPath string) string {

--- a/internal/commands/scaffold/from_plan.go
+++ b/internal/commands/scaffold/from_plan.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/config"
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/id"
+	"github.com/Obedience-Corp/fest/internal/progress"
 	sc "github.com/Obedience-Corp/fest/internal/scaffold"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
@@ -158,17 +159,17 @@ func runFromPlan(ctx context.Context, opts *fromPlanOptions) error {
 
 	if !opts.DryRun {
 		campaignRoot := filepath.Dir(festivalsRoot)
-		if werr := writeScaffoldFestYaml(festivalDir, campaignRoot, festivalID, destCategory, plan); werr != nil {
+		if werr := writeScaffoldFestYaml(ctx, festivalDir, campaignRoot, festivalID, destCategory, plan); werr != nil {
 			return emitError(opts, werr)
 		}
-		result.FilesCreated = append(result.FilesCreated, filepath.Join(festivalDir, config.FestivalConfigFileName))
 	}
+	result.FilesCreated = append(result.FilesCreated, filepath.Join(festivalDir, config.FestivalConfigFileName))
 
 	// Emit result
 	return emitResult(opts, result, festivalID)
 }
 
-func writeScaffoldFestYaml(festivalDir, campaignRoot, festivalID, destCategory string, plan *sc.ParsedPlan) error {
+func writeScaffoldFestYaml(ctx context.Context, festivalDir, campaignRoot, festivalID, destCategory string, plan *sc.ParsedPlan) error {
 	now := time.Now().UTC()
 	cfg := config.DefaultFestivalConfig()
 	cfg.Metadata = config.FestivalMetadata{
@@ -186,6 +187,9 @@ func writeScaffoldFestYaml(festivalDir, campaignRoot, festivalID, destCategory s
 				Notes:     "Festival scaffolded from plan",
 			},
 		},
+	}
+	if initialSize, sizeErr := progress.ComputeDirectorySize(ctx, festivalDir); sizeErr == nil && initialSize > 0 {
+		cfg.Metadata.InitialSizeBytes = initialSize
 	}
 	if err := config.SaveFestivalConfig(festivalDir, campaignRoot, cfg); err != nil {
 		return errors.Wrap(err, "writing fest.yaml").WithField("path", filepath.Join(festivalDir, config.FestivalConfigFileName))

--- a/internal/commands/scaffold/from_plan.go
+++ b/internal/commands/scaffold/from_plan.go
@@ -7,12 +7,16 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
+	"github.com/Obedience-Corp/fest/internal/config"
+	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/id"
 	sc "github.com/Obedience-Corp/fest/internal/scaffold"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
 	"github.com/Obedience-Corp/fest/internal/workspace"
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 )
 
@@ -152,8 +156,41 @@ func runFromPlan(ctx context.Context, opts *fromPlanOptions) error {
 		return emitError(opts, err)
 	}
 
+	if !opts.DryRun {
+		campaignRoot := filepath.Dir(festivalsRoot)
+		if werr := writeScaffoldFestYaml(festivalDir, campaignRoot, festivalID, destCategory, plan); werr != nil {
+			return emitError(opts, werr)
+		}
+		result.FilesCreated = append(result.FilesCreated, filepath.Join(festivalDir, config.FestivalConfigFileName))
+	}
+
 	// Emit result
 	return emitResult(opts, result, festivalID)
+}
+
+func writeScaffoldFestYaml(festivalDir, campaignRoot, festivalID, destCategory string, plan *sc.ParsedPlan) error {
+	now := time.Now().UTC()
+	cfg := config.DefaultFestivalConfig()
+	cfg.Metadata = config.FestivalMetadata{
+		ID:           festivalID,
+		UUID:         uuid.New().String(),
+		Name:         plan.FestivalName,
+		Goal:         plan.Goal,
+		FestivalType: "standard",
+		CreatedAt:    now,
+		StatusHistory: []config.StatusChange{
+			{
+				Status:    destCategory,
+				Timestamp: now,
+				Path:      festivalDir,
+				Notes:     "Festival scaffolded from plan",
+			},
+		},
+	}
+	if err := config.SaveFestivalConfig(festivalDir, campaignRoot, cfg); err != nil {
+		return errors.Wrap(err, "writing fest.yaml").WithField("path", filepath.Join(festivalDir, config.FestivalConfigFileName))
+	}
+	return nil
 }
 
 func emitResult(opts *fromPlanOptions, result *sc.RunResult, festivalID string) error {

--- a/internal/commands/scaffold/from_plan_test.go
+++ b/internal/commands/scaffold/from_plan_test.go
@@ -1,0 +1,44 @@
+package scaffold
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/config"
+	sc "github.com/Obedience-Corp/fest/internal/scaffold"
+)
+
+func TestWriteScaffoldFestYaml_ProducesRunnableMarker(t *testing.T) {
+	campaignRoot := t.TempDir()
+	festivalsRoot := filepath.Join(campaignRoot, "festivals", "planning")
+	festivalDir := filepath.Join(festivalsRoot, "data-safety-DS0001")
+	if err := os.MkdirAll(festivalDir, 0o755); err != nil {
+		t.Fatalf("mkdir festival: %v", err)
+	}
+
+	plan := &sc.ParsedPlan{FestivalName: "data-safety", Goal: "fix the thing"}
+
+	if err := writeScaffoldFestYaml(festivalDir, campaignRoot, "DS0001", "planning", plan); err != nil {
+		t.Fatalf("writeScaffoldFestYaml: %v", err)
+	}
+
+	festYaml := filepath.Join(festivalDir, config.FestivalConfigFileName)
+	if _, err := os.Stat(festYaml); err != nil {
+		t.Fatalf("fest.yaml not written: %v", err)
+	}
+
+	cfg, err := config.LoadFestivalConfig(festivalDir, campaignRoot)
+	if err != nil {
+		t.Fatalf("LoadFestivalConfig: %v", err)
+	}
+	if cfg.Metadata.ID != "DS0001" {
+		t.Fatalf("metadata.ID = %q, want DS0001", cfg.Metadata.ID)
+	}
+	if cfg.Metadata.Name != "data-safety" {
+		t.Fatalf("metadata.Name = %q, want data-safety", cfg.Metadata.Name)
+	}
+	if len(cfg.Metadata.StatusHistory) == 0 || cfg.Metadata.StatusHistory[0].Status != "planning" {
+		t.Fatalf("status history missing the planning entry: %+v", cfg.Metadata.StatusHistory)
+	}
+}

--- a/internal/commands/scaffold/from_plan_test.go
+++ b/internal/commands/scaffold/from_plan_test.go
@@ -1,6 +1,10 @@
 package scaffold
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -19,7 +23,7 @@ func TestWriteScaffoldFestYaml_ProducesRunnableMarker(t *testing.T) {
 
 	plan := &sc.ParsedPlan{FestivalName: "data-safety", Goal: "fix the thing"}
 
-	if err := writeScaffoldFestYaml(festivalDir, campaignRoot, "DS0001", "planning", plan); err != nil {
+	if err := writeScaffoldFestYaml(context.Background(), festivalDir, campaignRoot, "DS0001", "planning", plan); err != nil {
 		t.Fatalf("writeScaffoldFestYaml: %v", err)
 	}
 
@@ -41,4 +45,124 @@ func TestWriteScaffoldFestYaml_ProducesRunnableMarker(t *testing.T) {
 	if len(cfg.Metadata.StatusHistory) == 0 || cfg.Metadata.StatusHistory[0].Status != "planning" {
 		t.Fatalf("status history missing the planning entry: %+v", cfg.Metadata.StatusHistory)
 	}
+}
+
+func TestWriteScaffoldFestYaml_SetsInitialSizeBytes(t *testing.T) {
+	campaignRoot := t.TempDir()
+	festivalsRoot := filepath.Join(campaignRoot, "festivals", "planning")
+	festivalDir := filepath.Join(festivalsRoot, "data-safety-DS0001")
+	if err := os.MkdirAll(festivalDir, 0o755); err != nil {
+		t.Fatalf("mkdir festival: %v", err)
+	}
+
+	goalContent := []byte("# Festival Goal\n\nSome scaffolded content.\n")
+	if err := os.WriteFile(filepath.Join(festivalDir, "FESTIVAL_GOAL.md"), goalContent, 0o644); err != nil {
+		t.Fatalf("writing scaffolded content: %v", err)
+	}
+
+	plan := &sc.ParsedPlan{FestivalName: "data-safety", Goal: "fix the thing"}
+
+	if err := writeScaffoldFestYaml(context.Background(), festivalDir, campaignRoot, "DS0001", "planning", plan); err != nil {
+		t.Fatalf("writeScaffoldFestYaml: %v", err)
+	}
+
+	cfg, err := config.LoadFestivalConfig(festivalDir, campaignRoot)
+	if err != nil {
+		t.Fatalf("LoadFestivalConfig: %v", err)
+	}
+	if cfg.Metadata.InitialSizeBytes != int64(len(goalContent)) {
+		t.Fatalf("InitialSizeBytes = %d, want %d", cfg.Metadata.InitialSizeBytes, len(goalContent))
+	}
+}
+
+func TestRunFromPlan_DryRun_ReportsFestYamlInFilesCreated(t *testing.T) {
+	campaignRoot := t.TempDir()
+	festivalsRoot := filepath.Join(campaignRoot, "festivals")
+	if err := os.MkdirAll(filepath.Join(festivalsRoot, ".festival"), 0o755); err != nil {
+		t.Fatalf("mkdir .festival marker: %v", err)
+	}
+
+	planPath := filepath.Join(campaignRoot, "STRUCTURE.md")
+	planContent := "# Festival Structure\n\n" +
+		"## Festival Goal\n" +
+		"Dry run coverage for fest.yaml preview.\n\n" +
+		"## Hierarchy\n\n" +
+		"- **Festival:** dry-run-check-DR0001\n" +
+		"  - **Phase 001:** IMPLEMENT (implementation)\n" +
+		"    - Sequence 01: only_sequence\n" +
+		"      - Task 01: only task\n"
+	if err := os.WriteFile(planPath, []byte(planContent), 0o644); err != nil {
+		t.Fatalf("writing plan file: %v", err)
+	}
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+	if err := os.Chdir(campaignRoot); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+
+	opts := &fromPlanOptions{
+		PlanPath:   planPath,
+		Name:       "dry-run-check",
+		Dest:       "planning",
+		DryRun:     true,
+		JSONOutput: true,
+	}
+
+	out := captureStdout(t, func() error {
+		return runFromPlan(context.Background(), opts)
+	})
+
+	var result fromPlanResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("unmarshalling result: %v\noutput: %s", err, out)
+	}
+	if !result.OK {
+		t.Fatalf("result not OK: %+v", result)
+	}
+
+	found := false
+	for _, f := range result.FilesCreated {
+		if filepath.Base(f) == config.FestivalConfigFileName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("FilesCreated missing %s: %+v", config.FestivalConfigFileName, result.FilesCreated)
+	}
+
+	if _, statErr := os.Stat(filepath.Join(result.FestivalDir, config.FestivalConfigFileName)); statErr == nil {
+		t.Fatalf("dry-run must not write fest.yaml, but it exists at %s", result.FestivalDir)
+	}
+}
+
+func captureStdout(t *testing.T, fn func() error) string {
+	t.Helper()
+	old := os.Stdout
+	t.Cleanup(func() { os.Stdout = old })
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+
+	runErr := fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing pipe writer: %v", err)
+	}
+	os.Stdout = old
+	if runErr != nil {
+		t.Fatalf("fn() returned error: %v", runErr)
+	}
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("copying pipe output: %v", err)
+	}
+	return buf.String()
 }


### PR DESCRIPTION
Implements the fest core-loop fixes from the Fable 2026-07-01 code review (FD0001 festival). All findings independently confirmed in the review's adversarial second pass.

## Findings closed

- **NEXT-01 (HIGH)** — `fest next` cwd shortcut bypassed earlier-phase gates. When cwd is inside a phase with a `position=before` WORKFLOW.md, `next.go` routed straight into that phase's workflow before the earlier-incomplete gate/after-workflow checks (which only ran on the selector fallback path). Running from inside a later phase could walk past an earlier phase's unsatisfied `GATES.md`. Fixed by hoisting the ordering check (new `routeEarlierIncompleteWork`) above the cwd shortcut so an earlier incomplete gate/workflow always routes first.
- **NEXT-02 / NEXT-03 (MEDIUM)** — the ordering checks failed open on a read error (`ewErr == nil &&` / `egErr == nil &&` silently skipped), and `FindFirstIncompletePhase`'s error was swallowed. Both now fail closed and propagate, matching the deliberately fail-closed remediation-gate path.
- **STATE-07 (HIGH)** — `fest scaffold from-plan` never wrote `fest.yaml`, so a scaffolded festival failed `fest next` in place with `festival root (no fest.yaml found) not found` (fest.yaml is the `ResolveFestivalPath` marker and the `EnforcePreActive` requirement). The scaffold command now writes `fest.yaml` via `config.SaveFestivalConfig` with festival metadata after the structure is generated.

## Tests

- `TestRouteEarlierIncompleteWork_HandlesEarlierGateFromLaterPhase` — an incomplete earlier gate routes before a later phase (would not route on the pre-hoist path).
- `TestRouteEarlierIncompleteWork_NotHandledWhenEarlierComplete` — no misfire when the earlier phase is complete.
- `TestRouteEarlierIncompleteWork_FailsClosedOnUnreadableFestival` — a read error returns handled+error (would return handled=false/nil under the old fail-open pattern).
- `TestWriteScaffoldFestYaml_ProducesRunnableMarker` — scaffold writes a loadable fest.yaml with correct metadata (fails without the fix, which wrote no fest.yaml).

## Gates (verbatim, branch head)

- `just lint all` → `0 issues.` exit 0
- `just lint vet` → exit 0
- `just test unit` → `ALL 2325 TESTS PASSED` exit 0