### PR TITLE
fix(watch): serialize onChange dispatch and guard stale debounce timers

### DIFF
--- a/internal/watch/watcher.go
+++ b/internal/watch/watcher.go
@@ -53,6 +53,21 @@ type Watcher struct {
 	pending      bool
 	firstPending time.Time
 	watched      map[string]struct{}
+	// gen is bumped on every (re)schedule and on cancel. Each debounce timer
+	// captures the value live when it was scheduled and re-checks it under mu
+	// before firing. A timer whose Stop() lost the race (it already fired while
+	// scheduleCallback held mu) would otherwise run its stale func, clobber the
+	// live timer handle with nil, and fire a second time; the generation check
+	// makes that stale func a no-op so only the newest schedule ever fires.
+	gen uint64
+
+	// dispatchMu serializes onChange invocations so renders never overlap, even
+	// when MaxWait fires callbacks mid-storm faster than a slow render completes.
+	// stopped is set under dispatchMu by cancelPendingTimer: once that returns,
+	// no onChange is in flight and none can start, so nothing fires after Close
+	// or Watch return.
+	dispatchMu sync.Mutex
+	stopped    bool
 }
 
 // ErrNoWatchablePaths is returned when none of the specified paths can be watched.
@@ -187,26 +202,55 @@ func (w *Watcher) scheduleCallback() {
 			delay = 0
 		}
 	}
-	w.timer = time.AfterFunc(delay, func() {
-		w.mu.Lock()
-		w.pending = false
-		w.timer = nil
-		w.mu.Unlock()
 
-		w.onChange()
+	w.gen++
+	gen := w.gen
+	w.timer = time.AfterFunc(delay, func() {
+		w.dispatch(gen)
 	})
 }
 
-// cancelPendingTimer cancels any pending debounced callback.
+// dispatch runs the onChange callback for a scheduled timer generation.
+// A timer whose generation was superseded (by a newer schedule or by a cancel)
+// is a no-op, so the newest schedule owns the callback and stale timers can
+// neither double-fire nor clobber the live timer handle. Invocations are
+// serialized through dispatchMu so onChange never overlaps itself, and the
+// stopped gate prevents any callback after cancelPendingTimer has returned.
+func (w *Watcher) dispatch(gen uint64) {
+	w.mu.Lock()
+	if w.gen != gen {
+		w.mu.Unlock()
+		return
+	}
+	w.pending = false
+	w.timer = nil
+	w.mu.Unlock()
+
+	w.dispatchMu.Lock()
+	defer w.dispatchMu.Unlock()
+	if w.stopped {
+		return
+	}
+	w.onChange()
+}
+
+// cancelPendingTimer cancels any pending debounced callback and permanently
+// disables further dispatch. Bumping gen neutralizes any timer whose Stop()
+// lost the race, and setting stopped under dispatchMu (which waits for any
+// in-flight onChange to finish) guarantees no callback fires after this returns.
 func (w *Watcher) cancelPendingTimer() {
 	w.mu.Lock()
-	defer w.mu.Unlock()
-
 	if w.timer != nil {
 		w.timer.Stop()
 		w.timer = nil
 		w.pending = false
 	}
+	w.gen++
+	w.mu.Unlock()
+
+	w.dispatchMu.Lock()
+	w.stopped = true
+	w.dispatchMu.Unlock()
 }
 
 // Close releases all resources associated with the watcher.

--- a/internal/watch/watcher_test.go
+++ b/internal/watch/watcher_test.go
@@ -229,6 +229,92 @@ func TestWatcher_MaxWaitFiresDuringSustainedChanges(t *testing.T) {
 	}
 }
 
