### PR TITLE
fix(workflow): reserve the agent decision actor for the --auto judge path

### DIFF
--- a/docs/cli-reference/fest-reference.md
+++ b/docs/cli-reference/fest-reference.md
@@ -6972,6 +6972,10 @@ Auto approval:
   Manual approval is the default. Use --auto only when an operator has explicitly
   delegated this checkpoint decision to an external judge command.
 
+  Agents must not clear checkpoints themselves: --as agent is rejected. An
+  agent-actor decision is recorded only when the operator delegates via --auto
+  and the judge returns a verdict.
+
   The judge command receives JSON on stdin using schema fest.approval.judge/v1
   and must return JSON on stdout with decision "approve" or "reject" and a
   reason. Missing commands, timeouts, non-zero exits, malformed JSON, unknown
@@ -6992,7 +6996,7 @@ fest workflow approve [flags]
 ### Options
 
 ```
-      --as string                decision actor: user or agent (default "user")
+      --as string                decision actor (user; agent decisions require --auto with a configured judge) (default "user")
       --auto                     delegate this checkpoint decision to the configured approval judge command
   -h, --help                     help for approve
       --judge-command string     approval judge command for --auto (overrides the .festival/config.yaml hooks.approval_judge.command hook)
@@ -7128,7 +7132,7 @@ Examples:
 ```bash
   fest workflow reject --reason "needs revision"
   fest workflow reject --reason "PR not ready" --remediation-phase 005_FIX_PR_302
-  fest workflow reject --as agent --reason "missing acceptance proof"
+  fest workflow reject --reason "missing acceptance proof" --summary "reviewed the diff against the task spec"
 ```
 
 ```
@@ -7138,7 +7142,7 @@ fest workflow reject [flags]
 ### Options
 
 ```
-      --as string                  decision actor: user or agent (default "user")
+      --as string                  decision actor (user; agent decisions require 'fest workflow approve --auto' with a configured judge) (default "user")
   -h, --help                       help for reject
   -r, --reason string              reason for rejection (required)
       --remediation-phase string   link a remediation phase for a failed gate (e.g. 005_FIX_PR_302)

--- a/docs/cli-reference/fest-reference.md
+++ b/docs/cli-reference/fest-reference.md
@@ -6996,7 +6996,6 @@ fest workflow approve [flags]
 ### Options
 
 ```
-      --as string                decision actor (user; agent decisions require --auto with a configured judge) (default "user")
       --auto                     delegate this checkpoint decision to the configured approval judge command
   -h, --help                     help for approve
       --judge-command string     approval judge command for --auto (overrides the .festival/config.yaml hooks.approval_judge.command hook)
@@ -7142,7 +7141,6 @@ fest workflow reject [flags]
 ### Options
 
 ```
-      --as string                  decision actor (user; agent decisions require 'fest workflow approve --auto' with a configured judge) (default "user")
   -h, --help                       help for reject
   -r, --reason string              reason for rejection (required)
       --remediation-phase string   link a remediation phase for a failed gate (e.g. 005_FIX_PR_302)

--- a/docs/cli-reference/fest_workflow_approve.md
+++ b/docs/cli-reference/fest_workflow_approve.md
@@ -17,6 +17,10 @@ Auto approval:
   Manual approval is the default. Use --auto only when an operator has explicitly
   delegated this checkpoint decision to an external judge command.
 
+  Agents must not clear checkpoints themselves: --as agent is rejected. An
+  agent-actor decision is recorded only when the operator delegates via --auto
+  and the judge returns a verdict.
+
   The judge command receives JSON on stdin using schema fest.approval.judge/v1
   and must return JSON on stdout with decision "approve" or "reject" and a
   reason. Missing commands, timeouts, non-zero exits, malformed JSON, unknown
@@ -37,7 +41,7 @@ fest workflow approve [flags]
 ### Options
 
 ```
