### PR TITLE
chore(bginit): move seed import into commands, guard dep closure, fix edge cases

### DIFF
--- a/cmd/fest/main.go
+++ b/cmd/fest/main.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	// bginit must initialize before the bubbletea subtree under
-	// internal/commands; its path keeps it first under gofmt.
-	_ "github.com/Obedience-Corp/fest/internal/bginit"
 	"github.com/Obedience-Corp/fest/internal/commands"
 	festerrors "github.com/Obedience-Corp/fest/internal/errors"
 )

--- a/internal/bginit/bginit.go
+++ b/internal/bginit/bginit.go
@@ -10,16 +10,20 @@
 //
 // Seeding an explicit value makes lipgloss skip the terminal query entirely.
 // This package must initialize before bubbletea, so it may only import
-// lipgloss (never bubbletea or huh, directly or transitively), and cmd/fest
-// must import it alongside internal/commands: its path sorts before
-// internal/commands, so gofmt keeps it first and the compiler records its
-// inittask ahead of the bubbletea subtree.
+// lipgloss (never bubbletea, huh, or glamour, directly or transitively).
+// internal/commands blank-imports it at the top of its import block: the
+// bginit path sorts ahead of every bubbletea-linked import there, so gofmt
+// keeps it first and the compiler records its inittask ahead of the bubbletea
+// subtree. Every binary built on internal/commands inherits the seed, and
+// depgraph_test.go enforces the no-bubbletea import rule structurally.
 //
-// The seed mirrors termenv's own non-query fallback: the last field of
-// COLORFGBG is the background ANSI color, and a missing or unparsable value
-// means dark, matching the CLI palette's existing "adaptive falls back to
-// dark" behavior. An explicit theme choice refines this later via
-// ui.InitPalette.
+// The seed approximates termenv's own non-query fallback: the last field of
+// COLORFGBG is the background ANSI color, and a missing, unparsable, or
+// out-of-range value means dark, matching the CLI palette's existing
+// "adaptive falls back to dark" behavior. It intentionally diverges from
+// termenv for ANSI 8 (#808080), which termenv's luminance math reads as
+// light; bginit keeps 8 dark as the safer readability default. An explicit
+// theme choice refines this later via ui.InitPalette.
 package bginit
 
 import (
@@ -43,5 +47,11 @@ func backgroundIsDark(colorFGBG string) bool {
 	if err != nil {
 		return true
 	}
-	return bg >= 0 && bg <= 8 && bg != 7
+	// Anything outside the 0..15 ANSI range is unknown; default to dark.
+	if bg < 0 || bg > 15 {
+		return true
+	}
+	// Dark backgrounds are ANSI 0..6 and 8; 7 and bright 9..15 read light.
+	// Treating 8 as dark diverges from termenv on purpose (see package doc).
+	return bg <= 8 && bg != 7
 }

--- a/internal/bginit/bginit_test.go
+++ b/internal/bginit/bginit_test.go
@@ -4,16 +4,18 @@ import "testing"
 
 func TestBackgroundIsDark(t *testing.T) {
 	tests := []struct {
-		name     string
+		name      string
 		colorFGBG string
-		want     bool
+		want      bool
 	}{
 		{"unset defaults dark", "", true},
 		{"no separator defaults dark", "15", true},
 		{"unparsable background defaults dark", "15;default", true},
 		{"black background", "15;0", true},
 		{"blue background", "15;4", true},
-		{"bright black background", "15;8", true},
+		{"bright black background diverges from termenv, stays dark", "15;8", true},
+		{"negative background defaults dark", "15;-1", true},
+		{"out-of-range background defaults dark", "0;99", true},
 		{"light grey background", "0;7", false},
 		{"white background", "0;15", false},
 		{"bright yellow background", "0;11", false},

--- a/internal/bginit/depgraph_test.go
+++ b/internal/bginit/depgraph_test.go
@@ -1,0 +1,58 @@
+package bginit
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// forbiddenDeps are packages whose init runs a terminal query (bubbletea via
+// tea_init.go) or transitively links one (huh, glamour). If any enters
+// bginit's import closure, bginit's inittask can no longer be guaranteed to
+// run before the query fires, silently reverting the startup-stall fix.
+var forbiddenDeps = []string{
+	"github.com/charmbracelet/bubbletea",
+	"github.com/charmbracelet/huh",
+	"github.com/charmbracelet/glamour",
+}
+
+func TestDependencyClosureExcludesBubbletea(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go toolchain not available")
+	}
+
+	cmd := exec.Command("go", "list", "-deps", "./internal/bginit")
+	cmd.Dir = moduleRoot(t)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list -deps ./internal/bginit: %v\n%s", err, out)
+	}
+
+	for _, dep := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		for _, forbidden := range forbiddenDeps {
+			if dep == forbidden || strings.HasPrefix(dep, forbidden+"/") {
+				t.Errorf("bginit import closure includes %q; it must never link %q (breaks init ordering)", dep, forbidden)
+			}
+		}
+	}
+}
+
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found above test working directory")
+		}
+		dir = parent
+	}
+}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 
+	// bginit must initialize before the bubbletea subtree below; its path sorts first here so gofmt keeps it.
+	_ "github.com/Obedience-Corp/fest/internal/bginit"
 	chaincmd "github.com/Obedience-Corp/fest/internal/commands/chain"
 	commitcmd "github.com/Obedience-Corp/fest/internal/commands/commit"
 	"github.com/Obedience-Corp/fest/internal/commands/config"


