### PR TITLE
feat(list): fest list --watch live multi-festival status board

### DIFF
--- a/docs/cli-reference/fest-reference.md
+++ b/docs/cli-reference/fest-reference.md
@@ -2716,6 +2716,9 @@ dungeon, dungeon/completed, dungeon/archived, dungeon/someday
 By default, shows active, ready, planning, and ritual festivals.
 Use 'fest list all' (or --all) to include completed and dungeon festivals.
 
+Use --watch to continuously refresh the multi-festival status board in place
+(similar to fest watch, but without cycling between festivals). Ctrl+C to quit.
+
 ```
 fest list [status] [flags]
 ```
@@ -2731,6 +2734,8 @@ fest list [status] [flags]
   fest list active --sort progress                 # Active festivals, most complete first
   fest list --since 2026-01-01 --until 2026-02-01  # Created in January 2026
   fest list --json                                 # Output in JSON format
+  fest list --watch                                # Live multi-festival status board
+  fest list active --watch                         # Watch only active festivals
 ```
 
 ### Options
@@ -2746,6 +2751,7 @@ fest list [status] [flags]
       --sort string             sort by: date|status|progress|name|created|updated
       --status string           filter by status: active|planning|completed|dungeon
       --until string            show festivals created on or before this date (YYYY-MM-DD or RFC3339)
+  -w, --watch                   continuously refresh the list in place until Ctrl+C
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/fest_list.md
+++ b/docs/cli-reference/fest_list.md
@@ -14,6 +14,9 @@ dungeon, dungeon/completed, dungeon/archived, dungeon/someday
 By default, shows active, ready, planning, and ritual festivals.
 Use 'fest list all' (or --all) to include completed and dungeon festivals.
 
+Use --watch to continuously refresh the multi-festival status board in place
+(similar to fest watch, but without cycling between festivals). Ctrl+C to quit.
+
 ```
 fest list [status] [flags]
 ```
@@ -29,6 +32,8 @@ fest list [status] [flags]
   fest list active --sort progress                 # Active festivals, most complete first
   fest list --since 2026-01-01 --until 2026-02-01  # Created in January 2026
   fest list --json                                 # Output in JSON format
+  fest list --watch                                # Live multi-festival status board
+  fest list active --watch                         # Watch only active festivals
 ```
 
 ### Options
@@ -44,6 +49,7 @@ fest list [status] [flags]
       --sort string             sort by: date|status|progress|name|created|updated
       --status string           filter by status: active|planning|completed|dungeon
       --until string            show festivals created on or before this date (YYYY-MM-DD or RFC3339)
