### PR TITLE
feat(show,watch): scrollable per-festival viewport in the cycle TUI

### DIFF
--- a/internal/commands/show/cycle.go
+++ b/internal/commands/show/cycle.go
@@ -23,6 +23,14 @@ const (
 	CycleQuit
 	// CycleExtra dispatches a caller-registered ExtraKeys handler.
 	CycleExtra
+	// CycleScrollUp moves the content viewport up one line.
+	CycleScrollUp
+	// CycleScrollDown moves the content viewport down one line.
+	CycleScrollDown
+	// CyclePageUp moves the content viewport up one page.
+	CyclePageUp
+	// CyclePageDown moves the content viewport down one page.
+	CyclePageDown
 )
 
 // ExtraKeyHandler runs a custom action for a caller-registered key (e.g. watch's
@@ -41,7 +49,7 @@ type ExtraKeyHandler func(ctx context.Context, festival *FestivalInfo, rawState 
 // non-interactive consumers.
 type CycleOptions struct {
 	Detect         func(ctx context.Context, path string) (*FestivalInfo, error)
-	Render         func(ctx context.Context, festival *FestivalInfo, cycling bool) error
+	Render         func(ctx context.Context, festival *FestivalInfo, cycling bool, frame *FrameState) error
 	RenderFallback func(ctx context.Context, festival *FestivalInfo) error
 	ExtraKeys      map[byte]ExtraKeyHandler
 }
@@ -74,6 +82,7 @@ func RunCycle(ctx context.Context, paths []string, startIndex int, opts CycleOpt
 	cycling := len(paths) > 1
 	index := startIndex
 	staleSince := -1
+	frame := NewFrameState()
 	for {
 		if ctx.Err() != nil {
 			return nil
@@ -106,13 +115,35 @@ func RunCycle(ctx context.Context, paths []string, startIndex int, opts CycleOpt
 		}
 		staleSince = -1
 
+		frame.Reset()
 		renderCtx, cancelRender := context.WithCancel(ctx)
 		renderDone := make(chan error, 1)
 		go func() {
-			renderDone <- opts.Render(renderCtx, festival, cycling)
+			renderDone <- opts.Render(renderCtx, festival, cycling, frame)
 		}()
 
-		action, key := readCycleAction(ctx, os.Stdin, opts.ExtraKeys)
+		var action CycleAction
+		var key byte
+		for {
+			action, key = readCycleAction(ctx, os.Stdin, opts.ExtraKeys)
+			// Scroll keys adjust the live viewport without ending the render
+			// session, so the file watcher stays attached while scrolling.
+			switch action {
+			case CycleScrollUp:
+				frame.ScrollLines(-1)
+				continue
+			case CycleScrollDown:
+				frame.ScrollLines(1)
+				continue
+			case CyclePageUp:
+				frame.ScrollPages(-1)
+				continue
+			case CyclePageDown:
+				frame.ScrollPages(1)
+				continue
+			}
+			break
+		}
 		cancelRender()
 		renderErr := <-renderDone
 		if renderErr != nil && renderCtx.Err() == nil {
@@ -156,11 +187,13 @@ func renderCycleFrameOnce(ctx context.Context, path string, opts CycleOptions) e
 	if opts.RenderFallback != nil {
 		return opts.RenderFallback(ctx, festival)
 	}
-	return opts.Render(ctx, festival, false)
+	return opts.Render(ctx, festival, false, nil)
 }
 
-// classifyCycleKey maps a raw key sequence to a cycle action. Ctrl+C quits and
-// arrow keys move; any byte registered in extraKeys dispatches its handler.
+// classifyCycleKey maps a raw key sequence to a cycle action. Ctrl+C quits,
+// left/right arrows cycle festivals, up/down arrows scroll the viewport by
+// line, space and b page down/up; any byte registered in extraKeys dispatches
+// its handler (registered keys win over the built-in scroll keys).
 func classifyCycleKey(b []byte, extraKeys map[byte]ExtraKeyHandler) (CycleAction, byte, bool) {
 	if len(b) == 0 {
 		return CycleNone, 0, false
@@ -171,8 +204,18 @@ func classifyCycleKey(b []byte, extraKeys map[byte]ExtraKeyHandler) (CycleAction
 	if _, ok := extraKeys[b[0]]; ok {
 		return CycleExtra, b[0], true
 	}
+	switch b[0] {
+	case ' ':
+		return CyclePageDown, 0, true
+	case 'b', 'B':
+		return CyclePageUp, 0, true
+	}
 	if len(b) >= 3 && b[0] == 0x1b && b[1] == '[' {
 		switch b[2] {
+		case 'A':
+			return CycleScrollUp, 0, true
+		case 'B':
+			return CycleScrollDown, 0, true
 		case 'C':
 			return CycleNext, 0, true
 		case 'D':

--- a/internal/commands/show/cycle_test.go
+++ b/internal/commands/show/cycle_test.go
@@ -27,7 +27,11 @@ func TestClassifyCycleKey(t *testing.T) {
 		{"registered_p_dispatches_extra", []byte{'p'}, extra, CycleExtra, 'p', true},
 		{"registered_q_dispatches_extra", []byte{'q'}, extra, CycleExtra, 'q', true},
 		{"unregistered_p_ignored", []byte{'p'}, nil, CycleNone, 0, false},
-		{"up_arrow_ignored", []byte{0x1b, '[', 'A'}, extra, CycleNone, 0, false},
+		{"up_arrow_scrolls_up", []byte{0x1b, '[', 'A'}, extra, CycleScrollUp, 0, true},
+		{"down_arrow_scrolls_down", []byte{0x1b, '[', 'B'}, extra, CycleScrollDown, 0, true},
+		{"space_pages_down", []byte{' '}, extra, CyclePageDown, 0, true},
+		{"b_pages_up", []byte{'b'}, extra, CyclePageUp, 0, true},
+		{"registered_key_wins_over_page_up", []byte{'b'}, map[byte]ExtraKeyHandler{'b': noopExtraKey}, CycleExtra, 'b', true},
 		{"plain_char", []byte{'x'}, extra, CycleNone, 0, false},
 		{"short_escape", []byte{0x1b, '['}, extra, CycleNone, 0, false},
 		{"empty", nil, extra, CycleNone, 0, false},
@@ -46,7 +50,7 @@ func TestClassifyCycleKey(t *testing.T) {
 func TestRunCycle_EmptyPaths(t *testing.T) {
 	err := RunCycle(t.Context(), nil, 0, CycleOptions{
 		Detect: func(context.Context, string) (*FestivalInfo, error) { return &FestivalInfo{}, nil },
-		Render: func(context.Context, *FestivalInfo, bool) error { return nil },
+		Render: func(context.Context, *FestivalInfo, bool, *FrameState) error { return nil },
 	})
 	if err == nil {
 		t.Fatal("expected error for empty path list")
@@ -72,7 +76,7 @@ func TestRunCycle_NonTerminalRendersStartIndexOnce(t *testing.T) {
 		Detect: func(_ context.Context, path string) (*FestivalInfo, error) {
 			return &FestivalInfo{Path: path}, nil
 		},
-		Render: func(_ context.Context, festival *FestivalInfo, cycling bool) error {
+		Render: func(_ context.Context, festival *FestivalInfo, cycling bool, _ *FrameState) error {
 			rendered = festival.Path
 			renderCount++
 			if cycling {
@@ -100,7 +104,7 @@ func TestRunCycle_NonTerminalPrefersRenderFallback(t *testing.T) {
 		Detect: func(_ context.Context, path string) (*FestivalInfo, error) {
 			return &FestivalInfo{Path: path}, nil
 		},
-		Render: func(context.Context, *FestivalInfo, bool) error {
+		Render: func(context.Context, *FestivalInfo, bool, *FrameState) error {
 			t.Error("cycle renderer must not run outside raw mode when a fallback is set")
 			return nil
 		},
@@ -123,7 +127,7 @@ func TestRunCycle_NonTerminalPrefersRenderFallback(t *testing.T) {
 func TestRunCycle_NonTerminalDetectNilReturnsNotFound(t *testing.T) {
 	err := RunCycle(t.Context(), []string{"/festivals/active/gone-FS0001"}, 0, CycleOptions{
 		Detect: func(context.Context, string) (*FestivalInfo, error) { return nil, nil },
-		Render: func(context.Context, *FestivalInfo, bool) error {
+		Render: func(context.Context, *FestivalInfo, bool, *FrameState) error {
 			t.Fatal("render must not run when the start festival is missing")
 			return nil
 		},

--- a/internal/commands/show/frame.go
+++ b/internal/commands/show/frame.go
@@ -1,0 +1,115 @@
+package show
+
+import "sync"
+
+// FrameState carries live scroll state shared between the cycle key loop and
+// the watch renderer. The key loop moves the viewport; the renderer records
+// content extents on each draw (used for clamping) and redraws when Redraw
+// fires, so scrolling never tears down the underlying file-watch session.
+type FrameState struct {
+	mu     sync.Mutex
+	offset int
+	total  int
+	view   int
+	redraw chan struct{}
+}
+
+// NewFrameState returns scroll state starting at the top of the content.
+func NewFrameState() *FrameState {
+	return &FrameState{redraw: make(chan struct{}, 1)}
+}
+
+// ScrollLines moves the viewport by delta lines, clamped to the content
+// extents from the most recent draw, and signals a redraw when the offset
+// changed.
+func (f *FrameState) ScrollLines(delta int) {
+	f.mu.Lock()
+	changed := f.applyOffset(f.offset + delta)
+	f.mu.Unlock()
+	if changed {
+		f.signal()
+	}
+}
+
+// ScrollPages moves the viewport by whole viewports.
+func (f *FrameState) ScrollPages(delta int) {
+	f.mu.Lock()
+	page := f.view
+	if page < 1 {
+		page = 1
+	}
+	changed := f.applyOffset(f.offset + delta*page)
+	f.mu.Unlock()
+	if changed {
+		f.signal()
+	}
+}
+
+// Reset returns the viewport to the top without signaling; the caller is
+// about to start a fresh render (e.g. cycling to another festival).
+func (f *FrameState) Reset() {
+	f.mu.Lock()
+	f.offset = 0
+	f.total = 0
+	f.view = 0
+	f.mu.Unlock()
+}
+
+// Redraw exposes the signal channel the renderer selects on.
+func (f *FrameState) Redraw() <-chan struct{} {
+	return f.redraw
+}
+
+// Viewport slices content lines for a draw at the given viewport height and
+// records the extents used to clamp later scrolls. It returns the visible
+// lines with the 1-based from/to positions, and whether the content overflows
+// the viewport at all.
+func (f *FrameState) Viewport(lines []string, height int) (visible []string, from, to, total int, overflow bool) {
+	if height < 1 {
+		height = 1
+	}
+	total = len(lines)
+
+	f.mu.Lock()
+	f.total = total
+	f.view = height
+	f.applyOffset(f.offset)
+	offset := f.offset
+	f.mu.Unlock()
+
+	if total <= height {
+		return lines, 1, total, total, false
+	}
+	end := offset + height
+	if end > total {
+		end = total
+	}
+	return lines[offset:end], offset + 1, end, total, true
+}
+
+// applyOffset clamps and stores the offset, reporting whether it changed.
+// Callers must hold f.mu.
+func (f *FrameState) applyOffset(offset int) bool {
+	maxOffset := f.total - f.view
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+	if offset > maxOffset {
+		offset = maxOffset
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	if offset == f.offset {
+		return false
+	}
+	f.offset = offset
+	return true
+}
+
+func (f *FrameState) signal() {
+	select {
+	case f.redraw <- struct{}{}:
+	default:
+	}
+}

--- a/internal/commands/show/frame_test.go
+++ b/internal/commands/show/frame_test.go
@@ -1,0 +1,170 @@
+package show
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func contentLines(n int) []string {
+	lines := make([]string, n)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("line-%03d", i+1)
+	}
+	return lines
+}
+
+func TestFrameStateViewportShortContentNoOverflow(t *testing.T) {
+	f := NewFrameState()
+	lines := contentLines(5)
+
+	visible, from, to, total, overflow := f.Viewport(lines, 10)
+	if overflow {
+		t.Fatal("content shorter than viewport must not report overflow")
+	}
+	if len(visible) != 5 || from != 1 || to != 5 || total != 5 {
+		t.Fatalf("viewport = (%d lines, %d-%d/%d)", len(visible), from, to, total)
+	}
+}
+
+func TestFrameStateScrollLinesClampsToContent(t *testing.T) {
+	f := NewFrameState()
+	lines := contentLines(30)
+
+	f.Viewport(lines, 10)
+	f.ScrollLines(5)
+	visible, from, to, _, overflow := f.Viewport(lines, 10)
+	if !overflow {
+		t.Fatal("30 lines in a 10-line viewport must overflow")
+	}
+	if from != 6 || to != 15 || visible[0] != "line-006" {
+		t.Fatalf("after +5: %d-%d, first %q", from, to, visible[0])
+	}
+
+	f.ScrollLines(1000)
+	_, from, to, _, _ = f.Viewport(lines, 10)
+	if from != 21 || to != 30 {
+		t.Fatalf("over-scroll must clamp to bottom, got %d-%d", from, to)
+	}
+
+	f.ScrollLines(-1000)
+	_, from, to, _, _ = f.Viewport(lines, 10)
+	if from != 1 || to != 10 {
+		t.Fatalf("under-scroll must clamp to top, got %d-%d", from, to)
+	}
+}
+
+func TestFrameStateScrollPagesUsesViewportSize(t *testing.T) {
+	f := NewFrameState()
+	lines := contentLines(40)
+
+	f.Viewport(lines, 10)
+	f.ScrollPages(1)
+	_, from, _, _, _ := f.Viewport(lines, 10)
+	if from != 11 {
+		t.Fatalf("page down from top: from = %d, want 11", from)
+	}
+
+	f.ScrollPages(-1)
+	_, from, _, _, _ = f.Viewport(lines, 10)
+	if from != 1 {
+		t.Fatalf("page up back to top: from = %d, want 1", from)
+	}
+}
+
+func TestFrameStateScrollSignalsRedrawOnceAndOnlyOnChange(t *testing.T) {
+	f := NewFrameState()
+	f.Viewport(contentLines(30), 10)
+
+	f.ScrollLines(1)
+	select {
+	case <-f.Redraw():
+	default:
+		t.Fatal("offset change must signal redraw")
+	}
+
+	f.ScrollLines(-1000)
+	select {
+	case <-f.Redraw():
+	default:
+	}
+
+	f.ScrollLines(-1)
+	select {
+	case <-f.Redraw():
+		t.Fatal("scroll at clamp boundary must not signal redraw")
+	default:
+	}
+}
+
+func TestFrameStateResetReturnsToTop(t *testing.T) {
+	f := NewFrameState()
+	lines := contentLines(30)
+	f.Viewport(lines, 10)
+	f.ScrollLines(15)
+	f.Reset()
+
+	_, from, _, _, _ := f.Viewport(lines, 10)
+	if from != 1 {
+		t.Fatalf("after Reset: from = %d, want 1", from)
+	}
+}
+
+func TestWatchFrameSessionDrawSlicesViewport(t *testing.T) {
+	var buf bytes.Buffer
+	frame := NewFrameState()
+	session := newWatchFrameSession(&buf, frame, true, true, false, false)
+	session.height = func() int { return 12 }
+
+	session.setContent(strings.Join(contentLines(30), "\n") + "\n")
+	out := buf.String()
+	if !strings.Contains(out, "line-001") || !strings.Contains(out, "line-010") {
+		t.Fatalf("viewport should show first 10 lines, got:\n%s", out)
+	}
+	if strings.Contains(out, "line-011") {
+		t.Fatalf("line past the viewport leaked into the frame:\n%s", out)
+	}
+	if !strings.Contains(out, "scroll (1-10/30)") {
+		t.Fatalf("footer missing scroll indicator, got:\n%s", out)
+	}
+
+	buf.Reset()
+	frame.ScrollLines(5)
+	session.draw()
+	out = buf.String()
+	if !strings.Contains(out, "line-006") || strings.Contains(out, "line-005") {
+		t.Fatalf("scrolled viewport should start at line-006:\n%s", out)
+	}
+	if !strings.Contains(out, "scroll (6-15/30)") {
+		t.Fatalf("footer indicator not updated after scroll:\n%s", out)
+	}
+}
+
+func TestWatchFrameSessionNilFrameShowsFullContent(t *testing.T) {
+	var buf bytes.Buffer
+	session := newWatchFrameSession(&buf, nil, false, false, false, false)
+	session.height = func() int { return 12 }
+
+	session.setContent(strings.Join(contentLines(30), "\n") + "\n")
+	out := buf.String()
+	if !strings.Contains(out, "line-001") || !strings.Contains(out, "line-030") {
+		t.Fatalf("nil frame must print full content unchanged:\n%s", out)
+	}
+	if strings.Contains(out, "scroll (") {
+		t.Fatalf("nil frame must not show a scroll indicator:\n%s", out)
+	}
+}
+
+func TestWatchFrameSessionUnknownHeightShowsFullContent(t *testing.T) {
+	var buf bytes.Buffer
+	frame := NewFrameState()
+	session := newWatchFrameSession(&buf, frame, true, true, false, false)
+	session.height = func() int { return 0 }
+
+	session.setContent(strings.Join(contentLines(30), "\n") + "\n")
+	out := buf.String()
+	if !strings.Contains(out, "line-030") {
+		t.Fatalf("unknown terminal size must fall back to full content:\n%s", out)
+	}
+}

--- a/internal/commands/show/show.go
+++ b/internal/commands/show/show.go
@@ -267,8 +267,10 @@ func runShowCycle(ctx context.Context, cwd string, opts *showOptions, campaignRo
 		Detect: func(ctx context.Context, path string) (*FestivalInfo, error) {
 			return DetectCurrentFestival(ctx, path, campaignRoot)
 		},
-		Render: func(ctx context.Context, festival *FestivalInfo, cycling bool) error {
-			return WatchFestival(ctx, festival, showCycleWatchOptions(opts, cycling))
+		Render: func(ctx context.Context, festival *FestivalInfo, cycling bool, frame *FrameState) error {
+			watchOpts := showCycleWatchOptions(opts, cycling)
+			watchOpts.Frame = frame
+			return WatchFestival(ctx, festival, watchOpts)
 		},
 		RenderFallback: func(_ context.Context, festival *FestivalInfo) error {
 			return emitFestivalText(festival, opts, campaignRoot)
@@ -381,7 +383,7 @@ func runShowBySelector(ctx context.Context, selector string, opts *showOptions) 
 func emitShowFestival(ctx context.Context, festival *FestivalInfo, opts *showOptions, campaignRoot string) error {
 	// Watch mode - continuously refresh display
 	if opts.watch {
-		return runWatchMode(ctx, festival, opts, false, false, false)
+		return runWatchMode(ctx, festival, opts, false, false, false, nil)
 	}
 
 	// Roadmap mode - full execution plan

--- a/internal/commands/show/standalone_watch.go
+++ b/internal/commands/show/standalone_watch.go
@@ -82,7 +82,7 @@ func (s *standaloneWatchSession) render(ctx context.Context, polling bool) error
 
 	clearScreen(os.Stdout)
 	fmt.Print(formatStandaloneWorkflowProgress(info, standaloneRenderOptionsFromWatch(s.opts)))
-	printWatchFooter(os.Stdout, polling, false, false, false)
+	printWatchFooter(os.Stdout, polling)
 	s.addWatchPaths(info)
 	return nil
 }

--- a/internal/commands/show/watch.go
+++ b/internal/commands/show/watch.go
@@ -8,12 +8,15 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/ui"
 	"github.com/Obedience-Corp/fest/internal/watch"
+	"golang.org/x/term"
 )
 
 // crlfWriter translates a bare "\n" into "\r\n" before writing. The watch cycle
@@ -96,6 +99,9 @@ type WatchOptions struct {
 	// shown (watch); when false the footer advertises "q/Ctrl+C" exit instead
 	// (show's cycle has no promote affordance).
 	CyclePromote bool
+	// Frame, when set by the cycle engine, enables viewport scrolling of the
+	// rendered content (up/down arrows, space/b). Nil outside cycle mode.
+	Frame *FrameState
 }
 
 // WatchFestival watches a festival using the existing show watch renderer.
@@ -109,12 +115,145 @@ func WatchFestival(ctx context.Context, festival *FestivalInfo, opts WatchOption
 		goals:      opts.Goals,
 		collapsed:  opts.Collapsed,
 		inProgress: opts.InProgress,
-	}, opts.CycleHint, opts.Cycling, opts.CyclePromote)
+	}, opts.CycleHint, opts.Cycling, opts.CyclePromote, opts.Frame)
+}
+
+// watchFrameSession draws watch frames, applying the cycle viewport when a
+// FrameState is attached. Content is cached so scroll-triggered redraws never
+// rebuild the festival tree.
+type watchFrameSession struct {
+	mu          sync.Mutex
+	out         io.Writer
+	frame       *FrameState
+	cycleHint   bool
+	cycling     bool
+	promoteHint bool
+	polling     bool
+	content     string
+	// height returns the terminal row count; overridden in tests.
+	height func() int
+}
+
+func newWatchFrameSession(out io.Writer, frame *FrameState, cycleHint, cycling, promoteHint, polling bool) *watchFrameSession {
+	return &watchFrameSession{
+		out:         out,
+		frame:       frame,
+		cycleHint:   cycleHint,
+		cycling:     cycling,
+		promoteHint: promoteHint,
+		polling:     polling,
+		height:      terminalRows,
+	}
+}
+
+func terminalRows() int {
+	_, rows, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil || rows <= 0 {
+		return 0
+	}
+	return rows
+}
+
+// setContent replaces the cached frame content and draws it.
+func (s *watchFrameSession) setContent(content string) {
+	s.mu.Lock()
+	s.content = content
+	s.mu.Unlock()
+	s.draw()
+}
+
+// draw paints the cached content, sliced to the scroll viewport when a frame
+// is attached and the terminal size is known.
+func (s *watchFrameSession) draw() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	clearScreen(s.out)
+	rows := s.height()
+	if s.frame == nil || rows <= footerRows {
+		_, _ = fmt.Fprint(s.out, s.content)
+		s.printFooter(0, 0, 0, false)
+		return
+	}
+
+	lines := strings.Split(strings.TrimRight(s.content, "\n"), "\n")
+	visible, from, to, total, overflow := s.frame.Viewport(lines, rows-footerRows)
+	_, _ = fmt.Fprintln(s.out, strings.Join(visible, "\n"))
+	s.printFooter(from, to, total, overflow)
+}
+
+// footerRows is the screen space reserved for the footer (blank line + hint).
+const footerRows = 2
+
+func (s *watchFrameSession) printFooter(from, to, total int, overflow bool) {
+	_, _ = fmt.Fprintln(s.out)
+	suffix := "Watching for changes"
+	if s.polling {
+		suffix = "Polling for changes"
+	}
+	if !s.cycleHint {
+		_, _ = fmt.Fprintln(s.out, ui.Dim("Press Ctrl+C to exit • "+suffix))
+		return
+	}
+	hint := "Ctrl+C exit • "
+	if !s.promoteHint {
+		hint = "q/Ctrl+C exit • "
+	}
+	if s.cycling {
+		hint += "← → cycle • "
+	}
+	if s.promoteHint {
+		hint += "p promote • "
+	}
+	if overflow {
+		hint += fmt.Sprintf("↑↓/spc/b scroll (%d-%d/%d) • ", from, to, total)
+	}
+	hint += suffix
+	_, _ = fmt.Fprintln(s.out, ui.Dim(hint))
+}
+
+// render rebuilds the festival content and draws a fresh frame.
+func (s *watchFrameSession) render(ctx context.Context, festival *FestivalInfo, opts *showOptions) error {
+	var buf bytes.Buffer
+	if err := renderFestivalView(ctx, festival, opts, &buf); err != nil {
+		return err
+	}
+	s.setContent(buf.String())
+	return nil
+}
+
+// drainRedraw repaints the cached content whenever the cycle key loop scrolls,
+// until ctx ends. No-op when no frame is attached.
+func (s *watchFrameSession) drainRedraw(ctx context.Context) {
+	if s.frame == nil {
+		return
+	}
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-s.frame.Redraw():
+				s.draw()
+			}
+		}
+	}()
+}
+
+// printWatchFooter prints the plain (non-cycle) watch footer. Used by views
+// that never run inside the cycle key loop, e.g. standalone workflow watch.
+func printWatchFooter(out io.Writer, polling bool) {
+	_, _ = fmt.Fprintln(out)
+	suffix := "Watching for changes"
+	if polling {
+		suffix = "Polling for changes"
+	}
+	_, _ = fmt.Fprintln(out, ui.Dim("Press Ctrl+C to exit • "+suffix))
 }
 
 // runWatchMode watches for file changes and refreshes the festival display.
 // Falls back to polling if file watching is not available.
-func runWatchMode(ctx context.Context, festival *FestivalInfo, opts *showOptions, cycleHint bool, cycling bool, promoteHint bool) error {
+func runWatchMode(ctx context.Context, festival *FestivalInfo, opts *showOptions, cycleHint bool, cycling bool, promoteHint bool, frame *FrameState) error {
 	out := watchWriter(cycleHint)
 	errOut := watchErrWriter(cycleHint)
 
@@ -128,11 +267,10 @@ func runWatchMode(ctx context.Context, festival *FestivalInfo, opts *showOptions
 		stateDir,
 	}
 
-	clearScreen(out)
-	if err := renderFestivalView(ctx, festival, opts, out); err != nil {
+	session := newWatchFrameSession(out, frame, cycleHint, cycling, promoteHint, false)
+	if err := session.render(ctx, festival, opts); err != nil {
 		return err
 	}
-	printWatchFooter(out, false, cycleHint, cycling, promoteHint)
 
 	w, err := watch.New(watch.Config{
 		Paths:    watchPaths,
@@ -141,38 +279,37 @@ func runWatchMode(ctx context.Context, festival *FestivalInfo, opts *showOptions
 			_, _ = fmt.Fprintf(errOut, "%s file watch error: %v\n", ui.Warning("Warning:"), err)
 		},
 	}, func() {
-		clearScreen(out)
 		refreshed, err := DetectCurrentFestival(ctx, festival.Path, "")
 		if err == nil && refreshed != nil {
 			festival = refreshed
 		}
-		if err := renderFestivalView(ctx, festival, opts, out); err != nil {
+		if err := session.render(ctx, festival, opts); err != nil {
 			_, _ = fmt.Fprintf(errOut, "%s could not refresh festival view: %v\n", ui.Warning("Warning:"), err)
 		}
-		printWatchFooter(out, false, cycleHint, cycling, promoteHint)
 	})
 
 	if err != nil {
 		_, _ = fmt.Fprintf(errOut, "File watching unavailable (%v), using polling fallback\n", err)
-		return runPollingMode(ctx, festival, opts, cycleHint, cycling, promoteHint)
+		return runPollingMode(ctx, festival, opts, cycleHint, cycling, promoteHint, frame)
 	}
 	defer func() { _ = w.Close() }()
 
+	session.drainRedraw(ctx)
 	return w.Watch(ctx)
 }
 
 // runPollingMode continuously refreshes the festival display at the specified interval.
 // Used as a fallback when file watching is not available.
-func runPollingMode(ctx context.Context, festival *FestivalInfo, opts *showOptions, cycleHint bool, cycling bool, promoteHint bool) error {
+func runPollingMode(ctx context.Context, festival *FestivalInfo, opts *showOptions, cycleHint bool, cycling bool, promoteHint bool, frame *FrameState) error {
 	ticker := time.NewTicker(pollingInterval)
 	defer ticker.Stop()
 
 	out := watchWriter(cycleHint)
-	clearScreen(out)
-	if err := renderFestivalView(ctx, festival, opts, out); err != nil {
+	session := newWatchFrameSession(out, frame, cycleHint, cycling, promoteHint, true)
+	if err := session.render(ctx, festival, opts); err != nil {
 		return err
 	}
-	printWatchFooter(out, true, cycleHint, cycling, promoteHint)
+	session.drainRedraw(ctx)
 
 	for {
 		select {
@@ -180,17 +317,14 @@ func runPollingMode(ctx context.Context, festival *FestivalInfo, opts *showOptio
 			_, _ = fmt.Fprintln(out)
 			return nil
 		case <-ticker.C:
-			clearScreen(out)
-
 			refreshed, err := DetectCurrentFestival(ctx, festival.Path, "")
 			if err == nil && refreshed != nil {
 				festival = refreshed
 			}
 
-			if err := renderFestivalView(ctx, festival, opts, out); err != nil {
+			if err := session.render(ctx, festival, opts); err != nil {
 				return err
 			}
-			printWatchFooter(out, true, cycleHint, cycling, promoteHint)
 		}
 	}
 }
@@ -256,29 +390,3 @@ func clearScreen(out io.Writer) {
 	_, _ = fmt.Fprint(out, "\033[H\033[2J")
 }
 
-// printWatchFooter prints the watch mode footer with exit instructions. In cycle
-// mode the promote hint is shown only when promoteHint is set (watch); otherwise
-// the footer advertises "q/Ctrl+C" exit (show's cycle).
-func printWatchFooter(out io.Writer, polling bool, cycleHint bool, cycling bool, promoteHint bool) {
-	_, _ = fmt.Fprintln(out)
-	suffix := "Watching for changes"
-	if polling {
-		suffix = "Polling for changes"
-	}
-	if !cycleHint {
-		_, _ = fmt.Fprintln(out, ui.Dim("Press Ctrl+C to exit • "+suffix))
-		return
-	}
-	hint := "Ctrl+C exit • "
-	if !promoteHint {
-		hint = "q/Ctrl+C exit • "
-	}
-	if cycling {
-		hint += "← → cycle • "
-	}
-	if promoteHint {
-		hint += "p promote • "
-	}
-	hint += suffix
-	_, _ = fmt.Fprintln(out, ui.Dim(hint))
-}

--- a/internal/commands/show/watch_test.go
+++ b/internal/commands/show/watch_test.go
@@ -117,7 +117,8 @@ func TestCRLFWriter_PreservesPartialWriteCount(t *testing.T) {
 
 func TestPrintWatchFooter_CycleModeEmitsCRLF(t *testing.T) {
 	var buf bytes.Buffer
-	printWatchFooter(crlfWriter{w: &buf}, false, true, true, true)
+	session := newWatchFrameSession(crlfWriter{w: &buf}, nil, true, true, true, false)
+	session.printFooter(0, 0, 0, false)
 
 	out := buf.String()
 	if !strings.Contains(out, "\r\n") {
@@ -147,7 +148,8 @@ func TestPrintWatchFooter_PromoteHint(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			printWatchFooter(&buf, false, tc.cycleHint, tc.cycling, tc.promoteHint)
+			session := newWatchFrameSession(&buf, nil, tc.cycleHint, tc.cycling, tc.promoteHint, false)
+			session.printFooter(0, 0, 0, false)
 			out := buf.String()
 			if got := strings.Contains(out, "p promote"); got != tc.wantPromote {
 				t.Errorf("promote hint present = %v, want %v (footer %q)", got, tc.wantPromote, out)

--- a/internal/commands/watch/cycling.go
+++ b/internal/commands/watch/cycling.go
@@ -23,8 +23,10 @@ func runWatchCycle(ctx context.Context, paths []string, startIndex int, opts opt
 	}
 	return show.RunCycle(ctx, paths, startIndex, show.CycleOptions{
 		Detect: deps.detectFestival,
-		Render: func(ctx context.Context, festival *show.FestivalInfo, cycling bool) error {
-			return deps.watch(ctx, festival, cycleWatchOptions(opts, cycling))
+		Render: func(ctx context.Context, festival *show.FestivalInfo, cycling bool, frame *show.FrameState) error {
+			watchOpts := cycleWatchOptions(opts, cycling)
+			watchOpts.Frame = frame
+			return deps.watch(ctx, festival, watchOpts)
 		},
 		RenderFallback: func(ctx context.Context, festival *show.FestivalInfo) error {
 			return deps.watch(ctx, festival, showWatchOptions(opts))


### PR DESCRIPTION
Follow-up to #243. Long festivals overflow the cleared frame in the `fest show` / `fest watch` cycle TUI with no way to reach the top of the content.

## Design
- `FrameState` (new) is shared between the cycle key loop and the watch renderer: the key loop moves the viewport offset (clamped to content extents recorded on each draw) and signals a redraw channel; the renderer repaints the cached frame through the viewport. Scrolling never tears down the file-watch session, so it stays responsive and the watcher stays attached.
- Keys: up/down arrows scroll by line, `space`/`b` page down/up (pager convention). Registered extra keys (watch's `p` promote, show's `q` quit) win over the built-ins. Offset resets when cycling to another festival; survives live refreshes.
- Footer gains a range indicator only when content overflows: `↑↓/spc/b scroll (6-15/128)`.
- `fest watch` gets the same scrolling for free via the shared engine.

## Explicitly unchanged
Non-TTY output, `--json`, plain `fest show --watch`/`fest watch` outside cycle mode (no raw mode, so no key loop), standalone workflow watch, and short-content frames. The viewport engages only when a frame is attached AND the terminal size is known AND content overflows.

## Verification
- New tests: viewport slicing/clamping at both edges, page scrolling, redraw signaling (change-only), reset-on-cycle, session draw with injected heights, nil-frame and unknown-height fallbacks; key classification for the new keys incl. extra-key precedence. All with `-race`.
- `just lint all` 0 issues; `just test unit` 2454/2454; `just test integration` 59/59 (Docker, incl. watch PTY tests); `just docs` zero drift; windows cross-build of show/watch.
- Real binary: non-TTY `fest show` output byte-identical behavior (fails fast / renders once, no scroll artifacts).
- Needs interactive verification (cannot be simulated headlessly): arrow scrolling + footer indicator in a real terminal over a long festival.