### PR TITLE
fix: eliminate 5s tty-query stall at startup; q quits watch; watch survives write storms

### DIFF
--- a/cmd/fest/main.go
+++ b/cmd/fest/main.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"os"
 
+	// bginit must initialize before the bubbletea subtree under
+	// internal/commands; its path keeps it first under gofmt.
+	_ "github.com/Obedience-Corp/fest/internal/bginit"
 	"github.com/Obedience-Corp/fest/internal/commands"
 	festerrors "github.com/Obedience-Corp/fest/internal/errors"
 )

--- a/internal/bginit/bginit.go
+++ b/internal/bginit/bginit.go
@@ -1,0 +1,47 @@
+// Package bginit seeds lipgloss's background-color cache before any
+// charmbracelet package init can query the terminal.
+//
+// bubbletea v1 calls lipgloss.HasDarkBackground() from a package init
+// (tea_init.go). Without a cached value, lipgloss asks termenv, which writes
+// OSC 11 / DSR queries to the tty and blocks up to termenv.OSCTimeout (5s)
+// waiting for a reply. Interactive terminals answer instantly, but recorder,
+// CI, and agent ptys that never answer freeze every fest command for the full
+// timeout before a single byte of output appears.
+//
+// Seeding an explicit value makes lipgloss skip the terminal query entirely.
+// This package must initialize before bubbletea, so it may only import
+// lipgloss (never bubbletea or huh, directly or transitively), and cmd/fest
+// must import it alongside internal/commands: its path sorts before
+// internal/commands, so gofmt keeps it first and the compiler records its
+// inittask ahead of the bubbletea subtree.
+//
+// The seed mirrors termenv's own non-query fallback: the last field of
+// COLORFGBG is the background ANSI color, and a missing or unparsable value
+// means dark, matching the CLI palette's existing "adaptive falls back to
+// dark" behavior. An explicit theme choice refines this later via
+// ui.InitPalette.
+package bginit
+
+import (
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func init() {
+	lipgloss.SetHasDarkBackground(backgroundIsDark(os.Getenv("COLORFGBG")))
+}
+
+func backgroundIsDark(colorFGBG string) bool {
+	if !strings.Contains(colorFGBG, ";") {
+		return true
+	}
+	fields := strings.Split(colorFGBG, ";")
+	bg, err := strconv.Atoi(fields[len(fields)-1])
+	if err != nil {
+		return true
+	}
+	return bg >= 0 && bg <= 8 && bg != 7
+}

--- a/internal/bginit/bginit_test.go
+++ b/internal/bginit/bginit_test.go
@@ -1,0 +1,29 @@
+package bginit
+
+import "testing"
+
+func TestBackgroundIsDark(t *testing.T) {
+	tests := []struct {
+		name     string
+		colorFGBG string
+		want     bool
+	}{
+		{"unset defaults dark", "", true},
+		{"no separator defaults dark", "15", true},
+		{"unparsable background defaults dark", "15;default", true},
+		{"black background", "15;0", true},
+		{"blue background", "15;4", true},
+		{"bright black background", "15;8", true},
+		{"light grey background", "0;7", false},
+		{"white background", "0;15", false},
+		{"bright yellow background", "0;11", false},
+		{"three fields uses last", "15;default;0", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := backgroundIsDark(tt.colorFGBG); got != tt.want {
+				t.Errorf("backgroundIsDark(%q) = %v, want %v", tt.colorFGBG, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/commands/progress/watch.go
+++ b/internal/commands/progress/watch.go
@@ -45,6 +45,7 @@ func runWatchMode(ctx context.Context, mgr *progress.Manager, loc *show.Location
 	w, err := watch.New(watch.Config{
 		Paths:    watchPaths,
 		Debounce: 100 * time.Millisecond,
+		MaxWait:  watch.DefaultMaxWait,
 		OnError: func(err error) {
 			fmt.Fprintf(os.Stderr, "%s file watch error: %v\n", ui.Warning("Warning:"), err)
 		},

--- a/internal/commands/show/standalone_watch.go
+++ b/internal/commands/show/standalone_watch.go
@@ -28,6 +28,7 @@ func runStandaloneWatchMode(ctx context.Context, startDir string, opts WatchOpti
 	session := &standaloneWatchSession{startDir: startDir, opts: opts}
 	w, err := filewatch.New(filewatch.Config{
 		Debounce: filewatch.DefaultDebounce,
+		MaxWait:  filewatch.DefaultMaxWait,
 		OnError:  session.reportWatchError,
 	}, func() {
 		session.renderOrWarn(ctx, false)

--- a/internal/commands/show/watch.go
+++ b/internal/commands/show/watch.go
@@ -195,10 +195,7 @@ func (s *watchFrameSession) printFooter(from, to, total int, overflow bool) {
 		_, _ = fmt.Fprintln(s.out, ui.Dim("Press Ctrl+C to exit • "+suffix))
 		return
 	}
-	hint := "Ctrl+C exit • "
-	if !s.promoteHint {
-		hint = "q/Ctrl+C exit • "
-	}
+	hint := "q/Ctrl+C exit • "
 	if s.cycling {
 		hint += "← → cycle • "
 	}
@@ -275,6 +272,7 @@ func runWatchMode(ctx context.Context, festival *FestivalInfo, opts *showOptions
 	w, err := watch.New(watch.Config{
 		Paths:    watchPaths,
 		Debounce: 100 * time.Millisecond,
+		MaxWait:  watch.DefaultMaxWait,
 		OnError: func(err error) {
 			_, _ = fmt.Fprintf(errOut, "%s file watch error: %v\n", ui.Warning("Warning:"), err)
 		},

--- a/internal/commands/show/watch_test.go
+++ b/internal/commands/show/watch_test.go
@@ -139,8 +139,8 @@ func TestPrintWatchFooter_PromoteHint(t *testing.T) {
 		wantCycle   bool
 		wantQExit   bool
 	}{
-		{"watch_raw_single", true, false, true, true, false, false},
-		{"watch_raw_multi", true, true, true, true, true, false},
+		{"watch_raw_single", true, false, true, true, false, true},
+		{"watch_raw_multi", true, true, true, true, true, true},
 		{"show_raw_single", true, false, false, false, false, true},
 		{"show_raw_multi", true, true, false, false, true, true},
 		{"non_raw", false, false, false, false, false, false},

--- a/internal/commands/watch/cycling.go
+++ b/internal/commands/watch/cycling.go
@@ -31,11 +31,22 @@ func runWatchCycle(ctx context.Context, paths []string, startIndex int, opts opt
 		RenderFallback: func(ctx context.Context, festival *show.FestivalInfo) error {
 			return deps.watch(ctx, festival, showWatchOptions(opts))
 		},
-		ExtraKeys: map[byte]show.ExtraKeyHandler{
-			'p': promoteFromWatch,
-			'P': promoteFromWatch,
-		},
+		ExtraKeys: watchCycleExtraKeys(),
 	})
+}
+
+// watchCycleExtraKeys registers watch's cycle keys: p promotes and q quits,
+// matching show's cycle so the watch view is not Ctrl+C-only.
+func watchCycleExtraKeys() map[byte]show.ExtraKeyHandler {
+	quit := func(context.Context, *show.FestivalInfo, *term.State) (string, bool) {
+		return "", false
+	}
+	return map[byte]show.ExtraKeyHandler{
+		'p': promoteFromWatch,
+		'P': promoteFromWatch,
+		'q': quit,
+		'Q': quit,
+	}
 }
 
 // promoteFromWatch runs the fest promote flow outside raw mode and returns the

--- a/internal/commands/watch/cycling_test.go
+++ b/internal/commands/watch/cycling_test.go
@@ -26,6 +26,26 @@ func TestCycleWatchOptionsSetsCycleHint(t *testing.T) {
 	}
 }
 
+func TestWatchCycleExtraKeysRegistersPromoteAndQuit(t *testing.T) {
+	keys := watchCycleExtraKeys()
+
+	for _, key := range []byte{'p', 'P', 'q', 'Q'} {
+		if keys[key] == nil {
+			t.Errorf("expected handler registered for %q", key)
+		}
+	}
+
+	for _, key := range []byte{'q', 'Q'} {
+		newPath, cont := keys[key](t.Context(), nil, nil)
+		if cont {
+			t.Errorf("%q handler should end the cycle, got cont=true", key)
+		}
+		if newPath != "" {
+			t.Errorf("%q handler should not move the festival, got path %q", key, newPath)
+		}
+	}
+}
+
 func TestRunWatchCycle_EmptyPaths(t *testing.T) {
 	err := runWatchCycle(t.Context(), nil, 0, options{}, commandDeps{
 		detectFestival: func(context.Context, string) (*show.FestivalInfo, error) {

--- a/internal/ui/palette.go
+++ b/internal/ui/palette.go
@@ -65,12 +65,17 @@ func InitPalette(ctx context.Context) {
 		switch cfg.TUI.Theme {
 		case "light":
 			currentPalette = lightPalette()
+			lipgloss.SetHasDarkBackground(false)
 		case "dark":
 			currentPalette = defaultDarkPalette()
+			lipgloss.SetHasDarkBackground(true)
 		case "high-contrast":
 			currentPalette = highContrastPalette()
+			lipgloss.SetHasDarkBackground(true)
 		default:
-			// "adaptive" or unknown - use dark as safe default
+			// "adaptive" or unknown - use dark as safe default and keep the
+			// background seeded by bginit (COLORFGBG or dark); querying the
+			// terminal here would reintroduce the OSC 11 startup stall.
 			currentPalette = defaultDarkPalette()
 		}
 		paletteInit = true

--- a/internal/watch/watcher.go
+++ b/internal/watch/watcher.go
@@ -13,6 +13,10 @@ import (
 // DefaultDebounce is the default debounce duration for file changes.
 const DefaultDebounce = 100 * time.Millisecond
 
+// DefaultMaxWait is the default cap on debounce coalescing for live display
+// refreshers, keeping views current during sustained write storms.
+const DefaultMaxWait = 500 * time.Millisecond
+
 // Config configures the file watcher behavior.
 type Config struct {
 	// Paths lists files and directories to watch.
@@ -23,6 +27,12 @@ type Config struct {
 	// This coalesces rapid changes (e.g., editor save patterns) into a single event.
 	// Defaults to DefaultDebounce if zero.
 	Debounce time.Duration
+
+	// MaxWait caps how long coalescing can defer the callback. The trailing
+	// debounce timer resets on every event, so sustained writes arriving
+	// faster than Debounce would otherwise starve the callback until the
+	// storm ends. Zero means no cap.
+	MaxWait time.Duration
 
 	// FallbackPoll is the polling interval to use if fsnotify fails.
 	// If zero, no fallback is used and errors are returned.
@@ -38,10 +48,11 @@ type Watcher struct {
 	onChange func()
 	watcher  *fsnotify.Watcher
 
-	mu      sync.Mutex
-	timer   *time.Timer
-	pending bool
-	watched map[string]struct{}
+	mu           sync.Mutex
+	timer        *time.Timer
+	pending      bool
+	firstPending time.Time
+	watched      map[string]struct{}
 }
 
 // ErrNoWatchablePaths is returned when none of the specified paths can be watched.
@@ -151,7 +162,8 @@ func (w *Watcher) removePath(path string) {
 }
 
 // scheduleCallback schedules the onChange callback after the debounce period.
-// Multiple calls within the debounce period are coalesced into a single callback.
+// Multiple calls within the debounce period are coalesced into a single
+// callback, but never deferred past MaxWait since the first pending event.
 func (w *Watcher) scheduleCallback() {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -161,8 +173,21 @@ func (w *Watcher) scheduleCallback() {
 		w.timer.Stop()
 	}
 
+	if !w.pending {
+		w.firstPending = time.Now()
+	}
 	w.pending = true
-	w.timer = time.AfterFunc(w.config.Debounce, func() {
+
+	delay := w.config.Debounce
+	if w.config.MaxWait > 0 {
+		if remaining := w.config.MaxWait - time.Since(w.firstPending); remaining < delay {
+			delay = remaining
+		}
+		if delay < 0 {
+			delay = 0
+		}
+	}
+	w.timer = time.AfterFunc(delay, func() {
 		w.mu.Lock()
 		w.pending = false
 		w.timer = nil

--- a/internal/watch/watcher_test.go
+++ b/internal/watch/watcher_test.go
@@ -193,6 +193,49 @@ func TestWatcher_Debouncing(t *testing.T) {
 	cancel()
 }
 
+func TestWatcher_MaxWaitFiresDuringSustainedChanges(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "test.txt")
+	if err := os.WriteFile(tmpFile, []byte("initial"), 0644); err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+
+	var callCount atomic.Int32
+
+	cfg := Config{
+		Paths:    []string{tmpFile},
+		Debounce: 100 * time.Millisecond,
+		MaxWait:  250 * time.Millisecond,
+	}
+
+	w, err := New(cfg, func() {
+		callCount.Add(1)
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	// Sustained events every 20ms reset the trailing debounce timer forever;
+	// only the MaxWait cap lets the callback fire while the storm is running.
+	storm := 700 * time.Millisecond
+	deadline := time.Now().Add(storm)
+	for time.Now().Before(deadline) {
+		w.scheduleCallback()
+		time.Sleep(20 * time.Millisecond)
+	}
+	duringStorm := callCount.Load()
+
+	if duringStorm < 1 {
+		t.Errorf("expected at least 1 callback during a %v storm with MaxWait=%v, got %d", storm, cfg.MaxWait, duringStorm)
+	}
+
+	time.Sleep(300 * time.Millisecond)
+	if total := callCount.Load(); total <= duringStorm {
+		t.Errorf("expected a trailing callback after the storm, got %d during and %d total", duringStorm, total)
+	}
+}
+
 func TestWatcher_WatchDirectory(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/watch/watcher_test.go
+++ b/internal/watch/watcher_test.go
@@ -194,27 +194,20 @@ func TestWatcher_Debouncing(t *testing.T) {
 }
 
 func TestWatcher_MaxWaitFiresDuringSustainedChanges(t *testing.T) {
-	tmpDir := t.TempDir()
-	tmpFile := filepath.Join(tmpDir, "test.txt")
-	if err := os.WriteFile(tmpFile, []byte("initial"), 0644); err != nil {
-		t.Fatalf("failed to create temp file: %v", err)
-	}
-
 	var callCount atomic.Int32
 
 	cfg := Config{
-		Paths:    []string{tmpFile},
 		Debounce: 100 * time.Millisecond,
 		MaxWait:  250 * time.Millisecond,
 	}
 
-	w, err := New(cfg, func() {
-		callCount.Add(1)
-	})
-	if err != nil {
-		t.Fatalf("New() error = %v", err)
+	w := &Watcher{
+		config: cfg,
+		onChange: func() {
+			callCount.Add(1)
+		},
 	}
-	defer func() { _ = w.Close() }()
+	defer w.cancelPendingTimer()
 
 	// Sustained events every 20ms reset the trailing debounce timer forever;
 	// only the MaxWait cap lets the callback fire while the storm is running.


### PR DESCRIPTION
## Problem

Recording a fest demo froze the recorder and eventually took the whole machine down (WindowServer watchdog kill at 01:29 after logd's firehose queues hung under memory pressure). Diagnosis with a controlled pty harness traced it to three fest-side defects:

1. **Every fest command stalls up to 5s on ptys that don't answer terminal queries.** bubbletea v1 calls `lipgloss.HasDarkBackground()` from a package `init()` (`tea_init.go:21`), which makes termenv write OSC 11 + DSR queries to the tty and block in `waitForData(5s)`. Interactive terminals answer instantly so humans never see it; recorder/CI/agent ptys that never answer freeze every command — even `fest version --no-color` — for the full timeout before the first byte of output. Verified by SIGQUIT goroutine dump of a stalled process.
2. **`fest watch` could only be exited with Ctrl+C** — its cycle registered only `p`/`P`, unlike show's cycle which quits on `q`. A recorder driving the view with `q` waits forever on a session that never ends.
3. **Sustained writes starve the watch refresh.** The trailing debounce timer resets on every fs event, so events arriving faster than 100ms apart defer the callback until the storm ends — the live view goes stale exactly when things are busiest.

## Fix

- New `internal/bginit` package seeds `lipgloss.SetHasDarkBackground(...)` from `COLORFGBG` (dark fallback, mirroring termenv's own non-query fallback) and is imported first in `cmd/fest` so it initializes before the bubbletea subtree. lipgloss then skips the terminal query everywhere (`explicitBackgroundColor`). An explicit `light`/`dark`/`high-contrast` theme refines the value in `ui.InitPalette`; `adaptive` keeps the env seed rather than reintroducing the query.
- `fest watch` cycle registers `q`/`Q` to quit; the cycle footer now advertises `q/Ctrl+C exit` in both show and watch.
- `watch.Config.MaxWait` caps debounce coalescing (500ms for the display refreshers: show watch, standalone watch, progress watch).

## Tradeoff

Adaptive background detection no longer queries the terminal, so light terminals without `COLORFGBG` get dark-variant adaptive colors in huh forms unless the user sets `fest config theme set light`. The CLI's main palette already treated adaptive as dark, so the visible delta is small — and it buys deterministic, instant startup on every pty.

## Verification (controlled pty harness, before → after)

| Scenario | Before | After |
| --- | --- | --- |
| `fest version`, mute pty | 5.03s, OSC11+2×DSR emitted | 0.35s, zero queries |
| `fest show <name>`, mute pty | 5.36s stall then output | 0.04s, colored, exits |
| `fest watch` + `q` | ignored (Ctrl+C only) | exits rc=0 |
| `fest show` cycle + `q` | exits | exits (no regression) |
| `fest watch` under 50 writes/s for 6s | 3 redraws (stale view) | 14 redraws (~2/s), output bounded |

Gates: `just build dev` ✓, `just test unit` 2473/2473 ✓, `just lint all` 0 issues ✓