### PR TITLE
fix(link): never silently evict another festival's project link

### DIFF
--- a/docs/cli-reference/fest-reference.md
+++ b/docs/cli-reference/fest-reference.md
@@ -1903,7 +1903,7 @@ fest go link [path] [flags]
 ### Options
 
 ```
-      --force   overwrite an existing active festival link
+      --force   relink a project already linked to another festival
   -h, --help    help for link
 ```
 
@@ -2691,7 +2691,7 @@ fest link [path] [flags]
 ### Options
 
 ```
-      --force   overwrite an existing active festival link
+      --force   relink a project already linked to another festival
   -h, --help    help for link
       --json    output in JSON format
       --show    show current link

--- a/docs/cli-reference/fest_go_link.md
+++ b/docs/cli-reference/fest_go_link.md
@@ -35,7 +35,7 @@ fest go link [path] [flags]
 ### Options
 
 ```
-      --force   overwrite an existing active festival link
+      --force   relink a project already linked to another festival
   -h, --help    help for link
 ```
 

--- a/docs/cli-reference/fest_link.md
+++ b/docs/cli-reference/fest_link.md
@@ -37,7 +37,7 @@ fest link [path] [flags]
 ### Options
 
 ```
-      --force   overwrite an existing active festival link
+      --force   relink a project already linked to another festival
   -h, --help    help for link
       --json    output in JSON format
       --show    show current link

