### PR TITLE
fix(security): verified install.sh, default-off marketplace extensions (SEC-01/02)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,21 @@ These festivals span Go, Rust, Python, and web projects - from simple CLI fixes 
 
 ## Installation
 
+fest ships bundled with camp as part of the [Festival packaging repo](https://github.com/Obedience-Corp/festival), which is the canonical, checksum-verified distributor for prebuilt binaries:
+
 ```bash
-# Install from source
+# macOS/Linux, via Homebrew
+brew install --cask Obedience-Corp/tap/festival
+
+# or via the Festival installer directly
+curl -fsSL https://raw.githubusercontent.com/Obedience-Corp/festival/main/install.sh | bash
+```
+
+See the [festival repo](https://github.com/Obedience-Corp/festival#install) for the full package list (npm, deb, rpm, apk, Arch) and published `checksums.txt`.
+
+To install fest on its own from source:
+
+```bash
 git clone https://github.com/Obedience-Corp/fest
 cd fest
 just install
@@ -185,15 +198,7 @@ Or with Go:
 go install github.com/Obedience-Corp/fest/cmd/fest@latest
 ```
 
-### install.sh
-
-`install.sh` downloads a prebuilt binary from the [Obedience-Corp/fest releases](https://github.com/Obedience-Corp/fest/releases), verifies its sha256 checksum against the release's published `checksums.txt`, and installs it to `/usr/local/bin/fest` (using `sudo` if that directory isn't writable):
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/Obedience-Corp/fest/main/install.sh | bash
-```
-
-It refuses to install anything it cannot verify: if a release has no matching binary archive or no published `checksums.txt`, it fails with an error instead of installing an unverified binary. Prebuilt binaries are not yet published on every release; if the script fails for that reason, use `go install` or build from source above.
+This repo's `install.sh` does not download or install a binary itself; running it prints the install paths above.
 
 ## Shell Integration (Recommended)
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,16 @@ Or with Go:
 go install github.com/Obedience-Corp/fest/cmd/fest@latest
 ```
 
+### install.sh
+
+`install.sh` downloads a prebuilt binary from the [Obedience-Corp/fest releases](https://github.com/Obedience-Corp/fest/releases), verifies its sha256 checksum against the release's published `checksums.txt`, and installs it to `/usr/local/bin/fest` (using `sudo` if that directory isn't writable):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Obedience-Corp/fest/main/install.sh | bash
+```
+
+It refuses to install anything it cannot verify: if a release has no matching binary archive or no published `checksums.txt`, it fails with an error instead of installing an unverified binary. Prebuilt binaries are not yet published on every release; if the script fails for that reason, use `go install` or build from source above.
+
 ## Shell Integration (Recommended)
 
 Add to your shell config for quick navigation commands:

--- a/install.sh
+++ b/install.sh
@@ -1,116 +1,26 @@
 #!/bin/bash
-# Installation script for fest CLI
+# fest is not distributed as a standalone per-repo release binary; it ships
+# as part of the Festival packaging repo (camp + fest bundled together).
+# This script does not download or install anything itself - it points you
+# at the supported, checksum-verified install paths.
 
 set -euo pipefail
 
-# Detect OS and architecture
-OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-ARCH=$(uname -m)
+cat <<'EOF'
+fest ships as part of the Festival packaging repo, not as a standalone
+fest-only release binary. Install it one of these ways:
 
-# Map architecture names
-case "$ARCH" in
-    x86_64)
-        ARCH="amd64"
-        ;;
-    arm64|aarch64)
-        ARCH="arm64"
-        ;;
-    *)
-        echo "Unsupported architecture: $ARCH" >&2
-        exit 1
-        ;;
-esac
+Prebuilt binaries (macOS/Linux, checksum-verified):
+  brew install --cask Obedience-Corp/tap/festival
 
-# Set OS name used in release asset names
-case "$OS" in
-    darwin|linux)
-        ;;
-    *)
-        echo "Unsupported OS: $OS" >&2
-        exit 1
-        ;;
-esac
+  or run the Festival installer directly:
+  curl -fsSL https://raw.githubusercontent.com/Obedience-Corp/festival/main/install.sh | bash
 
-fail_no_verified_release() {
-    cat >&2 <<EOF
-error: $1
+  See https://github.com/Obedience-Corp/festival for the full package list
+  (npm, deb, rpm, apk, Arch, checksums.txt).
 
-This installer refuses to install a fest binary that cannot be
-downloaded from and checksum-verified against the official
-Obedience-Corp/fest GitHub releases. Use one of these instead:
-
+From source (fest only):
   go install github.com/Obedience-Corp/fest/cmd/fest@latest
-
-  git clone https://github.com/Obedience-Corp/fest
-  cd fest && just install
 EOF
-    exit 1
-}
 
-GITHUB_REPO="Obedience-Corp/fest"
-VERSION=${1:-latest}
-
-if [ "$VERSION" = "latest" ]; then
-    VERSION=$(curl -fsSL "https://api.github.com/repos/${GITHUB_REPO}/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/') || \
-        fail_no_verified_release "could not determine the latest fest release from the GitHub API"
-fi
-
-if [ -z "$VERSION" ]; then
-    fail_no_verified_release "could not determine the latest fest release from the GitHub API"
-fi
-
-echo "Installing fest ${VERSION} for ${OS}/${ARCH}..."
-
-ARCHIVE="fest-${VERSION}-${OS}-${ARCH}.tar.gz"
-DOWNLOAD_URL="https://github.com/${GITHUB_REPO}/releases/download/${VERSION}/${ARCHIVE}"
-CHECKSUMS_URL="https://github.com/${GITHUB_REPO}/releases/download/${VERSION}/checksums.txt"
-
-TEMP_DIR=$(mktemp -d)
-trap 'rm -rf "$TEMP_DIR"' EXIT
-
-echo "Downloading from ${DOWNLOAD_URL}..."
-if ! curl -fsSL -o "${TEMP_DIR}/${ARCHIVE}" "${DOWNLOAD_URL}"; then
-    fail_no_verified_release "no release archive found at ${DOWNLOAD_URL}"
-fi
-
-echo "Downloading checksums from ${CHECKSUMS_URL}..."
-if ! curl -fsSL -o "${TEMP_DIR}/checksums.txt" "${CHECKSUMS_URL}"; then
-    fail_no_verified_release "no checksums.txt published at ${CHECKSUMS_URL}; refusing to install an unverified binary"
-fi
-
-EXPECTED_SHA=$(grep " ${ARCHIVE}\$" "${TEMP_DIR}/checksums.txt" | awk '{print $1}')
-if [ -z "$EXPECTED_SHA" ]; then
-    fail_no_verified_release "checksums.txt has no entry for ${ARCHIVE}; refusing to install an unverified binary"
-fi
-
-if command -v sha256sum >/dev/null 2>&1; then
-    ACTUAL_SHA=$(sha256sum "${TEMP_DIR}/${ARCHIVE}" | awk '{print $1}')
-elif command -v shasum >/dev/null 2>&1; then
-    ACTUAL_SHA=$(shasum -a 256 "${TEMP_DIR}/${ARCHIVE}" | awk '{print $1}')
-else
-    fail_no_verified_release "neither sha256sum nor shasum is available to verify the download"
-fi
-
-if [ "$EXPECTED_SHA" != "$ACTUAL_SHA" ]; then
-    fail_no_verified_release "checksum mismatch for ${ARCHIVE} (expected ${EXPECTED_SHA}, got ${ACTUAL_SHA})"
-fi
-
-echo "Checksum verified."
-
-echo "Extracting..."
-tar -xzf "${TEMP_DIR}/${ARCHIVE}" -C "${TEMP_DIR}"
-
-# Install to /usr/local/bin (may require sudo)
-INSTALL_PATH="/usr/local/bin/fest"
-
-if [ -w "/usr/local/bin" ]; then
-    mv "${TEMP_DIR}/fest" "${INSTALL_PATH}"
-else
-    echo "Installing to /usr/local/bin requires sudo access..."
-    sudo mv "${TEMP_DIR}/fest" "${INSTALL_PATH}"
-fi
-
-chmod +x "${INSTALL_PATH}"
-
-echo "✅ fest installed successfully to ${INSTALL_PATH}"
-echo "Run 'fest --version' to verify the installation"
+exit 0

--- a/install.sh
+++ b/install.sh
@@ -16,48 +16,89 @@ case "$ARCH" in
         ARCH="arm64"
         ;;
     *)
-        echo "Unsupported architecture: $ARCH"
+        echo "Unsupported architecture: $ARCH" >&2
         exit 1
         ;;
 esac
 
-# Set binary name based on OS
+# Set OS name used in release asset names
 case "$OS" in
-    darwin)
-        BINARY="fest-darwin-${ARCH}"
-        ;;
-    linux)
-        BINARY="fest-linux-${ARCH}"
+    darwin|linux)
         ;;
     *)
-        echo "Unsupported OS: $OS"
+        echo "Unsupported OS: $OS" >&2
         exit 1
         ;;
 esac
 
-# GitHub release URL
-GITHUB_REPO="lancekrogers/festival-methodology"
+fail_no_verified_release() {
+    cat >&2 <<EOF
+error: $1
+
+This installer refuses to install a fest binary that cannot be
+downloaded from and checksum-verified against the official
+Obedience-Corp/fest GitHub releases. Use one of these instead:
+
+  go install github.com/Obedience-Corp/fest/cmd/fest@latest
+
+  git clone https://github.com/Obedience-Corp/fest
+  cd fest && just install
+EOF
+    exit 1
+}
+
+GITHUB_REPO="Obedience-Corp/fest"
 VERSION=${1:-latest}
 
 if [ "$VERSION" = "latest" ]; then
-    # Get latest release version from GitHub API
-    VERSION=$(curl -s "https://api.github.com/repos/${GITHUB_REPO}/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+    VERSION=$(curl -fsSL "https://api.github.com/repos/${GITHUB_REPO}/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/') || \
+        fail_no_verified_release "could not determine the latest fest release from the GitHub API"
+fi
+
+if [ -z "$VERSION" ]; then
+    fail_no_verified_release "could not determine the latest fest release from the GitHub API"
 fi
 
 echo "Installing fest ${VERSION} for ${OS}/${ARCH}..."
 
-# Download URL
-DOWNLOAD_URL="https://github.com/${GITHUB_REPO}/releases/download/${VERSION}/fest-${VERSION}-${OS}-${ARCH}.tar.gz"
+ARCHIVE="fest-${VERSION}-${OS}-${ARCH}.tar.gz"
+DOWNLOAD_URL="https://github.com/${GITHUB_REPO}/releases/download/${VERSION}/${ARCHIVE}"
+CHECKSUMS_URL="https://github.com/${GITHUB_REPO}/releases/download/${VERSION}/checksums.txt"
 
-# Download and extract
 TEMP_DIR=$(mktemp -d)
-trap "rm -rf $TEMP_DIR" EXIT
+trap 'rm -rf "$TEMP_DIR"' EXIT
 
 echo "Downloading from ${DOWNLOAD_URL}..."
-curl -L -o "${TEMP_DIR}/fest.tar.gz" "${DOWNLOAD_URL}"
+if ! curl -fsSL -o "${TEMP_DIR}/${ARCHIVE}" "${DOWNLOAD_URL}"; then
+    fail_no_verified_release "no release archive found at ${DOWNLOAD_URL}"
+fi
+
+echo "Downloading checksums from ${CHECKSUMS_URL}..."
+if ! curl -fsSL -o "${TEMP_DIR}/checksums.txt" "${CHECKSUMS_URL}"; then
+    fail_no_verified_release "no checksums.txt published at ${CHECKSUMS_URL}; refusing to install an unverified binary"
+fi
+
+EXPECTED_SHA=$(grep " ${ARCHIVE}\$" "${TEMP_DIR}/checksums.txt" | awk '{print $1}')
+if [ -z "$EXPECTED_SHA" ]; then
+    fail_no_verified_release "checksums.txt has no entry for ${ARCHIVE}; refusing to install an unverified binary"
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL_SHA=$(sha256sum "${TEMP_DIR}/${ARCHIVE}" | awk '{print $1}')
+elif command -v shasum >/dev/null 2>&1; then
+    ACTUAL_SHA=$(shasum -a 256 "${TEMP_DIR}/${ARCHIVE}" | awk '{print $1}')
+else
+    fail_no_verified_release "neither sha256sum nor shasum is available to verify the download"
+fi
+
+if [ "$EXPECTED_SHA" != "$ACTUAL_SHA" ]; then
+    fail_no_verified_release "checksum mismatch for ${ARCHIVE} (expected ${EXPECTED_SHA}, got ${ACTUAL_SHA})"
+fi
+
+echo "Checksum verified."
 
 echo "Extracting..."
-tar -xzf "${TEMP_DIR}/fest.tar.gz" -C "${TEMP_DIR}"
+tar -xzf "${TEMP_DIR}/${ARCHIVE}" -C "${TEMP_DIR}"
 
 # Install to /usr/local/bin (may require sudo)
 INSTALL_PATH="/usr/local/bin/fest"

--- a/internal/extensions/loader.go
+++ b/internal/extensions/loader.go
@@ -1,6 +1,7 @@
 package extensions
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -69,7 +70,10 @@ func (el *ExtensionLoader) LoadAll(festivalRoot string) error {
 func (el *ExtensionLoader) loadFromDirectory(dir string, source string) error {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return nil // Directory doesn't exist or can't be read
+		if !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "Warning: failed to read extensions directory %s: %v\n", dir, err)
+		}
+		return nil
 	}
 
 	for _, entry := range entries {
@@ -80,10 +84,14 @@ func (el *ExtensionLoader) loadFromDirectory(dir string, source string) error {
 		extPath := filepath.Join(dir, entry.Name())
 		ext, err := LoadExtensionFromDir(extPath, source)
 		if err != nil {
-			continue // Skip invalid extensions
+			fmt.Fprintf(os.Stderr, "Warning: skipping invalid extension %s (%s): %v\n", extPath, source, err)
+			continue
 		}
 
-		// Higher priority sources override lower ones
+		if existing, ok := el.extensions[ext.Name]; ok && existing.Source != ext.Source {
+			fmt.Fprintf(os.Stderr, "Warning: %s extension %q shadows %s extension of the same name\n", ext.Source, ext.Name, existing.Source)
+		}
+
 		el.extensions[ext.Name] = ext
 	}
 

--- a/internal/extensions/loader_test.go
+++ b/internal/extensions/loader_test.go
@@ -39,6 +39,21 @@ func TestLoadAll_MarketplaceFlagOn(t *testing.T) {
 	}
 }
 
+func TestLoadAll_MarketplaceDefaultOff(t *testing.T) {
+	cfg := t.TempDir()
+	t.Setenv("FEST_CONFIG_DIR", cfg)
+	t.Setenv("FEST_FEATURE_MARKETPLACE_EXTENSION_SOURCE", "")
+	writeExtension(t, MarketplaceExtensionsDir(), "demo")
+
+	l := NewExtensionLoader()
+	if err := l.LoadAll(""); err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if l.Get("demo") != nil {
+		t.Fatal("expected the marketplace path to be ignored by default")
+	}
+}
+
 func TestLoadAll_MarketplaceFlagOff(t *testing.T) {
 	cfg := t.TempDir()
 	t.Setenv("FEST_CONFIG_DIR", cfg)

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -37,9 +37,11 @@ func envFlag(key string, def bool) bool {
 		return def
 	}
 	switch strings.ToLower(v) {
+	case "1", "true", "on", "yes":
+		return true
 	case "0", "false", "off", "no":
 		return false
 	default:
-		return true
+		return def
 	}
 }

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -19,13 +19,13 @@ func Supported() []string {
 }
 
 // Enabled reports whether a capability is active. The marketplace extension
-// source defaults on (a missing marketplace dir is a harmless no-op for users
-// who never run the installer) and can be turned off with
-// FEST_FEATURE_MARKETPLACE_EXTENSION_SOURCE=0.
+// source defaults off (extensions are agent-guiding methodology content, so
+// loading them is opt-in) and can be turned on with
+// FEST_FEATURE_MARKETPLACE_EXTENSION_SOURCE=1.
 func Enabled(name string) bool {
 	switch name {
 	case MarketplaceExtensionSource:
-		return envFlag("FEST_FEATURE_MARKETPLACE_EXTENSION_SOURCE", true)
+		return envFlag("FEST_FEATURE_MARKETPLACE_EXTENSION_SOURCE", false)
 	default:
 		return false
 	}

--- a/internal/features/features_test.go
+++ b/internal/features/features_test.go
@@ -1,0 +1,43 @@
+package features
+
+import "testing"
+
+func TestEnabled_MarketplaceExtensionSourceDefaultsOff(t *testing.T) {
+	t.Setenv("FEST_FEATURE_MARKETPLACE_EXTENSION_SOURCE", "")
+
+	if Enabled(MarketplaceExtensionSource) {
+		t.Fatal("expected marketplace_extension_source_v1 to default off")
+	}
+}
+
+func TestEnabled_MarketplaceExtensionSourceExplicitEnable(t *testing.T) {
+	cases := []string{"1", "true", "on", "yes"}
+	for _, v := range cases {
+		t.Run(v, func(t *testing.T) {
+			t.Setenv("FEST_FEATURE_MARKETPLACE_EXTENSION_SOURCE", v)
+
+			if !Enabled(MarketplaceExtensionSource) {
+				t.Fatalf("expected marketplace_extension_source_v1 to be enabled for %q", v)
+			}
+		})
+	}
+}
+
+func TestEnabled_MarketplaceExtensionSourceExplicitDisable(t *testing.T) {
+	cases := []string{"0", "false", "off", "no"}
+	for _, v := range cases {
+		t.Run(v, func(t *testing.T) {
+			t.Setenv("FEST_FEATURE_MARKETPLACE_EXTENSION_SOURCE", v)
+
+			if Enabled(MarketplaceExtensionSource) {
+				t.Fatalf("expected marketplace_extension_source_v1 to stay disabled for %q", v)
+			}
+		})
+	}
+}
+
+func TestEnabled_UnknownCapability(t *testing.T) {
+	if Enabled("not_a_real_capability") {
+		t.Fatal("expected unknown capabilities to report disabled")
+	}
+}

--- a/internal/features/features_test.go
+++ b/internal/features/features_test.go
@@ -36,6 +36,19 @@ func TestEnabled_MarketplaceExtensionSourceExplicitDisable(t *testing.T) {
 	}
 }
 
+func TestEnabled_MarketplaceExtensionSourceUnrecognizedValueStaysOff(t *testing.T) {
+	cases := []string{"maybe", "enabled", "disable", "2", "yeah"}
+	for _, v := range cases {
+		t.Run(v, func(t *testing.T) {
+			t.Setenv("FEST_FEATURE_MARKETPLACE_EXTENSION_SOURCE", v)
+
+			if Enabled(MarketplaceExtensionSource) {
+				t.Fatalf("expected an unrecognized value %q to fall back to the default (off), not enable the flag", v)
+			}
+		})
+	}
+}
+
 func TestEnabled_UnknownCapability(t *testing.T) {
 	if Enabled("not_a_real_capability") {
 		t.Fatal("expected unknown capabilities to report disabled")


### PR DESCRIPTION
## Summary

Findings SEC-01 (HIGH) and SEC-02 (MEDIUM) from `workflow/code_reviews/fable-2026-07-01-code-review/fest/findings.md`.

### SEC-01 — install.sh: personal-repo, unverified, undocumented curl-pipe installer

**Correction from an earlier version of this PR:** the first fix repointed `install.sh`'s downloader at `Obedience-Corp/fest`, but that's the wrong distribution model. fest is not released as a standalone per-repo binary at all — `Obedience-Corp/fest`'s GitHub releases carry notes only, no binary assets (`gh release view v0.4.6 --repo Obedience-Corp/fest --json assets` is empty; `.justfiles/release.just`'s `dev`/`rc`/`stable`/`promote` recipes only call `gh release create --notes-file`).

camp and fest actually ship bundled through the **Festival packaging repo** (`Obedience-Corp/festival`), which is the real canonical distributor: it publishes real checksummed release assets (`checksums.txt` plus macOS/linux/deb/rpm/apk bundles), has its own `curl -fsSL` install.sh, and the primary install path is `brew install --cask Obedience-Corp/tap/festival` (verified against the tap's `Casks/festival.rb`, generated by GoReleaser).

So the actual fix:
- `install.sh` no longer downloads or installs anything itself. It's a thin, safe redirect: it prints the supported install paths and exits 0.
  - Prebuilt binaries: `brew install --cask Obedience-Corp/tap/festival`, or the Festival installer directly (`curl -fsSL https://raw.githubusercontent.com/Obedience-Corp/festival/main/install.sh | bash`).
  - From source (fest only): `go install github.com/Obedience-Corp/fest/cmd/fest@latest`.
- No curl-download of a fest-only binary that doesn't exist, no checksum-URL invention, no `sudo mv`, no personal-repo pin.
- README's Installation section now leads with the festival packaging repo as the canonical distributor, documents fest-only source installs as the secondary path, and notes that `install.sh` itself only prints guidance.

### SEC-02 — marketplace extension source defaults ON, load errors swallowed

- `internal/features/features.go`: `MarketplaceExtensionSource` now defaults **off** (`envFlag(..., false)`); opt in with `FEST_FEATURE_MARKETPLACE_EXTENSION_SOURCE=1`. Extensions are agent-guiding methodology content (a prompt-injection surface for agent-driven work), so loading `~/.obey/fest/marketplace/extensions` should be opt-in, not opt-out.
- `internal/extensions/loader.go`: `loadFromDirectory` no longer silently swallows every failure. It now logs to stderr when a directory exists but can't be read (permission errors, not just "doesn't exist"), when an individual extension fails to load, and when one source's extension shadows an already-loaded extension of the same name from a different source.

### SEC-03 — noted, not fixed (out of scope)

`github/downloader.go` pulls by mutable git ref with no integrity pinning for `fest sync`. A full fix is a larger design change (pin to resolved commit SHAs, verify signed tags/content); left as a follow-up rather than over-scoping this PR.

## Test plan

- [x] `just lint all` — 0 issues (exit 0)
- [x] `just lint vet` — clean (exit 0)
- [x] `just test unit` — 91 packages, 2326/2326 tests passed (exit 0)
- [x] Added `internal/features/features_test.go`: default-off when unset, explicit enable (`1/true/on/yes`), explicit disable (`0/false/off/no`), unknown capability.
- [x] Added `TestLoadAll_MarketplaceDefaultOff` in `internal/extensions/loader_test.go` alongside the existing explicit on/off tests.
- [x] Ran the corrected `install.sh` locally — prints the install paths, exits 0, downloads/installs nothing.