-      --as string                decision actor: user or agent (default "user")
+      --as string                decision actor (user; agent decisions require --auto with a configured judge) (default "user")
       --auto                     delegate this checkpoint decision to the configured approval judge command
   -h, --help                     help for approve
       --judge-command string     approval judge command for --auto (overrides the .festival/config.yaml hooks.approval_judge.command hook)

--- a/docs/cli-reference/fest_workflow_approve.md
+++ b/docs/cli-reference/fest_workflow_approve.md
@@ -41,7 +41,6 @@ fest workflow approve [flags]
 ### Options
 
 ```
-      --as string                decision actor (user; agent decisions require --auto with a configured judge) (default "user")
       --auto                     delegate this checkpoint decision to the configured approval judge command
   -h, --help                     help for approve
       --judge-command string     approval judge command for --auto (overrides the .festival/config.yaml hooks.approval_judge.command hook)

--- a/docs/cli-reference/fest_workflow_reject.md
+++ b/docs/cli-reference/fest_workflow_reject.md
@@ -21,7 +21,7 @@ Examples:
 ```bash
   fest workflow reject --reason "needs revision"
   fest workflow reject --reason "PR not ready" --remediation-phase 005_FIX_PR_302
-  fest workflow reject --as agent --reason "missing acceptance proof"
+  fest workflow reject --reason "missing acceptance proof" --summary "reviewed the diff against the task spec"
 ```
 
 ```
@@ -31,7 +31,7 @@ fest workflow reject [flags]
 ### Options
 
 ```
-      --as string                  decision actor: user or agent (default "user")
+      --as string                  decision actor (user; agent decisions require 'fest workflow approve --auto' with a configured judge) (default "user")
   -h, --help                       help for reject
   -r, --reason string              reason for rejection (required)
       --remediation-phase string   link a remediation phase for a failed gate (e.g. 005_FIX_PR_302)

--- a/docs/cli-reference/fest_workflow_reject.md
+++ b/docs/cli-reference/fest_workflow_reject.md
@@ -31,7 +31,6 @@ fest workflow reject [flags]
 ### Options
 
 ```
-      --as string                  decision actor (user; agent decisions require 'fest workflow approve --auto' with a configured judge) (default "user")
   -h, --help                       help for reject
   -r, --reason string              reason for rejection (required)
       --remediation-phase string   link a remediation phase for a failed gate (e.g. 005_FIX_PR_302)

--- a/embedded/templates/agent/workflow/checkpoint.tmpl
+++ b/embedded/templates/agent/workflow/checkpoint.tmpl
@@ -1,31 +1,28 @@
 {{/*
 TEMPLATE: workflow/checkpoint.tmpl
-PURPOSE: Shown when a step requires user approval
+PURPOSE: Shown when a step requires approval. Rendering is judge-aware:
+when the operator configured hooks.approval_judge.command the agent is
+instructed to run the delegated judge; otherwise the agent must stop and
+hand off to the operator, and --auto is not advertised.
 
-EXAMPLE OUTPUT:
+EXAMPLE OUTPUT (no judge configured):
   ═══════════════════════════════════════════════════════════════════════════════
                       BLOCKING CHECKPOINT
   ═══════════════════════════════════════════════════════════════════════════════
 
   Step 2: ANALYZE — Process the data
 
-  This step requires explicit user confirmation before proceeding.
+  This step requires explicit operator confirmation before proceeding.
 
   **What you should do:**
   1. Present your work to the user
   2. Summarize what you've completed
   3. Highlight any questions or decisions
-  4. Wait for user response
+  4. Wait for the user's response — do not run the approval commands yourself
 
-  **User commands:**
+  **Operator commands:**
   - Approve and continue: fest workflow approve
-  - Delegated judge:      fest workflow approve --auto
-  - Reject with feedback:  fest workflow reject --reason "..."
-
-  ───────────────────────────────────────────────────────────────────────────────
-  Cannot advance until user approves or an explicitly delegated judge returns a
-  valid approve decision.
-  ═══════════════════════════════════════════════════════════════════════════════
+  - Reject with feedback: fest workflow reject --reason "..."
 */}}
 {{- if .InstructionHeader}}
 {{.InstructionHeader}}
