### PR TITLE
feat(commands): add fest plugins command to list discovered plugins

### DIFF
--- a/internal/commands/plugin.go
+++ b/internal/commands/plugin.go
@@ -1,13 +1,19 @@
 package commands
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"slices"
+	"sort"
 	"strings"
 
 	festerrors "github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/plugins"
+	"github.com/Obedience-Corp/fest/internal/scope"
+	"github.com/Obedience-Corp/fest/internal/ui"
+	"github.com/spf13/cobra"
 )
 
 var errPluginHandled = errors.New("plugin handled")
@@ -105,4 +111,70 @@ func isKnownCommand(name string) bool {
 		}
 	}
 	return false
+}
+
+func newPluginsCommand() *cobra.Command {
+	var jsonOutput bool
+
+	cmd := &cobra.Command{
+		Use:   "plugins",
+		Short: "List discovered fest plugins",
+		Long: `List fest plugins discovered from the active config repo manifest and PATH.
+
+Any executable named fest-<name> on PATH is a fest plugin and runs as
+"fest <name> [args...]". Plugins declared in the active user config repo
+manifest (plugins/manifest.yml) carry richer metadata such as summaries.`,
+		Example: `  fest plugins
+  fest plugins --json`,
+		Annotations: map[string]string{
+			"scope": string(scope.Global),
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPluginsList(cmd, jsonOutput)
+		},
+	}
+
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output as JSON")
+	return cmd
+}
+
+func runPluginsList(cmd *cobra.Command, jsonOutput bool) error {
+	discovery := plugins.NewPluginDiscovery()
+	if err := discovery.DiscoverAll(); err != nil {
+		return err
+	}
+
+	found := slices.Clone(discovery.Plugins())
+	sort.Slice(found, func(i, j int) bool { return found[i].Command < found[j].Command })
+
+	out := cmd.OutOrStdout()
+
+	if jsonOutput {
+		payload := map[string]any{
+			"plugins": found,
+			"count":   len(found),
+		}
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(payload)
+	}
+
+	if len(found) == 0 {
+		_, _ = fmt.Fprintln(out, "No fest plugins found.")
+		_, _ = fmt.Fprintln(out, "Install an executable named fest-<name> on PATH to extend fest.")
+		return nil
+	}
+
+	_, _ = fmt.Fprintln(out, ui.Category("Installed Plugins:"))
+	for _, p := range found {
+		location := p.Path
+		if location == "" {
+			location = ui.Dim("(exec not found: " + p.Exec + ")")
+		}
+		_, _ = fmt.Fprintf(out, "  %-20s %s\n", ui.Accent(p.Command), location)
+		if p.Summary != "" && p.Summary != "Plugin: "+p.Exec {
+			_, _ = fmt.Fprintf(out, "  %-20s %s\n", "", ui.Dim(p.Summary))
+		}
+	}
+	return nil
 }

