### PR TITLE
feat(workflow): add --json to fest workflow status

### DIFF
--- a/docs/cli-reference/fest-reference.md
+++ b/docs/cli-reference/fest-reference.md
@@ -7331,6 +7331,9 @@ Shows:
   - Remaining steps
   - Checkpoint status if applicable
 
+Use --json for a stable machine-readable snapshot (schema fest.workflow.status/v1)
+that consumers can read without parsing the human-readable output.
+
 ```
 fest workflow status [flags]
 ```
@@ -7339,6 +7342,7 @@ fest workflow status [flags]
 
 ```
   -h, --help   help for status
+      --json   output as JSON
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/fest_workflow_status.md
+++ b/docs/cli-reference/fest_workflow_status.md
@@ -12,6 +12,9 @@ Shows:
   - Remaining steps
   - Checkpoint status if applicable
 
+Use --json for a stable machine-readable snapshot (schema fest.workflow.status/v1)
+that consumers can read without parsing the human-readable output.
+
 ```
 fest workflow status [flags]
 ```
@@ -20,6 +23,7 @@ fest workflow status [flags]
 
 ```
   -h, --help   help for status
+      --json   output as JSON
 ```
 
 ### Options inherited from parent commands

--- a/internal/commands/workflow/status.go
+++ b/internal/commands/workflow/status.go
@@ -20,7 +20,8 @@ import (
 )
 
 func newStatusCmd() *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Show workflow progress",
 		Long: `Display the current progress of the workflow in this phase.
@@ -29,20 +30,34 @@ Shows:
   - Current step number and name
   - Completed steps
   - Remaining steps
-  - Checkpoint status if applicable`,
+  - Checkpoint status if applicable
+
+Use --json for a stable machine-readable snapshot (schema fest.workflow.status/v1)
+that consumers can read without parsing the human-readable output.`,
 		Annotations: map[string]string{
 			"scope": string(scope.Festival),
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runStatus(cmd.Context())
+			return runStatus(cmd.Context(), jsonOutput)
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output as JSON")
+	return cmd
 }
 