+  -w, --watch                   continuously refresh the list in place until Ctrl+C
 ```
 
 ### Options inherited from parent commands

--- a/internal/commands/list/list.go
+++ b/internal/commands/list/list.go
@@ -395,269 +395,53 @@ func applyFilters(festivals []*show.FestivalInfo, opts *listOptions) ([]*show.Fe
 var dungeonSubstatuses = []string{"dungeon/completed", "dungeon/archived", "dungeon/someday"}
 
 func listDungeon(ctx context.Context, festivalsDir string, opts *listOptions, campaignRoot string) error {
-	result := make(map[string]interface{})
-	var totalCount int
-	allFestivals := make(map[string][]*show.FestivalInfo)
-	var allFestivalsList []*show.FestivalInfo
-
-	order := make([]string, 0, len(dungeonSubstatuses))
-	for _, status := range dungeonSubstatuses {
-		festivals, err := show.ListFestivalsByStatus(ctx, festivalsDir, status, campaignRoot)
-		if err != nil {
-			continue
-		}
-		festivals, err = applyFilters(festivals, opts)
-		if err != nil {
-			return err
-		}
-		if len(festivals) > 0 {
-			// Default dungeon listings order by bucket date (newest first);
-			// explicit --sort or --alpha still wins.
-			if opts.sortBy == "" && !opts.alpha {
-				sortByStatusDate(festivals)
-			} else {
-				applySorting(festivals, opts.sortBy, opts.alpha)
-			}
-			allFestivals[status] = festivals
-			order = append(order, status)
-			totalCount += len(festivals)
-			allFestivalsList = append(allFestivalsList, festivals...)
-		}
+	board, err := collectDungeonBoard(ctx, festivalsDir, opts, campaignRoot)
+	if err != nil {
+		return err
 	}
-
-	var progressMap map[string]*progress.FestivalProgress
-	if opts.progress {
-		progressMap = fetchProgressForFestivals(ctx, allFestivalsList)
-	}
-
 	if opts.json {
-		for status, festivals := range allFestivals {
-			result[status] = festivalsToMapWithProgress(festivals, progressMap)
+		result := make(map[string]interface{}, len(board.Festivals)+1)
+		for status, festivals := range board.Festivals {
+			result[status] = festivalsToMapWithProgress(festivals, board.Progress)
 		}
-		result["total"] = totalCount
+		result["total"] = board.Total
 		return outputJSON(result)
 	}
-
-	fmt.Print(formatDungeonHuman(allFestivals, order, progressMap, totalCount, opts.progress))
+	fmt.Print(formatDungeonHuman(board.Festivals, board.Order, board.Progress, board.Total, opts.progress))
 	return nil
 }
 
 func listByStatus(ctx context.Context, festivalsDir, status string, opts *listOptions, campaignRoot string) error {
-	festivals, err := show.ListFestivalsByStatus(ctx, festivalsDir, status, campaignRoot)
+	board, err := collectStatusBoard(ctx, festivalsDir, status, opts, campaignRoot)
 	if err != nil {
 		return err
 	}
-
-	festivals, err = applyFilters(festivals, opts)
-	if err != nil {
-		return err
-	}
-
-	// Dungeon listings default to newest bucket date first; explicit sort
-	// flags still take precedence.
-	if opts.sortBy == "" && !opts.alpha && strings.HasPrefix(status, "dungeon/") {
-		sortByStatusDate(festivals)
-	} else {
-		applySorting(festivals, opts.sortBy, opts.alpha)
-	}
-
-	// Fetch detailed progress if requested
-	var progressMap map[string]*progress.FestivalProgress
-	if opts.progress {
-		progressMap = fetchProgressForFestivals(ctx, festivals)
-	}
-
 	if opts.json {
 		return outputJSON(map[string]interface{}{
 			"status":    status,
-			"count":     len(festivals),
-			"festivals": festivalsToMapWithProgress(festivals, progressMap),
+			"count":     len(board.Festivals),
+			"festivals": festivalsToMapWithProgress(board.Festivals, board.Progress),
 		})
 	}
-
-	fmt.Print(formatStatusHuman(status, festivals, progressMap, opts.progress))
+	fmt.Print(formatStatusHuman(status, board.Festivals, board.Progress, opts.progress))
 	return nil
 }
 
 func listAll(ctx context.Context, festivalsDir string, opts *listOptions, campaignRoot string) error {
-	result := make(map[string]interface{})
-	var totalCount int
-	allFestivals := make(map[string][]*show.FestivalInfo)
-
-	// Use all statuses if --all flag, otherwise just active/planning
-	statuses := defaultStatuses
-	if opts.all {
-		statuses = validStatuses
+	board, err := collectAllBoard(ctx, festivalsDir, opts, campaignRoot)
+	if err != nil {
+		return err
 	}
-
-	statusOrder := make([]string, 0, len(statuses))
-	var allFestivalsList []*show.FestivalInfo
-
-	for _, status := range statuses {
-		festivals, err := show.ListFestivalsByStatus(ctx, festivalsDir, status, campaignRoot)
-		if err != nil {
-			continue
-		}
-		festivals, err = applyFilters(festivals, opts)
-		if err != nil {
-			return err
-		}
-		if len(festivals) > 0 {
-			applySorting(festivals, opts.sortBy, opts.alpha)
-			allFestivals[status] = festivals
-			statusOrder = append(statusOrder, status)
-			totalCount += len(festivals)
-			allFestivalsList = append(allFestivalsList, festivals...)
-		}
-	}
-
-	// Fetch detailed progress if requested
-	var progressMap map[string]*progress.FestivalProgress
-	if opts.progress {
-		progressMap = fetchProgressForFestivals(ctx, allFestivalsList)
-	}
-
 	if opts.json {
-		for status, festivals := range allFestivals {
-			result[status] = festivalsToMapWithProgress(festivals, progressMap)
+		result := make(map[string]interface{}, len(board.Festivals)+1)
+		for status, festivals := range board.Festivals {
+			result[status] = festivalsToMapWithProgress(festivals, board.Progress)
 		}
-		result["total"] = totalCount
+		result["total"] = board.Total
 		return outputJSON(result)
 	}
-
-	fmt.Print(formatAllHuman(allFestivals, statusOrder, progressMap, totalCount, opts.progress))
+	fmt.Print(formatAllHuman(board.Festivals, board.Order, board.Progress, board.Total, opts.progress))
 	return nil
-}
-
-// formatListBoard builds the human-readable list board for the current filters.
-// Used by one-shot list (via list*) and by --watch refresh frames.
-func formatListBoard(ctx context.Context, festivalsDir, filterStatus string, opts *listOptions, campaignRoot string) (string, error) {
-	if filterStatus != "" {
-		if filterStatus == "dungeon" {
-			return formatDungeonBoard(ctx, festivalsDir, opts, campaignRoot)
-		}
-		return formatStatusBoard(ctx, festivalsDir, filterStatus, opts, campaignRoot)
-	}
-	return formatAllBoard(ctx, festivalsDir, opts, campaignRoot)
-}
-
-func formatDungeonBoard(ctx context.Context, festivalsDir string, opts *listOptions, campaignRoot string) (string, error) {
-	var totalCount int
-	allFestivals := make(map[string][]*show.FestivalInfo)
-	order := make([]string, 0, len(dungeonSubstatuses))
-	var allFestivalsList []*show.FestivalInfo
-
-	for _, status := range dungeonSubstatuses {
-		festivals, err := show.ListFestivalsByStatus(ctx, festivalsDir, status, campaignRoot)
-		if err != nil {
-			continue
-		}
-		festivals, err = applyFilters(festivals, opts)
-		if err != nil {
-			return "", err
-		}
-		if len(festivals) > 0 {
-			if opts.sortBy == "" && !opts.alpha {
-				sortByStatusDate(festivals)
-			} else {
-				applySorting(festivals, opts.sortBy, opts.alpha)
-			}
-			allFestivals[status] = festivals
-			order = append(order, status)
-			totalCount += len(festivals)
-			allFestivalsList = append(allFestivalsList, festivals...)
-		}
-	}
-
-	var progressMap map[string]*progress.FestivalProgress
-	if opts.progress {
-		progressMap = fetchProgressForFestivals(ctx, allFestivalsList)
-	}
-	return formatDungeonHuman(allFestivals, order, progressMap, totalCount, opts.progress), nil
-}
-
-func formatStatusBoard(ctx context.Context, festivalsDir, status string, opts *listOptions, campaignRoot string) (string, error) {
-	festivals, err := show.ListFestivalsByStatus(ctx, festivalsDir, status, campaignRoot)
-	if err != nil {
-		return "", err
-	}
-	festivals, err = applyFilters(festivals, opts)
-	if err != nil {
-		return "", err
-	}
-	if opts.sortBy == "" && !opts.alpha && strings.HasPrefix(status, "dungeon/") {
-		sortByStatusDate(festivals)
-	} else {
-		applySorting(festivals, opts.sortBy, opts.alpha)
-	}
-	var progressMap map[string]*progress.FestivalProgress
-	if opts.progress {
-		progressMap = fetchProgressForFestivals(ctx, festivals)
-	}
-	return formatStatusHuman(status, festivals, progressMap, opts.progress), nil
-}
-
-func formatAllBoard(ctx context.Context, festivalsDir string, opts *listOptions, campaignRoot string) (string, error) {
-	var totalCount int
-	allFestivals := make(map[string][]*show.FestivalInfo)
-	statuses := defaultStatuses
-	if opts.all {
-		statuses = validStatuses
-	}
-	statusOrder := make([]string, 0, len(statuses))
-	var allFestivalsList []*show.FestivalInfo
-
-	for _, status := range statuses {
-		festivals, err := show.ListFestivalsByStatus(ctx, festivalsDir, status, campaignRoot)
-		if err != nil {
-			continue
-		}
-		festivals, err = applyFilters(festivals, opts)
-		if err != nil {
-			return "", err
-		}
-		if len(festivals) > 0 {
-			applySorting(festivals, opts.sortBy, opts.alpha)
-			allFestivals[status] = festivals
-			statusOrder = append(statusOrder, status)
-			totalCount += len(festivals)
-			allFestivalsList = append(allFestivalsList, festivals...)
-		}
-	}
-
-	var progressMap map[string]*progress.FestivalProgress
-	if opts.progress {
-		progressMap = fetchProgressForFestivals(ctx, allFestivalsList)
-	}
-	return formatAllHuman(allFestivals, statusOrder, progressMap, totalCount, opts.progress), nil
-}
-
-func formatDungeonHuman(allFestivals map[string][]*show.FestivalInfo, order []string, progressMap map[string]*progress.FestivalProgress, totalCount int, withProgress bool) string {
-	if totalCount == 0 {
-		return ui.Warning("No festivals in dungeon.") + "\n"
-	}
-	if withProgress {
-		return show.FormatAllFestivalsWithProgress(allFestivals, order, progressMap)
-	}
-	return show.FormatAllFestivals(allFestivals, order)
-}
-
-func formatStatusHuman(status string, festivals []*show.FestivalInfo, progressMap map[string]*progress.FestivalProgress, withProgress bool) string {
-	if withProgress {
-		return show.FormatFestivalListWithProgress(status, festivals, progressMap)
-	}
-	return show.FormatFestivalList(status, festivals)
-}
-
-func formatAllHuman(allFestivals map[string][]*show.FestivalInfo, statusOrder []string, progressMap map[string]*progress.FestivalProgress, totalCount int, withProgress bool) string {
-	if totalCount == 0 {
-		return ui.Warning("No festivals found.") + "\n" +
-			ui.Info("Create a festival with: fest create festival") + "\n"
-	}
-	if withProgress {
-		return show.FormatAllFestivalsWithProgress(allFestivals, statusOrder, progressMap)
-	}
-	return show.FormatAllFestivals(allFestivals, statusOrder)
 }
 
 func festivalsToMap(festivals []*show.FestivalInfo) []map[string]interface{} {
@@ -748,3 +532,32 @@ func festivalsToMapWithProgress(festivals []*show.FestivalInfo, progressMap map[
 	}
 	return result
 }
+
+func formatDungeonHuman(allFestivals map[string][]*show.FestivalInfo, order []string, progressMap map[string]*progress.FestivalProgress, totalCount int, withProgress bool) string {
+	if totalCount == 0 {
+		return ui.Warning("No festivals in dungeon.") + "\n"
+	}
+	if withProgress {
+		return show.FormatAllFestivalsWithProgress(allFestivals, order, progressMap)
+	}
+	return show.FormatAllFestivals(allFestivals, order)
+}
+
+func formatStatusHuman(status string, festivals []*show.FestivalInfo, progressMap map[string]*progress.FestivalProgress, withProgress bool) string {
+	if withProgress {
+		return show.FormatFestivalListWithProgress(status, festivals, progressMap)
+	}
+	return show.FormatFestivalList(status, festivals)
+}
+
+func formatAllHuman(allFestivals map[string][]*show.FestivalInfo, statusOrder []string, progressMap map[string]*progress.FestivalProgress, totalCount int, withProgress bool) string {
+	if totalCount == 0 {
+		return ui.Warning("No festivals found.") + "\n" +
+			ui.Info("Create a festival with: fest create festival") + "\n"
+	}
+	if withProgress {
+		return show.FormatAllFestivalsWithProgress(allFestivals, statusOrder, progressMap)
+	}
+	return show.FormatAllFestivals(allFestivals, statusOrder)
+}
+

--- a/internal/commands/list/list.go
+++ b/internal/commands/list/list.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/ui"
 	"github.com/Obedience-Corp/fest/internal/workspace"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 // validStatuses includes all festival directories plus "dungeon" as shorthand alias.
@@ -87,11 +88,17 @@ type listOptions struct {
 	all           bool
 	progress      bool
 	alpha         bool
+	watch         bool
 	status        string
 	sortBy        string
 	filterProject string
 	since         string
 	until         string
+}
+
+// listStdoutIsTerminal reports whether stdout is a terminal. Overridden in tests.
+var listStdoutIsTerminal = func() bool {
+	return term.IsTerminal(int(os.Stdout.Fd()))
 }
 
 // NewListCommand creates the list command for listing festivals by status.
@@ -109,7 +116,10 @@ STATUS can be: active, ready, planning, ritual, completed, all,
 dungeon, dungeon/completed, dungeon/archived, dungeon/someday
 
 By default, shows active, ready, planning, and ritual festivals.
-Use 'fest list all' (or --all) to include completed and dungeon festivals.`,
+Use 'fest list all' (or --all) to include completed and dungeon festivals.
+
+Use --watch to continuously refresh the multi-festival status board in place
+(similar to fest watch, but without cycling between festivals). Ctrl+C to quit.`,
 		Example: `  fest list                                        # Active, ready, planning, ritual festivals
   fest list active                                 # Only active festivals
   fest list all                                    # Every festival grouped by status
