### PR TITLE
fix(promote): exit cleanly when the interactive picker is cancelled

### DIFF
--- a/internal/commands/promote/promote.go
+++ b/internal/commands/promote/promote.go
@@ -149,6 +149,8 @@ func runPromoteCompletions(ctx context.Context, color bool) error {
 	return nil
 }
 
+var errPromoteCancelled = errors.New("promotion cancelled")
+
 // resolveFestivalForPromote resolves the festival to promote from an explicit
 // selector, the current directory, or an interactive picker. The returned bool
 // reports whether the festival was chosen from the picker.
@@ -167,13 +169,16 @@ func resolveFestivalForPromote(ctx context.Context, festivalsDir, cwd, selector 
 	}
 
 	if allowPicker && festivalsDir != "" {
-		picked, err := shared.PickFestivalPath(ctx, festivalsDir, promotePickerOptions())
+		picked, outcome, err := shared.PickFestival(ctx, festivalsDir, promotePickerOptions())
 		if err != nil {
 			return nil, false, err
 		}
-		if picked != "" {
+		switch outcome {
+		case shared.FestivalPicked:
 			festival, err := show.DetectCurrentFestival(ctx, picked, "")
 			return festival, true, err
+		case shared.FestivalPickCancelled:
+			return nil, false, errPromoteCancelled
 		}
 	}
 
@@ -217,6 +222,10 @@ func runPromote(ctx context.Context, opts *promoteOptions, selector string) erro
 
 	festival, fromPicker, err := resolveFestivalForPromote(ctx, festivalsDir, cwd, selector, !opts.json)
 	if err != nil {
+		if err == errPromoteCancelled {
+			fmt.Println(ui.Dim("Promotion cancelled"))
+			return nil
+		}
 		if opts.json {
 			if encErr := shared.EncodeJSON(os.Stdout, map[string]any{
 				"success": false,

--- a/internal/commands/shared/festival_picker.go
+++ b/internal/commands/shared/festival_picker.go
@@ -16,34 +16,46 @@ import (
 
 const progressDetailWorkers = 8
 
-// PickFestivalPath opens the shared festival picker and returns the selected path.
-func PickFestivalPath(ctx context.Context, festivalsDir string, opts FestivalPickerOptions) (string, error) {
+type FestivalPickOutcome int
+
+const (
+	FestivalPicked FestivalPickOutcome = iota
+	FestivalPickCancelled
+	FestivalPickUnavailable
+)
+
+func PickFestival(ctx context.Context, festivalsDir string, opts FestivalPickerOptions) (string, FestivalPickOutcome, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	if err := ctx.Err(); err != nil {
-		return "", err
+		return "", FestivalPickUnavailable, err
 	}
 
 	if !term.IsTerminal(int(os.Stdin.Fd())) || !term.IsTerminal(int(os.Stderr.Fd())) {
-		return "", nil
+		return "", FestivalPickUnavailable, nil
 	}
 
 	items := FestivalPickerItems(festivalsDir, opts)
 	if len(items) == 0 {
-		return "", nil
+		return "", FestivalPickUnavailable, nil
 	}
 	attachProgressDetails(ctx, items)
 
 	selected, err := picker.Run(items, navigation.Score)
 	if err != nil {
-		return "", errors.Wrap(err, "running festival picker")
+		return "", FestivalPickUnavailable, errors.Wrap(err, "running festival picker")
 	}
 	if selected == nil {
-		return "", nil
+		return "", FestivalPickCancelled, nil
 	}
 
-	return selected.Value, nil
+	return selected.Value, FestivalPicked, nil
+}
+
+func PickFestivalPath(ctx context.Context, festivalsDir string, opts FestivalPickerOptions) (string, error) {
+	path, _, err := PickFestival(ctx, festivalsDir, opts)
+	return path, err
 }
 
 // FestivalPickerItems returns picker items for festival candidates.

--- a/internal/commands/shared/festival_picker_test.go
+++ b/internal/commands/shared/festival_picker_test.go
@@ -219,3 +219,20 @@ func indexOf(values []string, target string) int {
 	}
 	return -1
 }
+
+func TestPickFestivalUnavailableWithoutFestivals(t *testing.T) {
+	path, outcome, err := PickFestival(t.Context(), t.TempDir(), FestivalPickerOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != "" || outcome != FestivalPickUnavailable {
+		t.Fatalf("empty workspace: path=%q outcome=%d, want empty path and FestivalPickUnavailable", path, outcome)
+	}
+}
+
+func TestPickFestivalPathDelegatesToPickFestival(t *testing.T) {
+	path, err := PickFestivalPath(t.Context(), t.TempDir(), FestivalPickerOptions{})
+	if err != nil || path != "" {
+		t.Fatalf("PickFestivalPath on empty workspace = %q, %v; want empty, nil", path, err)
+	}
+}


### PR DESCRIPTION
## The bug

`fest promote` with no arguments opens the interactive festival picker. **Dismissing** that picker (Esc / Ctrl-C) printed:

```
Error: festival not found
Hint: Run inside a festival, pass a name (fest promote <festival>), or run 'fest promote' in a terminal to pick one
```

…and exited non-zero — even though you were just shown a list and simply chose not to pick one. (Surfaced during review of #234.)

## Root cause

`shared.PickFestivalPath` returns `("", nil)` for **three** different situations:

1. no terminal (`!term.IsTerminal`),
2. no festivals to pick (`len(items) == 0`),
3. the user cancelled the picker (`selected == nil`).

`resolveFestivalForPromote` collapsed all three into `errors.NotFound("festival")`, so a cancelled picker looked identical to "nothing to promote."

## Fix

- Add `shared.PickFestival`, which returns the outcome: `FestivalPicked` / `FestivalPickCancelled` / `FestivalPickUnavailable`.
- `PickFestivalPath` becomes a thin wrapper over it, so `fgo` and `fest watch` (which treat any empty result the same) are unchanged.
- `fest promote` now:
  - **cancelled** → prints `Promotion cancelled` and exits `0`,
  - **unavailable** (no TTY / no festivals) → keeps the existing not-found hint (which correctly tells you to run in a terminal),
  - **picked** → resolves and promotes as before.

## Testing

`go build`, `go vet`, `gofmt`, full `go test ./...`, `golangci-lint run ./...` (0 issues) all pass. New unit tests cover the outcome for an unavailable picker and the `PickFestivalPath` delegation. Verified manually that the non-TTY path and the `fest promote <name>` selector path are unchanged. The cancel keypress itself needs an interactive TTY, so that path is covered by construction plus the picker's existing "cancel → no selection" test.
