### PR TITLE
feat(workflow): durable judge lifecycle events and waiting-on-judge indicator

### DIFF
--- a/internal/commands/shared/workflow_render.go
+++ b/internal/commands/shared/workflow_render.go
@@ -24,6 +24,13 @@ type WorkflowStepView struct {
 	HasCheckpoint bool
 	Goal          string
 	Feedback      string
+	Judge         *wf.JudgeState
+}
+
+// JudgeWaiting reports whether this step is currently waiting on a delegated
+// approval judge: the judge run started and no outcome has been recorded.
+func (v WorkflowStepView) JudgeWaiting() bool {
+	return v.Judge != nil && v.Judge.Status == wf.JudgeRunning
 }
 
 // WorkflowStepIcon returns the styled icon for a step status.
@@ -51,6 +58,9 @@ func RenderWorkflowStepLine(step WorkflowStepView, compact bool) string {
 	var sb strings.Builder
 
 	icon := WorkflowStepIcon(step.Status)
+	if step.JudgeWaiting() {
+		icon = ui.ColoredText("⚖", ui.JudgeColor)
+	}
 
 	// Current marker
 	marker := "  "
@@ -69,6 +79,9 @@ func RenderWorkflowStepLine(step WorkflowStepView, compact bool) string {
 	if step.HasCheckpoint {
 		checkpoint = ui.Warning(" [checkpoint]")
 	}
+	if step.JudgeWaiting() {
+		checkpoint += ui.ColoredText(" [waiting on judge]", ui.JudgeColor)
+	}
 
 	fmt.Fprintf(&sb, "%s%s Step %d: %s%s\n",
 		marker, icon, step.Number, stepName, checkpoint)
@@ -84,6 +97,21 @@ func RenderWorkflowStepLine(step WorkflowStepView, compact bool) string {
 			fmt.Fprintf(&sb, "     %s: %s\n", ui.Error("Feedback"), step.Feedback)
 		case wf.StepStatusSkipped, wf.StepStatusCompleted:
 			fmt.Fprintf(&sb, "     %s: %s\n", ui.Warning("Note"), step.Feedback)
+		}
+	}
+
+	if !compact && step.Judge != nil {
+		switch step.Judge.Status {
+		case wf.JudgeRunning:
+			started := ""
+			if step.Judge.StartedAt != nil {
+				started = " since " + step.Judge.StartedAt.Local().Format("15:04:05")
+			}
+			fmt.Fprintf(&sb, "     %s\n", ui.ColoredText(fmt.Sprintf("Waiting on judge (%s)%s", step.Judge.Command, started), ui.JudgeColor))
+		case wf.JudgeFailed:
+			fmt.Fprintf(&sb, "     %s: %s\n", ui.Error("Judge failed (fails closed)"), step.Judge.Detail)
+		case wf.JudgeApproved, wf.JudgeRejected:
+			fmt.Fprintf(&sb, "     %s: %s\n", ui.Dim("Judge "+step.Judge.Status), step.Judge.Detail)
 		}
 	}
 
@@ -147,9 +175,11 @@ func LoadWorkflowStepsForPhase(ctx context.Context, festivalPath, phasePath stri
 		stepState := state.GetStepState(step.Number)
 		status := wf.StepStatusPending
 		feedback := ""
+		var judge *wf.JudgeState
 		if stepState != nil {
 			status = stepState.Status
 			feedback = stepState.Feedback
+			judge = stepState.Judge
 		}
 
 		views[i] = WorkflowStepView{
@@ -160,6 +190,7 @@ func LoadWorkflowStepsForPhase(ctx context.Context, festivalPath, phasePath stri
 			HasCheckpoint: step.HasCheckpoint(),
 			Goal:          step.Goal,
 			Feedback:      feedback,
+			Judge:         judge,
 		}
 	}
 
@@ -241,9 +272,11 @@ func LoadGateStepsForPhase(ctx context.Context, festivalPath, phasePath string) 
 		stepState := state.GetStepState(step.Number)
 		status := wf.StepStatusPending
 		feedback := ""
+		var judge *wf.JudgeState
 		if stepState != nil {
 			status = stepState.Status
 			feedback = stepState.Feedback
+			judge = stepState.Judge
 		}
 
 		views[i] = WorkflowStepView{
@@ -254,6 +287,7 @@ func LoadGateStepsForPhase(ctx context.Context, festivalPath, phasePath string) 
 			HasCheckpoint: step.HasCheckpoint(),
 			Goal:          step.Goal,
 			Feedback:      feedback,
+			Judge:         judge,
 		}
 	}
 

--- a/internal/commands/shared/workflow_render_judge_test.go
+++ b/internal/commands/shared/workflow_render_judge_test.go
@@ -1,0 +1,60 @@
+package shared
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+)
+
+func judgeStepView(judge *wf.JudgeState) WorkflowStepView {
+	return WorkflowStepView{
+		Number:        2,
+		Name:          "REVIEW",
+		Status:        wf.StepStatusInProgress,
+		IsCurrent:     true,
+		HasCheckpoint: true,
+		Judge:         judge,
+	}
+}
+
+func TestRenderWorkflowStepLine_WaitingOnJudge(t *testing.T) {
+	started := time.Now()
+	out := RenderWorkflowStepLine(judgeStepView(&wf.JudgeState{
+		Status:    wf.JudgeRunning,
+		Command:   "ob judge",
+		StartedAt: &started,
+	}), false)
+
+	for _, want := range []string{"[waiting on judge]", "Waiting on judge (ob judge)", "⚖"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderWorkflowStepLine_JudgeFailed(t *testing.T) {
+	out := RenderWorkflowStepLine(judgeStepView(&wf.JudgeState{
+		Status: wf.JudgeFailed,
+		Detail: "judge timed out",
+	}), false)
+
+	if !strings.Contains(out, "Judge failed (fails closed)") || !strings.Contains(out, "judge timed out") {
+		t.Errorf("failed judge not surfaced:\n%s", out)
+	}
+	if strings.Contains(out, "[waiting on judge]") {
+		t.Errorf("failed judge must not render as waiting:\n%s", out)
+	}
+}
+
+func TestRenderWorkflowStepLine_JudgeOutcomeNote(t *testing.T) {
+	out := RenderWorkflowStepLine(judgeStepView(&wf.JudgeState{
+		Status: wf.JudgeApproved,
+		Detail: "evidence complete",
+	}), false)
+
+	if !strings.Contains(out, "Judge approved") || !strings.Contains(out, "evidence complete") {
+		t.Errorf("judge outcome note missing:\n%s", out)
+	}
+}

--- a/internal/commands/workflow/approve.go
+++ b/internal/commands/workflow/approve.go
@@ -268,9 +268,18 @@ func runApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum int, 
 		fmt.Println("When ready, run " + ui.Accent("fest workflow advance") + " to resubmit.")
 		return nil
 	default:
-		return festerrors.Validation("approval judge returned unsupported decision").
+		// Unreachable today: parseApprovalJudgeResponse already rejects any
+		// decision outside {approve, reject} (that path records JudgeFailed via
+		// the error branch above). Kept fail-closed so the judge lifecycle is
+		// still resolved rather than left "running" if that validation is ever
+		// relaxed.
+		unsupported := festerrors.Validation("approval judge returned unsupported decision").
 			WithField("decision", decision.Decision).
 			WithHint("allowed decisions are approve and reject")
+		if recErr := nav.RecordJudgeOutcome(ctx, wf.JudgeFailed, unsupported.Error()); recErr != nil {
+			fmt.Printf("%s failed to record judge outcome: %v\n", ui.Warning("⚠"), recErr)
+		}
+		return unsupported
 	}
 }
 

