### PR TITLE
Add festival picker to fest show

### DIFF
--- a/internal/commands/progress/picker_fallback_test.go
+++ b/internal/commands/progress/picker_fallback_test.go
@@ -4,25 +4,27 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-)
 
-func TestProgressPickerStatuses(t *testing.T) {
-	want := []string{"active", "ready", "planning"}
-	if len(progressPickerStatuses) != len(want) {
-		t.Fatalf("progressPickerStatuses length = %d, want %d", len(progressPickerStatuses), len(want))
-	}
-	for i, s := range want {
-		if progressPickerStatuses[i] != s {
-			t.Errorf("progressPickerStatuses[%d] = %q, want %q", i, progressPickerStatuses[i], s)
-		}
-	}
-}
+	"github.com/Obedience-Corp/fest/internal/commands/shared"
+)
 
 func TestPickFestivalForProgress_NoCampaign(t *testing.T) {
 	dir := t.TempDir()
 	path, err := pickFestivalForProgress(t.Context(), dir)
 	if err == nil {
 		t.Fatalf("expected error when no campaign workspace, got path %q", path)
+	}
+}
+
+func TestPickFestivalForProgress_NoFestivalsMarker(t *testing.T) {
+	dir := t.TempDir()
+	festivals := filepath.Join(dir, "festivals")
+	if err := os.MkdirAll(festivals, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, err := pickFestivalForProgress(t.Context(), dir)
+	if err == nil {
+		t.Fatal("expected error when no festivals marker, got nil")
 	}
 }
 
@@ -39,5 +41,11 @@ func TestPickFestivalForProgress_EmptyFestivals(t *testing.T) {
 	}
 	if path != "" {
 		t.Errorf("expected empty path for empty festivals dir, got %q", path)
+	}
+}
+
+func TestPickFestivalForProgress_UsesWorkingPickerStatuses(t *testing.T) {
+	if got, want := shared.WorkingFestivalPickerStatuses, []string{"active", "ready", "planning"}; len(got) != len(want) {
+		t.Fatalf("WorkingFestivalPickerStatuses length = %d, want %d", len(got), len(want))
 	}
 }

--- a/internal/commands/progress/progress.go
+++ b/internal/commands/progress/progress.go
@@ -188,8 +188,6 @@ func runProgress(ctx context.Context, opts *progressOptions) error {
 	return showProgressOverview(ctx, mgr, loc, opts)
 }
 