@@ -117,7 +127,9 @@ Use 'fest list all' (or --all) to include completed and dungeon festivals.`,
   fest list --filter-project camp                  # Festivals linked to "camp" project
   fest list active --sort progress                 # Active festivals, most complete first
   fest list --since 2026-01-01 --until 2026-02-01  # Created in January 2026
-  fest list --json                                 # Output in JSON format`,
+  fest list --json                                 # Output in JSON format
+  fest list --watch                                # Live multi-festival status board
+  fest list active --watch                         # Watch only active festivals`,
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: completeListStatus,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -153,11 +165,19 @@ Use 'fest list all' (or --all) to include completed and dungeon festivals.`,
 					return err
 				}
 			}
+			if opts.watch && opts.json {
+				return errors.Validation("--watch cannot be combined with --json").
+					WithField("hint", "use one-shot fest list --json for agents; --watch is human terminal output")
+			}
+			if opts.watch && !listStdoutIsTerminal() {
+				return errors.Validation("--watch requires an interactive terminal")
+			}
 			return runList(cmd.Context(), status, opts)
 		},
 	}
 
 	cmd.Flags().BoolVar(&opts.json, "json", false, "output in JSON format")
+	cmd.Flags().BoolVarP(&opts.watch, "watch", "w", false, "continuously refresh the list in place until Ctrl+C")
 	cmd.Flags().BoolVar(&opts.all, "all", false, "include completed and dungeon festivals")
 	cmd.Flags().BoolVar(&opts.progress, "progress", false, "show detailed progress for each festival")
 	cmd.Flags().BoolVar(&opts.alpha, "alpha", false, "sort alphabetically by name instead of by date")
@@ -193,6 +213,10 @@ func runList(ctx context.Context, filterStatus string, opts *listOptions) error 
 	}
 
 	campaignRoot, _ := workspace.DetectCampaign(ctx, "")
+
+	if opts.watch {
+		return runListWatch(ctx, festivalsDir, filterStatus, opts, campaignRoot)
+	}
 
 	if filterStatus != "" {
 		// "dungeon" without substatus: list all dungeon children
@@ -414,16 +438,7 @@ func listDungeon(ctx context.Context, festivalsDir string, opts *listOptions, ca
 		return outputJSON(result)
 	}
 
-	if totalCount == 0 {
-		fmt.Println(ui.Warning("No festivals in dungeon."))
-		return nil
-	}
-
-	if opts.progress {
-		fmt.Print(show.FormatAllFestivalsWithProgress(allFestivals, order, progressMap))
-	} else {
-		fmt.Print(show.FormatAllFestivals(allFestivals, order))
-	}
+	fmt.Print(formatDungeonHuman(allFestivals, order, progressMap, totalCount, opts.progress))
 	return nil
 }
 
@@ -460,12 +475,7 @@ func listByStatus(ctx context.Context, festivalsDir, status string, opts *listOp
 		})
 	}
 
-	if opts.progress {
-		fmt.Print(show.FormatFestivalListWithProgress(status, festivals, progressMap))
-	} else {
-		fmt.Print(show.FormatFestivalList(status, festivals))
-	}
-
+	fmt.Print(formatStatusHuman(status, festivals, progressMap, opts.progress))
 	return nil
 }
 
@@ -515,18 +525,139 @@ func listAll(ctx context.Context, festivalsDir string, opts *listOptions, campai
 		return outputJSON(result)
 	}
 
-	if totalCount == 0 {
-		fmt.Println(ui.Warning("No festivals found."))
-		fmt.Println(ui.Info("Create a festival with: fest create festival"))
-		return nil
+	fmt.Print(formatAllHuman(allFestivals, statusOrder, progressMap, totalCount, opts.progress))
+	return nil
+}
+
+// formatListBoard builds the human-readable list board for the current filters.
+// Used by one-shot list (via list*) and by --watch refresh frames.
+func formatListBoard(ctx context.Context, festivalsDir, filterStatus string, opts *listOptions, campaignRoot string) (string, error) {
+	if filterStatus != "" {
+		if filterStatus == "dungeon" {
+			return formatDungeonBoard(ctx, festivalsDir, opts, campaignRoot)
+		}
+		return formatStatusBoard(ctx, festivalsDir, filterStatus, opts, campaignRoot)
+	}
+	return formatAllBoard(ctx, festivalsDir, opts, campaignRoot)
+}
+
+func formatDungeonBoard(ctx context.Context, festivalsDir string, opts *listOptions, campaignRoot string) (string, error) {
+	var totalCount int
+	allFestivals := make(map[string][]*show.FestivalInfo)
+	order := make([]string, 0, len(dungeonSubstatuses))
+	var allFestivalsList []*show.FestivalInfo
+
+	for _, status := range dungeonSubstatuses {
+		festivals, err := show.ListFestivalsByStatus(ctx, festivalsDir, status, campaignRoot)
+		if err != nil {
+			continue
+		}
+		festivals, err = applyFilters(festivals, opts)
+		if err != nil {
+			return "", err
+		}
+		if len(festivals) > 0 {
+			if opts.sortBy == "" && !opts.alpha {
+				sortByStatusDate(festivals)
+			} else {
+				applySorting(festivals, opts.sortBy, opts.alpha)
+			}
+			allFestivals[status] = festivals
+			order = append(order, status)
+			totalCount += len(festivals)
+			allFestivalsList = append(allFestivalsList, festivals...)
+		}
 	}
 
+	var progressMap map[string]*progress.FestivalProgress
 	if opts.progress {
-		fmt.Print(show.FormatAllFestivalsWithProgress(allFestivals, statusOrder, progressMap))
-	} else {
-		fmt.Print(show.FormatAllFestivals(allFestivals, statusOrder))
+		progressMap = fetchProgressForFestivals(ctx, allFestivalsList)
 	}
-	return nil
+	return formatDungeonHuman(allFestivals, order, progressMap, totalCount, opts.progress), nil
+}
+
+func formatStatusBoard(ctx context.Context, festivalsDir, status string, opts *listOptions, campaignRoot string) (string, error) {
+	festivals, err := show.ListFestivalsByStatus(ctx, festivalsDir, status, campaignRoot)
+	if err != nil {
+		return "", err
+	}
+	festivals, err = applyFilters(festivals, opts)
+	if err != nil {
+		return "", err
+	}
+	if opts.sortBy == "" && !opts.alpha && strings.HasPrefix(status, "dungeon/") {
+		sortByStatusDate(festivals)
+	} else {
+		applySorting(festivals, opts.sortBy, opts.alpha)
+	}
+	var progressMap map[string]*progress.FestivalProgress
+	if opts.progress {
+		progressMap = fetchProgressForFestivals(ctx, festivals)
+	}
+	return formatStatusHuman(status, festivals, progressMap, opts.progress), nil
+}
+
+func formatAllBoard(ctx context.Context, festivalsDir string, opts *listOptions, campaignRoot string) (string, error) {
+	var totalCount int
+	allFestivals := make(map[string][]*show.FestivalInfo)
+	statuses := defaultStatuses
+	if opts.all {
+		statuses = validStatuses
+	}
+	statusOrder := make([]string, 0, len(statuses))
+	var allFestivalsList []*show.FestivalInfo
+
+	for _, status := range statuses {
+		festivals, err := show.ListFestivalsByStatus(ctx, festivalsDir, status, campaignRoot)
+		if err != nil {
+			continue
+		}
+		festivals, err = applyFilters(festivals, opts)
+		if err != nil {
+			return "", err
+		}
+		if len(festivals) > 0 {
+			applySorting(festivals, opts.sortBy, opts.alpha)
+			allFestivals[status] = festivals
+			statusOrder = append(statusOrder, status)
+			totalCount += len(festivals)
+			allFestivalsList = append(allFestivalsList, festivals...)
+		}
+	}
+
+	var progressMap map[string]*progress.FestivalProgress
+	if opts.progress {
+		progressMap = fetchProgressForFestivals(ctx, allFestivalsList)
+	}
+	return formatAllHuman(allFestivals, statusOrder, progressMap, totalCount, opts.progress), nil
+}
+
+func formatDungeonHuman(allFestivals map[string][]*show.FestivalInfo, order []string, progressMap map[string]*progress.FestivalProgress, totalCount int, withProgress bool) string {
+	if totalCount == 0 {
+		return ui.Warning("No festivals in dungeon.") + "\n"
+	}
+	if withProgress {
+		return show.FormatAllFestivalsWithProgress(allFestivals, order, progressMap)
+	}
+	return show.FormatAllFestivals(allFestivals, order)
+}
+
+func formatStatusHuman(status string, festivals []*show.FestivalInfo, progressMap map[string]*progress.FestivalProgress, withProgress bool) string {
+	if withProgress {
+		return show.FormatFestivalListWithProgress(status, festivals, progressMap)
+	}
+	return show.FormatFestivalList(status, festivals)
+}
+
+func formatAllHuman(allFestivals map[string][]*show.FestivalInfo, statusOrder []string, progressMap map[string]*progress.FestivalProgress, totalCount int, withProgress bool) string {
+	if totalCount == 0 {
+		return ui.Warning("No festivals found.") + "\n" +
+			ui.Info("Create a festival with: fest create festival") + "\n"
+	}
+	if withProgress {
+		return show.FormatAllFestivalsWithProgress(allFestivals, statusOrder, progressMap)
+	}
+	return show.FormatAllFestivals(allFestivals, statusOrder)
 }
 
 func festivalsToMap(festivals []*show.FestivalInfo) []map[string]interface{} {

--- a/internal/commands/list/list_board.go
+++ b/internal/commands/list/list_board.go
@@ -1,0 +1,154 @@
+package list
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Obedience-Corp/fest/internal/commands/show"
+	"github.com/Obedience-Corp/fest/internal/progress"
+)
+
+// multiStatusBoard is the shared collection model for dungeon and all-status
+// boards. One-shot list, JSON, and --watch all consume this so sort/filter/
+// progress behavior cannot drift between modes.
+type multiStatusBoard struct {
+	Festivals map[string][]*show.FestivalInfo
+	Order     []string
+	Total     int
+	Progress  map[string]*progress.FestivalProgress
+}
+
+// statusBoard is the single-status collection model.
+type statusBoard struct {
+	Festivals []*show.FestivalInfo
+	Progress  map[string]*progress.FestivalProgress
+}
+
+// formatListBoard builds the human-readable list board for the current filters.
+// Used by one-shot list (via list*) and by --watch refresh frames.
+func formatListBoard(ctx context.Context, festivalsDir, filterStatus string, opts *listOptions, campaignRoot string) (string, error) {
+	if filterStatus != "" {
+		if filterStatus == "dungeon" {
+			board, err := collectDungeonBoard(ctx, festivalsDir, opts, campaignRoot)
+			if err != nil {
+				return "", err
+			}
+			return formatDungeonHuman(board.Festivals, board.Order, board.Progress, board.Total, opts.progress), nil
+		}
+		board, err := collectStatusBoard(ctx, festivalsDir, filterStatus, opts, campaignRoot)
+		if err != nil {
+			return "", err
+		}
+		return formatStatusHuman(filterStatus, board.Festivals, board.Progress, opts.progress), nil
+	}
+	board, err := collectAllBoard(ctx, festivalsDir, opts, campaignRoot)
+	if err != nil {
+		return "", err
+	}
+	return formatAllHuman(board.Festivals, board.Order, board.Progress, board.Total, opts.progress), nil
+}
+
+func collectDungeonBoard(ctx context.Context, festivalsDir string, opts *listOptions, campaignRoot string) (multiStatusBoard, error) {
+	var totalCount int
+	allFestivals := make(map[string][]*show.FestivalInfo)
+	order := make([]string, 0, len(dungeonSubstatuses))
+	var allFestivalsList []*show.FestivalInfo
+
+	for _, status := range dungeonSubstatuses {
+		festivals, err := show.ListFestivalsByStatus(ctx, festivalsDir, status, campaignRoot)
+		if err != nil {
+			continue
+		}
+		festivals, err = applyFilters(festivals, opts)
+		if err != nil {
+			return multiStatusBoard{}, err
+		}
+		if len(festivals) > 0 {
+			// Default dungeon listings order by bucket date (newest first);
+			// explicit --sort or --alpha still wins.
+			if opts.sortBy == "" && !opts.alpha {
+				sortByStatusDate(festivals)
+			} else {
+				applySorting(festivals, opts.sortBy, opts.alpha)
+			}
+			allFestivals[status] = festivals
+			order = append(order, status)
+			totalCount += len(festivals)
+			allFestivalsList = append(allFestivalsList, festivals...)
+		}
+	}
+
+	var progressMap map[string]*progress.FestivalProgress
+	if opts.progress {
+		progressMap = fetchProgressForFestivals(ctx, allFestivalsList)
+	}
+	return multiStatusBoard{
+		Festivals: allFestivals,
+		Order:     order,
+		Total:     totalCount,
+		Progress:  progressMap,
+	}, nil
+}
+
+func collectStatusBoard(ctx context.Context, festivalsDir, status string, opts *listOptions, campaignRoot string) (statusBoard, error) {
+	festivals, err := show.ListFestivalsByStatus(ctx, festivalsDir, status, campaignRoot)
+	if err != nil {
+		return statusBoard{}, err
+	}
+	festivals, err = applyFilters(festivals, opts)
+	if err != nil {
+		return statusBoard{}, err
+	}
+	// Dungeon listings default to newest bucket date first; explicit sort
+	// flags still take precedence.
+	if opts.sortBy == "" && !opts.alpha && strings.HasPrefix(status, "dungeon/") {
+		sortByStatusDate(festivals)
+	} else {
+		applySorting(festivals, opts.sortBy, opts.alpha)
+	}
+	var progressMap map[string]*progress.FestivalProgress
+	if opts.progress {
+		progressMap = fetchProgressForFestivals(ctx, festivals)
+	}
+	return statusBoard{Festivals: festivals, Progress: progressMap}, nil
+}
+
+func collectAllBoard(ctx context.Context, festivalsDir string, opts *listOptions, campaignRoot string) (multiStatusBoard, error) {
+	var totalCount int
+	allFestivals := make(map[string][]*show.FestivalInfo)
+	statuses := defaultStatuses
+	if opts.all {
+		statuses = validStatuses
+	}
+	statusOrder := make([]string, 0, len(statuses))
+	var allFestivalsList []*show.FestivalInfo
+
+	for _, status := range statuses {
+		festivals, err := show.ListFestivalsByStatus(ctx, festivalsDir, status, campaignRoot)
+		if err != nil {
+			continue
+		}
+		festivals, err = applyFilters(festivals, opts)
+		if err != nil {
+			return multiStatusBoard{}, err
+		}
+		if len(festivals) > 0 {
+			applySorting(festivals, opts.sortBy, opts.alpha)
+			allFestivals[status] = festivals
+			statusOrder = append(statusOrder, status)
+			totalCount += len(festivals)
+			allFestivalsList = append(allFestivalsList, festivals...)
+		}
+	}
+
+	var progressMap map[string]*progress.FestivalProgress
+	if opts.progress {
+		progressMap = fetchProgressForFestivals(ctx, allFestivalsList)
+	}
+	return multiStatusBoard{
+		Festivals: allFestivals,
+		Order:     statusOrder,
+		Total:     totalCount,
+		Progress:  progressMap,
+	}, nil
+}

--- a/internal/commands/list/list_test.go
+++ b/internal/commands/list/list_test.go
@@ -1,10 +1,13 @@
 package list
 
 import (
+	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/Obedience-Corp/fest/internal/commands/show"
+	"golang.org/x/term"
 )
 
 func TestIsValidStatus(t *testing.T) {
@@ -478,5 +481,52 @@ func TestSortByStatusDate_EmptyStatusDateSinksToEnd(t *testing.T) {
 	if festivals[1].StatusDate != "" || festivals[2].StatusDate != "" {
 		t.Errorf("empty StatusDate entries should be at positions 1-2, got %q, %q",
 			festivals[1].StatusDate, festivals[2].StatusDate)
+	}
+}
+
+func TestListCommandExposesWatchFlag(t *testing.T) {
+	cmd := NewListCommand()
+	if cmd.Flags().Lookup("watch") == nil {
+		t.Fatal("expected --watch flag on fest list")
+	}
+	if cmd.Flags().ShorthandLookup("w") == nil {
+		t.Fatal("expected -w shorthand for --watch")
+	}
+}
+
+func TestListWatchRejectsJSON(t *testing.T) {
+	cmd := NewListCommand()
+	cmd.SetArgs([]string{"--watch", "--json"})
+	// Avoid terminal check failing first if order matters; both flags set.
+	listStdoutIsTerminal = func() bool { return true }
+	t.Cleanup(func() {
+		listStdoutIsTerminal = func() bool {
+			return term.IsTerminal(int(os.Stdout.Fd()))
+		}
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for --watch --json")
+	}
+	if !strings.Contains(err.Error(), "--watch cannot be combined with --json") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestListWatchRejectsNonTTY(t *testing.T) {
+	cmd := NewListCommand()
+	cmd.SetArgs([]string{"--watch"})
+	listStdoutIsTerminal = func() bool { return false }
+	t.Cleanup(func() {
+		listStdoutIsTerminal = func() bool {
+			return term.IsTerminal(int(os.Stdout.Fd()))
+		}
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for --watch on non-TTY")
+	}
+	if !strings.Contains(err.Error(), "interactive terminal") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/commands/list/list_watch.go
+++ b/internal/commands/list/list_watch.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/Obedience-Corp/fest/internal/id"
@@ -17,19 +18,19 @@ const listPollingInterval = 2 * time.Second
 
 // runListWatch continuously refreshes the multi-festival list board.
 // It does not cycle between festivals (that behavior stays on fest watch).
+//
+// Filesystem events and the 2s progress ticker both paint through one mutex so
+// clear+write frames never interleave on stdout.
 func runListWatch(ctx context.Context, festivalsDir, filterStatus string, opts *listOptions, campaignRoot string) error {
-	render := func(polling bool) error {
-		clearListScreen()
-		content, err := formatListBoard(ctx, festivalsDir, filterStatus, opts, campaignRoot)
-		if err != nil {
-			return err
-		}
-		fmt.Print(content)
-		printListWatchFooter(polling, festivalsDir)
-		return nil
+	var renderMu sync.Mutex
+	// Hybrid path always polls for deep progress updates; footer reflects that.
+	paint := func() error {
+		renderMu.Lock()
+		defer renderMu.Unlock()
+		return renderListFrame(ctx, festivalsDir, filterStatus, opts, campaignRoot, true)
 	}
 
-	if err := render(false); err != nil {
+	if err := paint(); err != nil {
 		return err
 	}
 
@@ -42,7 +43,7 @@ func runListWatch(ctx context.Context, festivalsDir, filterStatus string, opts *
 			fmt.Fprintf(os.Stderr, "%s file watch error: %v\n", ui.Warning("Warning:"), err)
 		},
 	}, func() {
-		if err := render(false); err != nil {
+		if err := paint(); err != nil {
 			fmt.Fprintf(os.Stderr, "%s could not refresh list view: %v\n", ui.Warning("Warning:"), err)
 		}
 	})
@@ -74,7 +75,7 @@ func runListWatch(ctx context.Context, festivalsDir, filterStatus string, opts *
 			fmt.Println()
 			return nil
 		case <-ticker.C:
-			if err := render(false); err != nil {
+			if err := paint(); err != nil {
 				fmt.Fprintf(os.Stderr, "%s could not refresh list view: %v\n", ui.Warning("Warning:"), err)
 			}
 		}

--- a/internal/commands/list/list_watch.go
+++ b/internal/commands/list/list_watch.go
@@ -1,0 +1,145 @@
+package list
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/Obedience-Corp/fest/internal/id"
+	"github.com/Obedience-Corp/fest/internal/ui"
+	"github.com/Obedience-Corp/fest/internal/watch"
+)
+
+// listPollingInterval matches show/progress watch fallback cadence.
+const listPollingInterval = 2 * time.Second
+
+// runListWatch continuously refreshes the multi-festival list board.
+// It does not cycle between festivals (that behavior stays on fest watch).
+func runListWatch(ctx context.Context, festivalsDir, filterStatus string, opts *listOptions, campaignRoot string) error {
+	render := func(polling bool) error {
+		clearListScreen()
+		content, err := formatListBoard(ctx, festivalsDir, filterStatus, opts, campaignRoot)
+		if err != nil {
+			return err
+		}
+		fmt.Print(content)
+		printListWatchFooter(polling, festivalsDir)
+		return nil
+	}
+
+	if err := render(false); err != nil {
+		return err
+	}
+
+	watchPaths := listWatchPaths(festivalsDir)
+	w, err := watch.New(watch.Config{
+		Paths:    watchPaths,
+		Debounce: 100 * time.Millisecond,
+		MaxWait:  watch.DefaultMaxWait,
+		OnError: func(err error) {
+			fmt.Fprintf(os.Stderr, "%s file watch error: %v\n", ui.Warning("Warning:"), err)
+		},
+	}, func() {
+		if err := render(false); err != nil {
+			fmt.Fprintf(os.Stderr, "%s could not refresh list view: %v\n", ui.Warning("Warning:"), err)
+		}
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "File watching unavailable (%v), using polling fallback\n", err)
+		return runListPollingMode(ctx, festivalsDir, filterStatus, opts, campaignRoot)
+	}
+	defer func() { _ = w.Close() }()
+
+	// Also poll so progress/stats updates inside festival trees surface even
+	// though status-dir watches are non-recursive.
+	ticker := time.NewTicker(listPollingInterval)
+	defer ticker.Stop()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- w.Watch(ctx)
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Println()
+			return nil
+		case err := <-errCh:
+			if err != nil && ctx.Err() == nil {
+				return err
+			}
+			fmt.Println()
+			return nil
+		case <-ticker.C:
+			if err := render(false); err != nil {
+				fmt.Fprintf(os.Stderr, "%s could not refresh list view: %v\n", ui.Warning("Warning:"), err)
+			}
+		}
+	}
+}
+
+func runListPollingMode(ctx context.Context, festivalsDir, filterStatus string, opts *listOptions, campaignRoot string) error {
+	ticker := time.NewTicker(listPollingInterval)
+	defer ticker.Stop()
+
+	if err := renderListFrame(ctx, festivalsDir, filterStatus, opts, campaignRoot, true); err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Println()
+			return nil
+		case <-ticker.C:
+			if err := renderListFrame(ctx, festivalsDir, filterStatus, opts, campaignRoot, true); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func renderListFrame(ctx context.Context, festivalsDir, filterStatus string, opts *listOptions, campaignRoot string, polling bool) error {
+	clearListScreen()
+	content, err := formatListBoard(ctx, festivalsDir, filterStatus, opts, campaignRoot)
+	if err != nil {
+		return err
+	}
+	fmt.Print(content)
+	printListWatchFooter(polling, festivalsDir)
+	return nil
+}
+
+// listWatchPaths returns non-recursive fsnotify paths covering status buckets
+// where festivals appear, move, or leave. Deep progress file changes are
+// covered by the polling interval in runListWatch.
+func listWatchPaths(festivalsDir string) []string {
+	paths := []string{festivalsDir}
+	for _, status := range id.StatusDirectories {
+		paths = append(paths, filepath.Join(festivalsDir, status))
+	}
+	// dungeon root so moves into/out of dungeon tree are noticed even when a
+	// dated bucket path is new.
+	paths = append(paths, filepath.Join(festivalsDir, "dungeon"))
+	return paths
+}
+
+func clearListScreen() {
+	fmt.Print("\033[H\033[2J")
+}
+
+func printListWatchFooter(polling bool, festivalsDir string) {
+	fmt.Println()
+	label := filepath.Base(festivalsDir)
+	if label == "" || label == "." {
+		label = "festivals"
+	}
+	if polling {
+		fmt.Println(ui.Dim(fmt.Sprintf("watching %s — Ctrl+C to quit • Polling every %s", label, listPollingInterval)))
+		return
+	}
+	fmt.Println(ui.Dim(fmt.Sprintf("watching %s — Ctrl+C to quit", label)))
+}

--- a/internal/commands/list/list_watch_test.go
+++ b/internal/commands/list/list_watch_test.go
@@ -1,0 +1,49 @@
+package list
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/id"
+)
+
+func TestListWatchPathsIncludeStatusBuckets(t *testing.T) {
+	root := "/tmp/festivals-workspace"
+	paths := listWatchPaths(root)
+
+	want := map[string]bool{
+		root: true,
+		filepath.Join(root, "dungeon"): true,
+	}
+	for _, status := range id.StatusDirectories {
+		want[filepath.Join(root, status)] = true
+	}
+
+	got := make(map[string]bool, len(paths))
+	for _, p := range paths {
+		got[p] = true
+	}
+	for p := range want {
+		if !got[p] {
+			t.Errorf("listWatchPaths missing %q", p)
+		}
+	}
+}
+
+func TestFormatAllHumanEmpty(t *testing.T) {
+	out := formatAllHuman(nil, nil, nil, 0, false)
+	if !strings.Contains(out, "No festivals found") {
+		t.Fatalf("expected empty-board message, got %q", out)
+	}
+	if !strings.Contains(out, "fest create festival") {
+		t.Fatalf("expected create hint, got %q", out)
+	}
+}
+
+func TestFormatDungeonHumanEmpty(t *testing.T) {
+	out := formatDungeonHuman(nil, nil, nil, 0, false)
+	if !strings.Contains(out, "No festivals in dungeon") {
+		t.Fatalf("expected empty dungeon message, got %q", out)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `fest list --watch` / `-w` to continuously refresh the multi-festival status board in place
- Reuses existing list filters (`status`, `--progress`, `--sort`, `--filter-project`, date filters)
- Explicitly **does not** cycle between festivals (that remains `fest watch`)
- Rejects `--watch --json` and non-TTY usage; fsnotify on status dirs + 2s poll for progress updates

Design workitem: `workflow/design/fest-list-watch` (`WI-2a7950`)

## Test plan

- [x] `go test ./internal/commands/list/`
- [x] Smoke: `fest list --watch --json` errors
- [x] Smoke: piped `fest list --watch` requires interactive terminal
- [x] Smoke: one-shot `fest list` still renders the board
- [ ] Manual: `fest list --watch` in a real campaign TTY; confirm progress/status moves refresh without cycling UI