--- a/internal/commands/workflow/approve.go
+++ b/internal/commands/workflow/approve.go
@@ -228,8 +228,17 @@ Or pass --judge-command <cmd> for a one-off.`)
 }
 
 func runApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum int, step wf.WorkflowStep, opts approvalJudgeOptions) error {
+	// Record the judge invocation before running it so watchers can render
+	// the waiting-on-judge state and a hung or crashed judge leaves a trace.
+	if err := nav.BeginJudge(ctx, opts.JudgeCommand); err != nil {
+		return festerrors.Wrap(err, "recording judge start")
+	}
+
 	decision, audit, err := judgeApproval(ctx, nav, step, opts)
 	if err != nil {
+		if recErr := nav.RecordJudgeOutcome(ctx, wf.JudgeFailed, err.Error()); recErr != nil {
+			fmt.Printf("%s failed to record judge outcome: %v\n", ui.Warning("⚠"), recErr)
+		}
 		return err
 	}
 
@@ -237,6 +246,9 @@ func runApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum int, 
 
 	switch decision.Decision {
 	case "approve":
+		if err := nav.RecordJudgeOutcome(ctx, wf.JudgeApproved, decision.Reason); err != nil {
+			return festerrors.Wrap(err, "recording judge outcome")
+		}
 		if err := nav.ApproveWithAudit(ctx, audit, judgeDecision); err != nil {
 			return festerrors.Wrap(err, "approving checkpoint from judge decision")
 		}
@@ -244,6 +256,9 @@ func runApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum int, 
 		fmt.Printf("  %s: %s\n", ui.Label("Reason"), decision.Reason)
 		return showNextStep(ctx, nav, nav.GetSteps())
 	case "reject":
+		if err := nav.RecordJudgeOutcome(ctx, wf.JudgeRejected, decision.Reason); err != nil {
+			return festerrors.Wrap(err, "recording judge outcome")
+		}
 		if err := nav.RejectWithDecision(ctx, audit, judgeDecision); err != nil {
 			return festerrors.Wrap(err, "recording judge rejection")
 		}

--- a/internal/commands/workflow/judge_state_test.go
+++ b/internal/commands/workflow/judge_state_test.go
@@ -1,0 +1,99 @@
+package workflow
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+)
+
+func TestRunApproveAuto_RecordsJudgeLifecycle(t *testing.T) {
+	dir := setupWorkflowFestival(t)
+	phaseDir := filepath.Join(dir, "001_INGEST")
+	nav := getNavigator(t, phaseDir)
+	ctx := context.Background()
+
+	if err := nav.Advance(ctx); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	steps := nav.GetSteps()
+
+	withApprovalJudgeRunner(t, func(ctx context.Context, command string, stdin []byte) ([]byte, error) {
+		return []byte(`{"schema_version":"fest.approval.judge/v1","decision":"approve","reason":"evidence complete"}`), nil
+	})
+
+	_ = captureStdout(t, func() {
+		if err := runApproveAuto(ctx, nav, 2, steps[1], approvalJudgeOptions{JudgeCommand: "fake judge", Timeout: time.Second}); err != nil {
+			t.Fatalf("runApproveAuto: %v", err)
+		}
+	})
+
+	judge := nav.GetWorkflowState().GetStepState(2).Judge
+	if judge == nil {
+		t.Fatal("step 2 judge state not recorded")
+	}
+	if judge.Status != wf.JudgeApproved {
+		t.Fatalf("judge status = %q, want %q", judge.Status, wf.JudgeApproved)
+	}
+	if judge.Command != "fake judge" {
+		t.Fatalf("judge command = %q, want fake judge", judge.Command)
+	}
+	if judge.StartedAt == nil || judge.FinishedAt == nil {
+		t.Fatalf("judge timestamps missing: %+v", judge)
+	}
+
+	// The lifecycle must survive a reload from the event stream so watchers
+	// in other processes see it.
+	reloaded := getNavigator(t, phaseDir)
+	replayed := reloaded.GetWorkflowState().GetStepState(2).Judge
+	if replayed == nil || replayed.Status != wf.JudgeApproved || replayed.Detail != "evidence complete" {
+		t.Fatalf("replayed judge state = %+v, want approved with reason", replayed)
+	}
+}
+
+func TestRunApproveAuto_JudgeFailureLeavesDurableTrace(t *testing.T) {
+	dir := setupWorkflowFestival(t)
+	phaseDir := filepath.Join(dir, "001_INGEST")
+	nav := getNavigator(t, phaseDir)
+	ctx := context.Background()
+
+	if err := nav.Advance(ctx); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	steps := nav.GetSteps()
+
+	withApprovalJudgeRunner(t, func(ctx context.Context, command string, stdin []byte) ([]byte, error) {
+		return nil, festerrors.Validation("judge exploded")
+	})
+
+	err := runApproveAuto(ctx, nav, 2, steps[1], approvalJudgeOptions{JudgeCommand: "fake judge", Timeout: time.Second})
+	if err == nil {
+		t.Fatal("runApproveAuto should fail when the judge fails")
+	}
+
+	// Checkpoint unchanged: still awaiting a decision.
+	state := nav.GetWorkflowState()
+	if state.CurrentStep != 2 {
+		t.Fatalf("current step = %d, want 2 (checkpoint unchanged)", state.CurrentStep)
+	}
+
+	// The failed run is durably recorded, including across a reload.
+	reloaded := getNavigator(t, phaseDir)
+	judge := reloaded.GetWorkflowState().GetStepState(2).Judge
+	if judge == nil {
+		t.Fatal("failed judge run left no durable trace")
+	}
+	if judge.Status != wf.JudgeFailed {
+		t.Fatalf("judge status = %q, want %q", judge.Status, wf.JudgeFailed)
+	}
+	if !strings.Contains(judge.Detail, "judge exploded") {
+		t.Fatalf("judge detail = %q, want failure text", judge.Detail)
+	}
+	if judge.StartedAt == nil || judge.FinishedAt == nil {
+		t.Fatalf("judge timestamps missing: %+v", judge)
+	}
+}

--- a/internal/guidance/workflow/navigator.go
+++ b/internal/guidance/workflow/navigator.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"time"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -261,6 +262,43 @@ func (n *Navigator) GetContextFiles(ctx context.Context) ([]string, error) {
 	}
 
 	return n.getContextFiles(), nil
+}
+
+// BeginJudge durably records that a delegated approval judge run started on
+// the current step, before the judge command executes, so concurrent watchers
+// (fest show --watch, fest progress) can render the waiting-on-judge state
+// and a crashed or timed-out judge still leaves a trace.
+func (n *Navigator) BeginJudge(ctx context.Context, command string) error {
+	return n.recordJudge(ctx, EmitJudgeStartedEvents(n.stateKey(), n.workflowState.CurrentStep, command), func(at time.Time) {
+		n.workflowState.BeginJudge(command, at)
+	})
+}
+
+// RecordJudgeOutcome durably records how the judge run ended: JudgeApproved,
+// JudgeRejected, or JudgeFailed with the reason or error text in detail.
+func (n *Navigator) RecordJudgeOutcome(ctx context.Context, status, detail string) error {
+	return n.recordJudge(ctx, EmitJudgeReturnedEvents(n.stateKey(), n.workflowState.CurrentStep, status, detail), func(at time.Time) {
+		n.workflowState.RecordJudgeOutcome(status, detail, at)
+	})
+}
+
+func (n *Navigator) recordJudge(ctx context.Context, events []WorkflowEvent, apply func(at time.Time)) error {
+	if err := n.EnsureInitialized(); err != nil {
+		return err
+	}
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+
+	apply(time.Now().UTC())
+
+	if n.store != nil {
+		n.store.QueueWorkflowEvents(events)
+		return n.store.SaveEvents(ctx)
+	}
+	return n.workflowState.Save(ctx, n.festivalPath, n.stateKey())
 }
 
 // Approve approves a blocking checkpoint and advances.

--- a/internal/guidance/workflow/navigator_format_judge_test.go
+++ b/internal/guidance/workflow/navigator_format_judge_test.go
@@ -69,6 +69,7 @@ func TestFormatCheckpoint_JudgeConfigured(t *testing.T) {
 
 func TestApprovalJudgeConfigured_NilAndMissing(t *testing.T) {
 	nav := &Navigator{}
+	//nolint:staticcheck // formatCheckpoint tolerates a nil context by design; verify the guard.
 	if nav.approvalJudgeConfigured(nil) {
 		t.Error("nil context should report no judge")
 	}

--- a/internal/guidance/workflow/state.go
+++ b/internal/guidance/workflow/state.go
@@ -47,12 +47,45 @@ type WorkflowEvent struct {
 	RemediationPhase string
 	DecisionActor    string
 	DecisionSummary  string
+	JudgeStatus      string
+	JudgeCommand     string
+	JudgeDetail      string
 }
 
 // DecisionMetadata records who made a checkpoint decision and the rationale.
 type DecisionMetadata struct {
 	Actor   string
 	Summary string
+}
+
+// Judge lifecycle status values recorded on StepState.Judge.
+const (
+	JudgeRunning  = "running"
+	JudgeApproved = "approved"
+	JudgeRejected = "rejected"
+	JudgeFailed   = "failed"
+)
+
+// JudgeState tracks the lifecycle of a delegated approval judge run for a
+// blocking checkpoint. It is persisted (and event-sourced) so concurrent
+// watchers like 'fest show --watch' can render a waiting-on-judge indicator
+// while the judge command runs, and so timeouts or judge crashes leave a
+// durable failed record instead of vanishing.
+type JudgeState struct {
+	// Status is one of running, approved, rejected, failed.
+	Status string `yaml:"status" json:"status"`
+
+	// Command is the judge command that was invoked.
+	Command string `yaml:"command,omitempty" json:"command,omitempty"`
+
+	// Detail carries the judge reason (approved/rejected) or the error text (failed).
+	Detail string `yaml:"detail,omitempty" json:"detail,omitempty"`
+
+	// StartedAt is when the judge command was invoked.
+	StartedAt *time.Time `yaml:"started_at,omitempty" json:"started_at,omitempty"`
+
+	// FinishedAt is when the judge outcome was recorded.
+	FinishedAt *time.Time `yaml:"finished_at,omitempty" json:"finished_at,omitempty"`
 }
 
 // StepState tracks the state of a single workflow step.
@@ -84,6 +117,10 @@ type StepState struct {
 
 	// DecisionAt is when the checkpoint decision was recorded.
 	DecisionAt *time.Time `yaml:"decision_at,omitempty" json:"decision_at,omitempty"`
+
+	// Judge tracks the delegated approval judge run for this checkpoint, when
+	// one was invoked via 'fest workflow approve --auto'.
+	Judge *JudgeState `yaml:"judge,omitempty" json:"judge,omitempty"`
 }
 
 // FestivalWorkflowState contains workflow state for all phases in a festival.
@@ -299,6 +336,29 @@ func (s *WorkflowState) StartCurrentStep() {
 		now := time.Now().UTC()
 		state.StartedAt = &now
 	}
+}
+
+// BeginJudge records a delegated judge run starting on the current step.
+func (s *WorkflowState) BeginJudge(command string, at time.Time) {
+	state := s.GetOrCreateStepState(s.CurrentStep)
+	started := at
+	state.Judge = &JudgeState{
+		Status:    JudgeRunning,
+		Command:   command,
+		StartedAt: &started,
+	}
+}
+
+// RecordJudgeOutcome records how the current step's judge run ended.
+func (s *WorkflowState) RecordJudgeOutcome(status, detail string, at time.Time) {
+	state := s.GetOrCreateStepState(s.CurrentStep)
+	if state.Judge == nil {
+		state.Judge = &JudgeState{}
+	}
+	finished := at
+	state.Judge.Status = status
+	state.Judge.Detail = detail
+	state.Judge.FinishedAt = &finished
 }
 
 // CompleteCurrentStep marks the current step as completed.
@@ -590,5 +650,30 @@ func EmitResetEvents(phaseName string) []WorkflowEvent {
 	return []WorkflowEvent{{
 		EventType: "wf_reset",
 		Phase:     phaseName,
+	}}
+}
+
+// EmitJudgeStartedEvents generates events for a delegated judge run starting
+// on a blocking checkpoint.
+func EmitJudgeStartedEvents(phaseName string, step int, command string) []WorkflowEvent {
+	return []WorkflowEvent{{
+		EventType:    "wf_judge_started",
+		Phase:        phaseName,
+		Step:         step,
+		JudgeStatus:  JudgeRunning,
+		JudgeCommand: command,
+	}}
+}
+
+// EmitJudgeReturnedEvents generates events recording how a delegated judge
+// run ended: approved, rejected, or failed (timeout, missing command,
+// malformed verdict).
+func EmitJudgeReturnedEvents(phaseName string, step int, status, detail string) []WorkflowEvent {
+	return []WorkflowEvent{{
+		EventType:   "wf_judge_returned",
+		Phase:       phaseName,
+		Step:        step,
+		JudgeStatus: status,
+		JudgeDetail: detail,
 	}}
 }

--- a/internal/guidance/workflow/state.go
+++ b/internal/guidance/workflow/state.go
@@ -482,6 +482,7 @@ func (s *WorkflowState) Reset() {
 		state.DecisionActor = ""
 		state.DecisionSummary = ""
 		state.DecisionAt = nil
+		state.Judge = nil
 	}
 	s.UpdatedAt = time.Now().UTC()
 }

--- a/internal/guidance/workflow/state_test.go
+++ b/internal/guidance/workflow/state_test.go
@@ -362,6 +362,10 @@ func TestWorkflowState_Reset(t *testing.T) {
 	state.CompleteCurrentStep()
 	state.CurrentStep = 3
 
+	// A delegated judge run recorded on a step must not survive a reset,
+	// otherwise ghost waiting/outcome UI persists after the workflow is reset.
+	state.Steps[2].Judge = &JudgeState{Status: JudgeRunning, Command: "ob judge"}
+
 	state.Reset()
 
 	if state.CurrentStep != 1 {
@@ -380,6 +384,9 @@ func TestWorkflowState_Reset(t *testing.T) {
 		}
 		if step.Feedback != "" {
 			t.Errorf("Steps[%d].Feedback should be empty", i)
+		}
+		if step.Judge != nil {
+			t.Errorf("Steps[%d].Judge should be nil after reset", i)
 		}
 	}
 }

--- a/internal/progress/events.go
+++ b/internal/progress/events.go
@@ -437,6 +437,7 @@ func materializeWorkflowState(events []ProgressEvent) *wf.FestivalWorkflowState 
 				ss.DecisionActor = ""
 				ss.DecisionSummary = ""
 				ss.DecisionAt = nil
+				ss.Judge = nil
 			}
 		}
 

--- a/internal/progress/events.go
+++ b/internal/progress/events.go
@@ -43,6 +43,14 @@ const (
 	// EventWorkflowStepRecheck records that the operator is re-entering a
 	// previously failed remediation step for re-evaluation.
 	EventWorkflowStepRecheck EventType = "wf_step_recheck"
+
+	// EventWorkflowJudgeStarted records that a delegated approval judge run
+	// was invoked on a blocking checkpoint via 'fest workflow approve --auto'.
+	EventWorkflowJudgeStarted EventType = "wf_judge_started"
+
+	// EventWorkflowJudgeReturned records how a delegated judge run ended:
+	// approved, rejected, or failed (timeout, missing command, bad verdict).
+	EventWorkflowJudgeReturned EventType = "wf_judge_returned"
 )
 
 // ProgressEvent represents a single progress event in JSONL format.
@@ -66,6 +74,9 @@ type ProgressEvent struct {
 	RemediationPhase string `json:"remediation_phase,omitempty"`
 	DecisionActor    string `json:"decision_actor,omitempty"`
 	DecisionSummary  string `json:"decision_summary,omitempty"`
+	JudgeStatus      string `json:"judge_status,omitempty"`
+	JudgeCommand     string `json:"judge_command,omitempty"`
+	JudgeDetail      string `json:"judge_detail,omitempty"`
 }
 
 // loadFromEvents reads the JSONL file and materializes current state.
@@ -391,7 +402,27 @@ func materializeWorkflowState(events []ProgressEvent) *wf.FestivalWorkflowState 
 				ss.DecisionActor = ""
 				ss.DecisionSummary = ""
 				ss.DecisionAt = nil
+				ss.Judge = nil
 			}
+
+		case EventWorkflowJudgeStarted:
+			ss := phaseState.GetOrCreateStepState(e.Step)
+			ts := e.Timestamp
+			ss.Judge = &wf.JudgeState{
+				Status:    wf.JudgeRunning,
+				Command:   e.JudgeCommand,
+				StartedAt: &ts,
+			}
+
+		case EventWorkflowJudgeReturned:
+			ss := phaseState.GetOrCreateStepState(e.Step)
+			if ss.Judge == nil {
+				ss.Judge = &wf.JudgeState{}
+			}
+			ts := e.Timestamp
+			ss.Judge.Status = e.JudgeStatus
+			ss.Judge.Detail = e.JudgeDetail
+			ss.Judge.FinishedAt = &ts
 
 		case EventWorkflowAdvance:
 			phaseState.CurrentStep = e.Step

--- a/internal/progress/store.go
+++ b/internal/progress/store.go
@@ -626,6 +626,9 @@ func (s *Store) QueueWorkflowEvents(events []wf.WorkflowEvent) {
 			RemediationPhase: we.RemediationPhase,
 			DecisionActor:    we.DecisionActor,
 			DecisionSummary:  we.DecisionSummary,
+			JudgeStatus:      we.JudgeStatus,
+			JudgeCommand:     we.JudgeCommand,
+			JudgeDetail:      we.JudgeDetail,
 		}
 		s.pendingEvents = append(s.pendingEvents, pe)
 	}

--- a/internal/progress/workflow_events_test.go
+++ b/internal/progress/workflow_events_test.go
@@ -49,6 +49,33 @@ func TestMaterializeWorkflowState_SkippedAndCompleted(t *testing.T) {
 	}
 }
 
+func TestMaterializeWorkflowState_ResetClearsJudge(t *testing.T) {
+	now := time.Now().UTC()
+	events := []ProgressEvent{
+		{Timestamp: now, Event: EventWorkflowInit, Phase: "001_INGEST", TotalSteps: 2},
+		{Timestamp: now.Add(1 * time.Second), Event: EventWorkflowJudgeStarted, Phase: "001_INGEST", Step: 1, JudgeCommand: "ob judge"},
+		{Timestamp: now.Add(2 * time.Second), Event: EventWorkflowJudgeReturned, Phase: "001_INGEST", Step: 1, JudgeStatus: wf.JudgeApproved, JudgeDetail: "evidence complete"},
+		{Timestamp: now.Add(3 * time.Second), Event: EventWorkflowReset, Phase: "001_INGEST"},
+	}
+
+	state := materializeWorkflowState(events)
+	phaseState, ok := state.Phases["001_INGEST"]
+	if !ok {
+		t.Fatal("expected phase state for 001_INGEST")
+	}
+
+	step1 := phaseState.GetStepState(1)
+	if step1 == nil {
+		t.Fatal("expected step 1 state")
+	}
+	if step1.Judge != nil {
+		t.Fatalf("step 1 Judge should be nil after reset, got %+v", step1.Judge)
+	}
+	if step1.Status != wf.StepStatusPending {
+		t.Fatalf("step 1 status = %s, want %s after reset", step1.Status, wf.StepStatusPending)
+	}
+}
+
 func TestGenerateWorkflowEventsFromYAML_EmitsStepSkip(t *testing.T) {
 	now := time.Now().UTC()
 	phaseState := wf.NewWorkflowState(2)

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -66,6 +66,7 @@ var (
 var (
 	PendingColor    = lipgloss.Color("250") // Light grey - not yet started (updated from 245)
 	InProgressColor = lipgloss.Color("220") // Yellow/amber - actively being worked
+	JudgeColor      = lipgloss.Color("135") // Purple - checkpoint waiting on a delegated judge
 	BlockedColor    = lipgloss.Color("196") // Red - blocked/waiting
 )
 


### PR DESCRIPTION
Stacked on #248 (base is `gate-actor-fix`; retarget to `main` after #248 merges).

## Problem

`fest workflow approve --auto` left no durable trace that a judge run started, and a timed-out or crashed judge recorded nothing at all. Watchers could not distinguish waiting-on-judge from stuck, making delegated approvals opaque, and there was no honest audit that a judge was even invoked.

## What this adds

**Durable judge lifecycle events** (event-sourced like the rest of workflow state):
- `wf_judge_started` persists before the judge command executes, so a hung or crashed judge still leaves a trace with a start timestamp
- `wf_judge_returned` records `approved` / `rejected` / `failed` with the judge reason or error text
- Replay materializes `StepState.Judge` (status, command, detail, started/finished timestamps), so any process reading the event stream sees the full lifecycle
- Failure still fails closed: the checkpoint itself is untouched on judge errors; only the trace is recorded

**Waiting-on-judge indicator** in the shared step renderer (used by `fest progress`, `--watch`, and show surfaces):
- In-flight: purple ⚖ icon, `[waiting on judge]` tag, and a detail line `Waiting on judge (<command>) since <time>` — purple (color 135) deliberately distinct from red/blocked, since the workflow is not stuck, it is delegated and in flight
- Failed: `Judge failed (fails closed): <error>`
- Completed: dim `Judge approved/rejected: <reason>` note

**Cross-repo safety**: camp's progress replay ignores unknown event types (verified in camp's `localrun.go` switch), so the new events are additive to the jsonl contract.

## Verification

- Unit: judge lifecycle recorded and replayed across a fresh navigator (approve and failure paths); failed judge leaves the checkpoint on step 2 with a durable failed record; renderer tests for waiting/failed/outcome lines.
- Live: with a slow judge, a **concurrent** `fest progress` rendered:
  ```
  → ⚖ Step 2: ANALYZE [checkpoint] [waiting on judge]
       Waiting on judge (.../slow-judge.sh) since 16:34:43
  ```
  and the checkpoint auto-approved with the judge's reason when it returned.
- Full `go test ./...` green; `just lint all` 0 issues; `go vet` clean.