### PR TITLE
fix(next): pass explicit markdown style so glamour never queries the terminal

### DIFF
--- a/internal/guidance/selection/output.go
+++ b/internal/guidance/selection/output.go
@@ -503,7 +503,7 @@ func buildTaskContentSection(taskPath string) string {
 	sb.WriteString("\n")
 	sb.WriteString(ui.Dim(strings.Repeat("─", 60)))
 	sb.WriteString("\n")
-	sb.WriteString(mdrender.Render(body))
+	sb.WriteString(mdrender.Render(body, mdrender.WithStyle(ui.MarkdownStyle())))
 	sb.WriteString("\n")
 	sb.WriteString(ui.Dim(strings.Repeat("─", 60)))
 	sb.WriteString("\n")
@@ -598,7 +598,7 @@ func buildFullTaskContentSection(taskPath string) string {
 
 	var sb strings.Builder
 	sb.WriteString("\n## Task Document\n\n")
-	sb.WriteString(mdrender.Render(body))
+	sb.WriteString(mdrender.Render(body, mdrender.WithStyle(ui.MarkdownStyle())))
 	sb.WriteString("\n")
 	return sb.String()
 }
@@ -902,7 +902,7 @@ func buildGateSection(task *TaskInfo) string {
 	}
 
 	if content != "" {
-		data.GateContent = mdrender.Render(content)
+		data.GateContent = mdrender.Render(content, mdrender.WithStyle(ui.MarkdownStyle()))
 	} else {
 		data.FallbackMessage = ui.Dim("Gate file could not be read. Run `fest gates` to evaluate gate criteria.")
 	}

--- a/internal/tui/explore/preview.go
+++ b/internal/tui/explore/preview.go
@@ -5,7 +5,9 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/Obedience-Corp/fest/internal/ui"
 	"github.com/charmbracelet/glamour"
+	"github.com/charmbracelet/glamour/styles"
 )
 
 // mdRenderer caches a glamour renderer and its configured width.
@@ -26,8 +28,12 @@ func (r *mdRenderer) render(content string, width int) string {
 	}
 
 	if r.renderer == nil || r.width != width {
+		styleConfig := styles.DarkStyleConfig
+		if ui.MarkdownStyle() == "light" {
+			styleConfig = styles.LightStyleConfig
+		}
 		renderer, err := glamour.NewTermRenderer(
-			glamour.WithAutoStyle(),
+			glamour.WithStyles(styleConfig),
 			glamour.WithWordWrap(width-4),
 		)
 		if err != nil {

--- a/internal/ui/color.go
+++ b/internal/ui/color.go
@@ -13,3 +13,16 @@ func SetNoColor(noColor bool) {
 	}
 	lipgloss.SetColorProfile(termenv.EnvColorProfile())
 }
+
+// MarkdownStyle returns an explicit glamour style ("dark" or "light") for
+// markdown rendering, chosen from lipgloss's cached background value.
+//
+// This never queries the terminal: internal/bginit seeds the background before
+// any render, so the "auto" style (which would send OSC 11 / DSR probes and
+// stall on ptys that never answer) is avoided entirely.
+func MarkdownStyle() string {
+	if lipgloss.HasDarkBackground() {
+		return "dark"
+	}
+	return "light"
+}

--- a/internal/ui/color_test.go
+++ b/internal/ui/color_test.go
@@ -1,0 +1,30 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestMarkdownStyle(t *testing.T) {
+	original := lipgloss.HasDarkBackground()
+	t.Cleanup(func() { lipgloss.SetHasDarkBackground(original) })
+
+	tests := []struct {
+		name string
+		dark bool
+		want string
+	}{
+		{name: "dark background", dark: true, want: "dark"},
+		{name: "light background", dark: false, want: "light"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lipgloss.SetHasDarkBackground(tt.dark)
+			if got := MarkdownStyle(); got != tt.want {
+				t.Errorf("MarkdownStyle() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

PR #254 seeded lipgloss's background cache (internal/bginit) so bubbletea's package init no longer probes the terminal. But `fest next` STILL emitted one OSC 11 plus one DSR query and stalled about 5 seconds on ptys that never answer (recorders, CI, agent ptys).

Root cause: task and gate content rendering calls `mdrender.Render(body)` from obey-shared v0.4.4. Its default style is "auto", which maps to `glamour.WithAutoStyle()` and runs termenv `HasDarkBackground()` on termenv's own uncached default output. The lipgloss seed from #254 does not cover termenv, and termenv re-queries per render, so every `fest next` that rendered markdown reintroduced the full startup stall.

Call sites: internal/guidance/selection/output.go (task content x2, gate content x1) and the dev-gated internal/tui/explore preview, which called `glamour.WithAutoStyle()` directly.

## Fix (fest-side only, obey-shared untouched)

- Add `ui.MarkdownStyle()` returning "dark" or "light" from `lipgloss.HasDarkBackground()`. This is query-free in fest because internal/bginit always seeds an explicit background before anything renders.
- Pass `mdrender.WithStyle(ui.MarkdownStyle())` at every fest call site of `mdrender.Render`. obey-shared's explicit "dark"/"light" styles use `glamour.WithStyles(...)`, which never queries the terminal.
- Switch internal/tui/explore preview from `glamour.WithAutoStyle()` to explicit `styles.DarkStyleConfig` / `styles.LightStyleConfig` from the same source, so dev builds do not re-query either.
- Unit test for `ui.MarkdownStyle()`.

## End-to-end verification (pty harness, mute pty that never answers queries)

Command: `fest next` from inside a fixture planning festival with a real task.

Before (base commit fbf13c8, has the #254 bginit seed but not this fix):
- Mute pty: wall=5.481s, first_byte=0.469s, osc11=1, dsr6n=1 (the ~5s stall)
- Answering pty: wall=0.020s, osc11=1, dsr6n=1 (confirms the 5s is the unanswered query)

After (this branch):
- Mute pty: wall=0.019s, first_byte=0.018s, osc11=0, dsr6n=0
- Output still contains ANSI-styled markdown and the task content, so rendering is unchanged for real terminals.

## Gates (worktree root)

- `just build dev`: pass (bin/fest produced)
- `just test unit`: pass (96 packages, 2474/2474 tests, incl. internal/tui/explore and internal/ui)
- `just lint all`: pass (0 issues)
