### PR TITLE
fix(create): append tasks at end by default; report renumbering; tolerate missing pre-move paths in promote auto-commit

### DIFF
--- a/internal/commands/festival/create_task.go
+++ b/internal/commands/festival/create_task.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
@@ -136,15 +137,16 @@ Run 'fest validate tasks' to verify task files exist in implementation sequences
 
 // resolveTaskInsertAfter maps the --after default (-1) to append-at-end by
 // detecting the highest existing task number in the sequence directory,
-// matching create sequence's behavior.
-func resolveTaskInsertAfter(ctx context.Context, sequenceDir string, after int) int {
+// matching create sequence's behavior. A parse failure is an error, not a
+// silent prepend into a possibly non-empty sequence.
+func resolveTaskInsertAfter(ctx context.Context, sequenceDir string, after int) (int, error) {
 	if after != -1 {
-		return after
+		return after, nil
 	}
 	parser := festival.NewParser()
 	tasks, err := parser.ParseTasks(ctx, sequenceDir)
-	if err != nil || len(tasks) == 0 {
-		return 0
+	if err != nil {
+		return 0, errors.Wrap(err, "detecting last task number").WithField("dir", sequenceDir)
 	}
 	maxNum := 0
 	for _, t := range tasks {
@@ -152,7 +154,34 @@ func resolveTaskInsertAfter(ctx context.Context, sequenceDir string, after int) 
 			maxNum = t.Number
 		}
 	}
-	return maxNum
+	return maxNum, nil
+}
+
+// netRenames collapses per-step rename chains from batch inserts (a->b in
+// one step, b->c in a later step) into net a->c entries, sorted by the
+// original name for stable, readable output.
+func netRenames(steps [][2]string) []string {
+	finalOf := map[string]string{}
+	originOf := map[string]string{}
+	var order []string
+	for _, s := range steps {
+		oldName, newName := s[0], s[1]
+		if origin, ok := originOf[oldName]; ok {
+			delete(originOf, oldName)
+			originOf[newName] = origin
+			finalOf[origin] = newName
+			continue
+		}
+		originOf[newName] = oldName
+		finalOf[oldName] = newName
+		order = append(order, oldName)
+	}
+	sort.Strings(order)
+	out := make([]string, 0, len(order))
+	for _, o := range order {
+		out = append(out, fmt.Sprintf("%s -> %s", o, finalOf[o]))
+	}
+	return out
 }
 
 // RunCreateTask executes the create task command logic.
@@ -206,12 +235,16 @@ func RunCreateTask(ctx context.Context, opts *CreateTaskOptions) error {
 	mgr := tpl.NewManager()
 	loader := tpl.NewLoader()
 
-	opts.After = resolveTaskInsertAfter(ctx, absPath, opts.After)
+	after, afterErr := resolveTaskInsertAfter(ctx, absPath, opts.After)
+	if afterErr != nil {
+		return emitCreateTaskError(opts, afterErr)
+	}
+	opts.After = after
 
 	// Track all created tasks for output
 	var createdTasks []map[string]any
 	var createdPaths []string
-	var renumbered []string
+	var renameSteps [][2]string
 	var totalMarkersFilled, totalMarkersCount int
 	currentAfter := opts.After
 
@@ -229,8 +262,8 @@ func RunCreateTask(ctx context.Context, opts *CreateTaskOptions) error {
 		}
 		for _, ch := range ren.Changes() {
 			if ch.Type == festival.ChangeRename {
-				renumbered = append(renumbered,
-					fmt.Sprintf("%s -> %s", filepath.Base(ch.OldPath), filepath.Base(ch.NewPath)))
+				renameSteps = append(renameSteps,
+					[2]string{filepath.Base(ch.OldPath), filepath.Base(ch.NewPath)})
 			}
 		}
 
@@ -380,6 +413,7 @@ func RunCreateTask(ctx context.Context, opts *CreateTaskOptions) error {
 	}
 
 	// Output results
+	renumbered := netRenames(renameSteps)
 	remainingMarkers := totalMarkersCount - totalMarkersFilled
 
 	if opts.JSONOutput {

--- a/internal/commands/festival/create_task.go
+++ b/internal/commands/festival/create_task.go
@@ -76,16 +76,19 @@ TEMPLATE VARIABLES (automatically set from --name):
   {{ full_path }}            Complete path from festival root
 
 EXAMPLES:
-  # Create single task in current sequence
+  # Create single task in current sequence (appends at the end)
   fest create task --name "design endpoints" --json
 
-  # Create multiple tasks at once (sequential numbering)
+  # Create multiple tasks at once (sequential numbering, appended at end)
   fest create task --name "requirements" --name "design" --name "implement"
   # Creates: 01_requirements.md, 02_design.md, 03_implement.md
 
-  # Create tasks starting after position 2
+  # Insert tasks after position 2 (existing tasks renumber down, reported)
   fest create task --after 2 --name "new step" --name "another step"
   # Creates: 03_new_step.md, 04_another_step.md
+
+  # Insert at the beginning
+  fest create task --after 0 --name "prerequisite"
 
   # Create task in specific sequence
   fest create task --name "setup" --path ./002_IMPLEMENT/01_api --json
@@ -118,7 +121,7 @@ Run 'fest validate tasks' to verify task files exist in implementation sequences
 			return RunCreateTask(cmd.Context(), opts)
 		},
 	}
-	cmd.Flags().IntVar(&opts.After, "after", 0, "Insert after this number (0 inserts at beginning)")
+	cmd.Flags().IntVar(&opts.After, "after", -1, "Insert after this task number (-1 or omit to append at end; 0 inserts at beginning)")
 	cmd.Flags().StringSliceVar(&opts.Names, "name", nil, "Task name(s) - can be specified multiple times for batch creation")
 	cmd.Flags().StringVar(&opts.Path, "path", ".", "Path to sequence directory (directory containing numbered task files)")
 	cmd.Flags().StringVar(&opts.VarsFile, "vars-file", "", "JSON vars for rendering")
@@ -129,6 +132,27 @@ Run 'fest validate tasks' to verify task files exist in implementation sequences
 	cmd.Flags().BoolVar(&opts.JSONOutput, "json", false, "Emit JSON output")
 	cmd.Flags().BoolVar(&opts.AgentMode, "agent", false, "Strict mode: require markers, auto-validate, block on errors, JSON output")
 	return cmd
+}
+
+// resolveTaskInsertAfter maps the --after default (-1) to append-at-end by
+// detecting the highest existing task number in the sequence directory,
+// matching create sequence's behavior.
+func resolveTaskInsertAfter(ctx context.Context, sequenceDir string, after int) int {
+	if after != -1 {
+		return after
+	}
+	parser := festival.NewParser()
+	tasks, err := parser.ParseTasks(ctx, sequenceDir)
+	if err != nil || len(tasks) == 0 {
+		return 0
+	}
+	maxNum := 0
+	for _, t := range tasks {
+		if t.Number > maxNum {
+			maxNum = t.Number
+		}
+	}
+	return maxNum
 }
 
 // RunCreateTask executes the create task command logic.