@@ -36,29 +33,51 @@ EXAMPLE OUTPUT:
 
 Step {{.StepNumber}}: {{.StepName}}
 
-This step requires explicit user confirmation before proceeding.
-
 {{- if .Goal}}
-**Question:** {{.Goal}}
 
+**Question:** {{.Goal}}
 {{- end}}
 {{- if .Actions}}
+
 **Actions to verify:**
 {{range .Actions}}- {{.}}
 {{end}}
-{{end}}
+{{- end}}
+{{- if .JudgeConfigured}}
+
+This checkpoint is delegated: the operator configured an approval judge
+(hooks.approval_judge.command).
+
+**What you should do:**
+1. Run: fest workflow approve --auto
+2. Wait for it to return. The command blocks until the judge answers and fails
+   closed on timeout or judge errors, leaving the checkpoint unchanged.
+3. Approved: run fest next to continue.
+4. Rejected: address the recorded feedback, then run fest workflow advance to
+   resubmit.
+
+**Operator commands:**
+- Manual approve: fest workflow approve
+- Reject with feedback: fest workflow reject --reason "..."
+{{- else}}
+
+This step requires explicit operator confirmation before proceeding.
+
 **What you should do:**
 1. Present your work to the user
 2. Summarize what you've completed
 3. Highlight any questions or decisions
-4. Wait for user response
+4. Wait for the user's response — do not run the approval commands yourself
 
-**User commands:**
+**Operator commands:**
 - Approve and continue: fest workflow approve
-- Delegated judge:      fest workflow approve --auto
-- Reject with feedback:  fest workflow reject --reason "..."
+- Reject with feedback: fest workflow reject --reason "..."
+- Delegate this decision: configure hooks.approval_judge.command, then
+  fest workflow approve --auto
+{{- end}}
 
 ───────────────────────────────────────────────────────────────────────────────
-Cannot advance until user approves or an explicitly delegated judge returns a valid approve decision.
-Auto mode is default-off and fails closed if the judge command is missing or invalid.
+Cannot advance until the operator approves or an explicitly delegated judge
+returns a valid approve decision. Auto mode fails closed if the judge command
+is missing or invalid.
 ═══════════════════════════════════════════════════════════════════════════════

--- a/embedded/templates/agent/workflow/step.tmpl
+++ b/embedded/templates/agent/workflow/step.tmpl
@@ -61,11 +61,14 @@ Address the feedback and try again.
 {{else if .IsBlocking}}
 When work is complete, submit for review:
   fest workflow advance
-
-This will require user approval before proceeding.
-If the operator explicitly delegated this checkpoint to a judge command, use:
+{{if .JudgeConfigured}}
+This checkpoint is delegated to the operator-configured approval judge. After
+advancing, run:
   fest workflow approve --auto
 {{else}}
+This will require operator approval before proceeding. Present the work and
+wait for the operator; do not approve it yourself.
+{{end}}{{else}}
 When complete, run: fest workflow advance
 {{end}}
 ═══════════════════════════════════════════════════════════════════════════════

--- a/internal/commands/workflow/approve.go
+++ b/internal/commands/workflow/approve.go
@@ -105,7 +105,8 @@ Auto approval:
 		},
 	}
 
-	cmd.Flags().StringVar(&actor, "as", decisionActorUser, "decision actor (user; agent decisions require --auto with a configured judge)")
+	cmd.Flags().StringVar(&actor, "as", decisionActorUser, "deprecated: manual approvals are always recorded as the user; agent decisions require --auto with a configured judge")
+	_ = cmd.Flags().MarkHidden("as")
 	cmd.Flags().StringVar(&summary, "summary", "", "approval summary or rationale")
 	cmd.Flags().BoolVar(&opts.Auto, "auto", false, "delegate this checkpoint decision to the configured approval judge command")
 	cmd.Flags().StringVar(&opts.JudgeCommand, "judge-command", opts.JudgeCommand, "approval judge command for --auto (overrides the .festival/config.yaml hooks.approval_judge.command hook)")