-func runStatus(ctx context.Context) error {
+func runStatus(ctx context.Context, jsonOutput bool) error {
 	nav, err := getWorkflowNavigator(ctx)
 	if err != nil {
 		return err
+	}
+
+	if jsonOutput {
+		out, err := renderWorkflowStatusJSON(nav)
+		if err != nil {
+			return err
+		}
+		fmt.Println(out)
+		return nil
 	}
 
 	steps := nav.GetSteps()

--- a/internal/commands/workflow/status_json.go
+++ b/internal/commands/workflow/status_json.go
@@ -1,0 +1,120 @@
+package workflow
+
+import (
+	"encoding/json"
+
+	"github.com/Obedience-Corp/fest/internal/config"
+	"github.com/Obedience-Corp/fest/internal/errors"
+	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+)
+
+// workflowStatusSchema identifies the structured workflow status contract.
+// Consumers should treat any object carrying this schema_version as stable.
+const workflowStatusSchema = "fest.workflow.status/v1"
+
+// workflowStatusJSON is the machine-readable snapshot emitted by
+// `fest workflow status --json`. It is derived from structured navigator state,
+// never from the human-readable rendering.
+type workflowStatusJSON struct {
+	SchemaVersion string                   `json:"schema_version"`
+	FestivalID    string                   `json:"festival_id"`
+	FestivalName  string                   `json:"festival_name"`
+	FestivalPath  string                   `json:"festival_path"`
+	Phase         string                   `json:"phase"`
+	PhasePath     string                   `json:"phase_path"`
+	Mode          string                   `json:"mode"`
+	Workflow      string                   `json:"workflow"`
+	WorkflowStep  *string                  `json:"workflow_step"`
+	CurrentStep   *int                     `json:"current_step"`
+	TotalSteps    int                      `json:"total_steps"`
+	Complete      bool                     `json:"complete"`
+	Steps         []workflowStatusStepJSON `json:"steps"`
+}
+
+// workflowStatusStepJSON is one step entry in the structured snapshot.
+type workflowStatusStepJSON struct {
+	Number           int    `json:"number"`
+	Name             string `json:"name"`
+	Status           string `json:"status"`
+	IsCurrent        bool   `json:"is_current"`
+	HasCheckpoint    bool   `json:"has_checkpoint"`
+	Goal             string `json:"goal"`
+	Feedback         string `json:"feedback,omitempty"`
+	RemediationPhase string `json:"remediation_phase,omitempty"`
+}
+
+// collectWorkflowStatus builds the structured snapshot from navigator state.
+// An empty workflow (no steps) is reported as complete with a null current step
+// and an empty steps slice, matching the documented no-active-workflow contract.
+func collectWorkflowStatus(nav *wf.Navigator) workflowStatusJSON {
+	steps := nav.GetSteps()
+	state := nav.GetWorkflowState()
+
+	out := workflowStatusJSON{
+		SchemaVersion: workflowStatusSchema,
+		FestivalPath:  nav.Ctx.FestivalPath,
+		Phase:         nav.Ctx.PhaseName,
+		PhasePath:     nav.Ctx.PhasePath,
+		Mode:          "workflow",
+		Workflow:      nav.Ctx.PhaseName,
+		Steps:         make([]workflowStatusStepJSON, 0, len(steps)),
+	}
+	if nav.IsGate() {
+		out.Mode = "gate"
+	}
+	if cfg, err := config.LoadFestivalConfig(nav.Ctx.FestivalPath, ""); err == nil {
+		out.FestivalID = cfg.Metadata.ID
+		out.FestivalName = cfg.Metadata.Name
+	}
+
+	if len(steps) == 0 {
+		out.Complete = true
+		return out
+	}
+
+	out.TotalSteps = state.TotalSteps
+	out.Complete = state.IsComplete()
+	if !out.Complete {
+		current := state.CurrentStep
+		out.CurrentStep = &current
+	}
+
+	for _, step := range steps {
+		status := wf.StepStatusPending
+		feedback := ""
+		remediation := ""
+		if stepState := state.GetStepState(step.Number); stepState != nil {
+			status = stepState.Status
+			feedback = stepState.Feedback
+			remediation = stepState.RemediationPhase
+		}
+		isCurrent := step.Number == state.CurrentStep && !out.Complete
+
+		out.Steps = append(out.Steps, workflowStatusStepJSON{
+			Number:           step.Number,
+			Name:             step.Name,
+			Status:           string(status),
+			IsCurrent:        isCurrent,
+			HasCheckpoint:    step.HasCheckpoint(),
+			Goal:             step.Goal,
+			Feedback:         feedback,
+			RemediationPhase: remediation,
+		})
+
+		if isCurrent {
+			name := step.Name
+			out.WorkflowStep = &name
+		}
+	}
+
+	return out
+}
+
+// renderWorkflowStatusJSON encodes the structured snapshot as indented JSON.
+func renderWorkflowStatusJSON(nav *wf.Navigator) (string, error) {
+	data, err := json.MarshalIndent(collectWorkflowStatus(nav), "", "  ")
+	if err != nil {
+		return "", errors.Parse("formatting workflow status JSON", err)
+	}
+	return string(data), nil
+}

--- a/internal/commands/workflow/status_json_test.go
+++ b/internal/commands/workflow/status_json_test.go
@@ -1,0 +1,226 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/guidance"
+	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+)
+
+func decodeStatusJSON(t *testing.T, nav *wf.Navigator) workflowStatusJSON {
+	t.Helper()
+	out, err := renderWorkflowStatusJSON(nav)
+	if err != nil {
+		t.Fatalf("renderWorkflowStatusJSON: %v", err)
+	}
+	var got workflowStatusJSON
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal status json: %v\noutput: %s", err, out)
+	}
+	return got
+}
+
+func TestWorkflowStatusJSON_Normal(t *testing.T) {
+	dir := setupWorkflowFestival(t)
+	phaseDir := filepath.Join(dir, "001_INGEST")
+	nav := getNavigator(t, phaseDir)
+
+	got := decodeStatusJSON(t, nav)
+
+	if got.SchemaVersion != workflowStatusSchema {
+		t.Errorf("schema_version = %q, want %q", got.SchemaVersion, workflowStatusSchema)
+	}
+	if got.FestivalID != "TEST-001" {
+		t.Errorf("festival_id = %q, want TEST-001", got.FestivalID)
+	}
+	if got.FestivalPath != dir {
+		t.Errorf("festival_path = %q, want %q", got.FestivalPath, dir)
+	}
+	if got.Phase != "001_INGEST" {
+		t.Errorf("phase = %q, want 001_INGEST", got.Phase)
+	}
+	if got.PhasePath != phaseDir {
+		t.Errorf("phase_path = %q, want %q", got.PhasePath, phaseDir)
+	}
+	if got.Mode != "workflow" {
+		t.Errorf("mode = %q, want workflow", got.Mode)
+	}
+	if got.Workflow != "001_INGEST" {
+		t.Errorf("workflow = %q, want 001_INGEST", got.Workflow)
+	}
+	if got.Complete {
+		t.Error("complete = true, want false for fresh workflow")
+	}
+	if got.TotalSteps != 3 {
+		t.Errorf("total_steps = %d, want 3", got.TotalSteps)
+	}
+	if got.CurrentStep == nil || *got.CurrentStep != 1 {
+		t.Errorf("current_step = %v, want 1", got.CurrentStep)
+	}
+	if got.WorkflowStep == nil || *got.WorkflowStep != "READ" {
+		t.Errorf("workflow_step = %v, want READ", got.WorkflowStep)
+	}
+	if len(got.Steps) != 3 {
+		t.Fatalf("steps len = %d, want 3", len(got.Steps))
+	}
+	if !got.Steps[0].IsCurrent {
+		t.Error("step 1 is_current = false, want true")
+	}
+	if got.Steps[0].Name != "READ" {
+		t.Errorf("step 1 name = %q, want READ", got.Steps[0].Name)
+	}
+	if got.Steps[0].HasCheckpoint {
+		t.Error("step 1 has_checkpoint = true, want false")
+	}
+	// Step 2 (ANALYZE) declares USER APPROVAL REQUIRED.
+	if !got.Steps[1].HasCheckpoint {
+		t.Error("step 2 has_checkpoint = false, want true")
+	}
+}
+
+func TestWorkflowStatusJSON_Complete(t *testing.T) {
+	dir := setupWorkflowFestival(t)
+	phaseDir := filepath.Join(dir, "001_INGEST")
+	nav := getNavigator(t, phaseDir)
+	ctx := context.Background()
+
+	if err := nav.Advance(ctx); err != nil {
+		t.Fatalf("advance step 1: %v", err)
+	}
+	if err := nav.Advance(ctx); err != nil {
+		t.Fatalf("advance step 2: %v", err)
+	}
+	if err := nav.Approve(ctx); err != nil {
+		t.Fatalf("approve checkpoint: %v", err)
+	}
+	if err := nav.Advance(ctx); err != nil && err != guidance.ErrAlreadyComplete {
+		if !nav.GetWorkflowState().IsComplete() {
+			t.Fatalf("advance step 3: %v", err)
+		}
+	}
+	if !nav.GetWorkflowState().IsComplete() {
+		t.Fatal("workflow should be complete before asserting JSON")
+	}
+
+	got := decodeStatusJSON(t, nav)
+
+	if !got.Complete {
+		t.Error("complete = false, want true")
+	}
+	if got.CurrentStep != nil {
+		t.Errorf("current_step = %v, want null when complete", *got.CurrentStep)
+	}
+	if got.WorkflowStep != nil {
+		t.Errorf("workflow_step = %v, want null when complete", *got.WorkflowStep)
+	}
+	for i, s := range got.Steps {
+		if s.IsCurrent {
+			t.Errorf("step %d is_current = true, want false when complete", i+1)
+		}
+	}
+}
+
+func TestWorkflowStatusJSON_GateMode(t *testing.T) {
+	dir := setupGateOnlyFestival(t)
+	phaseDir := filepath.Join(dir, "001_IMPLEMENT")
+
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(phaseDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	nav, err := getWorkflowNavigator(context.Background())
+	if err != nil {
+		t.Fatalf("getWorkflowNavigator: %v", err)
+	}
+
+	got := decodeStatusJSON(t, nav)
+
+	if got.Mode != "gate" {
+		t.Errorf("mode = %q, want gate", got.Mode)
+	}
+	if got.Phase != "001_IMPLEMENT" {
+		t.Errorf("phase = %q, want 001_IMPLEMENT", got.Phase)
+	}
+	if got.TotalSteps != 2 {
+		t.Errorf("total_steps = %d, want 2", got.TotalSteps)
+	}
+}
+
+func TestWorkflowStatusJSON_EmptyStepsSerializesArray(t *testing.T) {
+	dir := t.TempDir()
+	phaseDir := filepath.Join(dir, "001_EMPTY")
+	if err := os.MkdirAll(phaseDir, 0o755); err != nil {
+		t.Fatalf("mkdir phase: %v", err)
+	}
+	nav := getNavigator(t, phaseDir) // no WORKFLOW.md/GATES.md => empty steps
+
+	out, err := renderWorkflowStatusJSON(nav)
+	if err != nil {
+		t.Fatalf("renderWorkflowStatusJSON: %v", err)
+	}
+	// Empty steps must serialize as [] (not null) for stable consumers.
+	if !strings.Contains(out, `"steps": []`) {
+		t.Errorf("expected empty steps array, got:\n%s", out)
+	}
+
+	got := decodeStatusJSON(t, nav)
+	if !got.Complete {
+		t.Error("complete = false, want true for empty workflow")
+	}
+	if got.CurrentStep != nil {
+		t.Errorf("current_step = %v, want null for empty workflow", *got.CurrentStep)
+	}
+	if got.WorkflowStep != nil {
+		t.Error("workflow_step should be null for empty workflow")
+	}
+	if len(got.Steps) != 0 {
+		t.Errorf("steps len = %d, want 0", len(got.Steps))
+	}
+}
+
+// TestRunStatus_JSONAndText exercises the real command entrypoint for both
+// modes: --json emits parseable structured output and default text mode still
+// renders the human-readable status without leaking JSON.
+func TestRunStatus_JSONAndText(t *testing.T) {
+	dir := setupWorkflowFestival(t)
+	phaseDir := filepath.Join(dir, "001_INGEST")
+
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(phaseDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	ctx := context.Background()
+
+	jsonOut := captureStdout(t, func() {
+		if err := runStatus(ctx, true); err != nil {
+			t.Fatalf("runStatus(json): %v", err)
+		}
+	})
+	var parsed workflowStatusJSON
+	if err := json.Unmarshal([]byte(jsonOut), &parsed); err != nil {
+		t.Fatalf("json mode did not emit valid JSON: %v\noutput: %s", err, jsonOut)
+	}
+	if parsed.SchemaVersion != workflowStatusSchema {
+		t.Errorf("schema_version = %q, want %q", parsed.SchemaVersion, workflowStatusSchema)
+	}
+
+	textOut := captureStdout(t, func() {
+		if err := runStatus(ctx, false); err != nil {
+			t.Fatalf("runStatus(text): %v", err)
+		}
+	})
+	if !strings.Contains(textOut, "Workflow Status") {
+		t.Errorf("text mode missing human header, got:\n%s", textOut)
+	}
+	if strings.Contains(textOut, "schema_version") {
+		t.Errorf("text mode leaked JSON: %s", textOut)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a structured `--json` output to `fest workflow status` so consumers can read the current workflow position without parsing the human-readable text. This is the implementation half of RI0002 sequence 02 (design workitem WI-1e4ac2); the festival-app consumer will use it to populate `FestContext.workflow` and `FestContext.workflow_step`.

Default text output is unchanged.

## Contract (schema `fest.workflow.status/v1`)

Top-level fields: `schema_version`, `festival_id`, `festival_name`, `festival_path`, `phase`, `phase_path`, `mode` (`workflow` or `gate`), `workflow`, `workflow_step`, `current_step`, `total_steps`, `complete`, and `steps[]`.

Each `steps[]` entry: `number`, `name`, `status`, `is_current`, `has_checkpoint`, `goal`, and `feedback` / `remediation_phase` (omitted when empty).

Null and empty behavior:

- When the workflow is complete, `current_step` and `workflow_step` are `null` and `complete` is `true`.
- A phase with no navigable workflow returns a valid object with `complete: true`, `current_step: null`, and `steps: []` (an empty array, never `null`).
- Missing festival or phase context returns the same non-zero command error as text mode.

## Implementation

- `status.go`: adds the `--json` flag on `newStatusCmd` and threads `jsonOutput` through `runStatus`, branching to structured output before the text path. Text rendering is untouched.
- `status_json.go`: private DTOs plus `collectWorkflowStatus`, built entirely from structured navigator state (`nav.GetSteps()`, `nav.GetWorkflowState()`, `nav.Ctx`) and never from the rendered string. Festival id and name come from `config.LoadFestivalConfig` (best effort; empty if unavailable). Gate mode is derived from `nav.IsGate()`.
- Encodes with `encoding/json` (`MarshalIndent`); JSON errors use the repo `errors.Parse` convention, matching the existing `--json` commands.

## Tests

`status_json_test.go` covers the normal workflow snapshot, the completed state (null current step), gate mode, empty-steps array serialization, and a real command-path test asserting both `--json` emits parseable JSON and text mode still renders the human header without leaking JSON.

## Validation

- `just lint all`: 0 issues
- `just test unit-raw`: 0 failures
- Real end-to-end run of `fest workflow status --json` against a scaffolded festival produced the full contract, and text mode plus `--help` (now documenting `--json`) were confirmed unchanged.

The CLI reference under `docs/cli-reference/` was regenerated in a separate commit; only the workflow-status entry changed (the new flag and schema note), with no unrelated command drift.
