### PR TITLE
fix(workflow): no default deadline on the approval judge

### DIFF
--- a/docs/cli-reference/fest-reference.md
+++ b/docs/cli-reference/fest-reference.md
@@ -6930,7 +6930,7 @@ fest workflow approve [flags]
       --auto                     delegate this checkpoint decision to the configured approval judge command
   -h, --help                     help for approve
       --judge-command string     approval judge command for --auto (overrides the .festival/config.yaml hooks.approval_judge.command hook)
-      --judge-timeout duration   maximum time to wait for the approval judge (default 2m0s)
+      --judge-timeout duration   maximum time to wait for the approval judge (0 waits until it returns)
       --summary string           approval summary or rationale
 ```
 

--- a/docs/cli-reference/fest_workflow_approve.md
+++ b/docs/cli-reference/fest_workflow_approve.md
@@ -44,7 +44,7 @@ fest workflow approve [flags]
       --auto                     delegate this checkpoint decision to the configured approval judge command
   -h, --help                     help for approve
       --judge-command string     approval judge command for --auto (overrides the .festival/config.yaml hooks.approval_judge.command hook)
-      --judge-timeout duration   maximum time to wait for the approval judge (default 2m0s)
+      --judge-timeout duration   maximum time to wait for the approval judge (0 waits until it returns)
       --summary string           approval summary or rationale
 ```
 