--- a/internal/commands/workflow/approve.go
+++ b/internal/commands/workflow/approve.go
@@ -74,6 +74,10 @@ Auto approval:
   Manual approval is the default. Use --auto only when an operator has explicitly
   delegated this checkpoint decision to an external judge command.
 
+  Agents must not clear checkpoints themselves: --as agent is rejected. An
+  agent-actor decision is recorded only when the operator delegates via --auto
+  and the judge returns a verdict.
+
   The judge command receives JSON on stdin using schema fest.approval.judge/v1
   and must return JSON on stdout with decision "approve" or "reject" and a
   reason. Missing commands, timeouts, non-zero exits, malformed JSON, unknown
@@ -93,7 +97,7 @@ Auto approval:
 			if opts.Auto {
 				return runApproveWithOptions(cmd.Context(), wf.DecisionMetadata{}, opts)
 			}
-			decision, err := normalizeDecision("approval", actor, summary, "")
+			decision, err := normalizeDecision("approval", actor, summary)
 			if err != nil {
 				return err
 			}
@@ -101,7 +105,7 @@ Auto approval:
 		},
 	}
 
-	cmd.Flags().StringVar(&actor, "as", decisionActorUser, "decision actor: user or agent")
+	cmd.Flags().StringVar(&actor, "as", decisionActorUser, "decision actor (user; agent decisions require --auto with a configured judge)")
 	cmd.Flags().StringVar(&summary, "summary", "", "approval summary or rationale")
 	cmd.Flags().BoolVar(&opts.Auto, "auto", false, "delegate this checkpoint decision to the configured approval judge command")
 	cmd.Flags().StringVar(&opts.JudgeCommand, "judge-command", opts.JudgeCommand, "approval judge command for --auto (overrides the .festival/config.yaml hooks.approval_judge.command hook)")

--- a/internal/commands/workflow/decision.go
+++ b/internal/commands/workflow/decision.go
@@ -12,7 +12,12 @@ const (
 	decisionActorAgent = "agent"
 )
 