--- a/internal/commands/plugins_list_test.go
+++ b/internal/commands/plugins_list_test.go
@@ -1,0 +1,138 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writePluginFile(t *testing.T, dir, name string, mode os.FileMode) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), mode); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func isolatePluginEnv(t *testing.T, pathDir string) {
+	t.Helper()
+	t.Setenv("PATH", pathDir)
+	t.Setenv("FEST_CONFIG_DIR", t.TempDir())
+}
+
+func runPluginsCmd(t *testing.T, args ...string) string {
+	t.Helper()
+	cmd := newPluginsCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs(args)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	return buf.String()
+}
+
+func TestPluginsListEmpty(t *testing.T) {
+	isolatePluginEnv(t, t.TempDir())
+
+	out := runPluginsCmd(t)
+	if !strings.Contains(out, "No fest plugins found.") {
+		t.Fatalf("expected empty-state message, got %q", out)
+	}
+}
+
+func TestPluginsListSkipsNonExecutable(t *testing.T) {
+	dir := t.TempDir()
+	writePluginFile(t, dir, "fest-noexec", 0o644)
+	isolatePluginEnv(t, dir)
+
+	out := runPluginsCmd(t)
+	if strings.Contains(out, "noexec") {
+		t.Fatalf("non-executable file listed as plugin: %q", out)
+	}
+}
+
+func TestPluginsListHuman(t *testing.T) {
+	dir := t.TempDir()
+	path := writePluginFile(t, dir, "fest-graph", 0o755)
+	isolatePluginEnv(t, dir)
+
+	out := runPluginsCmd(t)
+	if !strings.Contains(out, "graph") {
+		t.Fatalf("expected plugin name in output, got %q", out)
+	}
+	if !strings.Contains(out, path) {
+		t.Fatalf("expected plugin path in output, got %q", out)
+	}
+}
+
+func TestPluginsListJSON(t *testing.T) {
+	dir := t.TempDir()
+	writePluginFile(t, dir, "fest-graph", 0o755)
+	writePluginFile(t, dir, "fest-export-jira", 0o755)
+	isolatePluginEnv(t, dir)
+
+	out := runPluginsCmd(t, "--json")
+
+	var payload struct {
+		Plugins []struct {
+			Command string `json:"command"`
+			Exec    string `json:"exec"`
+			Source  string `json:"source"`
+			Path    string `json:"path"`
+		} `json:"plugins"`
+		Count int `json:"count"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("unmarshal: %v\noutput: %s", err, out)
+	}
+	if payload.Count != 2 || len(payload.Plugins) != 2 {
+		t.Fatalf("expected 2 plugins, got count=%d len=%d", payload.Count, len(payload.Plugins))
+	}
+	if payload.Plugins[0].Command != "export jira" || payload.Plugins[1].Command != "graph" {
+		t.Fatalf("expected sorted commands [export jira, graph], got %+v", payload.Plugins)
+	}
+	for _, p := range payload.Plugins {
+		if p.Source != "path" {
+			t.Fatalf("expected source %q, got %q", "path", p.Source)
+		}
+		if p.Path == "" || p.Exec == "" {
+			t.Fatalf("expected non-empty path and exec, got %+v", p)
+		}
+	}
+	if !strings.Contains(out, `"source"`) || !strings.Contains(out, `"path"`) {
+		t.Fatalf("expected snake_case keys in JSON output, got %s", out)
+	}
+}
+
+func TestPluginsListManifestSummaryAndMissingExec(t *testing.T) {
+	configDir := t.TempDir()
+	pluginsDir := filepath.Join(configDir, "active", "user", "plugins")
+	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := `version: 1
+plugins:
+  - command: export jira
+    exec: fest-export-jira
+    summary: Export festival data to Jira
+`
+	if err := os.WriteFile(filepath.Join(pluginsDir, "manifest.yml"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("FEST_CONFIG_DIR", configDir)
+
+	out := runPluginsCmd(t)
+	if !strings.Contains(out, "Export festival data to Jira") {
+		t.Fatalf("expected manifest summary in output, got %q", out)
+	}
+	if !strings.Contains(out, "exec not found: fest-export-jira") {
+		t.Fatalf("expected missing-exec marker, got %q", out)
+	}
+}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -337,6 +337,10 @@ func init() {
 	extensionCmd.GroupID = "system"
 	rootCmd.AddCommand(extensionCmd)
 
+	pluginsCmd := newPluginsCommand()
+	pluginsCmd.GroupID = "system"
+	rootCmd.AddCommand(pluginsCmd)
+
 	if shared.NewTUICommand != nil {
 		tuiCmd := shared.NewTUICommand()
 		tuiCmd.GroupID = "creation"

--- a/internal/plugins/discovery.go
+++ b/internal/plugins/discovery.go
@@ -17,8 +17,8 @@ const (
 // DiscoveredPlugin represents a plugin found during discovery
 type DiscoveredPlugin struct {
 	Plugin
-	Source string // "manifest", "path", or path to manifest
-	Path   string // Full path to executable
+	Source string `json:"source"` // "manifest", "path", or path to manifest
+	Path   string `json:"path"`   // Full path to executable
 }
 
 // PluginDiscovery handles plugin discovery from multiple sources


### PR DESCRIPTION
## Problem

fest has full git-style plugin dispatch — any `fest-<name>` binary on PATH runs as `fest <name>`, plus a discovery layer covering the active config repo manifest (`plugins/manifest.yml`) and PATH — but none of it is surfaced. There is no way for users or agents to find out what plugins are installed; `camp` has had `camp plugins` for this, fest had nothing.

## Change

- New global-scope `fest plugins` command (system group), built directly on the existing `PluginDiscovery` — no new discovery logic.
- Human output: sorted command names with executable paths; manifest entries whose executable is missing show an `(exec not found: fest-<name>)` marker; manifest summaries render as a dim second line (the synthetic `Plugin: <exec>` default summary is suppressed).
- `--json` for agents: `{"plugins": [...], "count": N}` with snake_case keys, matching the `fest extension list` shape. `DiscoveredPlugin.Source/Path` gain json tags (previously untagged; the type was never JSON-marshaled before, so no consumer sees a casing change). Empty result emits `"plugins": []`, not `null`.
- Command name is `plugins` to match camp exactly (confirmed with Lance).

## Verification

- `just test unit`: 92 packages, 2370/2370 pass. `just lint all`: 0 issues.
- 5 new tests in `internal/commands/plugins_list_test.go`: empty state, non-executable skipped, human output, JSON shape/sort/casing, manifest summary + missing-exec marker (isolated via `FEST_CONFIG_DIR` + `PATH`).
- Live check with a locally built binary and a fake `fest-demo` on PATH:

```
$ fest plugins
Installed Plugins:
  demo                 .../fakebin/fest-demo
$ fest demo
demo        # dispatch unaffected
```

`fest --help` now lists the command under System Commands.

## Follow-up (out of scope)

Inlining an "Installed plugins" section into `fest --help` / `camp --help` output itself (so the plugin names appear without running the listing command) — planned as a small paired change across both CLIs.