### PR TITLE
fix(show,promote,dungeon): non-zero JSON exit codes + depth-tolerant dungeon resolution (CON-01/02/03)

### DIFF
--- a/internal/commands/promote/promote.go
+++ b/internal/commands/promote/promote.go
@@ -175,10 +175,13 @@ func runPromote(ctx context.Context, opts *promoteOptions, selector string) erro
 	festival, fromPicker, err := resolveFestivalForPromote(ctx, festivalsDir, cwd, selector, !opts.json)
 	if err != nil {
 		if opts.json {
-			return shared.EncodeJSON(os.Stdout, map[string]any{
+			if encErr := shared.EncodeJSON(os.Stdout, map[string]any{
 				"success": false,
 				"error":   err.Error(),
-			})
+			}); encErr != nil {
+				return encErr
+			}
+			return errors.ErrAlreadyPrinted
 		}
 		return err
 	}
@@ -202,6 +205,17 @@ func promoteCore(ctx context.Context, festival *show.FestivalInfo, confirm bool,
 		// Dungeon override: resolve the dungeon status
 		resolved := id.ResolveStatusPath(opts.dungeon)
 		if !strings.HasPrefix(resolved, "dungeon/") {
+			if opts.json {
+				if encErr := shared.EncodeJSON(os.Stdout, map[string]any{
+					"success": false,
+					"error":   fmt.Sprintf("invalid dungeon status %q", opts.dungeon),
+					"value":   opts.dungeon,
+					"hint":    "valid values: completed, archived, someday",
+				}); encErr != nil {
+					return "", encErr
+				}
+				return "", errors.ErrAlreadyPrinted
+			}
 			return "", errors.Validation("invalid dungeon status").
 				WithField("value", opts.dungeon).
 				WithField("hint", "valid values: completed, archived, someday")

--- a/internal/commands/promote/promote.go
+++ b/internal/commands/promote/promote.go
@@ -213,11 +213,14 @@ func promoteCore(ctx context.Context, festival *show.FestivalInfo, confirm bool,
 		nextStatus, ok = validTransitions[currentStatus]
 		if !ok {
 			if opts.json {
-				return "", shared.EncodeJSON(os.Stdout, map[string]any{
+				if encErr := shared.EncodeJSON(os.Stdout, map[string]any{
 					"success": false,
 					"error":   fmt.Sprintf("cannot promote festival with status %q", currentStatus),
 					"status":  currentStatus,
-				})
+				}); encErr != nil {
+					return "", encErr
+				}
+				return "", errors.ErrAlreadyPrinted
 			}
 			return "", errors.Validation("cannot promote festival").
 				WithField("status", currentStatus).
@@ -228,13 +231,16 @@ func promoteCore(ctx context.Context, festival *show.FestivalInfo, confirm bool,
 		if !opts.force {
 			if err := validateReadiness(ctx, festival, currentStatus, nextStatus); err != nil {
 				if opts.json {
-					return "", shared.EncodeJSON(os.Stdout, map[string]any{
+					if encErr := shared.EncodeJSON(os.Stdout, map[string]any{
 						"success": false,
 						"error":   err.Error(),
 						"from":    currentStatus,
 						"to":      nextStatus,
 						"hint":    "use --force to skip validation",
-					})
+					}); encErr != nil {
+						return "", encErr
+					}
+					return "", errors.ErrAlreadyPrinted
 				}
 				fmt.Printf("%s %s\n", ui.Warning("Promotion blocked"), ui.Dim(err.Error()))
 				fmt.Printf("\n  %s\n", ui.Dim("Use --force to skip validation"))
@@ -247,12 +253,15 @@ func promoteCore(ctx context.Context, festival *show.FestivalInfo, confirm bool,
 	if nextStatus == "active" && !opts.force && opts.dungeon == "" {
 		if blocked, blockMsg := checkChainDependencies(ctx, festival); blocked {
 			if opts.json {
-				return "", shared.EncodeJSON(os.Stdout, map[string]any{
+				if encErr := shared.EncodeJSON(os.Stdout, map[string]any{
 					"success": false,
 					"error":   "chain dependencies not met",
 					"details": blockMsg,
 					"hint":    "use --force to skip chain dependency check",
-				})
+				}); encErr != nil {
+					return "", encErr
+				}
+				return "", errors.ErrAlreadyPrinted
 			}
 			fmt.Printf("%s %s\n", ui.Warning("Chain dependency gate:"), blockMsg)
 			fmt.Printf("\n  %s\n", ui.Dim("Use --force to skip chain dependency check"))

--- a/internal/commands/promote/promote_test.go
+++ b/internal/commands/promote/promote_test.go
@@ -1,6 +1,10 @@
 package promote
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -8,6 +12,7 @@ import (
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
 	"github.com/Obedience-Corp/fest/internal/commands/show"
+	ferrors "github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/id"
 )
 
@@ -445,4 +450,69 @@ func TestPromoteResolved_DeclinedDoesNotMove(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(festivalsDir, "planning", "alpha-feature-FE0001")); err != nil {
 		t.Fatalf("festival must remain in planning after decline: %v", err)
 	}
+}
+
+func capturePromoteStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+
+	done := make(chan struct{})
+	var buf bytes.Buffer
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(done)
+	}()
+
+	fnErr := fn()
+	_ = w.Close()
+	<-done
+	return buf.String(), fnErr
+}
+
+func assertJSONFailureBody(t *testing.T, out string) {
+	t.Helper()
+	var body map[string]any
+	if err := json.Unmarshal([]byte(out), &body); err != nil {
+		t.Fatalf("stdout must be parseable JSON, got %q (err: %v)", out, err)
+	}
+	if body["success"] != false {
+		t.Fatalf("JSON body should carry success=false, got %v", body["success"])
+	}
+	if body["error"] == nil || body["error"] == "" {
+		t.Fatalf("JSON body should carry a non-empty error, got %v", body["error"])
+	}
+}
+
+func TestRunPromote_ResolveFailureJSONExitsNonZeroWithBody(t *testing.T) {
+	root, _ := setupPromoteCampaign(t)
+	t.Chdir(root)
+
+	out, err := capturePromoteStdout(t, func() error {
+		return runPromote(t.Context(), &promoteOptions{json: true, noCommit: true}, "no-such-festival-FE9999")
+	})
+
+	if !errors.Is(err, ferrors.ErrAlreadyPrinted) {
+		t.Fatalf("resolve failure under --json must return ErrAlreadyPrinted (non-zero exit), got %v", err)
+	}
+	assertJSONFailureBody(t, out)
+}
+
+func TestPromoteCore_InvalidDungeonJSONExitsNonZeroWithBody(t *testing.T) {
+	festival := &show.FestivalInfo{Name: "alpha-feature", Status: "planning", Path: t.TempDir()}
+
+	out, err := capturePromoteStdout(t, func() error {
+		_, e := promoteCore(t.Context(), festival, false, &promoteOptions{dungeon: "bogus", json: true})
+		return e
+	})
+
+	if !errors.Is(err, ferrors.ErrAlreadyPrinted) {
+		t.Fatalf("invalid --dungeon under --json must return ErrAlreadyPrinted (non-zero exit), got %v", err)
+	}
+	assertJSONFailureBody(t, out)
 }

--- a/internal/commands/show/detect.go
+++ b/internal/commands/show/detect.go
@@ -93,7 +93,8 @@ func DetectCurrentFestival(ctx context.Context, startDir, campaignRoot string) (
 // directories, including festivals nested under organizational buckets.
 func findLinkedFestivalPath(festivalsRoot, name string) string {
 	for _, status := range id.StatusDirectories {
-		for _, entry := range festivalDirsUnderStatus(filepath.Join(festivalsRoot, status)) {
+		deep := strings.HasPrefix(status, "dungeon/")
+		for _, entry := range festivalDirsUnderStatus(filepath.Join(festivalsRoot, status), deep) {
 			if filepath.Base(entry.path) == name {
 				return entry.path
 			}
@@ -103,22 +104,35 @@ func findLinkedFestivalPath(festivalsRoot, name string) string {
 }
 
 // maxDungeonNestDepth bounds how deep festival resolution recurses under a
-// status directory when festivals are filed inside organizational subfolders
-// (date buckets like 2026-03-01, or free-form buckets like pre-2026-03-01).
+// dungeon status directory when festivals are filed inside organizational
+// subfolders (date buckets like 2026-03-01, or free-form buckets like
+// pre-2026-03-01).
 const maxDungeonNestDepth = 3
 
-// festivalDir is a resolved festival root plus the immediate bucket it was
-// nested under, if any.
+// maxWorkingStatusNestDepth bounds recursion under a working status
+// directory (active/ready/planning/ritual) to a single date-bucket level,
+// matching the shallow lookup those statuses have always used.
+const maxWorkingStatusNestDepth = 1
+
+// festivalDir is a resolved festival root plus the outermost organizational
+// bucket it was nested under below the status dir, if any.
 type festivalDir struct {
 	path   string
 	bucket string
 }
 
-// festivalDirsUnderStatus returns every festival root at or below statusDir,
-// recursing through non-festival subdirectories up to maxDungeonNestDepth so a
-// festival filed under any organizational bucket resolves, not only ones whose
-// bucket name matches a date pattern.
-func festivalDirsUnderStatus(statusDir string) []festivalDir {
+// festivalDirsUnderStatus returns every festival root at or below statusDir.
+// When deep is true (dungeon statuses), it recurses through any non-festival
+// subdirectory up to maxDungeonNestDepth so a festival filed under any
+// organizational bucket resolves. When deep is false (working statuses), it
+// only recurses one level into date-bucket-shaped subdirectories, preserving
+// the prior shallow lookup for active/ready/planning/ritual.
+func festivalDirsUnderStatus(statusDir string, deep bool) []festivalDir {
+	maxDepth := maxWorkingStatusNestDepth
+	if deep {
+		maxDepth = maxDungeonNestDepth
+	}
+
 	var out []festivalDir
 	var walk func(dir, bucket string, depth int)
 	walk = func(dir, bucket string, depth int) {
@@ -135,13 +149,17 @@ func festivalDirsUnderStatus(statusDir string) []festivalDir {
 				out = append(out, festivalDir{path: child, bucket: bucket})
 				continue
 			}
-			if depth < maxDungeonNestDepth {
-				nextBucket := bucket
-				if nextBucket == "" {
-					nextBucket = entry.Name()
-				}
-				walk(child, nextBucket, depth+1)
+			if depth >= maxDepth {
+				continue
 			}
+			if !deep && !LooksLikeDateDir(entry.Name()) {
+				continue
+			}
+			nextBucket := bucket
+			if nextBucket == "" {
+				nextBucket = entry.Name()
+			}
+			walk(child, nextBucket, depth+1)
 		}
 	}
 	walk(statusDir, "", 0)
@@ -176,19 +194,39 @@ func FindFestivalByName(ctx context.Context, festivalsDir, name, campaignRoot st
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	var loose *festivalDir
+	var looseStatus string
+
 	for _, status := range id.StatusDirectories {
-		for _, entry := range festivalDirsUnderStatus(filepath.Join(festivalsDir, status)) {
+		deep := strings.HasPrefix(status, "dungeon/")
+		for _, entry := range festivalDirsUnderStatus(filepath.Join(festivalsDir, status), deep) {
 			base := filepath.Base(entry.path)
-			if base != name && !strings.HasPrefix(base, name+"_") && !strings.Contains(base, name) {
-				continue
+			switch {
+			case base == name || strings.HasPrefix(base, name+"_"):
+				info, err := parseFestivalInfo(ctx, entry.path, campaignRoot)
+				if err != nil {
+					continue
+				}
+				info.Status = status
+				if entry.bucket != "" {
+					info.StatusDate = entry.bucket
+				}
+				return info, nil
+			case loose == nil && strings.Contains(base, name):
+				match := entry
+				loose = &match
+				looseStatus = status
 			}
-			info, err := parseFestivalInfo(ctx, entry.path, campaignRoot)
-			if err != nil {
-				continue
-			}
-			info.Status = status
-			if entry.bucket != "" {
-				info.StatusDate = entry.bucket
+		}
+	}
+
+	if loose != nil {
+		info, err := parseFestivalInfo(ctx, loose.path, campaignRoot)
+		if err == nil {
+			info.Status = looseStatus
+			if loose.bucket != "" {
+				info.StatusDate = loose.bucket
 			}
 			return info, nil
 		}
@@ -213,7 +251,7 @@ func ListFestivalsByStatus(ctx context.Context, festivalsDir, status, campaignRo
 	}
 
 	var festivals []*FestivalInfo
-	for _, entry := range festivalDirsUnderStatus(statusDir) {
+	for _, entry := range festivalDirsUnderStatus(statusDir, strings.HasPrefix(status, "dungeon/")) {
 		info, err := parseFestivalInfo(ctx, entry.path, campaignRoot)
 		if err != nil {
 			info = &FestivalInfo{
@@ -247,7 +285,7 @@ func ListFestivalsByStatusLight(_ context.Context, festivalsDir, status string) 
 	}
 
 	var festivals []*FestivalInfo
-	for _, entry := range festivalDirsUnderStatus(statusDir) {
+	for _, entry := range festivalDirsUnderStatus(statusDir, strings.HasPrefix(status, "dungeon/")) {
 		info := lightFestivalInfo(entry.path, filepath.Base(entry.path), status)
 		if entry.bucket != "" {
 			info.StatusDate = entry.bucket

--- a/internal/commands/show/detect.go
+++ b/internal/commands/show/detect.go
@@ -89,38 +89,63 @@ func DetectCurrentFestival(ctx context.Context, startDir, campaignRoot string) (
 	return nil, errors.NotFound("festival").WithHint(errors.HintFestivalNotFound)
 }
 
-// findLinkedFestivalPath searches for a festival by name in all status directories.
-// For dungeon statuses, also searches inside date subdirectories.
+// findLinkedFestivalPath searches for a festival by exact name in all status
+// directories, including festivals nested under organizational buckets.
 func findLinkedFestivalPath(festivalsRoot, name string) string {
 	for _, status := range id.StatusDirectories {
-		// Try direct path
-		festivalPath := filepath.Join(festivalsRoot, status, name)
-		if info, err := os.Stat(festivalPath); err == nil && info.IsDir() {
-			if isValidFestival(festivalPath) {
-				return festivalPath
-			}
-		}
-
-		// For dungeon statuses, search inside date subdirectories
-		if strings.HasPrefix(status, "dungeon/") {
-			statusDir := filepath.Join(festivalsRoot, status)
-			entries, err := os.ReadDir(statusDir)
-			if err != nil {
-				continue
-			}
-			for _, entry := range entries {
-				if entry.IsDir() && LooksLikeDateDir(entry.Name()) {
-					datePath := filepath.Join(statusDir, entry.Name(), name)
-					if info, err := os.Stat(datePath); err == nil && info.IsDir() {
-						if isValidFestival(datePath) {
-							return datePath
-						}
-					}
-				}
+		for _, entry := range festivalDirsUnderStatus(filepath.Join(festivalsRoot, status)) {
+			if filepath.Base(entry.path) == name {
+				return entry.path
 			}
 		}
 	}
 	return ""
+}
+
+// maxDungeonNestDepth bounds how deep festival resolution recurses under a
+// status directory when festivals are filed inside organizational subfolders
+// (date buckets like 2026-03-01, or free-form buckets like pre-2026-03-01).
+const maxDungeonNestDepth = 3
+
+// festivalDir is a resolved festival root plus the immediate bucket it was
+// nested under, if any.
+type festivalDir struct {
+	path   string
+	bucket string
+}
+
+// festivalDirsUnderStatus returns every festival root at or below statusDir,
+// recursing through non-festival subdirectories up to maxDungeonNestDepth so a
+// festival filed under any organizational bucket resolves, not only ones whose
+// bucket name matches a date pattern.
+func festivalDirsUnderStatus(statusDir string) []festivalDir {
+	var out []festivalDir
+	var walk func(dir, bucket string, depth int)
+	walk = func(dir, bucket string, depth int) {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			child := filepath.Join(dir, entry.Name())
+			if isValidFestival(child) {
+				out = append(out, festivalDir{path: child, bucket: bucket})
+				continue
+			}
+			if depth < maxDungeonNestDepth {
+				nextBucket := bucket
+				if nextBucket == "" {
+					nextBucket = entry.Name()
+				}
+				walk(child, nextBucket, depth+1)
+			}
+		}
+	}
+	walk(statusDir, "", 0)
+	return out
 }
 
 // isValidFestival checks if a directory is a valid festival root.
@@ -152,55 +177,20 @@ func FindFestivalByName(ctx context.Context, festivalsDir, name, campaignRoot st
 		ctx = context.Background()
 	}
 	for _, status := range id.StatusDirectories {
-		statusDir := filepath.Join(festivalsDir, status)
-		entries, err := os.ReadDir(statusDir)
-		if err != nil {
-			continue // Skip inaccessible directories
-		}
-
-		for _, entry := range entries {
-			if !entry.IsDir() {
+		for _, entry := range festivalDirsUnderStatus(filepath.Join(festivalsDir, status)) {
+			base := filepath.Base(entry.path)
+			if base != name && !strings.HasPrefix(base, name+"_") && !strings.Contains(base, name) {
 				continue
 			}
-
-			// Check exact match or prefix match
-			if entry.Name() == name || strings.HasPrefix(entry.Name(), name+"_") || strings.Contains(entry.Name(), name) {
-				festivalDir := filepath.Join(statusDir, entry.Name())
-				if isValidFestival(festivalDir) {
-					info, err := parseFestivalInfo(ctx, festivalDir, campaignRoot)
-					if err != nil {
-						continue
-					}
-					info.Status = status
-					return info, nil
-				}
+			info, err := parseFestivalInfo(ctx, entry.path, campaignRoot)
+			if err != nil {
+				continue
 			}
-
-			// If this is a date directory, search inside it
-			if LooksLikeDateDir(entry.Name()) {
-				bucket := entry.Name()
-				subEntries, subErr := os.ReadDir(filepath.Join(statusDir, bucket))
-				if subErr != nil {
-					continue
-				}
-				for _, sub := range subEntries {
-					if !sub.IsDir() {
-						continue
-					}
-					if sub.Name() == name || strings.HasPrefix(sub.Name(), name+"_") || strings.Contains(sub.Name(), name) {
-						festivalDir := filepath.Join(statusDir, bucket, sub.Name())
-						if isValidFestival(festivalDir) {
-							info, err := parseFestivalInfo(ctx, festivalDir, campaignRoot)
-							if err != nil {
-								continue
-							}
-							info.Status = status
-							info.StatusDate = bucket
-							return info, nil
-						}
-					}
-				}
+			info.Status = status
+			if entry.bucket != "" {
+				info.StatusDate = entry.bucket
 			}
+			return info, nil
 		}
 	}
 
@@ -215,8 +205,7 @@ func ListFestivalsByStatus(ctx context.Context, festivalsDir, status, campaignRo
 		ctx = context.Background()
 	}
 	statusDir := filepath.Join(festivalsDir, status)
-	entries, err := os.ReadDir(statusDir)
-	if err != nil {
+	if _, err := os.ReadDir(statusDir); err != nil {
 		if os.IsNotExist(err) {
 			return []*FestivalInfo{}, nil
 		}
@@ -224,53 +213,21 @@ func ListFestivalsByStatus(ctx context.Context, festivalsDir, status, campaignRo
 	}
 
 	var festivals []*FestivalInfo
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-
-		festivalDir := filepath.Join(statusDir, entry.Name())
-		if isValidFestival(festivalDir) {
-			info, err := parseFestivalInfo(ctx, festivalDir, campaignRoot)
-			if err != nil {
-				info = &FestivalInfo{
-					ID:     entry.Name(),
-					Name:   entry.Name(),
-					Status: status,
-					Path:   festivalDir,
-				}
-			}
-			info.Status = status
-			festivals = append(festivals, info)
-		} else if LooksLikeDateDir(entry.Name()) {
-			// Recurse into date subdirectory
-			bucket := entry.Name()
-			subEntries, subErr := os.ReadDir(festivalDir)
-			if subErr != nil {
-				continue
-			}
-			for _, sub := range subEntries {
-				if !sub.IsDir() {
-					continue
-				}
-				subDir := filepath.Join(festivalDir, sub.Name())
-				if !isValidFestival(subDir) {
-					continue
-				}
-				info, err := parseFestivalInfo(ctx, subDir, campaignRoot)
-				if err != nil {
-					info = &FestivalInfo{
-						ID:     sub.Name(),
-						Name:   sub.Name(),
-						Status: status,
-						Path:   subDir,
-					}
-				}
-				info.Status = status
-				info.StatusDate = bucket
-				festivals = append(festivals, info)
+	for _, entry := range festivalDirsUnderStatus(statusDir) {
+		info, err := parseFestivalInfo(ctx, entry.path, campaignRoot)
+		if err != nil {
+			info = &FestivalInfo{
+				ID:     filepath.Base(entry.path),
+				Name:   filepath.Base(entry.path),
+				Status: status,
+				Path:   entry.path,
 			}
 		}
+		info.Status = status
+		if entry.bucket != "" {
+			info.StatusDate = entry.bucket
+		}
+		festivals = append(festivals, info)
 	}
 
 	return festivals, nil
@@ -282,8 +239,7 @@ func ListFestivalsByStatus(ctx context.Context, festivalsDir, status, campaignRo
 // For dungeon statuses, also recurses into date subdirectories.
 func ListFestivalsByStatusLight(_ context.Context, festivalsDir, status string) ([]*FestivalInfo, error) {
 	statusDir := filepath.Join(festivalsDir, status)
-	entries, err := os.ReadDir(statusDir)
-	if err != nil {
+	if _, err := os.ReadDir(statusDir); err != nil {
 		if os.IsNotExist(err) {
 			return []*FestivalInfo{}, nil
 		}
@@ -291,35 +247,12 @@ func ListFestivalsByStatusLight(_ context.Context, festivalsDir, status string) 
 	}
 
 	var festivals []*FestivalInfo
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
+	for _, entry := range festivalDirsUnderStatus(statusDir) {
+		info := lightFestivalInfo(entry.path, filepath.Base(entry.path), status)
+		if entry.bucket != "" {
+			info.StatusDate = entry.bucket
 		}
-
-		festivalDir := filepath.Join(statusDir, entry.Name())
-		if isValidFestival(festivalDir) {
-			info := lightFestivalInfo(festivalDir, entry.Name(), status)
-			festivals = append(festivals, info)
-		} else if LooksLikeDateDir(entry.Name()) {
-			// Recurse into date subdirectory
-			bucket := entry.Name()
-			subEntries, subErr := os.ReadDir(festivalDir)
-			if subErr != nil {
-				continue
-			}
-			for _, sub := range subEntries {
-				if !sub.IsDir() {
-					continue
-				}
-				subDir := filepath.Join(festivalDir, sub.Name())
-				if !isValidFestival(subDir) {
-					continue
-				}
-				info := lightFestivalInfo(subDir, sub.Name(), status)
-				info.StatusDate = bucket
-				festivals = append(festivals, info)
-			}
-		}
+		festivals = append(festivals, info)
 	}
 
 	return festivals, nil

--- a/internal/commands/show/show.go
+++ b/internal/commands/show/show.go
@@ -403,7 +403,7 @@ func emitShowErrorJSON(message string) error {
 	if err := shared.EncodeJSON(os.Stdout, result); err != nil {
 		return errors.Wrap(err, "encoding JSON output")
 	}
-	return nil
+	return errors.ErrAlreadyPrinted
 }
 
 type festivalShowJSON struct {

--- a/internal/commands/show/show_detect_test.go
+++ b/internal/commands/show/show_detect_test.go
@@ -363,6 +363,72 @@ func TestParseFestivalInfo_DateDirectoryStatus(t *testing.T) {
 	}
 }
 
+func TestListFestivalsByStatus_ActiveWrapperDirNotSurfaced(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	festivalsDir := filepath.Join(tmpDir, "festivals")
+	activeDir := filepath.Join(festivalsDir, "active")
+	wrappedFestival := filepath.Join(activeDir, "backup", "old-fest")
+
+	if err := os.MkdirAll(wrappedFestival, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wrappedFestival, FestivalGoalFile), []byte("# Test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	directFestival := filepath.Join(activeDir, "direct-fest")
+	if err := os.MkdirAll(directFestival, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(directFestival, FestivalGoalFile), []byte("# Test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	festivals, err := ListFestivalsByStatus(context.Background(), festivalsDir, "active", "")
+	if err != nil {
+		t.Fatalf("ListFestivalsByStatus() error = %v", err)
+	}
+
+	if len(festivals) != 1 {
+		t.Fatalf("ListFestivalsByStatus() returned %d festivals, want 1: %+v", len(festivals), festivals)
+	}
+	if festivals[0].Name != "direct-fest" {
+		t.Errorf("ListFestivalsByStatus() surfaced %q, want %q", festivals[0].Name, "direct-fest")
+	}
+}
+
+func TestFindFestivalByName_ExactMatchPreferredOverSubstring(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	festivalsDir := filepath.Join(tmpDir, "festivals")
+	activeDir := filepath.Join(festivalsDir, "active")
+
+	exactFestival := filepath.Join(activeDir, "FA0001")
+	if err := os.MkdirAll(exactFestival, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(exactFestival, FestivalGoalFile), []byte("# Test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	substringFestival := filepath.Join(activeDir, "FA00010")
+	if err := os.MkdirAll(substringFestival, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(substringFestival, FestivalGoalFile), []byte("# Test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := FindFestivalByName(context.Background(), festivalsDir, "FA0001", "")
+	if err != nil {
+		t.Fatalf("FindFestivalByName() error = %v", err)
+	}
+	if info.Name != "FA0001" {
+		t.Errorf("FindFestivalByName(%q) = %q, want %q", "FA0001", info.Name, "FA0001")
+	}
+}
+
 // TestParseFestivalInfo_LegacyFestivalNoMetadata tests legacy festivals without metadata
 func TestParseFestivalInfo_LegacyFestivalNoMetadata(t *testing.T) {
 	tmpDir := t.TempDir()

--- a/internal/commands/show/show_dungeon_nesting_test.go
+++ b/internal/commands/show/show_dungeon_nesting_test.go
@@ -1,0 +1,68 @@
+package show
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+)
+
+func writeFestival(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, FestivalGoalFile), []byte("# Test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFindFestivalByName_ResolvesNonDateDungeonBucket(t *testing.T) {
+	festivals := t.TempDir()
+	name := "obey-search-shared-module-OS0001"
+	writeFestival(t, filepath.Join(festivals, "dungeon/someday/pre-2026-03-01", name))
+
+	info, err := FindFestivalByName(context.Background(), festivals, name, "")
+	if err != nil {
+		t.Fatalf("expected festival to resolve under pre-2026-03-01 bucket, got: %v", err)
+	}
+	if info.Status != "dungeon/someday" {
+		t.Fatalf("status = %q, want dungeon/someday", info.Status)
+	}
+	if info.StatusDate != "pre-2026-03-01" {
+		t.Fatalf("bucket = %q, want pre-2026-03-01", info.StatusDate)
+	}
+}
+
+func TestListFestivalsByStatus_IncludesNonDateDungeonBucket(t *testing.T) {
+	festivals := t.TempDir()
+	name := "nested-beta-NB0001"
+	writeFestival(t, filepath.Join(festivals, "dungeon/someday/pre-2026-03-01", name))
+
+	got, err := ListFestivalsByStatus(context.Background(), festivals, "dungeon/someday", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, f := range got {
+		if f.Name == name {
+			found = true
+			if f.StatusDate != "pre-2026-03-01" {
+				t.Fatalf("bucket = %q, want pre-2026-03-01", f.StatusDate)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("festival %q not listed under dungeon/someday", name)
+	}
+}
+
+func TestEmitShowErrorJSON_ReturnsAlreadyPrintedSentinel(t *testing.T) {
+	err := emitShowErrorJSON("festival not found")
+	if !errors.Is(err, festerrors.ErrAlreadyPrinted) {
+		t.Fatalf("emitShowErrorJSON returned %v, want ErrAlreadyPrinted so the process exits non-zero", err)
+	}
+}


### PR DESCRIPTION
Implements three findings from the Fable 2026-07-01 code review (fest area), all adversarially confirmed in `second-pass-fable.md`.

## CON-01 (HIGH) — depth-tolerant dungeon resolution
Festival resolution recursed exactly one level into dungeon buckets whose name matched `^\d{4}-\d{2}(-\d{2})?$`, so a festival under `festivals/dungeon/someday/pre-2026-03-01/` was unresolvable (`pre-` fails the pattern, recursion skipped). This is the fest-side cause of fest-gif's silent empty GIF and of `fest show --festival <nested> --json` returning `not found`.

Fix: collapse `detect.go`'s four date-gated recursions into one bounded-depth walker (`festivalDirsUnderStatus`) that descends any organizational subfolder up to a depth cap, then resolves the festival marker. Covers `FindFestivalByName` (the `fest show --festival` path), `findLinkedFestivalPath` (linked detection), `ListFestivalsByStatus`, and `ListFestivalsByStatusLight` (`fest show all`).

## CON-02 / CON-03 (HIGH) — non-zero exit on JSON error
`fest show --json` and `fest promote --json` emitted an error body but returned `nil`, so the process exited 0 on error and any exit-code-checking consumer saw false success. Both now return the existing `ErrAlreadyPrinted` sentinel, so the process exits 1 while still printing the JSON body (and `main.go` skips the stderr double-print).

## Scope note (explicit tradeoff)
Three other date-pattern sites (`status/helpers.go`, `shared/festival_selector.go`, `navigation/completions.go`) retain date-bucket assumptions and are a documented follow-up. `detect.go` is the path behind the reported bug; `status/helpers.go` in particular feeds the data-mutating status-move path being changed concurrently in the FD0001 data-safety work, so it is left untouched here to avoid conflict.

## Tests / gates
New regression tests: nested `pre-2026-03-01` festival resolves via `FindFestivalByName` and lists via `ListFestivalsByStatus`; `emitShowErrorJSON` returns the exit-1 sentinel. Gates at branch head: `just lint all` 0 issues, `just lint vet` clean, `just test unit` ALL 2324 TESTS PASSED.