--- a/internal/commands/festival/create_festival.go
+++ b/internal/commands/festival/create_festival.go
@@ -271,6 +271,7 @@ type createResult struct {
 	autoPhasesCreated []string
 	projectPath       string
 	projectLinked     bool
+	linkSkipReason    string
 	markersFilled     int
 	markersTotal      int
 	allMarkers        []map[string]any
@@ -600,6 +601,16 @@ func resolveProjectLink(cfg *createConfig, festConfig *config.FestivalConfig, re
 
 	nav, navErr := navigation.LoadNavigation()
 	if navErr == nil {
+		// A project holds one festival link at a time. Creating a festival must
+		// never silently evict another festival's link; skip and tell the user.
+		if existing, _, hasConflict := nav.ProjectConflict(cfg.dirName, resolved); hasConflict {
+			res.linkSkipReason = "already linked to " + existing
+			if !cfg.opts.JSONOutput {
+				cfg.display.Warning("Project is already linked to festival %s; link not changed", existing)
+				cfg.display.Info("Run 'fest link --force %s' from this festival to take over the link", resolved)
+			}
+			return
+		}
 		nav.SetLinkWithPath(cfg.dirName, resolved, cfg.destDir)
 		if saveErr := nav.Save(); saveErr == nil {
 			res.projectLinked = true
@@ -888,6 +899,8 @@ func emitCreateOutput(cfg *createConfig, res *createResult) error {
 	if res.projectPath != "" {
 		if res.projectLinked {
 			cfg.display.Success("Project path: %s (linked)", displayPath(res.projectPath))
+		} else if res.linkSkipReason != "" {
+			cfg.display.Info("Project path: %s (not linked - %s)", displayPath(res.projectPath), res.linkSkipReason)
 		} else {
 			cfg.display.Info("Project path: %s (not linked - path doesn't exist yet)", displayPath(res.projectPath))
 		}

--- a/internal/commands/navigation/go_link.go
+++ b/internal/commands/navigation/go_link.go
@@ -27,7 +27,36 @@ var (
 	pathStyle     = lipgloss.NewStyle().Foreground(ui.MetadataColor)
 )
 
-const linkForceHint = "use 'fest link --force' to override, or run 'fest unlink' from the active festival first"
+const linkForceHint = "use 'fest link --force' to relink the project to this festival, or run 'fest unlink' from the linked festival first"
+
+// guardProjectConflict blocks relinking a project that is already linked to a
+// different festival unless force is set. A project holds exactly one festival
+// link; before this guard, a second link silently evicted the first (the
+// "promote dropped my link" reports were this eviction, not promote). It
+// returns the existing festival's name on a permitted takeover so callers can
+// report the eviction.
+func guardProjectConflict(nav *navigation.Navigation, festivalName, projectPath string, force bool) (string, error) {
+	existing, existingFestivalPath, hasConflict := nav.ProjectConflict(festivalName, projectPath)
+	if !hasConflict {
+		return "", nil
+	}
+	if !force {
+		return "", festErrors.Validation("project is already linked to festival " + existing).
+			WithField("existing_festival", existing).
+			WithField("existing_festival_path", existingFestivalPath).
+			WithField("project", projectPath).
+			WithHint(linkForceHint)
+	}
+	return existing, nil
+}
+
+// reportLinkEviction prints the takeover an accepted --force link performed.
+func reportLinkEviction(evicted string) {
+	if evicted == "" {
+		return
+	}
+	fmt.Printf("%s %s\n", ui.Label("Replaced link"), ui.Dim("project was linked to "+evicted))
+}
 
 // NewGoLinkCommand creates the context-aware link subcommand for fest go
 func NewGoLinkCommand() *cobra.Command {
@@ -67,7 +96,7 @@ Examples:
 		},
 	}
 
-	cmd.Flags().BoolVar(&force, "force", false, "overwrite an existing active festival link")
+	cmd.Flags().BoolVar(&force, "force", false, "relink a project already linked to another festival")
 
 	return cmd
 }
@@ -80,7 +109,7 @@ func runGoLink(ctx context.Context, targetPath string, force bool) error {
 
 	// Detect context: are we inside a festival?
 	if isInsideFestival(cwd) {
-		return linkFestivalToProject(ctx, cwd, targetPath)
+		return linkFestivalToProject(ctx, cwd, targetPath, force)
 	}
 
 	// We're in a project directory, show festival picker
@@ -121,7 +150,7 @@ func isInsideFestival(path string) bool {
 }
 
 // linkFestivalToProject links the current festival to a project directory
-func linkFestivalToProject(ctx context.Context, cwd, targetPath string) error {
+func linkFestivalToProject(ctx context.Context, cwd, targetPath string, force bool) error {
 	// Detect current festival
 	loc, err := show.DetectCurrentLocation(ctx, cwd)
 	if err != nil || loc == nil || loc.Festival == nil || loc.Festival.Name == "" {
@@ -171,17 +200,12 @@ func linkFestivalToProject(ctx context.Context, cwd, targetPath string) error {
 	// Get the festival path for reverse navigation
 	festivalPath := loc.Festival.Path
 
-	if existing, existingFestivalPath, hasConflict := nav.ProjectConflict(festivalName, projectPath); hasConflict {
-		if isActiveFestivalPath(existingFestivalPath) {
-			return festErrors.Validation("project is already linked to an active festival").
-				WithField("existing_festival", existing).
-				WithField("project", projectPath).
-				WithField("hint", linkForceHint)
-		}
+	if _, err := guardProjectConflict(nav, festivalName, projectPath, force); err != nil {
+		return err
 	}
 
 	// Set the bidirectional link with festival path
-	nav.SetLinkWithPath(festivalName, projectPath, festivalPath)
+	evicted := nav.SetLinkWithPath(festivalName, projectPath, festivalPath)
 
 	// Save
 	if err := nav.Save(); err != nil {
@@ -191,6 +215,7 @@ func linkFestivalToProject(ctx context.Context, cwd, targetPath string) error {
 	fmt.Println(ui.H1("Link Created"))
 	fmt.Printf("%s %s\n", ui.Label("Festival"), ui.Value(festivalName, ui.FestivalColor))
 	fmt.Printf("%s %s\n", ui.Label("Project"), ui.Dim(projectPath))
+	reportLinkEviction(evicted)
 	fmt.Println()
 	fmt.Println(ui.Dim("Use 'fgo' to navigate between them."))
 
@@ -273,19 +298,12 @@ func linkProjectToFestival(cwd string, force bool) error {
 		return festErrors.Wrap(err, "loading navigation state")
 	}
 
-	if !force {
-		if existing, existingFestivalPath, hasConflict := nav.ProjectConflict(selectedFestival, absPath); hasConflict {
-			if isActiveFestivalPath(existingFestivalPath) {
-				return festErrors.Validation("project is already linked to an active festival").
-					WithField("existing_festival", existing).
-					WithField("project", absPath).
-					WithField("hint", linkForceHint)
-			}
-		}
+	if _, err := guardProjectConflict(nav, selectedFestival, absPath, force); err != nil {
+		return err
 	}
 
 	// Set the bidirectional link with festival path
-	nav.SetLinkWithPath(selectedFestival, absPath, festivalPath)
+	evicted := nav.SetLinkWithPath(selectedFestival, absPath, festivalPath)
 
 	// Save
 	if err := nav.Save(); err != nil {
@@ -295,6 +313,7 @@ func linkProjectToFestival(cwd string, force bool) error {
 	fmt.Println(ui.H1("Link Created"))
 	fmt.Printf("%s %s\n", ui.Label("Festival"), ui.Value(selectedFestival, ui.FestivalColor))
 	fmt.Printf("%s %s\n", ui.Label("Project"), ui.Dim(absPath))
+	reportLinkEviction(evicted)
 	fmt.Println()
 	fmt.Println(ui.Dim("Use 'fgo' to navigate between them."))
 

--- a/internal/commands/navigation/go_link_test.go
+++ b/internal/commands/navigation/go_link_test.go
@@ -346,51 +346,80 @@ func TestResolveFestivalPath(t *testing.T) {
 	}
 }
 
-func TestIsActiveFestivalPath_ImmediateParentOnly(t *testing.T) {
+func TestGuardProjectConflict(t *testing.T) {
+	projectPath := "/campaign/projects/camp"
+
 	tests := []struct {
-		name         string
-		festivalPath string
-		want         bool
+		name             string
+		existingFestival string
+		existingPath     string
+		force            bool
+		wantErr          bool
+		wantEvictable    string
 	}{
 		{
-			"active festival",
-			"/campaign/festivals/active/my-fest",
-			true,
+			name: "no existing link permits linking",
 		},
 		{
-			"planning festival",
-			"/campaign/festivals/planning/my-fest",
-			false,
+			name:             "active festival link blocks without force",
+			existingFestival: "active-fest-AF0001",
+			existingPath:     "/campaign/festivals/active/active-fest-AF0001",
+			wantErr:          true,
 		},
 		{
-			"dungeon completed",
-			"/campaign/festivals/dungeon/completed/my-fest",
-			false,
+			name:             "planning festival link blocks without force",
+			existingFestival: "planning-fest-PF0001",
+			existingPath:     "/campaign/festivals/planning/planning-fest-PF0001",
+			wantErr:          true,
 		},
 		{
-			"empty path treated as active",
-			"",
-			true,
+			name:             "legacy link without festival path blocks without force",
+			existingFestival: "legacy-fest-LF0001",
+			wantErr:          true,
 		},
 		{
-			"workspace under ancestor dir named active is not misclassified",
-			"/home/active/campaign/festivals/planning/my-fest",
-			false,
-		},
-		{
-			"deep active path with active ancestor dir not misclassified",
-			"/home/active/projects/active/campaign/festivals/planning/my-fest",
-			false,
+			name:             "force permits takeover and names the evicted festival",
+			existingFestival: "planning-fest-PF0001",
+			existingPath:     "/campaign/festivals/planning/planning-fest-PF0001",
+			force:            true,
+			wantEvictable:    "planning-fest-PF0001",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := isActiveFestivalPath(tc.festivalPath)
-			if got != tc.want {
-				t.Errorf("isActiveFestivalPath(%q) = %v, want %v", tc.festivalPath, got, tc.want)
+			n := newTestNav()
+			if tc.existingFestival != "" {
+				n.SetLinkWithPath(tc.existingFestival, projectPath, tc.existingPath)
+			}
+
+			existing, err := guardProjectConflict(n, "new-fest-NF0001", projectPath, tc.force)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("guardProjectConflict() error = nil, want conflict error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("guardProjectConflict() error: %v", err)
+			}
+			if existing != tc.wantEvictable {
+				t.Fatalf("guardProjectConflict() existing = %q, want %q", existing, tc.wantEvictable)
 			}
 		})
+	}
+}
+
+func TestGuardProjectConflict_SameFestivalRelinks(t *testing.T) {
+	n := newTestNav()
+	n.SetLinkWithPath("my-fest-MF0001", "/campaign/projects/camp", "/campaign/festivals/planning/my-fest-MF0001")
+
+	existing, err := guardProjectConflict(n, "my-fest-MF0001", "/campaign/projects/camp", false)
+	if err != nil {
+		t.Fatalf("relinking the same festival should not conflict: %v", err)
+	}
+	if existing != "" {
+		t.Fatalf("existing = %q, want empty for same-festival relink", existing)
 	}
 }
 
@@ -419,32 +448,25 @@ func TestLinkProjectToFestival_HijackGuardBlocks(t *testing.T) {
 	n := newTestNav()
 	n.SetLinkWithPath("active-fest-AF0001", projectPath, activeFestPath)
 
-	existing, existingFestivalPath, hasConflict := n.ProjectConflict("planning-fest-PF0001", projectPath)
-	if !hasConflict {
-		t.Fatal("ProjectConflict() should detect conflict: project already linked to a different festival")
-	}
-	if existing != "active-fest-AF0001" {
-		t.Errorf("ProjectConflict() existing = %q, want %q", existing, "active-fest-AF0001")
-	}
-	if !isActiveFestivalPath(existingFestivalPath) {
-		t.Errorf("isActiveFestivalPath(%q) = false; guard should block re-link to planning festival", existingFestivalPath)
+	if _, err := guardProjectConflict(n, "planning-fest-PF0001", projectPath, false); err == nil {
+		t.Fatal("guardProjectConflict() should block re-linking a project held by another festival")
 	}
 
 	n2 := newTestNav()
 	n2.SetLinkWithPath("active-fest-AF0001", projectPath, activeFestPath)
-	n2.SetLinkWithPath("planning-fest-PF0001", projectPath, planningFestPath)
+	evicted := n2.SetLinkWithPath("planning-fest-PF0001", projectPath, planningFestPath)
 
+	if evicted != "active-fest-AF0001" {
+		t.Errorf("SetLinkWithPath() evicted = %q, want active-fest-AF0001 so callers can report the takeover", evicted)
+	}
 	link, ok := n2.GetLink("active-fest-AF0001")
 	if ok && link.Path == projectPath {
-		t.Error("without guard, SetLinkWithPath silently re-points project away from active festival — this is the hijack bug #201 fixes")
+		t.Error("SetLinkWithPath must re-point the project to exactly one festival")
 	}
 
 	n3 := newTestNav()
 	n3.SetLinkWithPath("active-fest-AF0001", filepath.Join(tmpDir, "projects", "other"), activeFestPath)
-	_, _, hasConflict = n3.ProjectConflict("planning-fest-PF0001", projectPath)
-	if hasConflict {
+	if _, _, hasConflict := n3.ProjectConflict("planning-fest-PF0001", projectPath); hasConflict {
 		t.Error("ProjectConflict() should not report conflict when project is not yet linked")
 	}
-
-	_ = planningFestPath
 }

--- a/internal/commands/navigation/link.go
+++ b/internal/commands/navigation/link.go
@@ -66,7 +66,7 @@ Use 'fest unlink' to remove the link for current festival.`,
 
 	cmd.Flags().BoolVar(&opts.showLink, "show", false, "show current link")
 	cmd.Flags().BoolVar(&opts.json, "json", false, "output in JSON format")
-	cmd.Flags().BoolVar(&opts.force, "force", false, "overwrite an existing active festival link")
+	cmd.Flags().BoolVar(&opts.force, "force", false, "relink a project already linked to another festival")
 
 	return cmd
 }
@@ -100,7 +100,7 @@ func runLink(ctx context.Context, targetPath string, opts *linkOptions) error {
 
 	// Inside a festival - if no path provided, use the TUI prompt from go_link
 	if targetPath == "" {
-		return linkFestivalToProject(ctx, cwd, "")
+		return linkFestivalToProject(ctx, cwd, "", opts.force)
 	}
 
 	// Resolve target path
@@ -147,18 +147,11 @@ func runLink(ctx context.Context, targetPath string, opts *linkOptions) error {
 	festivalName := loc.Festival.Name
 	festivalPath := loc.Festival.Path
 
-	if !opts.force {
-		if existing, existingFestivalPath, hasConflict := nav.ProjectConflict(festivalName, absPath); hasConflict {
-			if isActiveFestivalPath(existingFestivalPath) {
-				return errors.Validation("project is already linked to an active festival").
-					WithField("existing_festival", existing).
-					WithField("project", absPath).
-					WithField("hint", "use --force to override, or run 'fest unlink' from the active festival first")
-			}
-		}
+	if _, err := guardProjectConflict(nav, festivalName, absPath, opts.force); err != nil {
+		return err
 	}
 
-	nav.SetLinkWithPath(festivalName, absPath, festivalPath)
+	evicted := nav.SetLinkWithPath(festivalName, absPath, festivalPath)
 
 	// Save navigation state
 	if err := nav.Save(); err != nil {
@@ -173,6 +166,9 @@ func runLink(ctx context.Context, targetPath string, opts *linkOptions) error {
 			"project":   absPath,
 			"linked_at": time.Now().UTC().Format(time.RFC3339),
 		}
+		if evicted != "" {
+			result["replaced_festival"] = evicted
+		}
 		if err := shared.EncodeJSON(os.Stdout, result); err != nil {
 			return errors.Wrap(err, "encoding JSON output")
 		}
@@ -180,6 +176,7 @@ func runLink(ctx context.Context, targetPath string, opts *linkOptions) error {
 		fmt.Println(ui.H1("Festival Link"))
 		fmt.Printf("%s %s\n", ui.Label("Festival"), ui.Value(festivalName, ui.FestivalColor))
 		fmt.Printf("%s %s\n", ui.Label("Project"), ui.Dim(absPath))
+		reportLinkEviction(evicted)
 		fmt.Println()
 		fmt.Println(ui.Dim("Use 'fgo project' to navigate to the project (after shell-init setup)"))
 		fmt.Println(ui.Dim("Use 'fest link --show' to view this link"))
@@ -451,14 +448,4 @@ func findFestivalStatus(festivalsDir, festivalName string) string {
 		}
 	}
 	return ""
-}
-
-// isActiveFestivalPath reports whether the stored festival path is inside the active/ directory.
-// A festival path of "" means the link predates festival-path tracking; treat it as active
-// to be safe (prefer the existing link when uncertain).
-func isActiveFestivalPath(festivalPath string) bool {
-	if festivalPath == "" {
-		return true
-	}
-	return filepath.Base(filepath.Dir(festivalPath)) == "active"
 }

--- a/internal/navigation/state.go
+++ b/internal/navigation/state.go
@@ -161,21 +161,27 @@ func (n *Navigation) Save() error {
 	return nil
 }
 
-// SetLink creates or updates a bidirectional festival-to-project link
-func (n *Navigation) SetLink(festivalName, projectPath string) {
-	n.SetLinkWithPath(festivalName, projectPath, "")
+// SetLink creates or updates a bidirectional festival-to-project link.
+// It returns the name of any festival whose link to the project was evicted.
+func (n *Navigation) SetLink(festivalName, projectPath string) string {
+	return n.SetLinkWithPath(festivalName, projectPath, "")
 }
 
-// SetLinkWithPath creates or updates a bidirectional festival-to-project link with festival path
-func (n *Navigation) SetLinkWithPath(festivalName, projectPath, festivalPath string) {
+// SetLinkWithPath creates or updates a bidirectional festival-to-project link
+// with festival path. A project can only be linked to one festival at a time:
+// if the project was linked to a different festival, that link is replaced and
+// the evicted festival's name is returned so callers can surface the takeover
+// instead of dropping it silently.
+func (n *Navigation) SetLinkWithPath(festivalName, projectPath, festivalPath string) (evicted string) {
 	// Remove old reverse link if this festival was linked elsewhere
 	if oldLink, ok := n.Links[festivalName]; ok {
 		delete(n.ProjectLinks, oldLink.Path)
 	}
 
 	// Remove old link if this project was linked to another festival
-	if oldFestival, ok := n.ProjectLinks[projectPath]; ok {
+	if oldFestival, ok := n.ProjectLinks[projectPath]; ok && oldFestival != festivalName {
 		delete(n.Links, oldFestival)
+		evicted = oldFestival
 	}
 
 	// Set forward link: festival -> project
@@ -187,6 +193,7 @@ func (n *Navigation) SetLinkWithPath(festivalName, projectPath, festivalPath str
 
 	// Set reverse link: project -> festival
 	n.ProjectLinks[projectPath] = festivalName
+	return evicted
 }
 
 // ProjectConflict returns information about a conflicting project link, if one exists.

--- a/internal/navigation/state_test.go
+++ b/internal/navigation/state_test.go
@@ -699,3 +699,30 @@ func TestNavigation_ProjectConflict_LegacyLinkTreatedAsActive(t *testing.T) {
 		t.Errorf("ProjectConflict() existingFestivalPath should be empty for legacy link (no festival path stored), got %q", existingFestivalPath)
 	}
 }
+
+func TestNavigation_SetLinkWithPathReturnsEvicted(t *testing.T) {
+	n := &Navigation{
+		Version:      1,
+		Links:        make(map[string]*Link),
+		ProjectLinks: make(map[string]string),
+	}
+
+	if evicted := n.SetLinkWithPath("fest-a", "/projects/camp", "/festivals/planning/fest-a"); evicted != "" {
+		t.Fatalf("first link evicted = %q, want empty", evicted)
+	}
+
+	if evicted := n.SetLinkWithPath("fest-a", "/projects/camp", "/festivals/ready/fest-a"); evicted != "" {
+		t.Fatalf("same-festival relink evicted = %q, want empty", evicted)
+	}
+
+	evicted := n.SetLinkWithPath("fest-b", "/projects/camp", "/festivals/planning/fest-b")
+	if evicted != "fest-a" {
+		t.Fatalf("takeover evicted = %q, want fest-a", evicted)
+	}
+	if _, ok := n.GetLink("fest-a"); ok {
+		t.Fatal("evicted festival should no longer have a link")
+	}
+	if got := n.GetLinkedFestival("/projects/camp"); got != "fest-b" {
+		t.Fatalf("project linked to %q, want fest-b", got)
+	}
+}


### PR DESCRIPTION
## The bug (root cause of "promote dropped my link")

Campaign-history autopsy of the CF0001 incident shows `fest promote` was innocent: its `UpdateNavigationAfterMove` correctly rewrites `festival_path` on every non-terminal move (verified against commit 1157b76e4 in obey-campaign, and end-to-end in a scratch campaign).

The links actually vanished when a **second festival linked the same project**. `SetLinkWithPath` enforces one-festival-per-project by evicting the previous holder, and the old guard (#201) only blocked when the holder was in `active/`. Planning/ready festivals were evicted silently. In the recorded incident, creating/linking MM0001 against `projects/camp` deleted CF0001's link hours before CF0001's promote; the missing link was then noticed after the promote and misattributed to it.

## The fix

- `fest link` / `fest go link`: relinking a project held by ANY other festival now errors, naming the holder, unless `--force`. Forced takeovers print `Replaced link: project was linked to <festival>` and emit `replaced_festival` in `--json`.
- `fest create festival --project`: never evicts; warns, skips the auto-link, and the summary states the real reason.
- `navigation.SetLinkWithPath` returns the evicted festival name so every caller must handle the takeover explicitly. Same-festival relinks (including promote's path refresh) report no eviction.
- Removed the now-obsolete `isActiveFestivalPath` special case.

## Verification

- `just lint all` 0 issues; `just test unit` 2446/2446; `just docs` regenerated.
- Scratch-campaign end-to-end with the built binary: steal without `--force` blocked with holder named + hint; `--force` succeeds and reports the eviction; `create festival --project` on a held project warns and leaves the link intact; promote planning->ready preserves the link with updated `festival_path` (regression).