### PR TITLE
docs(cli-reference): add pages for new understand subcommands

### DIFF
--- a/docs/cli-reference/fest-reference.md
+++ b/docs/cli-reference/fest-reference.md
@@ -5713,6 +5713,34 @@ fest understand [flags]
 ```
 ---
 
+## fest understand chains
+
+Chains: dependencies between festivals
+
+### Synopsis
+
+Link festivals so a downstream festival waits for its upstream dependencies, via fest chain.
+
+```
+fest understand chains [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for chains
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
 ## fest understand checklist
 
 Quick festival validation checklist
@@ -5859,6 +5887,34 @@ fest understand gates [flags]
 ```
 ---
 
+## fest understand lifecycle
+
+Festival lifecycle: planning -> ready -> active -> dungeon
+
+### Synopsis
+
+How festivals move through lifecycle directories, and how fest promote advances them.
+
+```
+fest understand lifecycle [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for lifecycle
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
 ## fest understand loop
 
 The fest next loop: festivals and standalone WORKFLOW.md as work loops
@@ -5962,6 +6018,34 @@ fest understand nodeids [flags]
 ```
 ---
 
+## fest understand planning
+
+The planning process: turning a goal into a structured plan
+
+### Synopsis
+
+How a goal becomes a festival: define, break down, organize into phases, plus common phase patterns.
+
+```
+fest understand planning [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for planning
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
 ## fest understand plugins
 
 Show discovered plugins
@@ -6016,6 +6100,62 @@ fest understand resources [flags]
 
 ```
   -h, --help   help for resources
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## fest understand rituals
+
+Ritual festivals: reusable templates for recurring work
+
+### Synopsis
+
+Define recurring work once as a ritual, then spin up fresh runs with fest ritual run.
+
+```
+fest understand rituals [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for rituals
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## fest understand roles
+
+Human vs agent responsibilities and the planning/implementation boundary
+
+### Synopsis
+
+Who does what in the human-AI collaboration, and the rule that implementation steps only follow defined requirements.
+
+```
+fest understand roles [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for roles
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/fest_understand.md
+++ b/docs/cli-reference/fest_understand.md
@@ -49,18 +49,22 @@ fest understand [flags]
 ### SEE ALSO
 
 * [fest](fest.md)	 - Festival Methodology CLI - goal-oriented project management for AI agents
+* [fest understand chains](fest_understand_chains.md)	 - Chains: dependencies between festivals
 * [fest understand checklist](fest_understand_checklist.md)	 - Quick festival validation checklist
 * [fest understand context](fest_understand_context.md)	 - CONTEXT.md - session memory for AI agents (CREATE FIRST)
 * [fest understand extensions](fest_understand_extensions.md)	 - Show loaded extensions
 * [fest understand gates](fest_understand_gates.md)	 - Show quality gate configuration
+* [fest understand lifecycle](fest_understand_lifecycle.md)	 - Festival lifecycle: planning -> ready -> active -> dungeon
 * [fest understand loop](fest_understand_loop.md)	 - The fest next loop: festivals and standalone WORKFLOW.md as work loops
 * [fest understand methodology](fest_understand_methodology.md)	 - Core principles - START HERE for new agents
 * [fest understand nodeids](fest_understand_nodeids.md)	 - Node reference system for code traceability
+* [fest understand planning](fest_understand_planning.md)	 - The planning process: turning a goal into a structured plan
 * [fest understand plugins](fest_understand_plugins.md)	 - Show discovered plugins
 * [fest understand resources](fest_understand_resources.md)	 - What's in the .festival/ directory
+* [fest understand rituals](fest_understand_rituals.md)	 - Ritual festivals: reusable templates for recurring work
+* [fest understand roles](fest_understand_roles.md)	 - Human vs agent responsibilities and the planning/implementation boundary
 * [fest understand rules](fest_understand_rules.md)	 - MANDATORY structure rules for automation
 * [fest understand structure](fest_understand_structure.md)	 - 3-level hierarchy: Festival → Phase → Sequence → Task
 * [fest understand tasks](fest_understand_tasks.md)	 - When and how to create task files (CRITICAL)
 * [fest understand templates](fest_understand_templates.md)	 - Template variables that save tokens
 * [fest understand workflow](fest_understand_workflow.md)	 - Just-in-time reading plus workflow/gate execution
-

--- a/docs/cli-reference/fest_understand_chains.md
+++ b/docs/cli-reference/fest_understand_chains.md
@@ -1,0 +1,30 @@
+## fest understand chains
+
+Chains: dependencies between festivals
+
+### Synopsis
+
+Link festivals so a downstream festival waits for its upstream dependencies, via fest chain.
+
+```
+fest understand chains [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for chains
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest understand](fest_understand.md)	 - Learn methodology FIRST - run before executing festival tasks

--- a/docs/cli-reference/fest_understand_lifecycle.md
+++ b/docs/cli-reference/fest_understand_lifecycle.md
@@ -1,0 +1,30 @@
+## fest understand lifecycle
+
+Festival lifecycle: planning -> ready -> active -> dungeon
+
+### Synopsis
+
+How festivals move through lifecycle directories, and how fest promote advances them.
+
+```
+fest understand lifecycle [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for lifecycle
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest understand](fest_understand.md)	 - Learn methodology FIRST - run before executing festival tasks

--- a/docs/cli-reference/fest_understand_planning.md
+++ b/docs/cli-reference/fest_understand_planning.md
@@ -1,0 +1,30 @@
+## fest understand planning
+
+The planning process: turning a goal into a structured plan
+
+### Synopsis
+
+How a goal becomes a festival: define, break down, organize into phases, plus common phase patterns.
+
+```
+fest understand planning [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for planning
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest understand](fest_understand.md)	 - Learn methodology FIRST - run before executing festival tasks

--- a/docs/cli-reference/fest_understand_rituals.md
+++ b/docs/cli-reference/fest_understand_rituals.md
@@ -1,0 +1,30 @@
+## fest understand rituals
+
+Ritual festivals: reusable templates for recurring work
+
+### Synopsis
+
+Define recurring work once as a ritual, then spin up fresh runs with fest ritual run.
+
+```
+fest understand rituals [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for rituals
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest understand](fest_understand.md)	 - Learn methodology FIRST - run before executing festival tasks

--- a/docs/cli-reference/fest_understand_roles.md
+++ b/docs/cli-reference/fest_understand_roles.md
@@ -1,0 +1,30 @@
+## fest understand roles
+
+Human vs agent responsibilities and the planning/implementation boundary
+
+### Synopsis
+
+Who does what in the human-AI collaboration, and the rule that implementation steps only follow defined requirements.
+
+```
+fest understand roles [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for roles
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest understand](fest_understand.md)	 - Learn methodology FIRST - run before executing festival tasks


### PR DESCRIPTION
Follow-up to #237. Regenerates the CLI reference to add the pages for the `fest understand` subcommands merged there (`roles`, `planning`, `lifecycle`, `chains`, `rituals`) and lists them in `fest_understand.md` + `fest-reference.md` SEE ALSO.

Scoped deliberately: only those 7 files, EOF-trimmed to match the `18ac133` convention. A full `just docs` also re-adds the trailing blank line to ~13 previously-trimmed files; that EOF churn was reverted so this PR is only the genuinely-new content.

Generated from `origin/main` (which includes the merged subcommand code).