+func TestWatcher_OnChangeNeverOverlaps(t *testing.T) {
+	var inFlight atomic.Int32
+	var maxInFlight atomic.Int32
+	// plainCounter is deliberately unsynchronized: if two onChange calls ever
+	// overlap, the read-modify-write races and -race fails the test.
+	var plainCounter int
+
+	cfg := Config{
+		Debounce: 5 * time.Millisecond,
+		MaxWait:  10 * time.Millisecond,
+	}
+
+	w := &Watcher{config: cfg}
+	w.onChange = func() {
+		n := inFlight.Add(1)
+		for {
+			m := maxInFlight.Load()
+			if n <= m || maxInFlight.CompareAndSwap(m, n) {
+				break
+			}
+		}
+		plainCounter++
+		// Render slower than the fire cadence so a following timer fires while
+		// this callback is still running, exercising the serialization path.
+		time.Sleep(15 * time.Millisecond)
+		inFlight.Add(-1)
+	}
+
+	// Sustained events reset the trailing debounce forever; MaxWait keeps firing
+	// callbacks mid-storm, so without serialization these would overlap.
+	storm := 400 * time.Millisecond
+	deadline := time.Now().Add(storm)
+	for time.Now().Before(deadline) {
+		w.scheduleCallback()
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	// cancelPendingTimer waits on dispatchMu for any in-flight onChange and
+	// neutralizes pending timers, so once it returns no callback runs or will
+	// run. That release/acquire also orders every onChange write to plainCounter
+	// before the reads below, keeping the canary honest under -race.
+	w.cancelPendingTimer()
+
+	if got := maxInFlight.Load(); got > 1 {
+		t.Fatalf("onChange overlapped: max concurrent invocations = %d, want <= 1", got)
+	}
+	if plainCounter == 0 {
+		t.Fatal("expected at least one onChange during the storm, got none")
+	}
+}
+
+func TestWatcher_DispatchIgnoresStaleGeneration(t *testing.T) {
+	var calls atomic.Int32
+
+	// Debounce is long enough that no AfterFunc timer fires on its own; the test
+	// drives dispatch directly to exercise the generation guard deterministically.
+	w := &Watcher{
+		config:   Config{Debounce: time.Hour},
+		onChange: func() { calls.Add(1) },
+	}
+
+	w.scheduleCallback() // gen == 1
+	w.scheduleCallback() // gen == 2, supersedes gen 1
+
+	// A stale timer func from generation 1 must be inert.
+	w.dispatch(1)
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("stale dispatch fired onChange: calls = %d, want 0", got)
+	}
+
+	// The current generation dispatches exactly once.
+	w.dispatch(2)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("current dispatch: calls = %d, want 1", got)
+	}
+
+	// After cancel, even a formerly-current generation is inert (gen bumped and
+	// stopped set), so no callback can fire once the watcher is torn down.
+	w.scheduleCallback()   // gen == 3
+	w.cancelPendingTimer() // gen == 4, stopped == true
+	w.dispatch(3)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("post-cancel dispatch fired onChange: calls = %d, want 1", got)
+	}
+}
+
 func TestWatcher_WatchDirectory(t *testing.T) {
 	tmpDir := t.TempDir()
 


### PR DESCRIPTION
## Summary

Fixes two confirmed concurrency defects in the file watcher (`internal/watch/watcher.go`), surfaced by adversarial review of the merged MaxWait change (#254). Both bugs manifest during sustained write storms, which is exactly when MaxWait was designed to keep firing callbacks, so they became reachable once MaxWait shipped. The fix is at the watcher layer so every caller (`show`, `progress`, `standalone` watch commands) is protected without touching command code.

## Defect 1: concurrent onChange callbacks

`scheduleCallback`'s `time.AfterFunc` cleared `pending`/`timer` under `w.mu` but then called `w.onChange()` outside the lock. MaxWait now fires callbacks mid-storm, so an onChange (a render) slower than the fire cadence overlaps the next fire. The reviewer reproduced 4 concurrent callbacks under `-race` (Debounce 50ms, MaxWait 100ms, 150ms slow callback). Downstream, `show`'s callback reassigns the captured `festival` variable and writes stdout via `session.render` with no synchronization, so overlap means data races and garbled frames.

Fix: a dedicated `dispatchMu` held around `w.onChange()` serializes all invocations, so renders never overlap regardless of caller.

## Defect 2: timer-clobber race

`w.timer.Stop()`'s return value was ignored. If the old timer already fired and its func was blocked acquiring `w.mu`, that stale func would later run, set `w.timer = nil` (clobbering the handle of the newer timer that `scheduleCallback` had just installed), and fire anyway. Consequences: occasional double-fire, and `cancelPendingTimer` could no longer stop the live timer, so onChange could fire once after `Watch` returned or `Close` ran (a stray frame after the terminal was restored).

Fix: a monotonic generation counter. Each timer captures `gen` live at schedule time and re-checks it under `w.mu` before firing; a superseded timer (newer schedule, or a cancel that also bumps `gen`) becomes a no-op, so only the newest schedule ever fires and stale funcs cannot clobber the live handle.

## Design chosen and why

Option (a): dedicated dispatch mutex plus generation counter (chosen). Option (b) was moving dispatch into the Watch loop via a signal channel.

Chose (a) because it keeps semantics clean while preserving two properties that (b) would have changed:

1. The Watch loop keeps draining fsnotify events during a slow render (dispatch stays on the timer goroutines, serialized by `dispatchMu`), so there is no fsnotify backpressure or dropped-event risk.
2. The existing direct-drive unit test (`TestWatcher_MaxWaitFiresDuringSustainedChanges`) remains valid as written, since onChange still fires from timers without requiring `Watch` to be running. No test was weakened.

No-fire-after-close is provable: `cancelPendingTimer` bumps `gen` (neutralizing any timer whose `Stop()` lost the race) and sets `stopped` while holding `dispatchMu`. Acquiring `dispatchMu` waits for any in-flight onChange to finish, so once `cancelPendingTimer` returns, nothing is running and the `stopped` gate blocks anything queued behind it. Lock order is always `w.mu` then `dispatchMu`, never nested, so there is no deadlock; onChange holds only `dispatchMu`, so a re-entrant `AddPath` (which takes `w.mu`) is safe.

MaxWait cap, Debounce trailing behavior, and MaxWait=0 (no cap) are all unchanged.

## Test evidence

Added two regression tests:

- `TestWatcher_OnChangeNeverOverlaps`: aggressive constants (Debounce 5ms, MaxWait 10ms, 15ms slow onChange, 2ms event cadence, 400ms storm). Tracks an atomic in-flight counter that must never exceed 1, plus an unsynchronized plain int written inside onChange as a `-race` canary. It drains via `cancelPendingTimer` (establishing the happens-before edge) before asserting.
- `TestWatcher_DispatchIgnoresStaleGeneration`: deterministic white-box coverage of the generation guard, asserting a stale generation is inert, the current generation dispatches exactly once, and a post-cancel generation is inert.

Confirmed the overlap test actually catches the bug: reverting only the serialization makes it fail with `WARNING: DATA RACE` and `max concurrent invocations = 3, want <= 1`, then it passes again once restored.

Gate results (from worktree root):

- `just build dev`: exit 0
- `just test unit`: 96 packages, 2475/2475 passed
- `just lint all`: 0 issues
- `go test -race -count=3 ./internal/watch/`: ok

Scope: `internal/watch/watcher.go` and `internal/watch/watcher_test.go` only.