--- a/internal/commands/workflow/approve.go
+++ b/internal/commands/workflow/approve.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -54,9 +55,7 @@ var runApprovalJudgeCommand approvalJudgeRunner = runApprovalJudgeCommandDefault
 func newApproveCmd() *cobra.Command {
 	var actor string
 	var summary string
-	opts := approvalJudgeOptions{
-		Timeout: 2 * time.Minute,
-	}
+	opts := approvalJudgeOptions{}
 
 	cmd := &cobra.Command{
 		Use:   "approve",
@@ -110,7 +109,7 @@ Auto approval:
 	cmd.Flags().StringVar(&summary, "summary", "", "approval summary or rationale")
 	cmd.Flags().BoolVar(&opts.Auto, "auto", false, "delegate this checkpoint decision to the configured approval judge command")
 	cmd.Flags().StringVar(&opts.JudgeCommand, "judge-command", opts.JudgeCommand, "approval judge command for --auto (overrides the .festival/config.yaml hooks.approval_judge.command hook)")
-	cmd.Flags().DurationVar(&opts.Timeout, "judge-timeout", opts.Timeout, "maximum time to wait for the approval judge")
+	cmd.Flags().DurationVar(&opts.Timeout, "judge-timeout", opts.Timeout, "maximum time to wait for the approval judge (0 waits until it returns)")
 	cmd.MarkFlagsMutuallyExclusive("auto", "as")
 	cmd.MarkFlagsMutuallyExclusive("auto", "summary")
 
@@ -284,10 +283,6 @@ func runApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum int, 
 }
 
 func judgeApproval(ctx context.Context, nav *wf.Navigator, step wf.WorkflowStep, opts approvalJudgeOptions) (*approvalJudgeResponse, string, error) {
-	if opts.Timeout <= 0 {
-		opts.Timeout = 2 * time.Minute
-	}
-
 	req := approvalJudgeRequest{
 		SchemaVersion: approvalJudgeSchemaVersion,
 		FestivalPath:  nav.Ctx.FestivalPath,
@@ -308,24 +303,28 @@ func judgeApproval(ctx context.Context, nav *wf.Navigator, step wf.WorkflowStep,
 }
 
 func evaluateApprovalJudge(ctx context.Context, req approvalJudgeRequest, opts approvalJudgeOptions) (*approvalJudgeResponse, string, error) {
-	if opts.Timeout <= 0 {
-		opts.Timeout = 2 * time.Minute
-	}
-
 	stdin, err := json.Marshal(req)
 	if err != nil {
 		return nil, "", festerrors.Wrap(err, "encoding approval judge request")
 	}
 
-	judgeCtx, cancel := context.WithTimeout(ctx, opts.Timeout)
+	// No default deadline: judge evaluations can legitimately run long, and
+	// killing one mid-inference wastes the run. --judge-timeout opts into a
+	// bound; the judge remains observable while it runs (wf_judge_started,
+	// waiting-on-judge indicator).
+	judgeCtx := ctx
+	cancel := context.CancelFunc(func() {})
+	if opts.Timeout > 0 {
+		judgeCtx, cancel = context.WithTimeout(ctx, opts.Timeout)
+	}
 	defer cancel()
 
 	out, err := runApprovalJudgeCommand(judgeCtx, opts.JudgeCommand, append(stdin, '\n'))
 	if err != nil {
-		if judgeCtx.Err() != nil {
+		if errors.Is(judgeCtx.Err(), context.DeadlineExceeded) {
 			return nil, "", festerrors.Wrap(judgeCtx.Err(), "approval judge timed out").
 				WithField("judge_command", opts.JudgeCommand).
-				WithHint("the checkpoint was not approved; rerun manually or use a working judge command")
+				WithHint("the checkpoint was not approved; rerun manually or raise --judge-timeout")
 		}
 		return nil, "", festerrors.Wrap(err, "approval judge failed").
 			WithField("judge_command", opts.JudgeCommand).

--- a/internal/commands/workflow/approve_auto_test.go
+++ b/internal/commands/workflow/approve_auto_test.go
@@ -160,6 +160,25 @@ func TestEvaluateApprovalJudge_MissingCommandFailsClosed(t *testing.T) {
 	}
 }
 
+// Judge evaluations can run long; a default deadline would kill them
+// mid-inference. Zero timeout must mean no deadline on the judge context.
+func TestEvaluateApprovalJudge_ZeroTimeoutMeansNoDeadline(t *testing.T) {
+	var hadDeadline bool
+	withApprovalJudgeRunner(t, func(ctx context.Context, command string, stdin []byte) ([]byte, error) {
+		_, hadDeadline = ctx.Deadline()
+		return []byte(`{"schema_version":"fest.approval.judge/v1","decision":"approve","reason":"ok"}`), nil
+	})
+
+	if _, _, err := evaluateApprovalJudge(context.Background(), approvalJudgeRequest{}, approvalJudgeOptions{
+		JudgeCommand: "fake judge",
+	}); err != nil {
+		t.Fatalf("evaluateApprovalJudge: %v", err)
+	}
+	if hadDeadline {
+		t.Fatal("zero judge timeout must not impose a deadline")
+	}
+}
+
 func TestEvaluateApprovalJudge_TimeoutFailsClosed(t *testing.T) {
 	withApprovalJudgeRunner(t, func(ctx context.Context, command string, stdin []byte) ([]byte, error) {
 		<-ctx.Done()


### PR DESCRIPTION
A judge evaluation can legitimately run 15+ minutes; the 2m default on `--judge-timeout` killed the judge process mid-inference, wasting the run and leaving the checkpoint blocked with what looked like a judge failure rather than an early kill.

- `--judge-timeout` now defaults to 0: the judge is waited on until it returns. Bounding is opt-in.
- The `<= 0` coercions to 2m in `judgeApproval`/`evaluateApprovalJudge` are removed; zero means no deadline on the judge context (regression-tested via the runner seam).
- The "approval judge timed out" error now fires only on a real `context.DeadlineExceeded`; interrupts (ctrl-C) fall through to the generic failure instead of being mislabeled as timeouts. The timeout hint points at `--judge-timeout`.
- Long-running judges stay observable while blocking: `wf_judge_started` is already durable and `fest show`/`watch` render the waiting-on-judge indicator (#250).

Companion PR on the ob side removes the 90s client default: Obedience-Corp/obey#154.

One operational note for agent-driven loops: with no deadline, `fest workflow approve --auto` blocks for the full judge duration, so agents running it through a shell tool with its own timeout should raise that tool timeout or run it in the background.

Testing: `just lint all` 0 issues; unit suite green including the new zero-timeout-means-no-deadline test; existing fail-closed timeout test still passes with an explicit bound. Docs regenerated separately.