@@ -182,9 +206,12 @@ func RunCreateTask(ctx context.Context, opts *CreateTaskOptions) error {
 	mgr := tpl.NewManager()
 	loader := tpl.NewLoader()
 
+	opts.After = resolveTaskInsertAfter(ctx, absPath, opts.After)
+
 	// Track all created tasks for output
 	var createdTasks []map[string]any
 	var createdPaths []string
+	var renumbered []string
 	var totalMarkersFilled, totalMarkersCount int
 	currentAfter := opts.After
 
@@ -199,6 +226,12 @@ func RunCreateTask(ctx context.Context, opts *CreateTaskOptions) error {
 		ren := festival.NewRenumberer(festival.RenumberOptions{AutoApprove: true, Quiet: true})
 		if err := ren.InsertTask(ctx, absPath, currentAfter, name); err != nil {
 			return emitCreateTaskError(opts, errors.Wrap(err, "inserting task").WithField("name", name))
+		}
+		for _, ch := range ren.Changes() {
+			if ch.Type == festival.ChangeRename {
+				renumbered = append(renumbered,
+					fmt.Sprintf("%s -> %s", filepath.Base(ch.OldPath), filepath.Base(ch.NewPath)))
+			}
 		}
 
 		// Compute new task id
@@ -372,7 +405,7 @@ func RunCreateTask(ctx context.Context, opts *CreateTaskOptions) error {
 			OK:              true,
 			Action:          "create_task",
 			Created:         createdPaths,
-			Renumber:        []string{},
+			Renumber:        renumbered,
 			MarkersFilled:   totalMarkersFilled,
 			MarkersTotal:    totalMarkersCount,
 			MarkersUnfilled: remainingMarkers,
@@ -410,6 +443,12 @@ func RunCreateTask(ctx context.Context, opts *CreateTaskOptions) error {
 		display.Success("Created %d tasks:", len(createdTasks))
 		for _, task := range createdTasks {
 			display.Info("  └── %s", task["id"])
+		}
+	}
+	if len(renumbered) > 0 {
+		display.Warning("Renumbered %d existing task(s):", len(renumbered))
+		for _, r := range renumbered {
+			display.Info("  └── %s", r)
 		}
 	}
 

--- a/internal/commands/festival/create_task_append_test.go
+++ b/internal/commands/festival/create_task_append_test.go
@@ -1,0 +1,108 @@
+package festival
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/festival"
+)
+
+func writeTaskFile(t *testing.T, dir string, number int, name string) {
+	t.Helper()
+	path := filepath.Join(dir, fmt.Sprintf("%02d_%s.md", number, name))
+	if err := os.WriteFile(path, []byte("# Task: "+name+"\n"), 0644); err != nil {
+		t.Fatalf("writing task file %s: %v", path, err)
+	}
+}
+
+func seedTasks(t *testing.T, dir string, names ...string) {
+	t.Helper()
+	ren := festival.NewRenumberer(festival.RenumberOptions{AutoApprove: true, Quiet: true})
+	after := 0
+	for _, name := range names {
+		if err := ren.InsertTask(context.Background(), dir, after, name); err != nil {
+			t.Fatalf("seeding task %s: %v", name, err)
+		}
+		writeTaskFile(t, dir, after+1, name)
+		after++
+	}
+}
+
+func TestResolveTaskInsertAfter_AppendsAtEnd(t *testing.T) {
+	dir := t.TempDir()
+	seedTasks(t, dir, "first", "second", "third")
+
+	got := resolveTaskInsertAfter(context.Background(), dir, -1)
+	if got != 3 {
+		t.Fatalf("resolveTaskInsertAfter(-1) = %d, want 3 (append after last)", got)
+	}
+}
+
+func TestResolveTaskInsertAfter_EmptyDirInsertsAtBeginning(t *testing.T) {
+	dir := t.TempDir()
+	if got := resolveTaskInsertAfter(context.Background(), dir, -1); got != 0 {
+		t.Fatalf("resolveTaskInsertAfter(-1) on empty dir = %d, want 0", got)
+	}
+}
+
+func TestResolveTaskInsertAfter_ExplicitValuesPassThrough(t *testing.T) {
+	dir := t.TempDir()
+	seedTasks(t, dir, "first", "second")
+
+	for _, after := range []int{0, 1, 2, 7} {
+		if got := resolveTaskInsertAfter(context.Background(), dir, after); got != after {
+			t.Fatalf("resolveTaskInsertAfter(%d) = %d, want passthrough", after, got)
+		}
+	}
+}
+
+func TestCreateTask_DictationOrderYieldsSequentialNumbers(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+	ren := festival.NewRenumberer(festival.RenumberOptions{AutoApprove: true, Quiet: true})
+
+	for _, name := range []string{"alpha", "beta", "gamma"} {
+		after := resolveTaskInsertAfter(ctx, dir, -1)
+		if err := ren.InsertTask(ctx, dir, after, name); err != nil {
+			t.Fatalf("InsertTask %s: %v", name, err)
+		}
+		writeTaskFile(t, dir, after+1, name)
+	}
+
+	for _, want := range []string{"01_alpha.md", "02_beta.md", "03_gamma.md"} {
+		if _, err := os.Stat(filepath.Join(dir, want)); err != nil {
+			t.Errorf("expected %s to exist: %v", want, err)
+		}
+	}
+}
+
+func TestRenumberer_ChangesReportsRenames(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+	seedTasks(t, dir, "first", "second")
+
+	ren := festival.NewRenumberer(festival.RenumberOptions{AutoApprove: true, Quiet: true})
+	if err := ren.InsertTask(ctx, dir, 0, "zeroth"); err != nil {
+		t.Fatalf("InsertTask: %v", err)
+	}
+	writeTaskFile(t, dir, 1, "zeroth")
+
+	renames := 0
+	for _, ch := range ren.Changes() {
+		if ch.Type == festival.ChangeRename {
+			renames++
+		}
+	}
+	if renames != 2 {
+		t.Fatalf("Changes() reported %d renames, want 2", renames)
+	}
+
+	for _, want := range []string{"01_zeroth.md", "02_first.md", "03_second.md"} {
+		if _, err := os.Stat(filepath.Join(dir, want)); err != nil {
+			t.Errorf("expected %s to exist: %v", want, err)
+		}
+	}
+}

--- a/internal/commands/festival/create_task_append_test.go
+++ b/internal/commands/festival/create_task_append_test.go
@@ -35,7 +35,10 @@ func TestResolveTaskInsertAfter_AppendsAtEnd(t *testing.T) {
 	dir := t.TempDir()
 	seedTasks(t, dir, "first", "second", "third")
 
-	got := resolveTaskInsertAfter(context.Background(), dir, -1)
+	got, err := resolveTaskInsertAfter(context.Background(), dir, -1)
+	if err != nil {
+		t.Fatalf("resolveTaskInsertAfter: %v", err)
+	}
 	if got != 3 {
 		t.Fatalf("resolveTaskInsertAfter(-1) = %d, want 3 (append after last)", got)
 	}
@@ -43,8 +46,19 @@ func TestResolveTaskInsertAfter_AppendsAtEnd(t *testing.T) {
 
 func TestResolveTaskInsertAfter_EmptyDirInsertsAtBeginning(t *testing.T) {
 	dir := t.TempDir()
-	if got := resolveTaskInsertAfter(context.Background(), dir, -1); got != 0 {
+	got, err := resolveTaskInsertAfter(context.Background(), dir, -1)
+	if err != nil {
+		t.Fatalf("resolveTaskInsertAfter: %v", err)
+	}
+	if got != 0 {
 		t.Fatalf("resolveTaskInsertAfter(-1) on empty dir = %d, want 0", got)
+	}
+}
+
+func TestResolveTaskInsertAfter_ParseFailureIsAnError(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	if _, err := resolveTaskInsertAfter(context.Background(), missing, -1); err == nil {
+		t.Fatal("expected an error for an unreadable sequence dir, got prepend fallback")
 	}
 }
 
@@ -53,8 +67,72 @@ func TestResolveTaskInsertAfter_ExplicitValuesPassThrough(t *testing.T) {
 	seedTasks(t, dir, "first", "second")
 
 	for _, after := range []int{0, 1, 2, 7} {
-		if got := resolveTaskInsertAfter(context.Background(), dir, after); got != after {
+		got, err := resolveTaskInsertAfter(context.Background(), dir, after)
+		if err != nil {
+			t.Fatalf("resolveTaskInsertAfter(%d): %v", after, err)
+		}
+		if got != after {
 			t.Fatalf("resolveTaskInsertAfter(%d) = %d, want passthrough", after, got)
+		}
+	}
+}
+
+func TestNetRenames_CollapsesChains(t *testing.T) {
+	tests := []struct {
+		name  string
+		steps [][2]string
+		want  []string
+	}{
+		{"empty", nil, nil},
+		{"single", [][2]string{{"01_a.md", "02_a.md"}}, []string{"01_a.md -> 02_a.md"}},
+		{"chain collapses", [][2]string{{"01_a.md", "02_a.md"}, {"02_a.md", "03_a.md"}}, []string{"01_a.md -> 03_a.md"}},
+		{"independent sorted by origin", [][2]string{{"02_b.md", "03_b.md"}, {"01_a.md", "02_a.md"}}, []string{"01_a.md -> 02_a.md", "02_b.md -> 03_b.md"}},
+		{"batch shape", [][2]string{{"01_x.md", "02_x.md"}, {"02_x.md", "03_x.md"}, {"03_y.md", "04_y.md"}}, []string{"01_x.md -> 03_x.md", "03_y.md -> 04_y.md"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := netRenames(tt.steps)
+			if len(got) != len(tt.want) {
+				t.Fatalf("netRenames = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("netRenames = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestCreateTask_BatchInsertReportsNetRenames(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+	seedTasks(t, dir, "first", "second")
+
+	var steps [][2]string
+	after := 0
+	for _, name := range []string{"new_a", "new_b"} {
+		ren := festival.NewRenumberer(festival.RenumberOptions{AutoApprove: true, Quiet: true})
+		if err := ren.InsertTask(ctx, dir, after, name); err != nil {
+			t.Fatalf("InsertTask %s: %v", name, err)
+		}
+		writeTaskFile(t, dir, after+1, name)
+		for _, ch := range ren.Changes() {
+			if ch.Type == festival.ChangeRename {
+				steps = append(steps, [2]string{filepath.Base(ch.OldPath), filepath.Base(ch.NewPath)})
+			}
+		}
+		after++
+	}
+
+	got := netRenames(steps)
+	want := []string{"01_first.md -> 03_first.md", "02_second.md -> 04_second.md"}
+	if len(got) != len(want) {
+		t.Fatalf("net renames = %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("net renames = %v, want %v", got, want)
 		}
 	}
 }
@@ -65,7 +143,10 @@ func TestCreateTask_DictationOrderYieldsSequentialNumbers(t *testing.T) {
 	ren := festival.NewRenumberer(festival.RenumberOptions{AutoApprove: true, Quiet: true})
 
 	for _, name := range []string{"alpha", "beta", "gamma"} {
-		after := resolveTaskInsertAfter(ctx, dir, -1)
+		after, err := resolveTaskInsertAfter(ctx, dir, -1)
+		if err != nil {
+			t.Fatalf("resolveTaskInsertAfter: %v", err)
+		}
 		if err := ren.InsertTask(ctx, dir, after, name); err != nil {
 			t.Fatalf("InsertTask %s: %v", name, err)
 		}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	chaincmd "github.com/Obedience-Corp/fest/internal/commands/chain"
 	commitcmd "github.com/Obedience-Corp/fest/internal/commands/commit"
@@ -44,6 +45,7 @@ import (
 	watchcmd "github.com/Obedience-Corp/fest/internal/commands/watch"
 	"github.com/Obedience-Corp/fest/internal/commands/wizard"
 	workflowcmd "github.com/Obedience-Corp/fest/internal/commands/workflow"
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
 	"github.com/Obedience-Corp/fest/internal/version"
@@ -184,6 +186,7 @@ func init() {
 	createCmd.AddCommand(festival.NewCreateSequenceCommand())
 	createCmd.AddCommand(festival.NewCreateTaskCommand())
 	createCmd.AddCommand(festival.NewCreateWorkflowCommand())
+	setCreateScopeFlagHints(createCmd)
 	rootCmd.AddCommand(createCmd)
 
 	scaffoldCmd := scaffoldcmd.NewScaffoldCommand()
@@ -452,4 +455,26 @@ func styledUsageTemplate() string {
 
 Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
 `
+}
+
+// scopeFlagHints maps scoping flags users reach for onto the cwd-based
+// creation model, so unknown-flag errors teach instead of just rejecting.
+var scopeFlagHints = map[string]string{
+	"--phase":    "phases are created in the festival root; sequences are created inside a phase directory (cd 003_IMPLEMENT first)",
+	"--sequence": "tasks are created inside a sequence directory (cd into the sequence first, or pass --path)",
+	"--festival": "run this from inside the festival directory (fest go <festival>), or pass --path",
+}
+
+func setCreateScopeFlagHints(create *cobra.Command) {
+	for _, sub := range create.Commands() {
+		sub.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+			msg := err.Error()
+			for flag, hint := range scopeFlagHints {
+				if strings.Contains(msg, flag) && cmd.Flags().Lookup(strings.TrimPrefix(flag, "--")) == nil {
+					return festerrors.Validation(msg + "\nHint: " + hint)
+				}
+			}
+			return err
+		})
+	}
 }

--- a/internal/commands/root_flaghint_test.go
+++ b/internal/commands/root_flaghint_test.go
@@ -1,0 +1,49 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestCreateScopeFlagHints(t *testing.T) {
+	create := &cobra.Command{Use: "create"}
+	seq := &cobra.Command{
+		Use:  "sequence",
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	seq.Flags().String("name", "", "")
+	create.AddCommand(seq)
+	setCreateScopeFlagHints(create)
+
+	tests := []struct {
+		name     string
+		args     []string
+		wantHint string
+	}{
+		{"phase flag teaches cwd model", []string{"sequence", "--phase", "003_IMPLEMENT"}, "cd 003_IMPLEMENT first"},
+		{"festival flag teaches navigation", []string{"sequence", "--festival", "x"}, "fest go"},
+		{"unrelated unknown flag stays bare", []string{"sequence", "--bogus"}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			create.SetArgs(tt.args)
+			seq.SilenceErrors = true
+			seq.SilenceUsage = true
+			err := create.Execute()
+			if err == nil {
+				t.Fatal("expected an unknown-flag error")
+			}
+			if tt.wantHint == "" {
+				if strings.Contains(err.Error(), "Hint:") {
+					t.Fatalf("unrelated flag should not get a scope hint, got: %v", err)
+				}
+				return
+			}
+			if !strings.Contains(err.Error(), tt.wantHint) {
+				t.Fatalf("error missing hint %q, got: %v", tt.wantHint, err)
+			}
+		})
+	}
+}

--- a/internal/commands/status/handlers_festival.go
+++ b/internal/commands/status/handlers_festival.go
@@ -478,9 +478,20 @@ func AutoCommitStatusChange(ctx context.Context, festivalName, festivalID, oldSt
 		}
 	}
 
-	// Stage only the paths affected by the status change (lock-aware with retry).
-	if err := commitkit.StageFiles(ctx, ws.Root, changedPaths...); err != nil {
-		return "", errors.Wrap(err, "stage")
+	// Stage each affected path independently (lock-aware with retry): a
+	// pathspec matching nothing (e.g. a never-committed pre-move festival
+	// directory) must not sink staging for the paths that do exist.
+	var stageFailures []string
+	staged := 0
+	for _, p := range changedPaths {
+		if err := commitkit.StageFiles(ctx, ws.Root, p); err != nil {
+			stageFailures = append(stageFailures, fmt.Sprintf("%s (%v)", p, err))
+			continue
+		}
+		staged++
+	}
+	if staged == 0 && len(stageFailures) > 0 {
+		return "", errors.New("stage: no paths could be staged: " + strings.Join(stageFailures, "; "))
 	}
 
 	// Check if anything is actually staged.

--- a/internal/commands/status/handlers_festival.go
+++ b/internal/commands/status/handlers_festival.go
@@ -478,20 +478,18 @@ func AutoCommitStatusChange(ctx context.Context, festivalName, festivalID, oldSt
 		}
 	}
 
-	// Stage each affected path independently (lock-aware with retry): a
-	// pathspec matching nothing (e.g. a never-committed pre-move festival
-	// directory) must not sink staging for the paths that do exist.
-	var stageFailures []string
-	staged := 0
+	// Stage each affected path independently (lock-aware with retry). The
+	// only benign failure is a path that no longer exists anywhere (e.g. a
+	// never-committed pre-move festival directory after the move); any
+	// staging error on an existing path is real and must fail loudly, or a
+	// lifecycle commit could silently land without the festival content.
 	for _, p := range changedPaths {
 		if err := commitkit.StageFiles(ctx, ws.Root, p); err != nil {
-			stageFailures = append(stageFailures, fmt.Sprintf("%s (%v)", p, err))
-			continue
+			if _, statErr := os.Stat(p); os.IsNotExist(statErr) {
+				continue
+			}
+			return "", errors.Wrap(err, "stage").WithField("path", p)
 		}
-		staged++
-	}
-	if staged == 0 && len(stageFailures) > 0 {
-		return "", errors.New("stage: no paths could be staged: " + strings.Join(stageFailures, "; "))
 	}
 
 	// Check if anything is actually staged.

--- a/internal/commands/status/handlers_festival_stage_test.go
+++ b/internal/commands/status/handlers_festival_stage_test.go
@@ -1,0 +1,73 @@
+package status
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/scope"
+)
+
+func TestAutoCommitStatusChange_ToleratesMissingPremovePath(t *testing.T) {
+	root := t.TempDir()
+	initTestRepo(t, root)
+
+	newDir := filepath.Join(root, "festivals", "ready", "my-fest")
+	if err := os.MkdirAll(newDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(newDir, "FESTIVAL_GOAL.md"), []byte("# Goal"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := scope.WithWorkspace(context.Background(), &scope.WorkspaceInfo{
+		Root:          root,
+		FestivalsPath: filepath.Join(root, "festivals"),
+		Type:          scope.WorkspaceTypeStandalone,
+	})
+
+	missingOldDir := filepath.Join(root, "festivals", "planning", "my-fest")
+	hash, err := AutoCommitStatusChange(ctx, "my-fest", "MF001", "planning", "ready", []string{missingOldDir, newDir})
+	if err != nil {
+		t.Fatalf("AutoCommitStatusChange failed with a missing pre-move path: %v", err)
+	}
+	if hash == "" {
+		t.Fatal("expected a commit hash, got empty string")
+	}
+
+	cmd := exec.Command("git", "log", "-1", "--name-only", "--pretty=format:")
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git log failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "festivals/ready/my-fest/FESTIVAL_GOAL.md") {
+		t.Errorf("moved festival file missing from commit, log:\n%s", out)
+	}
+}
+
+func TestAutoCommitStatusChange_AllPathsFailReturnsError(t *testing.T) {
+	root := t.TempDir()
+	initTestRepo(t, root)
+
+	ctx := scope.WithWorkspace(context.Background(), &scope.WorkspaceInfo{
+		Root:          root,
+		FestivalsPath: filepath.Join(root, "festivals"),
+		Type:          scope.WorkspaceTypeStandalone,
+	})
+
+	missing1 := filepath.Join(root, "festivals", "planning", "ghost")
+	missing2 := filepath.Join(root, "festivals", "ready", "ghost")
+	_, err := AutoCommitStatusChange(ctx, "ghost", "GH001", "planning", "ready", []string{missing1, missing2})
+	if err == nil {
+		t.Fatal("expected an error when no path can be staged")
+	}
+	for _, p := range []string{missing1, missing2} {
+		if !strings.Contains(err.Error(), p) {
+			t.Errorf("error should name failed path %s, got: %v", p, err)
+		}
+	}
+}

--- a/internal/commands/status/handlers_festival_stage_test.go
+++ b/internal/commands/status/handlers_festival_stage_test.go
@@ -49,7 +49,7 @@ func TestAutoCommitStatusChange_ToleratesMissingPremovePath(t *testing.T) {
 	}
 }
 
-func TestAutoCommitStatusChange_AllPathsFailReturnsError(t *testing.T) {
+func TestAutoCommitStatusChange_MissingOnlyPathsIsNoOp(t *testing.T) {
 	root := t.TempDir()
 	initTestRepo(t, root)
 
@@ -61,13 +61,61 @@ func TestAutoCommitStatusChange_AllPathsFailReturnsError(t *testing.T) {
 
 	missing1 := filepath.Join(root, "festivals", "planning", "ghost")
 	missing2 := filepath.Join(root, "festivals", "ready", "ghost")
-	_, err := AutoCommitStatusChange(ctx, "ghost", "GH001", "planning", "ready", []string{missing1, missing2})
-	if err == nil {
-		t.Fatal("expected an error when no path can be staged")
+	hash, err := AutoCommitStatusChange(ctx, "ghost", "GH001", "planning", "ready", []string{missing1, missing2})
+	if err != nil {
+		t.Fatalf("missing-only paths are benign, expected no error, got: %v", err)
 	}
-	for _, p := range []string{missing1, missing2} {
-		if !strings.Contains(err.Error(), p) {
-			t.Errorf("error should name failed path %s, got: %v", p, err)
-		}
+	if hash != "" {
+		t.Fatalf("expected no commit for missing-only paths, got hash %q", hash)
+	}
+}
+
+func TestAutoCommitStatusChange_RealStageFailurePropagates(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission-based failure injection does not work as root")
+	}
+	root := t.TempDir()
+	initTestRepo(t, root)
+
+	okDir := filepath.Join(root, "festivals", "ready", "my-fest")
+	if err := os.MkdirAll(okDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(okDir, "FESTIVAL_GOAL.md"), []byte("# Goal"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	brokenDir := filepath.Join(root, "festivals", "ready", "broken")
+	if err := os.MkdirAll(brokenDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	brokenFile := filepath.Join(brokenDir, "file.md")
+	if err := os.WriteFile(brokenFile, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(brokenFile, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(brokenFile, 0644) })
+
+	ctx := scope.WithWorkspace(context.Background(), &scope.WorkspaceInfo{
+		Root:          root,
+		FestivalsPath: filepath.Join(root, "festivals"),
+		Type:          scope.WorkspaceTypeStandalone,
+	})
+
+	_, err := AutoCommitStatusChange(ctx, "my-fest", "MF001", "planning", "ready", []string{brokenDir, okDir})
+	if err == nil {
+		t.Fatal("expected a real staging failure on an existing path to propagate, not a partial commit")
+	}
+	if !strings.Contains(err.Error(), filepath.Join("festivals", "ready", "broken")) {
+		t.Errorf("error should name the failing path, got: %v", err)
+	}
+
+	cmd := exec.Command("git", "log", "--oneline")
+	cmd.Dir = root
+	out, _ := cmd.CombinedOutput()
+	if strings.Count(strings.TrimSpace(string(out)), "\n")+1 > 1 {
+		t.Errorf("no lifecycle commit should land on a staging failure, log:\n%s", out)
 	}
 }

--- a/internal/festival/execute.go
+++ b/internal/festival/execute.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/frontmatter"
 )
 
 // executeChanges applies the planned changes
@@ -175,7 +176,7 @@ func refreshRenamedMetadata(newPath string) error {
 	base := filepath.Base(newPath)
 
 	if m := taskParsePattern.FindStringSubmatch(base); m != nil {
-		return rewriteFrontmatterFields(newPath, map[string]string{
+		return frontmatter.UpdateFieldsInFile(newPath, map[string]string{
 			"fest_id":    base,
 			"fest_order": strings.TrimLeft(m[1], "0"),
 		})
@@ -200,7 +201,7 @@ func refreshRenamedMetadata(newPath string) error {
 
 	goalPath := filepath.Join(newPath, goalFile)
 	if _, statErr := os.Stat(goalPath); statErr == nil {
-		if err := rewriteFrontmatterFields(goalPath, map[string]string{
+		if err := frontmatter.UpdateFieldsInFile(goalPath, map[string]string{
 			"fest_id":    base,
 			"fest_order": number,
 		}); err != nil {
@@ -217,51 +218,12 @@ func refreshRenamedMetadata(newPath string) error {
 			if filepath.Base(child) == goalFile {
 				continue
 			}
-			if err := rewriteFrontmatterFields(child, map[string]string{
+			if err := frontmatter.UpdateFieldsInFile(child, map[string]string{
 				"fest_parent": base,
 			}); err != nil {
 				return err
 			}
 		}
-	}
-	return nil
-}
-
-// rewriteFrontmatterFields replaces the values of existing top-level keys
-// inside a file's frontmatter block, leaving every other byte alone. Keys
-// absent from the block are not added; files without frontmatter are
-// left untouched.
-func rewriteFrontmatterFields(path string, fields map[string]string) error {
-	content, err := os.ReadFile(path)
-	if err != nil {
-		return errors.IO("Renumberer.readFrontmatter", err).WithField("path", path)
-	}
-	lines := strings.Split(string(content), "\n")
-	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
-		return nil
-	}
-	changed := false
-	for i := 1; i < len(lines); i++ {
-		trimmed := strings.TrimSpace(lines[i])
-		if trimmed == "---" {
-			break
-		}
-		for key, value := range fields {
-			if strings.HasPrefix(trimmed, key+":") {
-				lines[i] = key + ": " + value
-				changed = true
-			}
-		}
-	}
-	if !changed {
-		return nil
-	}
-	mode := os.FileMode(0644)
-	if info, statErr := os.Stat(path); statErr == nil {
-		mode = info.Mode()
-	}
-	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")), mode); err != nil {
-		return errors.IO("Renumberer.writeFrontmatter", err).WithField("path", path)
 	}
 	return nil
 }

--- a/internal/festival/execute.go
+++ b/internal/festival/execute.go
@@ -73,6 +73,10 @@ func (r *Renumberer) executeChanges() error {
 					WithField("from", change.OldPath).
 					WithField("to", change.NewPath)
 			}
+			if err := refreshRenamedMetadata(change.NewPath); err != nil {
+				fmt.Printf("Warning: renamed %s but could not refresh its frontmatter: %v\n",
+					filepath.Base(change.NewPath), err)
+			}
 			if r.options.Verbose {
 				fmt.Printf("Renamed: %s → %s\n", filepath.Base(change.OldPath), filepath.Base(change.NewPath))
 			}
@@ -158,5 +162,106 @@ func (r *Renumberer) createBackup() error {
 	// Implementation would create timestamped backup
 	// For now, just log
 	fmt.Println("Creating backup...")
+	return nil
+}
+
+// refreshRenamedMetadata keeps frontmatter consistent with a renumber
+// rename: a renamed task file gets its fest_id/fest_order updated; a
+// renamed sequence or phase directory gets its goal file's fest_id and
+// fest_order updated plus the fest_parent of its immediate children.
+// Rewrites are line-surgical so unknown frontmatter keys and formatting
+// survive untouched (the schema round-trip would drop unknown keys).
+func refreshRenamedMetadata(newPath string) error {
+	base := filepath.Base(newPath)
+
+	if m := taskParsePattern.FindStringSubmatch(base); m != nil {
+		return rewriteFrontmatterFields(newPath, map[string]string{
+			"fest_id":    base,
+			"fest_order": strings.TrimLeft(m[1], "0"),
+		})
+	}
+
+	info, err := os.Stat(newPath)
+	if err != nil || !info.IsDir() {
+		return err
+	}
+
+	var goalFile, number string
+	var childPatterns []string
+	if m := sequenceParsePattern.FindStringSubmatch(base); m != nil {
+		goalFile, number = "SEQUENCE_GOAL.md", strings.TrimLeft(m[1], "0")
+		childPatterns = []string{"*.md"}
+	} else if m := phaseParsePattern.FindStringSubmatch(base); m != nil {
+		goalFile, number = "PHASE_GOAL.md", strings.TrimLeft(m[1], "0")
+		childPatterns = []string{"*/SEQUENCE_GOAL.md"}
+	} else {
+		return nil
+	}
+
+	goalPath := filepath.Join(newPath, goalFile)
+	if _, statErr := os.Stat(goalPath); statErr == nil {
+		if err := rewriteFrontmatterFields(goalPath, map[string]string{
+			"fest_id":    base,
+			"fest_order": number,
+		}); err != nil {
+			return err
+		}
+	}
+
+	for _, pattern := range childPatterns {
+		children, globErr := filepath.Glob(filepath.Join(newPath, pattern))
+		if globErr != nil {
+			continue
+		}
+		for _, child := range children {
+			if filepath.Base(child) == goalFile {
+				continue
+			}
+			if err := rewriteFrontmatterFields(child, map[string]string{
+				"fest_parent": base,
+			}); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// rewriteFrontmatterFields replaces the values of existing top-level keys
+// inside a file's frontmatter block, leaving every other byte alone. Keys
+// absent from the block are not added; files without frontmatter are
+// left untouched.
+func rewriteFrontmatterFields(path string, fields map[string]string) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return errors.IO("Renumberer.readFrontmatter", err).WithField("path", path)
+	}
+	lines := strings.Split(string(content), "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return nil
+	}
+	changed := false
+	for i := 1; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == "---" {
+			break
+		}
+		for key, value := range fields {
+			if strings.HasPrefix(trimmed, key+":") {
+				lines[i] = key + ": " + value
+				changed = true
+			}
+		}
+	}
+	if !changed {
+		return nil
+	}
+	mode := os.FileMode(0644)
+	if info, statErr := os.Stat(path); statErr == nil {
+		mode = info.Mode()
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")), mode); err != nil {
+		return errors.IO("Renumberer.writeFrontmatter", err).WithField("path", path)
+	}
 	return nil
 }

--- a/internal/festival/execute.go
+++ b/internal/festival/execute.go
@@ -75,7 +75,7 @@ func (r *Renumberer) executeChanges() error {
 					WithField("to", change.NewPath)
 			}
 			if err := refreshRenamedMetadata(change.NewPath); err != nil {
-				fmt.Printf("Warning: renamed %s but could not refresh its frontmatter: %v\n",
+				fmt.Fprintf(os.Stderr, "Warning: renamed %s but could not refresh its frontmatter: %v\n",
 					filepath.Base(change.NewPath), err)
 			}
 			if r.options.Verbose {

--- a/internal/festival/renumber.go
+++ b/internal/festival/renumber.go
@@ -66,6 +66,14 @@ func NewRenumberer(options RenumberOptions) *Renumberer {
 	}
 }
 
+// Changes returns the change set built by the most recent insert or
+// renumber operation, letting callers report renames they triggered.
+func (r *Renumberer) Changes() []Change {
+	out := make([]Change, len(r.changes))
+	copy(out, r.changes)
+	return out
+}
+
 // RenumberPhases renumbers all phases starting from a given number
 func (r *Renumberer) RenumberPhases(ctx context.Context, festivalDir string, startFrom int) error {
 	if err := ctx.Err(); err != nil {

--- a/internal/festival/renumber_frontmatter_test.go
+++ b/internal/festival/renumber_frontmatter_test.go
@@ -93,19 +93,3 @@ func TestRenumber_SequenceRenameRefreshesGoalAndChildren(t *testing.T) {
 		t.Errorf("task's own id/order should be untouched by a parent rename:\n%s", tk)
 	}
 }
-
-func TestRewriteFrontmatterFields_NoFrontmatterUntouched(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "01_plain.md")
-	original := "# No frontmatter here\n\nfest_id: not-frontmatter\n"
-	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
-		t.Fatal(err)
-	}
-	if err := rewriteFrontmatterFields(path, map[string]string{"fest_id": "02_plain.md"}); err != nil {
-		t.Fatalf("rewrite: %v", err)
-	}
-	got, _ := os.ReadFile(path)
-	if string(got) != original {
-		t.Errorf("file without frontmatter was modified:\n%s", got)
-	}
-}

--- a/internal/festival/renumber_frontmatter_test.go
+++ b/internal/festival/renumber_frontmatter_test.go
@@ -1,0 +1,111 @@
+package festival
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeFM(t *testing.T, path, id string, order int, extra string) {
+	t.Helper()
+	content := "---\nfest_type: task\nfest_id: " + id + "\nfest_order: " +
+		string(rune('0'+order)) + "\n" + extra + "---\n\n# Body\n\ncontent stays\n"
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRenumber_TaskRenameRefreshesFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	writeFM(t, filepath.Join(dir, "01_first.md"), "01_first.md", 1, "custom_key: keep-me\n")
+	writeFM(t, filepath.Join(dir, "02_second.md"), "02_second.md", 2, "")
+
+	ren := NewRenumberer(RenumberOptions{AutoApprove: true, Quiet: true})
+	if err := ren.InsertTask(context.Background(), dir, 0, "zeroth"); err != nil {
+		t.Fatalf("InsertTask: %v", err)
+	}
+
+	shifted, err := os.ReadFile(filepath.Join(dir, "02_first.md"))
+	if err != nil {
+		t.Fatalf("shifted file missing: %v", err)
+	}
+	s := string(shifted)
+	for _, want := range []string{"fest_id: 02_first.md", "fest_order: 2", "custom_key: keep-me", "content stays"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("shifted frontmatter missing %q:\n%s", want, s)
+		}
+	}
+	if strings.Contains(s, "fest_id: 01_first.md") {
+		t.Error("stale fest_id survived the rename")
+	}
+
+	third, err := os.ReadFile(filepath.Join(dir, "03_second.md"))
+	if err != nil {
+		t.Fatalf("second shifted file missing: %v", err)
+	}
+	if !strings.Contains(string(third), "fest_order: 3") {
+		t.Errorf("second shifted file kept stale order:\n%s", third)
+	}
+}
+
+func TestRenumber_SequenceRenameRefreshesGoalAndChildren(t *testing.T) {
+	phaseDir := t.TempDir()
+	seqDir := filepath.Join(phaseDir, "01_alpha")
+	if err := os.MkdirAll(seqDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	goal := "---\nfest_type: sequence\nfest_id: 01_alpha\nfest_order: 1\nfest_parent: 003_IMPLEMENT\n---\n\n# Goal\n"
+	if err := os.WriteFile(filepath.Join(seqDir, "SEQUENCE_GOAL.md"), []byte(goal), 0644); err != nil {
+		t.Fatal(err)
+	}
+	task := "---\nfest_type: task\nfest_id: 01_do.md\nfest_order: 1\nfest_parent: 01_alpha\n---\n\n# Task\n"
+	if err := os.WriteFile(filepath.Join(seqDir, "01_do.md"), []byte(task), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ren := NewRenumberer(RenumberOptions{AutoApprove: true, Quiet: true})
+	if err := ren.InsertSequence(context.Background(), phaseDir, 0, "zero"); err != nil {
+		t.Fatalf("InsertSequence: %v", err)
+	}
+
+	movedGoal, err := os.ReadFile(filepath.Join(phaseDir, "02_alpha", "SEQUENCE_GOAL.md"))
+	if err != nil {
+		t.Fatalf("moved goal missing: %v", err)
+	}
+	g := string(movedGoal)
+	for _, want := range []string{"fest_id: 02_alpha", "fest_order: 2", "fest_parent: 003_IMPLEMENT"} {
+		if !strings.Contains(g, want) {
+			t.Errorf("goal frontmatter missing %q:\n%s", want, g)
+		}
+	}
+
+	movedTask, err := os.ReadFile(filepath.Join(phaseDir, "02_alpha", "01_do.md"))
+	if err != nil {
+		t.Fatalf("moved task missing: %v", err)
+	}
+	tk := string(movedTask)
+	if !strings.Contains(tk, "fest_parent: 02_alpha") {
+		t.Errorf("task fest_parent not refreshed to new sequence id:\n%s", tk)
+	}
+	if !strings.Contains(tk, "fest_id: 01_do.md") || !strings.Contains(tk, "fest_order: 1") {
+		t.Errorf("task's own id/order should be untouched by a parent rename:\n%s", tk)
+	}
+}
+
+func TestRewriteFrontmatterFields_NoFrontmatterUntouched(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "01_plain.md")
+	original := "# No frontmatter here\n\nfest_id: not-frontmatter\n"
+	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := rewriteFrontmatterFields(path, map[string]string{"fest_id": "02_plain.md"}); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != original {
+		t.Errorf("file without frontmatter was modified:\n%s", got)
+	}
+}

--- a/internal/festival/renumber_frontmatter_test.go
+++ b/internal/festival/renumber_frontmatter_test.go
@@ -93,3 +93,48 @@ func TestRenumber_SequenceRenameRefreshesGoalAndChildren(t *testing.T) {
 		t.Errorf("task's own id/order should be untouched by a parent rename:\n%s", tk)
 	}
 }
+
+func TestRenumber_PhaseRenameRefreshesGoalAndChildren(t *testing.T) {
+	festivalDir := t.TempDir()
+	phaseDir := filepath.Join(festivalDir, "001_ALPHA")
+	seqDir := filepath.Join(phaseDir, "01_seq")
+	if err := os.MkdirAll(seqDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	phaseGoal := "---\nfest_type: phase\nfest_id: 001_ALPHA\nfest_order: 1\nfest_parent: onboarding-FE0001\n---\n\n# Phase Goal\n"
+	if err := os.WriteFile(filepath.Join(phaseDir, "PHASE_GOAL.md"), []byte(phaseGoal), 0644); err != nil {
+		t.Fatal(err)
+	}
+	seqGoal := "---\nfest_type: sequence\nfest_id: 01_seq\nfest_order: 1\nfest_parent: 001_ALPHA\n---\n\n# Sequence Goal\n"
+	if err := os.WriteFile(filepath.Join(seqDir, "SEQUENCE_GOAL.md"), []byte(seqGoal), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ren := NewRenumberer(RenumberOptions{AutoApprove: true, Quiet: true})
+	if err := ren.InsertPhase(context.Background(), festivalDir, 0, "zero"); err != nil {
+		t.Fatalf("InsertPhase: %v", err)
+	}
+
+	movedGoal, err := os.ReadFile(filepath.Join(festivalDir, "002_ALPHA", "PHASE_GOAL.md"))
+	if err != nil {
+		t.Fatalf("moved phase goal missing: %v", err)
+	}
+	g := string(movedGoal)
+	for _, want := range []string{"fest_id: 002_ALPHA", "fest_order: 2", "fest_parent: onboarding-FE0001"} {
+		if !strings.Contains(g, want) {
+			t.Errorf("phase goal frontmatter missing %q:\n%s", want, g)
+		}
+	}
+
+	movedSeqGoal, err := os.ReadFile(filepath.Join(festivalDir, "002_ALPHA", "01_seq", "SEQUENCE_GOAL.md"))
+	if err != nil {
+		t.Fatalf("moved sequence goal missing: %v", err)
+	}
+	s := string(movedSeqGoal)
+	if !strings.Contains(s, "fest_parent: 002_ALPHA") {
+		t.Errorf("child sequence fest_parent not refreshed to new phase id:\n%s", s)
+	}
+	if !strings.Contains(s, "fest_id: 01_seq") || !strings.Contains(s, "fest_order: 1") {
+		t.Errorf("child sequence's own id/order should be untouched by a phase rename:\n%s", s)
+	}
+}

--- a/internal/frontmatter/schema.go
+++ b/internal/frontmatter/schema.go
@@ -215,6 +215,12 @@ type Frontmatter struct {
 	EstimatedTokens int        `yaml:"fest_estimated_tokens,omitempty" json:"fest_estimated_tokens,omitempty"`
 	RequiresHuman   bool       `yaml:"fest_requires_human,omitempty" json:"fest_requires_human,omitempty"`
 	RequiresContext bool       `yaml:"fest_requires_context,omitempty" json:"fest_requires_context,omitempty"`
+
+	// Extra preserves keys this schema does not know about, so every
+	// parse -> mutate -> inject round-trip (task status updates, goal
+	// status changes, migrations) keeps user-added metadata instead of
+	// silently dropping it.
+	Extra map[string]any `yaml:",inline" json:"-"`
 }
 
 // Validate checks if the frontmatter is valid

--- a/internal/frontmatter/update.go
+++ b/internal/frontmatter/update.go
@@ -1,0 +1,62 @@
+package frontmatter
+
+import (
+	"os"
+	"strings"
+
+	"github.com/Obedience-Corp/fest/internal/errors"
+)
+
+// UpdateFields replaces the values of existing top-level keys inside a
+// document's frontmatter block, leaving every other byte alone: unknown
+// keys, comments, ordering, and the body all survive untouched. Keys not
+// present in the block are not added; content without a frontmatter block
+// is returned unchanged. The boolean reports whether anything changed.
+//
+// Use this for targeted single-field updates where preserving the file's
+// existing formatting matters; use Parse/Inject for full rewrites.
+func UpdateFields(content []byte, fields map[string]string) ([]byte, bool) {
+	lines := strings.Split(string(content), "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return content, false
+	}
+	changed := false
+	for i := 1; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == "---" {
+			break
+		}
+		for key, value := range fields {
+			if strings.HasPrefix(trimmed, key+":") {
+				lines[i] = key + ": " + value
+				changed = true
+			}
+		}
+	}
+	if !changed {
+		return content, false
+	}
+	return []byte(strings.Join(lines, "\n")), true
+}
+
+// UpdateFieldsInFile applies UpdateFields to a file in place, preserving
+// its mode. Files without frontmatter or without any of the keys are left
+// untouched.
+func UpdateFieldsInFile(path string, fields map[string]string) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return errors.IO("frontmatter.UpdateFieldsInFile.read", err).WithField("path", path)
+	}
+	updated, changed := UpdateFields(content, fields)
+	if !changed {
+		return nil
+	}
+	mode := os.FileMode(0644)
+	if info, statErr := os.Stat(path); statErr == nil {
+		mode = info.Mode()
+	}
+	if err := os.WriteFile(path, updated, mode); err != nil {
+		return errors.IO("frontmatter.UpdateFieldsInFile.write", err).WithField("path", path)
+	}
+	return nil
+}

--- a/internal/frontmatter/update_test.go
+++ b/internal/frontmatter/update_test.go
@@ -1,0 +1,103 @@
+package frontmatter
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUpdateFields(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		fields      map[string]string
+		wantChanged bool
+		wantContain []string
+		wantSame    bool
+	}{
+		{
+			name:        "replaces existing keys only",
+			content:     "---\nfest_id: 01_a.md\nfest_order: 1\ncustom: keep\n---\n\nbody fest_id: not-fm\n",
+			fields:      map[string]string{"fest_id": "02_a.md", "fest_order": "2", "fest_parent": "new"},
+			wantChanged: true,
+			wantContain: []string{"fest_id: 02_a.md", "fest_order: 2", "custom: keep", "body fest_id: not-fm"},
+		},
+		{
+			name:     "no frontmatter untouched",
+			content:  "# Doc\n\nfest_id: not-frontmatter\n",
+			fields:   map[string]string{"fest_id": "x"},
+			wantSame: true,
+		},
+		{
+			name:     "keys absent untouched",
+			content:  "---\nfest_type: task\n---\n\nbody\n",
+			fields:   map[string]string{"fest_id": "x"},
+			wantSame: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, changed := UpdateFields([]byte(tt.content), tt.fields)
+			if changed != tt.wantChanged {
+				t.Fatalf("changed = %v, want %v", changed, tt.wantChanged)
+			}
+			if tt.wantSame && string(got) != tt.content {
+				t.Fatalf("content changed:\n%s", got)
+			}
+			for _, want := range tt.wantContain {
+				if !strings.Contains(string(got), want) {
+					t.Errorf("missing %q in:\n%s", want, got)
+				}
+			}
+			if tt.wantChanged && strings.Contains(string(got), "fest_parent: new") {
+				t.Error("absent key was added")
+			}
+		})
+	}
+}
+
+func TestUpdateFieldsInFile_PreservesMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "01_a.md")
+	if err := os.WriteFile(path, []byte("---\nfest_id: 01_a.md\n---\n\nbody\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := UpdateFieldsInFile(path, map[string]string{"fest_id": "02_a.md"}); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("mode = %v, want 0600 preserved", info.Mode().Perm())
+	}
+	content, _ := os.ReadFile(path)
+	if !strings.Contains(string(content), "fest_id: 02_a.md") {
+		t.Errorf("field not updated:\n%s", content)
+	}
+}
+
+func TestRoundTripPreservesUnknownKeys(t *testing.T) {
+	content := []byte("---\nfest_type: task\nfest_id: 01_a.md\nfest_status: pending\nfest_created: 2026-07-02T00:00:00Z\nmy_custom_field: precious\nanother.custom: also-precious\n---\n\n# Body\n")
+
+	fm, body, err := Parse(content)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if fm.Extra["my_custom_field"] != "precious" {
+		t.Fatalf("unknown key not captured: %#v", fm.Extra)
+	}
+
+	fm.Status = StatusCompleted
+	out, err := Inject(body, fm)
+	if err != nil {
+		t.Fatalf("Inject: %v", err)
+	}
+	for _, want := range []string{"my_custom_field: precious", "another.custom: also-precious", "fest_status: completed"} {
+		if !strings.Contains(string(out), want) {
+			t.Errorf("round-trip lost %q:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
PR-1 of 3 from the fest planning-loop UX audit (obey-campaign design workitem `workflow/design/fest-planning-loop-ux-fixes`, WI-7b386b; findings recorded live in the CA0002 festival's `fest feedback` ledger while planning a real festival through the `fest next` loop).

## F1: `fest create task` reversed dictation order (P0)

`--after` defaulted to 0, inserting every new task at position 01 and silently renumbering existing tasks down. Creating tasks one-per-invocation in intended order produced exactly reversed sequences, and the success echo printed the pre-renumber `01_<name>` for every creation, masking it (17 consecutive creations across 6 sequences all echoed `01_` during the audit).

- Default is now `-1`: append at end, auto-detected from the highest existing task number via the same pattern `fest create sequence` already uses (`create_sequence.go` had this exact design; task creation was inconsistent with its sibling).
- `--after 0` still inserts at the beginning; `--after N` unchanged.
- The echo now reports renumbering (`Renumbered N existing task(s)` with old -> new names), and the JSON contract's already-existing `renumbered` field is populated instead of always `[]`.
- `Renumberer` gains a `Changes()` accessor so callers can report the renames they trigger.

Compat: behavior change called out deliberately; prepend-by-default produced reversed plans and was undocumented, and batch `--name` invocations (the documented happy path) are unaffected in their result ordering. Explicit insertion is fully preserved.

## F4: `fest promote` auto-commit failed on never-committed festivals (P0)

`AutoCommitStatusChange` staged all changed paths in one `git add`; a pathspec matching nothing (the pre-move directory of a festival that had never been committed) failed the entire staging, so promote succeeded but the lifecycle transition landed uncommitted behind a dim warning. Paths now stage independently: a no-match path is skipped, staging fails only when NO path can be staged, and that error names every failed path. Regression test drives a real promote-shaped move with a missing pre-move path and asserts the commit contents.

## F8: scoping-flag errors teach the cwd model (P2 rider)

`fest create sequence --phase X` and friends now append a hint ("sequences are created in the current phase directory; cd 003_IMPLEMENT first") instead of a bare `unknown flag` error. Static mapping on the create subcommands only; unrelated unknown flags unchanged.

## Testing

- New: append/passthrough/empty-dir resolution tests, dictation-order integration of resolve+insert, `Changes()` rename reporting, missing-pre-move-path and all-paths-fail auto-commit tests, flag-hint golden tests.
- `just test unit` (2329 passed), `just test integration` (59 passed), `just lint all` (0 issues) at head.

PR-2 (workflow guidance rendering) and PR-3 (feedback subsystem + delegated approvals) follow per the design package.