### PR DESCRIPTION
## Summary

Hardening and cleanup for the bginit startup-stall fix that shipped in #254. The seed that pre-populates lipgloss's background cache (so bubbletea's init never sends OSC 11 / DSR terminal queries that block up to 5s on mute ptys) depended on a fragile init-order invariant living in `cmd/fest/main.go`. A future import added to main.go that both sorted before the bginit import and transitively linked bubbletea would have silently reverted the fix with nothing to catch it. This PR moves the invariant next to the dependency, guards it with a structural test, and fixes a few correctness and doc nits found in an adversarial review.

## Changes

1. **Move the seed import into `internal/commands` (root.go), drop it from `cmd/fest/main.go`.** Every current and future binary built on `internal/commands` now inherits the seed. Within root.go's gofmt-sorted import block, `github.com/Obedience-Corp/fest/internal/bginit` sorts ahead of every bubbletea-linked import ("bginit" precedes "commands", and Obedience-Corp precedes charmbracelet and spf13), so gofmt keeps it first and the compiler records its inittask ahead of the bubbletea subtree.

2. **Add a dep-graph guard test (`internal/bginit/depgraph_test.go`).** Runs `go list -deps ./internal/bginit` from the module root and fails if the closure ever contains bubbletea, huh, or glamour. Hermetic and fast (about 40ms), skips with t.Skip if the go toolchain is unavailable.

3. **Fix formatting on `internal/bginit/bginit_test.go`** (struct field alignment) via `gofmt -w` on that file only. No other flagged files were reformatted.

4. **backgroundIsDark correctness and doc nits (`internal/bginit/bginit.go`):**
   - Negative parsed values like `15;-1` previously returned light because the `bg >= 0` range check failed. Anything outside the 0..15 ANSI range (negatives included) now clamps to dark, matching the documented "unparsable or unknown means dark" intent.
   - The doc claimed the function mirrors termenv's non-query fallback, but termenv's luminance math treats ANSI 8 (#808080) as light while this function returns dark. Kept dark (safer readability default) and corrected the doc to state the divergence is intentional.
   - Updated the table test for the negative-value case, an out-of-range case, and annotated the ANSI 8 case.

## Verification

Gates from the worktree root:

- `just build dev`: pass (produces bin/fest, exit 0)
- `just test unit`: pass (96 packages, 2474/2474 tests, 58.02s)
- `just lint all`: pass (golangci-lint, 0 issues)

Init-order proof on a mute pty (harness never answers terminal queries; child has COLORFGBG cleared, TERM=xterm-256color):

```
fest version   wall=0.507s* osc11=0 osc10=0 dsr6n=0 dsr5n=0
fest --help    wall=0.015s  osc11=0 osc10=0 dsr6n=0 dsr5n=0
fest --version wall=0.012s  osc11=0 osc10=0 dsr6n=0 dsr5n=0
```

Zero terminal queries and sub-second startup across commands (before the fix, mute ptys stalled about 5s). (*The 0.507s on the first pty run was cold-cache first-invocation overhead; direct and warm runs of the same command are 12 to 22ms.)

## Notes

Scope was kept strictly to bginit plus the single required import line in `internal/commands/root.go`. No other files under `internal/commands/`, `internal/watch/`, `internal/tui/`, `internal/ui/`, or `internal/guidance/` were touched, and no other gofmt-flagged files were reformatted.
