### PR TITLE
fix(navigation): serialize navigation.yaml mutations with flock + atomic writes

### DIFF
--- a/internal/commands/festival/create_festival.go
+++ b/internal/commands/festival/create_festival.go
@@ -555,7 +555,7 @@ func writeFestYaml(ctx context.Context, cfg *createConfig) (*createResult, error
 	res := &createResult{festConfig: festConfig}
 
 	if cfg.opts.Project != "" {
-		resolveProjectLink(cfg, festConfig, res)
+		resolveProjectLink(ctx, cfg, festConfig, res)
 	}
 
 	if cfg.festivalType != nil {
@@ -578,7 +578,7 @@ func writeFestYaml(ctx context.Context, cfg *createConfig) (*createResult, error
 }
 
 // resolveProjectLink resolves and optionally links a project path for the festival.
-func resolveProjectLink(cfg *createConfig, festConfig *config.FestivalConfig, res *createResult) {
+func resolveProjectLink(ctx context.Context, cfg *createConfig, festConfig *config.FestivalConfig, res *createResult) {
 	workspaceRoot := filepath.Dir(cfg.festivalsRoot)
 	resolved, err := ResolveProjectPath(cfg.opts.Project, workspaceRoot)
 	if err != nil {
@@ -599,8 +599,7 @@ func resolveProjectLink(cfg *createConfig, festConfig *config.FestivalConfig, re
 		return
 	}
 
-	nav, navErr := navigation.LoadNavigation()
-	if navErr == nil {
+	updateErr := navigation.Update(ctx, func(nav *navigation.Navigation) error {
 		// A project holds one festival link at a time. Creating a festival must
 		// never silently evict another festival's link; skip and tell the user.
 		if existing, _, hasConflict := nav.ProjectConflict(cfg.dirName, resolved); hasConflict {
@@ -609,15 +608,18 @@ func resolveProjectLink(cfg *createConfig, festConfig *config.FestivalConfig, re
 				cfg.display.Warning("Project is already linked to festival %s; link not changed", existing)
 				cfg.display.Info("Run 'fest link --force %s' from this festival to take over the link", resolved)
 			}
-			return
+			return nil
 		}
 		nav.SetLinkWithPath(cfg.dirName, resolved, cfg.destDir)
-		if saveErr := nav.Save(); saveErr == nil {
-			res.projectLinked = true
-			if !cfg.opts.JSONOutput {
-				cfg.display.Success("Linked to project: %s", resolved)
-			}
-		}
+		res.projectLinked = true
+		return nil
+	})
+	if updateErr != nil {
+		res.projectLinked = false
+		return
+	}
+	if res.projectLinked && !cfg.opts.JSONOutput {
+		cfg.display.Success("Linked to project: %s", resolved)
 	}
 }
 
@@ -1051,13 +1053,11 @@ func rollbackCreatedFestival(ctx context.Context, cfg *createConfig, res *create
 	var failures []string
 
 	if res != nil && res.projectLinked {
-		nav, err := navigation.LoadNavigation()
-		if err != nil {
+		if err := navigation.Update(ctx, func(nav *navigation.Navigation) error {
+			nav.RemoveLink(cfg.dirName)
+			return nil
+		}); err != nil {
 			failures = append(failures, fmt.Sprintf("removing navigation link: %v", err))
-		} else if nav.RemoveLink(cfg.dirName) {
-			if err := nav.Save(); err != nil {
-				failures = append(failures, fmt.Sprintf("saving navigation rollback: %v", err))
-			}
 		}
 	}
 

--- a/internal/commands/navigation/go_link.go
+++ b/internal/commands/navigation/go_link.go
@@ -113,7 +113,7 @@ func runGoLink(ctx context.Context, targetPath string, force bool) error {
 	}
 
 	// We're in a project directory, show festival picker
-	return linkProjectToFestival(cwd, force)
+	return linkProjectToFestival(ctx, cwd, force)
 }
 
 // isInsideFestival checks if the path is within a festivals/ directory
@@ -191,25 +191,18 @@ func linkFestivalToProject(ctx context.Context, cwd, targetPath string, force bo
 		projectPath = selectedPath
 	}
 
-	// Load navigation state
-	nav, err := navigation.LoadNavigation()
-	if err != nil {
-		return festErrors.Wrap(err, "loading navigation state")
-	}
-
 	// Get the festival path for reverse navigation
 	festivalPath := loc.Festival.Path
 
-	if _, err := guardProjectConflict(nav, festivalName, projectPath, force); err != nil {
+	var evicted string
+	if err := navigation.Update(ctx, func(nav *navigation.Navigation) error {
+		if _, err := guardProjectConflict(nav, festivalName, projectPath, force); err != nil {
+			return err
+		}
+		evicted = nav.SetLinkWithPath(festivalName, projectPath, festivalPath)
+		return nil
+	}); err != nil {
 		return err
-	}
-
-	// Set the bidirectional link with festival path
-	evicted := nav.SetLinkWithPath(festivalName, projectPath, festivalPath)
-
-	// Save
-	if err := nav.Save(); err != nil {
-		return festErrors.Wrap(err, "saving navigation state")
 	}
 
 	fmt.Println(ui.H1("Link Created"))
@@ -223,7 +216,7 @@ func linkFestivalToProject(ctx context.Context, cwd, targetPath string, force bo
 }
 
 // linkProjectToFestival shows a picker to select a festival to link
-func linkProjectToFestival(cwd string, force bool) error {
+func linkProjectToFestival(ctx context.Context, cwd string, force bool) error {
 	absPath, err := filepath.Abs(cwd)
 	if err != nil {
 		return festErrors.Wrap(err, "resolving current directory")
@@ -292,22 +285,15 @@ func linkProjectToFestival(cwd string, force bool) error {
 		}
 	}
 
-	// Load navigation state
-	nav, err := navigation.LoadNavigation()
-	if err != nil {
-		return festErrors.Wrap(err, "loading navigation state")
-	}
-
-	if _, err := guardProjectConflict(nav, selectedFestival, absPath, force); err != nil {
+	var evicted string
+	if err := navigation.Update(ctx, func(nav *navigation.Navigation) error {
+		if _, err := guardProjectConflict(nav, selectedFestival, absPath, force); err != nil {
+			return err
+		}
+		evicted = nav.SetLinkWithPath(selectedFestival, absPath, festivalPath)
+		return nil
+	}); err != nil {
 		return err
-	}
-
-	// Set the bidirectional link with festival path
-	evicted := nav.SetLinkWithPath(selectedFestival, absPath, festivalPath)
-
-	// Save
-	if err := nav.Save(); err != nil {
-		return festErrors.Wrap(err, "saving navigation state")
 	}
 
 	fmt.Println(ui.H1("Link Created"))

--- a/internal/commands/navigation/link.go
+++ b/internal/commands/navigation/link.go
@@ -92,7 +92,7 @@ func runLink(ctx context.Context, targetPath string, opts *linkOptions) error {
 			}
 			projectDir = absPath
 		}
-		return linkProjectToFestival(projectDir, opts.force)
+		return linkProjectToFestival(ctx, projectDir, opts.force)
 	}
 
 	// Inside a festival - detect location for festival metadata
@@ -137,25 +137,19 @@ func runLink(ctx context.Context, targetPath string, opts *linkOptions) error {
 		}
 	}
 
-	// Load navigation state
-	nav, err := navigation.LoadNavigation()
-	if err != nil {
-		return errors.Wrap(err, "loading navigation state")
-	}
-
 	// Create link with festival path for reverse navigation
 	festivalName := loc.Festival.Name
 	festivalPath := loc.Festival.Path
 
-	if _, err := guardProjectConflict(nav, festivalName, absPath, opts.force); err != nil {
+	var evicted string
+	if err := navigation.Update(ctx, func(nav *navigation.Navigation) error {
+		if _, err := guardProjectConflict(nav, festivalName, absPath, opts.force); err != nil {
+			return err
+		}
+		evicted = nav.SetLinkWithPath(festivalName, absPath, festivalPath)
+		return nil
+	}); err != nil {
 		return err
-	}
-
-	evicted := nav.SetLinkWithPath(festivalName, absPath, festivalPath)
-
-	// Save navigation state
-	if err := nav.Save(); err != nil {
-		return errors.Wrap(err, "saving navigation state")
 	}
 
 	// Output result
@@ -316,13 +310,12 @@ func runUnlink(ctx context.Context, jsonOutput bool) error {
 		}
 	}
 
-	removed := nav.RemoveLink(festivalName)
-
-	if removed {
-		// Save navigation state
-		if err := nav.Save(); err != nil {
-			return errors.Wrap(err, "saving navigation state")
-		}
+	var removed bool
+	if err := navigation.Update(ctx, func(nav *navigation.Navigation) error {
+		removed = nav.RemoveLink(festivalName)
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	if jsonOutput {

--- a/internal/commands/navigation/shortcuts.go
+++ b/internal/commands/navigation/shortcuts.go
@@ -53,7 +53,7 @@ Usage with fgo:
 			if len(args) > 1 {
 				path = args[1]
 			}
-			return runGoMap(name, path, jsonOutput)
+			return runGoMap(cmd.Context(), name, path, jsonOutput)
 		},
 	}
 
@@ -62,7 +62,7 @@ Usage with fgo:
 	return cmd
 }
 
-func runGoMap(name, path string, jsonOutput bool) error {
+func runGoMap(ctx context.Context, name, path string, jsonOutput bool) error {
 	// Validate shortcut name
 	if !isValidShortcutName(name) {
 		return errors.Validation("invalid shortcut name").
@@ -97,19 +97,11 @@ func runGoMap(name, path string, jsonOutput bool) error {
 		return errors.Validation("path must be a directory").WithField("path", absPath)
 	}
 
-	// Load navigation state
-	nav, err := navigation.LoadNavigation()
-	if err != nil {
-		return errors.Wrap(err, "loading navigation state")
-	}
-
-	// Create shortcut
-	nav.Shortcuts[name] = absPath
-	nav.UpdatedAt = time.Now().UTC()
-
-	// Save navigation state
-	if err := nav.Save(); err != nil {
-		return errors.Wrap(err, "saving navigation state")
+	if err := navigation.Update(ctx, func(nav *navigation.Navigation) error {
+		nav.Shortcuts[name] = absPath
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	// Output result
@@ -145,7 +137,7 @@ func NewGoUnmapCommand() *cobra.Command {
   fest go unmap api   # Remove shortcut 'api'`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runGoUnmap(args[0], jsonOutput)
+			return runGoUnmap(cmd.Context(), args[0], jsonOutput)
 		},
 	}
 
@@ -154,24 +146,14 @@ func NewGoUnmapCommand() *cobra.Command {
 	return cmd
 }
 
-func runGoUnmap(name string, jsonOutput bool) error {
-	// Load navigation state
-	nav, err := navigation.LoadNavigation()
-	if err != nil {
-		return errors.Wrap(err, "loading navigation state")
-	}
-
-	// Check if shortcut exists
-	_, exists := nav.Shortcuts[name]
-
-	if exists {
+func runGoUnmap(ctx context.Context, name string, jsonOutput bool) error {
+	var exists bool
+	if err := navigation.Update(ctx, func(nav *navigation.Navigation) error {
+		_, exists = nav.Shortcuts[name]
 		delete(nav.Shortcuts, name)
-		nav.UpdatedAt = time.Now().UTC()
-
-		// Save navigation state
-		if err := nav.Save(); err != nil {
-			return errors.Wrap(err, "saving navigation state")
-		}
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	// Output result

--- a/internal/commands/promote/promote.go
+++ b/internal/commands/promote/promote.go
@@ -365,7 +365,7 @@ func promoteCore(ctx context.Context, festival *show.FestivalInfo, confirm bool,
 	}
 
 	// Update navigation links after successful move
-	linkAction := status.UpdateNavigationAfterMove(festival.Name, nextStatus, newPath)
+	linkAction := status.UpdateNavigationAfterMove(ctx, festival.Name, nextStatus, newPath)
 
 	// Auto-commit the status change unless --no-commit was specified
 	var commitHash string

--- a/internal/commands/status/handlers_festival.go
+++ b/internal/commands/status/handlers_festival.go
@@ -355,7 +355,7 @@ func executeFestivalMove(ctx context.Context, festival *show.FestivalInfo, newSt
 	}
 
 	// Update navigation links after successful move
-	linkAction := UpdateNavigationAfterMove(festival.Name, newStatus, newPath)
+	linkAction := UpdateNavigationAfterMove(ctx, festival.Name, newStatus, newPath)
 
 	// Auto-commit the status change unless --no-commit was specified
 	var commitHash string
@@ -382,34 +382,35 @@ func executeFestivalMove(ctx context.Context, festival *show.FestivalInfo, newSt
 // On completion, the link is removed (project freed). On other transitions, the
 // festival path is updated so the link stays accurate.
 // Returns a human-readable description of the action taken, or empty string.
-func UpdateNavigationAfterMove(festivalName, newStatus, newPath string) string {
-	nav, err := navigation.LoadNavigation()
+func UpdateNavigationAfterMove(ctx context.Context, festivalName, newStatus, newPath string) string {
+	action := ""
+	err := navigation.Update(ctx, func(nav *navigation.Navigation) error {
+		link, linked := nav.GetLink(festivalName)
+		if !linked {
+			return nil
+		}
+
+		// Terminal statuses (anything under dungeon/) should unlink the project
+		resolvedStatus := id.ResolveStatusPath(newStatus)
+		if strings.HasPrefix(resolvedStatus, "dungeon/") {
+			nav.RemoveLink(festivalName)
+			action = fmt.Sprintf("unlinked project %s", link.Path)
+			return nil
+		}
+
+		// Non-terminal transition: update the festival path in the link
+		nav.SetLinkWithPath(festivalName, link.Path, newPath)
+		action = "link path updated"
+		return nil
+	})
 	if err != nil {
+		if action != "" {
+			return fmt.Sprintf("warning: could not save link update: %v", err)
+		}
 		// Navigation not available (no campaign context, etc.) - skip silently
 		return ""
 	}
-
-	link, linked := nav.GetLink(festivalName)
-	if !linked {
-		return ""
-	}
-
-	// Terminal statuses (anything under dungeon/) should unlink the project
-	resolvedStatus := id.ResolveStatusPath(newStatus)
-	if strings.HasPrefix(resolvedStatus, "dungeon/") {
-		nav.RemoveLink(festivalName)
-		if saveErr := nav.Save(); saveErr != nil {
-			return fmt.Sprintf("warning: could not unlink project: %v", saveErr)
-		}
-		return fmt.Sprintf("unlinked project %s", link.Path)
-	}
-
-	// Non-terminal transition: update the festival path in the link
-	nav.SetLinkWithPath(festivalName, link.Path, newPath)
-	if saveErr := nav.Save(); saveErr != nil {
-		return fmt.Sprintf("warning: could not update link path: %v", saveErr)
-	}
-	return "link path updated"
+	return action
 }
 
 // emitFestivalMoveSuccess outputs success message after moving a festival.

--- a/internal/navigation/lock_other.go
+++ b/internal/navigation/lock_other.go
@@ -1,0 +1,9 @@
+//go:build !unix
+
+package navigation
+
+// lockNavigationFile is a no-op on platforms without flock support; writes
+// fall back to the pre-locking last-writer-wins behavior.
+func lockNavigationFile(string) (func(), error) {
+	return func() {}, nil
+}

--- a/internal/navigation/lock_unix.go
+++ b/internal/navigation/lock_unix.go
@@ -1,0 +1,27 @@
+//go:build unix
+
+package navigation
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// lockNavigationFile takes an exclusive advisory lock guarding navigation
+// state mutations. It blocks until the lock is available and returns a
+// release function.
+func lockNavigationFile(lockPath string) (func(), error) {
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return nil, err
+	}
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	return func() {
+		_ = unix.Flock(int(f.Fd()), unix.LOCK_UN)
+		_ = f.Close()
+	}, nil
+}

--- a/internal/navigation/state.go
+++ b/internal/navigation/state.go
@@ -154,11 +154,67 @@ func (n *Navigation) Save() error {
 		return errors.IO("creating config directory", err).WithField("path", configDir)
 	}
 
-	if err := os.WriteFile(navPath, data, 0644); err != nil {
-		return errors.IO("writing navigation file", err).WithField("path", navPath)
+	// Write atomically (temp + rename) so readers and crashed writers never
+	// observe a partially written navigation file.
+	tmp, err := os.CreateTemp(configDir, NavigationFileName+".tmp-*")
+	if err != nil {
+		return errors.IO("creating temp navigation file", err).WithField("path", configDir)
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return errors.IO("writing navigation file", err).WithField("path", tmpPath)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return errors.IO("closing navigation file", err).WithField("path", tmpPath)
+	}
+	if err := os.Chmod(tmpPath, 0644); err != nil {
+		_ = os.Remove(tmpPath)
+		return errors.IO("setting navigation file permissions", err).WithField("path", tmpPath)
+	}
+	if err := os.Rename(tmpPath, navPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return errors.IO("replacing navigation file", err).WithField("path", navPath)
 	}
 
 	return nil
+}
+
+// Update atomically applies fn to the on-disk navigation state. It takes an
+// exclusive advisory lock, loads the freshest state, applies fn, and saves,
+// so concurrent fest processes cannot clobber each other's link changes
+// (last-writer-wins lost updates). fn returning an error aborts without
+// saving. Never save a Navigation loaded outside Update: stale in-memory
+// snapshots are exactly the lost-update bug this prevents.
+func Update(ctx context.Context, fn func(*Navigation) error) error {
+	if err := ctx.Err(); err != nil {
+		return errors.Wrap(err, "context cancelled").WithOp("navigation.Update")
+	}
+
+	navPath, err := NavigationPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(navPath), 0755); err != nil {
+		return errors.IO("creating navigation directory", err).WithField("path", filepath.Dir(navPath))
+	}
+
+	release, err := lockNavigationFile(navPath + ".lock")
+	if err != nil {
+		return errors.IO("locking navigation file", err).WithField("path", navPath+".lock")
+	}
+	defer release()
+
+	nav, err := LoadNavigation()
+	if err != nil {
+		return err
+	}
+	if err := fn(nav); err != nil {
+		return err
+	}
+	return nav.Save()
 }
 
 // SetLink creates or updates a bidirectional festival-to-project link.

--- a/internal/navigation/state_test.go
+++ b/internal/navigation/state_test.go
@@ -1,9 +1,12 @@
 package navigation
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -724,5 +727,103 @@ func TestNavigation_SetLinkWithPathReturnsEvicted(t *testing.T) {
 	}
 	if got := n.GetLinkedFestival("/projects/camp"); got != "fest-b" {
 		t.Fatalf("project linked to %q, want fest-b", got)
+	}
+}
+
+func TestNavigation_UpdateConcurrentWritersPreserveAllLinks(t *testing.T) {
+	setupTestCampaign(t)
+
+	const writers = 12
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	errs := make(chan error, writers)
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			name := fmt.Sprintf("fest-%02d", i)
+			errs <- Update(ctx, func(nav *Navigation) error {
+				nav.SetLinkWithPath(name, "/projects/"+name, "/festivals/planning/"+name)
+				return nil
+			})
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("Update() error: %v", err)
+		}
+	}
+
+	nav, err := LoadNavigation()
+	if err != nil {
+		t.Fatalf("LoadNavigation() error: %v", err)
+	}
+	if len(nav.Links) != writers {
+		t.Fatalf("links = %d, want %d (lost update: concurrent writers clobbered each other)", len(nav.Links), writers)
+	}
+}
+
+func TestNavigation_UpdateErrAbortsSave(t *testing.T) {
+	setupTestCampaign(t)
+	ctx := context.Background()
+
+	if err := Update(ctx, func(nav *Navigation) error {
+		nav.SetLink("keep-me", "/projects/keep")
+		return nil
+	}); err != nil {
+		t.Fatalf("seed Update() error: %v", err)
+	}
+
+	wantErr := fmt.Errorf("boom")
+	err := Update(ctx, func(nav *Navigation) error {
+		nav.RemoveLink("keep-me")
+		return wantErr
+	})
+	if err == nil {
+		t.Fatal("Update() error = nil, want fn error")
+	}
+
+	nav, err := LoadNavigation()
+	if err != nil {
+		t.Fatalf("LoadNavigation() error: %v", err)
+	}
+	if _, ok := nav.GetLink("keep-me"); !ok {
+		t.Fatal("failed Update must not persist its mutations")
+	}
+}
+
+func TestNavigation_UpdateContextCancelled(t *testing.T) {
+	setupTestCampaign(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := Update(ctx, func(nav *Navigation) error {
+		nav.SetLink("nope", "/projects/nope")
+		return nil
+	}); err == nil {
+		t.Fatal("Update() with cancelled context should error")
+	}
+}
+
+func TestNavigation_SaveLeavesNoTempFiles(t *testing.T) {
+	root := setupTestCampaign(t)
+
+	if err := Update(context.Background(), func(nav *Navigation) error {
+		nav.SetLink("fest-a", "/projects/a")
+		return nil
+	}); err != nil {
+		t.Fatalf("Update() error: %v", err)
+	}
+
+	entries, err := os.ReadDir(filepath.Join(root, ".campaign", "fest"))
+	if err != nil {
+		t.Fatalf("ReadDir() error: %v", err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp-") {
+			t.Fatalf("temp file left behind: %s", e.Name())
+		}
 	}
 }


### PR DESCRIPTION
Follow-up to #246. That PR fixed silent link eviction; this one closes the residual loss mechanism: navigation.yaml was whole-file read-modify-write with no cross-process locking, so a concurrent fest process saving a stale snapshot silently dropped links added in between (last writer wins).

## Changes
- `navigation.Update(ctx, fn)`: takes an exclusive flock on `navigation.yaml.lock`, loads the freshest state inside the lock, applies `fn`, saves. `fn` returning an error aborts without saving.
- Every mutating call site migrated (`fest link`, `fest go link` both directions, `fest unlink`, `fest go map`/`unmap`, `fest create festival` auto-link + rollback, `UpdateNavigationAfterMove` for promote/status moves). No raw Load+Save mutators remain in commands.
- `Save` now writes temp + rename, so readers and crashed writers never observe a partial file, and no temp files are left behind.
- `!unix` builds get a no-op lock (pre-existing last-writer-wins behavior); windows cross-build verified.

## Verification
- New tests: 12 concurrent `Update` writers all preserved (fails as a lost-update on the old code), fn-error aborts save, cancelled context rejected, no temp-file leftovers. Passed with `-race`.
- `just lint all` 0 issues; `just test unit` 2450/2450.
- CLI-level: `fest link` / `fest link --show` work through the lock in a scratch campaign; `.campaign/fest/navigation.yaml.lock` created alongside.