-var progressPickerStatuses = []string{"active", "ready", "planning"}
-
 func pickFestivalForProgress(ctx context.Context, cwd string) (string, error) {
 	festivalsDir, err := workspace.FindFestivals(cwd)
 	if err != nil || festivalsDir == "" {
@@ -198,8 +196,8 @@ func pickFestivalForProgress(ctx context.Context, cwd string) (string, error) {
 	}
 	return shared.PickFestivalPath(ctx, festivalsDir, shared.FestivalPickerOptions{
 		IncludeStatusDirectories: false,
-		PreferredStatuses:        progressPickerStatuses,
-		FallbackStatuses:         progressPickerStatuses,
+		PreferredStatuses:        shared.WorkingFestivalPickerStatuses,
+		FallbackStatuses:         shared.WorkingFestivalPickerStatuses,
 		OrderByStatusThenRecency: true,
 	})
 }

--- a/internal/commands/shared/festival_picker.go
+++ b/internal/commands/shared/festival_picker.go
@@ -16,6 +16,15 @@ import (
 
 const progressDetailWorkers = 8
 
+// WorkingFestivalPickerStatuses is the default status priority for execution-oriented
+// pickers (status, progress, watch): festivals you are likely working on now.
+var WorkingFestivalPickerStatuses = []string{"active", "ready", "planning"}
+
+// BrowseFestivalPickerStatuses extends the working set for browse-oriented pickers
+// (show). Ritual festivals are inspectable via fest show but intentionally omitted
+// from watch/progress pickers that target active execution context.
+var BrowseFestivalPickerStatuses = []string{"active", "ready", "planning", "ritual"}
+
 type FestivalPickOutcome int
 
 const (

--- a/internal/commands/shared/festival_picker_statuses_test.go
+++ b/internal/commands/shared/festival_picker_statuses_test.go
@@ -1,0 +1,27 @@
+package shared
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestWorkingFestivalPickerStatuses(t *testing.T) {
+	want := []string{"active", "ready", "planning"}
+	if !reflect.DeepEqual(WorkingFestivalPickerStatuses, want) {
+		t.Fatalf("WorkingFestivalPickerStatuses = %#v, want %#v", WorkingFestivalPickerStatuses, want)
+	}
+}
+
+func TestBrowseFestivalPickerStatusesExtendsWorkingSet(t *testing.T) {
+	if len(BrowseFestivalPickerStatuses) != len(WorkingFestivalPickerStatuses)+1 {
+		t.Fatalf("BrowseFestivalPickerStatuses = %#v, want working set plus ritual", BrowseFestivalPickerStatuses)
+	}
+	for i, status := range WorkingFestivalPickerStatuses {
+		if BrowseFestivalPickerStatuses[i] != status {
+			t.Fatalf("BrowseFestivalPickerStatuses[%d] = %q, want %q", i, BrowseFestivalPickerStatuses[i], status)
+		}
+	}
+	if BrowseFestivalPickerStatuses[len(WorkingFestivalPickerStatuses)] != "ritual" {
+		t.Fatalf("BrowseFestivalPickerStatuses ritual suffix = %q, want ritual", BrowseFestivalPickerStatuses[len(WorkingFestivalPickerStatuses)])
+	}
+}

--- a/internal/commands/show/picker_fallback_test.go
+++ b/internal/commands/show/picker_fallback_test.go
@@ -1,0 +1,68 @@
+package show
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/commands/shared"
+)
+
+func TestPickFestivalForShow_NoCampaignReturnsUnavailable(t *testing.T) {
+	dir := t.TempDir()
+	path, outcome, err := pickFestivalForShow(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome != shared.FestivalPickUnavailable {
+		t.Fatalf("outcome = %v, want unavailable", outcome)
+	}
+	if path != "" {
+		t.Fatalf("path = %q, want empty", path)
+	}
+}
+
+func TestPickFestivalForShow_NoFestivalsMarkerReturnsUnavailable(t *testing.T) {
+	dir := t.TempDir()
+	festivals := filepath.Join(dir, "festivals")
+	if err := os.MkdirAll(festivals, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	path, outcome, err := pickFestivalForShow(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome != shared.FestivalPickUnavailable {
+		t.Fatalf("outcome = %v, want unavailable", outcome)
+	}
+	if path != "" {
+		t.Fatalf("path = %q, want empty", path)
+	}
+}
+
+func TestPickFestivalForShow_UsesBrowsePickerStatuses(t *testing.T) {
+	if got, want := shared.BrowseFestivalPickerStatuses, []string{"active", "ready", "planning", "ritual"}; len(got) != len(want) {
+		t.Fatalf("BrowseFestivalPickerStatuses length = %d, want %d", len(got), len(want))
+	}
+}
+
+func TestPickFestivalForShow_EmptyFestivalsReturnsUnavailable(t *testing.T) {
+	dir := t.TempDir()
+	dotFestival := filepath.Join(dir, "festivals", ".festival")
+	if err := os.MkdirAll(dotFestival, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	path, outcome, err := pickFestivalForShow(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome != shared.FestivalPickUnavailable {
+		t.Fatalf("outcome = %v, want unavailable", outcome)
+	}
+	if path != "" {
+		t.Fatalf("path = %q, want empty", path)
+	}
+}

--- a/internal/commands/show/show.go
+++ b/internal/commands/show/show.go
@@ -246,8 +246,6 @@ func runShowCurrent(ctx context.Context, opts *showOptions) error {
 	return emitShowFestival(ctx, festival, opts, campaignRoot)
 }
 
-var showPickerStatuses = []string{"active", "ready", "planning", "ritual"}
-
 func pickFestivalForShow(ctx context.Context, cwd string) (string, shared.FestivalPickOutcome, error) {
 	festivalsDir, err := workspace.FindFestivals(cwd)
 	if err != nil || festivalsDir == "" {
@@ -255,8 +253,8 @@ func pickFestivalForShow(ctx context.Context, cwd string) (string, shared.Festiv
 	}
 	return showPickFestival(ctx, festivalsDir, shared.FestivalPickerOptions{
 		IncludeStatusDirectories: false,
-		PreferredStatuses:        showPickerStatuses,
-		FallbackStatuses:         showPickerStatuses,
+		PreferredStatuses:        shared.BrowseFestivalPickerStatuses,
+		FallbackStatuses:         shared.BrowseFestivalPickerStatuses,
 		OrderByStatusThenRecency: true,
 	})
 }

--- a/internal/commands/show/show.go
+++ b/internal/commands/show/show.go
@@ -26,6 +26,8 @@ type showOptions struct {
 	festival   string
 }
 
+var showPickFestival = shared.PickFestival
+
 // NewShowCommand creates the show command with all subcommands.
 func NewShowCommand() *cobra.Command {
 	opts := &showOptions{}
@@ -36,10 +38,11 @@ func NewShowCommand() *cobra.Command {
 		Long: `Display festival information by status or show details of a specific festival.
 
 When run inside a festival directory, shows the current festival's details.
+When run outside a festival in an interactive campaign workspace, opens a festival picker.
 When run with a status argument, lists all festivals with that status.
 
 SUBCOMMANDS:
-  fest show              Show current festival (detect from cwd)
+  fest show              Show current festival, or pick one from a campaign workspace
   fest show active       List festivals in active/ directory
   fest show planning     List festivals in planning/ directory
   fest show completed    List festivals in completed/ directory
@@ -219,14 +222,43 @@ func runShowCurrent(ctx context.Context, opts *showOptions) error {
 			if opts.json {
 				return emitShowErrorJSON("not in a festival directory or linked project")
 			}
+			picked, outcome, pickErr := pickFestivalForShow(ctx, cwd)
+			if pickErr != nil {
+				return pickErr
+			}
+			switch outcome {
+			case shared.FestivalPicked:
+				festival, err := DetectCurrentFestival(ctx, picked, campaignRoot)
+				if err != nil {
+					return err
+				}
+				return emitShowFestival(ctx, festival, opts, campaignRoot)
+			case shared.FestivalPickCancelled:
+				return nil
+			}
 			return errors.NotFound("festival").WithOp("show").
-				WithField("hint", "navigate to a festival directory, use 'fest link' to link a project, or specify a festival name")
+				WithHint("navigate to a festival directory, use 'fest link' to link a project, pass --festival <selector>, or run from a terminal in a campaign workspace to pick one")
 		}
 		return err
 	}
 
 	// Watch mode - continuously refresh display
 	return emitShowFestival(ctx, festival, opts, campaignRoot)
+}
+
+var showPickerStatuses = []string{"active", "ready", "planning", "ritual"}
+
+func pickFestivalForShow(ctx context.Context, cwd string) (string, shared.FestivalPickOutcome, error) {
+	festivalsDir, err := workspace.FindFestivals(cwd)
+	if err != nil || festivalsDir == "" {
+		return "", shared.FestivalPickUnavailable, nil
+	}
+	return showPickFestival(ctx, festivalsDir, shared.FestivalPickerOptions{
+		IncludeStatusDirectories: false,
+		PreferredStatuses:        showPickerStatuses,
+		FallbackStatuses:         showPickerStatuses,
+		OrderByStatusThenRecency: true,
+	})
 }
 
 func runShow(ctx context.Context, target string, opts *showOptions) error {

--- a/internal/commands/show/show_command_test.go
+++ b/internal/commands/show/show_command_test.go
@@ -8,6 +8,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/commands/shared"
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
 )
 
 func TestShowCommand_RejectsPositionalWithFestivalFlag(t *testing.T) {
@@ -76,6 +79,126 @@ func TestRunShowBySelector_RequiresCampaignWorkspace(t *testing.T) {
 	}
 	if !strings.Contains(strings.ToLower(err.Error()), "campaign workspace") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunShowCurrent_PicksFestivalOutsideFestival(t *testing.T) {
+	campaignRoot, festivalDir := makeShowPickerCampaign(t)
+	projectDir := filepath.Join(campaignRoot, "projects", "app", "src")
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	restoreCWD := chdirForShowTest(t, projectDir)
+	defer restoreCWD()
+
+	origPicker := showPickFestival
+	defer func() { showPickFestival = origPicker }()
+
+	var gotFestivalsDir string
+	var gotOptions shared.FestivalPickerOptions
+	showPickFestival = func(_ context.Context, festivalsDir string, opts shared.FestivalPickerOptions) (string, shared.FestivalPickOutcome, error) {
+		gotFestivalsDir = festivalsDir
+		gotOptions = opts
+		return festivalDir, shared.FestivalPicked, nil
+	}
+
+	output := captureShowStdout(t, func() error {
+		return runShowCurrent(context.Background(), &showOptions{summary: true})
+	})
+
+	if !strings.Contains(output, "launch-readiness-LR0001") {
+		t.Fatalf("output missing selected festival name:\n%s", output)
+	}
+	wantFestivalsDir := filepath.Join(campaignRoot, "festivals")
+	if !sameShowTestPath(t, gotFestivalsDir, wantFestivalsDir) {
+		t.Fatalf("picker festivalsDir = %q, want %q", gotFestivalsDir, wantFestivalsDir)
+	}
+	if gotOptions.IncludeStatusDirectories {
+		t.Fatal("picker should not include status directories for show")
+	}
+	if strings.Join(gotOptions.PreferredStatuses, ",") != strings.Join(showPickerStatuses, ",") {
+		t.Fatalf("preferred statuses = %#v, want %#v", gotOptions.PreferredStatuses, showPickerStatuses)
+	}
+	if !gotOptions.OrderByStatusThenRecency {
+		t.Fatal("picker should order candidates by status and recency")
+	}
+}
+
+func TestRunShowCurrent_JSONDoesNotPromptOutsideFestival(t *testing.T) {
+	campaignRoot, _ := makeShowPickerCampaign(t)
+	projectDir := filepath.Join(campaignRoot, "projects", "app")
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	restoreCWD := chdirForShowTest(t, projectDir)
+	defer restoreCWD()
+
+	origPicker := showPickFestival
+	defer func() { showPickFestival = origPicker }()
+	showPickFestival = func(context.Context, string, shared.FestivalPickerOptions) (string, shared.FestivalPickOutcome, error) {
+		t.Fatal("JSON show should not invoke interactive picker")
+		return "", shared.FestivalPickUnavailable, nil
+	}
+
+	output, err := captureShowStdoutAllowError(t, func() error {
+		return runShowCurrent(context.Background(), &showOptions{json: true})
+	})
+	if err != festerrors.ErrAlreadyPrinted {
+		t.Fatalf("runShowCurrent() error = %v, want ErrAlreadyPrinted", err)
+	}
+	if !strings.Contains(output, `"error"`) || !strings.Contains(output, "not in a festival directory or linked project") {
+		t.Fatalf("unexpected JSON error output:\n%s", output)
+	}
+}
+
+func TestRunShowCurrent_PickerCancelledExitsCleanly(t *testing.T) {
+	campaignRoot, _ := makeShowPickerCampaign(t)
+	projectDir := filepath.Join(campaignRoot, "projects", "app")
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	restoreCWD := chdirForShowTest(t, projectDir)
+	defer restoreCWD()
+
+	origPicker := showPickFestival
+	defer func() { showPickFestival = origPicker }()
+	showPickFestival = func(context.Context, string, shared.FestivalPickerOptions) (string, shared.FestivalPickOutcome, error) {
+		return "", shared.FestivalPickCancelled, nil
+	}
+
+	output := captureShowStdout(t, func() error {
+		return runShowCurrent(context.Background(), &showOptions{})
+	})
+	if strings.TrimSpace(output) != "" {
+		t.Fatalf("cancelled picker should not emit output, got:\n%s", output)
+	}
+}
+
+func TestRunShowCurrent_PickerUnavailableReturnsActionableHint(t *testing.T) {
+	campaignRoot, _ := makeShowPickerCampaign(t)
+	projectDir := filepath.Join(campaignRoot, "projects", "app")
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	restoreCWD := chdirForShowTest(t, projectDir)
+	defer restoreCWD()
+
+	origPicker := showPickFestival
+	defer func() { showPickFestival = origPicker }()
+	showPickFestival = func(context.Context, string, shared.FestivalPickerOptions) (string, shared.FestivalPickOutcome, error) {
+		return "", shared.FestivalPickUnavailable, nil
+	}
+
+	err := runShowCurrent(context.Background(), &showOptions{})
+	if err == nil {
+		t.Fatal("expected not found error, got nil")
+	}
+	if !strings.Contains(err.Error(), "--festival <selector>") {
+		t.Fatalf("error hint should mention explicit selector, got: %v", err)
 	}
 }
 
@@ -200,6 +323,59 @@ func TestEmitShowFestivalJSONSummaryModePreservesMetadata(t *testing.T) {
 	}
 }
 
+func makeShowPickerCampaign(t *testing.T) (string, string) {
+	t.Helper()
+
+	campaignRoot := filepath.Join(t.TempDir(), "campaign")
+	if err := os.MkdirAll(filepath.Join(campaignRoot, ".campaign"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(campaignRoot, "festivals", ".festival"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	festivalDir := filepath.Join(campaignRoot, "festivals", "active", "launch-readiness-LR0001")
+	if err := os.MkdirAll(festivalDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(festivalDir, FestivalGoalFile), []byte("# Launch Readiness\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	return campaignRoot, festivalDir
+}
+
+func chdirForShowTest(t *testing.T, dir string) func() {
+	t.Helper()
+
+	origCWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	return func() {
+		if err := os.Chdir(origCWD); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func sameShowTestPath(t *testing.T, got, want string) bool {
+	t.Helper()
+
+	gotInfo, err := os.Stat(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantInfo, err := os.Stat(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return os.SameFile(gotInfo, wantInfo)
+}
+
 func makeShowJSONFestival(t *testing.T) string {
 	t.Helper()
 
@@ -243,6 +419,16 @@ fest_tracking: true
 func captureShowStdout(t *testing.T, fn func() error) string {
 	t.Helper()
 
+	output, runErr := captureShowStdoutAllowError(t, fn)
+	if runErr != nil {
+		t.Fatalf("function returned error: %v\noutput:\n%s", runErr, output)
+	}
+	return output
+}
+
+func captureShowStdoutAllowError(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+
 	origStdout := os.Stdout
 	r, w, err := os.Pipe()
 	if err != nil {
@@ -261,8 +447,5 @@ func captureShowStdout(t *testing.T, fn func() error) string {
 	if _, readErr := buf.ReadFrom(r); readErr != nil {
 		t.Fatal(readErr)
 	}
-	if runErr != nil {
-		t.Fatalf("function returned error: %v\noutput:\n%s", runErr, buf.String())
-	}
-	return buf.String()
+	return buf.String(), runErr
 }

--- a/internal/commands/show/show_command_test.go
+++ b/internal/commands/show/show_command_test.go
@@ -117,8 +117,8 @@ func TestRunShowCurrent_PicksFestivalOutsideFestival(t *testing.T) {
 	if gotOptions.IncludeStatusDirectories {
 		t.Fatal("picker should not include status directories for show")
 	}
-	if strings.Join(gotOptions.PreferredStatuses, ",") != strings.Join(showPickerStatuses, ",") {
-		t.Fatalf("preferred statuses = %#v, want %#v", gotOptions.PreferredStatuses, showPickerStatuses)
+	if strings.Join(gotOptions.PreferredStatuses, ",") != strings.Join(shared.BrowseFestivalPickerStatuses, ",") {
+		t.Fatalf("preferred statuses = %#v, want %#v", gotOptions.PreferredStatuses, shared.BrowseFestivalPickerStatuses)
 	}
 	if !gotOptions.OrderByStatusThenRecency {
 		t.Fatal("picker should order candidates by status and recency")

--- a/internal/commands/status/handlers.go
+++ b/internal/commands/status/handlers.go
@@ -68,13 +68,11 @@ func pickFestivalForDisplay(ctx context.Context, cwd string) (string, error) {
 	}
 	return shared.PickFestivalPath(ctx, festivalsDir, shared.FestivalPickerOptions{
 		IncludeStatusDirectories: false,
-		PreferredStatuses:        statusPickerStatuses,
-		FallbackStatuses:         statusPickerStatuses,
+		PreferredStatuses:        shared.WorkingFestivalPickerStatuses,
+		FallbackStatuses:         shared.WorkingFestivalPickerStatuses,
 		OrderByStatusThenRecency: true,
 	})
 }
-
-var statusPickerStatuses = []string{"active", "ready", "planning"}
 
 // statusHandler is the signature for status set handler functions.
 type statusHandler func(ctx context.Context, display *ui.UI, cwd, newStatus string, opts *statusOptions) error

--- a/internal/commands/status/picker_fallback_test.go
+++ b/internal/commands/status/picker_fallback_test.go
@@ -4,19 +4,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-)
 
-func TestStatusPickerStatuses(t *testing.T) {
-	want := []string{"active", "ready", "planning"}
-	if len(statusPickerStatuses) != len(want) {
-		t.Fatalf("statusPickerStatuses length = %d, want %d", len(statusPickerStatuses), len(want))
-	}
-	for i, s := range want {
-		if statusPickerStatuses[i] != s {
-			t.Errorf("statusPickerStatuses[%d] = %q, want %q", i, statusPickerStatuses[i], s)
-		}
-	}
-}
+	"github.com/Obedience-Corp/fest/internal/commands/shared"
+)
 
 func TestPickFestivalForDisplay_NoCampaign(t *testing.T) {
 	dir := t.TempDir()
@@ -51,5 +41,11 @@ func TestPickFestivalForDisplay_EmptyFestivals(t *testing.T) {
 	}
 	if path != "" {
 		t.Errorf("expected empty path for empty festivals dir, got %q", path)
+	}
+}
+
+func TestPickFestivalForDisplay_UsesWorkingPickerStatuses(t *testing.T) {
+	if got, want := shared.WorkingFestivalPickerStatuses, []string{"active", "ready", "planning"}; len(got) != len(want) {
+		t.Fatalf("WorkingFestivalPickerStatuses length = %d, want %d", len(got), len(want))
 	}
 }


### PR DESCRIPTION
## Summary

- Opens the shared festival picker when `fest show` is run outside a festival but inside an interactive campaign workspace.
- Keeps JSON and non-interactive behavior deterministic, with an actionable `--festival <selector>` hint when no picker is available.
- Reuses the existing picker candidate ordering for active, ready, planning, and ritual festivals.

## Validation

- `go test ./internal/commands/show`
- `just test unit`
- `just lint vet`
- `just lint all`
- `just build quick`