-func normalizeDecision(action, actor, summary, fallbackSummary string) (wf.DecisionMetadata, error) {
+// normalizeDecision validates the actor for a manual checkpoint decision.
+// Only the user actor is accepted here: the agent actor is reserved for
+// judge-mediated decisions recorded by 'fest workflow approve --auto', so an
+// agent-actor entry in the audit trail always corresponds to an explicit
+// operator delegation rather than an agent clearing its own gate.
+func normalizeDecision(action, actor, summary string) (wf.DecisionMetadata, error) {
 	actor = strings.TrimSpace(strings.ToLower(actor))
 	if actor == "" {
 		actor = decisionActorUser
@@ -20,24 +25,30 @@ func normalizeDecision(action, actor, summary, fallbackSummary string) (wf.Decis
 	summary = strings.TrimSpace(summary)
 
 	switch actor {
-	case decisionActorUser, decisionActorAgent:
+	case decisionActorUser:
+	case decisionActorAgent:
+		return wf.DecisionMetadata{}, festerrors.Validation("--as agent is not allowed for manual " + action).
+			WithField("actor", actor).
+			WithHint(agentActorHint(action))
 	default:
 		return wf.DecisionMetadata{}, festerrors.Validation("invalid decision actor").
 			WithField("actor", actor).
-			WithHint("use --as user or --as agent")
-	}
-
-	if actor == decisionActorAgent && summary == "" {
-		if fallbackSummary != "" {
-			summary = strings.TrimSpace(fallbackSummary)
-		} else {
-			return wf.DecisionMetadata{}, festerrors.Validation("--summary is required for agent " + action).
-				WithHint("record the approval basis with --summary \"...\"")
-		}
+			WithHint("use --as user; agent-actor decisions are recorded only by 'fest workflow approve --auto' with a configured approval judge")
 	}
 
 	return wf.DecisionMetadata{
 		Actor:   actor,
 		Summary: summary,
 	}, nil
+}
+
+func agentActorHint(action string) string {
+	const delegation = "agent-actor decisions enter the audit trail only through 'fest workflow approve --auto' with a configured approval judge (hooks.approval_judge.command)"
+	switch action {
+	case "approval":
+		return "blocking checkpoints are operator decisions: stop, present the work, and ask the operator to run 'fest workflow approve'; " + delegation
+	case "rejection":
+		return "blocking checkpoints are operator decisions: share your findings and ask the operator to run 'fest workflow reject'; " + delegation
+	}
+	return "blocking checkpoints are operator decisions; " + delegation
 }

--- a/internal/commands/workflow/decision_test.go
+++ b/internal/commands/workflow/decision_test.go
@@ -1,30 +1,55 @@
 package workflow
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
-func TestNormalizeDecisionRequiresAgentApprovalSummary(t *testing.T) {
-	_, err := normalizeDecision("approval", "agent", "", "")
+func TestNormalizeDecisionRejectsAgentApproval(t *testing.T) {
+	_, err := normalizeDecision("approval", "agent", "looks good to me")
 	if err == nil {
-		t.Fatal("normalizeDecision() error = nil, want summary validation error")
+		t.Fatal("normalizeDecision() error = nil, want agent actor rejection")
+	}
+	if !strings.Contains(err.Error(), "--as agent is not allowed") {
+		t.Fatalf("error = %v, want --as agent rejection", err)
 	}
 }
 
-func TestNormalizeDecisionUsesFallbackForAgentRejection(t *testing.T) {
-	decision, err := normalizeDecision("rejection", "agent", "", "needs revision")
-	if err != nil {
-		t.Fatalf("normalizeDecision() error: %v", err)
+func TestNormalizeDecisionRejectsAgentRejection(t *testing.T) {
+	_, err := normalizeDecision("rejection", "agent", "needs revision")
+	if err == nil {
+		t.Fatal("normalizeDecision() error = nil, want agent actor rejection")
 	}
-	if decision.Actor != decisionActorAgent {
-		t.Fatalf("Actor = %q, want %q", decision.Actor, decisionActorAgent)
-	}
-	if decision.Summary != "needs revision" {
-		t.Fatalf("Summary = %q, want reason fallback", decision.Summary)
+	if !strings.Contains(err.Error(), "--as agent is not allowed") {
+		t.Fatalf("error = %v, want --as agent rejection", err)
 	}
 }
 
 func TestNormalizeDecisionRejectsInvalidActor(t *testing.T) {
-	_, err := normalizeDecision("approval", "operator", "approved", "")
+	_, err := normalizeDecision("approval", "operator", "approved")
 	if err == nil {
 		t.Fatal("normalizeDecision() error = nil, want invalid actor error")
+	}
+}
+
+func TestNormalizeDecisionDefaultsToUser(t *testing.T) {
+	decision, err := normalizeDecision("approval", "", "  ship it  ")
+	if err != nil {
+		t.Fatalf("normalizeDecision() error: %v", err)
+	}
+	if decision.Actor != decisionActorUser {
+		t.Fatalf("Actor = %q, want %q", decision.Actor, decisionActorUser)
+	}
+	if decision.Summary != "ship it" {
+		t.Fatalf("Summary = %q, want trimmed summary", decision.Summary)
+	}
+}
+
+func TestAgentActorHintNamesOperatorPath(t *testing.T) {
+	for _, action := range []string{"approval", "rejection", "other"} {
+		hint := agentActorHint(action)
+		if !strings.Contains(hint, "approve --auto") {
+			t.Fatalf("agentActorHint(%q) = %q, want delegation path mentioned", action, hint)
+		}
 	}
 }

--- a/internal/commands/workflow/reject.go
+++ b/internal/commands/workflow/reject.go
@@ -40,7 +40,7 @@ Failed gates with remediation:
 Examples:
   fest workflow reject --reason "needs revision"
   fest workflow reject --reason "PR not ready" --remediation-phase 005_FIX_PR_302
-  fest workflow reject --as agent --reason "missing acceptance proof"`,
+  fest workflow reject --reason "missing acceptance proof" --summary "reviewed the diff against the task spec"`,
 		Annotations: map[string]string{
 			"scope": string(scope.Festival),
 		},
@@ -49,7 +49,7 @@ Examples:
 				return festerrors.Validation("--reason is required").
 					WithHint("Usage: fest workflow reject --reason \"your feedback here\"")
 			}
-			decision, err := normalizeDecision("rejection", actor, summary, reason)
+			decision, err := normalizeDecision("rejection", actor, summary)
 			if err != nil {
 				return err
 			}
@@ -59,7 +59,7 @@ Examples:
 
 	cmd.Flags().StringVarP(&reason, "reason", "r", "", "reason for rejection (required)")
 	cmd.Flags().StringVar(&remediationPhase, "remediation-phase", "", "link a remediation phase for a failed gate (e.g. 005_FIX_PR_302)")
-	cmd.Flags().StringVar(&actor, "as", decisionActorUser, "decision actor: user or agent")
+	cmd.Flags().StringVar(&actor, "as", decisionActorUser, "decision actor (user; agent decisions require 'fest workflow approve --auto' with a configured judge)")
 	cmd.Flags().StringVar(&summary, "summary", "", "decision summary or rationale")
 	_ = cmd.MarkFlagRequired("reason")
 

--- a/internal/commands/workflow/reject.go
+++ b/internal/commands/workflow/reject.go
@@ -59,7 +59,8 @@ Examples:
 
 	cmd.Flags().StringVarP(&reason, "reason", "r", "", "reason for rejection (required)")
 	cmd.Flags().StringVar(&remediationPhase, "remediation-phase", "", "link a remediation phase for a failed gate (e.g. 005_FIX_PR_302)")
-	cmd.Flags().StringVar(&actor, "as", decisionActorUser, "decision actor (user; agent decisions require 'fest workflow approve --auto' with a configured judge)")
+	cmd.Flags().StringVar(&actor, "as", decisionActorUser, "deprecated: manual rejections are always recorded as the user; agent decisions require 'fest workflow approve --auto' with a configured judge")
+	_ = cmd.Flags().MarkHidden("as")
 	cmd.Flags().StringVar(&summary, "summary", "", "decision summary or rationale")
 	_ = cmd.MarkFlagRequired("reason")
 

--- a/internal/guidance/workflow/navigator_format.go
+++ b/internal/guidance/workflow/navigator_format.go
@@ -5,7 +5,9 @@ import (
 	"strings"
 
 	"github.com/Obedience-Corp/fest/embedded/templates/agent"
+	"github.com/Obedience-Corp/fest/internal/config"
 	"github.com/Obedience-Corp/fest/internal/guidance"
+	"github.com/Obedience-Corp/fest/internal/scope"
 )
 
 // FormatInstructions generates agent-friendly workflow instructions using templates.
@@ -41,10 +43,10 @@ func (n *Navigator) FormatInstructions(ctx context.Context) (string, error) {
 	// Check if this is a blocking step that's currently in progress (awaiting user action)
 	// A blocking checkpoint means the user needs to approve before advancing
 	if step.Checkpoint.IsBlocking() && stepState.Status == StepStatusInProgress {
-		return n.formatCheckpoint(step)
+		return n.formatCheckpoint(ctx, step)
 	}
 
-	return n.formatStep(step, stepState)
+	return n.formatStep(ctx, step, stepState)
 }
 
 // displayPhaseType returns the uppercased phase type for use in rendered headers.
@@ -88,20 +90,40 @@ func (n *Navigator) formatComplete() string {
 }
 
 // formatCheckpoint renders the checkpoint template for blocking steps.
-func (n *Navigator) formatCheckpoint(step WorkflowStep) (string, error) {
+func (n *Navigator) formatCheckpoint(ctx context.Context, step WorkflowStep) (string, error) {
 	data := map[string]any{
 		"InstructionHeader": guidance.InstructionHeader,
 		"StepNumber":        step.Number,
 		"StepName":          step.Name,
 		"Goal":              step.Goal,
 		"Actions":           step.Actions,
+		"JudgeConfigured":   n.approvalJudgeConfigured(ctx),
 	}
 
 	return agent.Render("workflow/checkpoint", data)
 }
 
+// approvalJudgeConfigured reports whether the operator has delegated blocking
+// checkpoints to an approval judge via hooks.approval_judge.command. Guidance
+// only advertises 'fest workflow approve --auto' when this returns true, so
+// agents are never handed a delegation affordance the operator did not set up.
+func (n *Navigator) approvalJudgeConfigured(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	ws, ok := scope.WorkspaceFrom(ctx)
+	if !ok || ws == nil || ws.FestivalsPath == "" {
+		return false
+	}
+	cfg, err := config.LoadWorkspaceConfig(ws.FestivalsPath)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(cfg.Hooks.ApprovalJudge.Command) != ""
+}
+
 // formatStep renders the step template for the current workflow step.
-func (n *Navigator) formatStep(step WorkflowStep, stepState *StepState) (string, error) {
+func (n *Navigator) formatStep(ctx context.Context, step WorkflowStep, stepState *StepState) (string, error) {
 	status := string(stepState.Status)
 	feedback := stepState.Feedback
 
@@ -126,6 +148,7 @@ func (n *Navigator) formatStep(step WorkflowStep, stepState *StepState) (string,
 		"Feedback":          feedback,
 		"CurrentStep":       n.workflowState.CurrentStep,
 		"IsGate":            isGate,
+		"JudgeConfigured":   n.approvalJudgeConfigured(ctx),
 	}
 
 	return agent.Render("workflow/step", data)

--- a/internal/guidance/workflow/navigator_format_judge_test.go
+++ b/internal/guidance/workflow/navigator_format_judge_test.go
@@ -1,0 +1,82 @@
+package workflow
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/config"
+	"github.com/Obedience-Corp/fest/internal/scope"
+)
+
+func TestFormatCheckpoint_NoJudgeConfigured(t *testing.T) {
+	nav := &Navigator{}
+	step := WorkflowStep{Number: 2, Name: "REVIEW", Goal: "Is the work acceptable?"}
+
+	out, err := nav.formatCheckpoint(context.Background(), step)
+	if err != nil {
+		t.Fatalf("formatCheckpoint() error = %v", err)
+	}
+
+	for _, want := range []string{
+		"Wait for the user's response",
+		"Delegate this decision",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("checkpoint output missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "1. Run: fest workflow approve --auto") {
+		t.Errorf("checkpoint output must not instruct --auto without a configured judge:\n%s", out)
+	}
+}
+
+func TestFormatCheckpoint_JudgeConfigured(t *testing.T) {
+	festivalsRoot := t.TempDir()
+	dotFestival := filepath.Join(festivalsRoot, config.DotFestivalDir)
+	if err := os.MkdirAll(dotFestival, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfgYAML := "version: \"1.0\"\nhooks:\n  approval_judge:\n    command: ob judge\n"
+	if err := os.WriteFile(filepath.Join(dotFestival, config.WorkspaceConfigFileName), []byte(cfgYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	ctx := scope.WithWorkspace(context.Background(), &scope.WorkspaceInfo{FestivalsPath: festivalsRoot})
+
+	nav := &Navigator{}
+	step := WorkflowStep{Number: 2, Name: "REVIEW"}
+
+	out, err := nav.formatCheckpoint(ctx, step)
+	if err != nil {
+		t.Fatalf("formatCheckpoint() error = %v", err)
+	}
+
+	for _, want := range []string{
+		"This checkpoint is delegated",
+		"Run: fest workflow approve --auto",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("checkpoint output missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "Present your work to the user") {
+		t.Errorf("delegated checkpoint should not tell the agent to wait for the user:\n%s", out)
+	}
+}
+
+func TestApprovalJudgeConfigured_NilAndMissing(t *testing.T) {
+	nav := &Navigator{}
+	if nav.approvalJudgeConfigured(nil) {
+		t.Error("nil context should report no judge")
+	}
+	if nav.approvalJudgeConfigured(context.Background()) {
+		t.Error("context without workspace should report no judge")
+	}
+	ctx := scope.WithWorkspace(context.Background(), &scope.WorkspaceInfo{FestivalsPath: t.TempDir()})
+	if nav.approvalJudgeConfigured(ctx) {
+		t.Error("workspace without a configured judge should report no judge")
+	}
+}


### PR DESCRIPTION
## Problem

Agents have started clearing blocking checkpoints with `fest workflow approve --as agent`, bypassing the human-AI checkpoint model. This regressed on 2026-07-09:

- #241 (decision metadata) added `--as agent` to manual `approve`/`reject` with no guard beyond `--summary`. The help text, the validation hint (`use --as user or --as agent`), and a worked example in reject's help (`fest workflow reject --as agent --reason ...`) all read as a sanctioned agent lane, so agents that hit a gate and check `--help` now find documented instructions for clearing it themselves.
- #245 (approval auto mode guardrails) locked down `--auto` (fail-closed judge, explicit config) but left the `--as agent` manual path unguarded. Internally, the agent actor was meant to mark judge-mediated decisions (`runApproveAuto` stamps it after a real verdict); the flag let any headless agent claim that actor with a self-written summary.

Contrast: `fest workflow skip` requires an interactive TTY and is annotated operator-only. `approve --as agent` had neither.

## Fix

The agent actor is reserved for judge-mediated decisions recorded by `fest workflow approve --auto`, so an agent-actor entry in the decision audit trail always corresponds to an explicit operator delegation. Manual `approve`/`reject` accept only the user actor.

The `--as` flag itself is now **hidden from help, completion, and the generated CLI reference** — it survives only as an erroring tombstone so agents that learned `--as agent` during the window it was advertised get a stop-and-hand-off hint rather than an unknown-flag error they would retry without the flag (which would succeed and be recorded as `user`):

```
Error: --as agent is not allowed for manual approval
Hint: blocking checkpoints are operator decisions: stop, present the work, and ask the operator to run 'fest workflow approve'; agent-actor decisions enter the audit trail only through 'fest workflow approve --auto' with a configured approval judge (hooks.approval_judge.command)
```

Rejection gets the same treatment; the `reject --as agent` example is removed from the help and docs. `--as user` behavior is unchanged for anything that adopted it.

## Deliberately out of scope

A skip-style TTY gate on plain `fest workflow approve` would close the remaining unlabeled headless path, but festival-app's approve button shells out to exactly `fest workflow approve` without a TTY on behalf of a human click (`src-tauri/src/cli/commands.rs`). Hardening that path needs an app-aware design (mediated-operator marker or PTY) and is captured as a campaign intent rather than bundled here.

## Testing

- Unit: agent actor rejected for approval and rejection with the redirect hint; invalid actors still rejected; user default and summary trimming covered; hint always names the `--auto` delegation path.
- Full `go test ./...` green; `just lint all` 0 issues; `go vet` clean.
- Smoke-tested the built binary inside a real festival: `approve --as agent` and `reject --as agent` fail closed with the hint before touching workflow state; `--as` no longer appears in `--help`.

Docs regen commits are separate and scoped to the affected pages.