### PR TITLE
docs(cli): drop legacy Guild branding from index/parse help

### DIFF
--- a/internal/commands/navigation/index.go
+++ b/internal/commands/navigation/index.go
@@ -19,12 +19,12 @@ func NewIndexCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "index",
 		Short: "Manage festival indices",
-		Long: `Generate and validate festival indices for Guild integration.
+		Long: `Generate and validate festival indices.
 
 The index file (.festival/index.json) provides a machine-readable representation
 of the festival structure, including phases, sequences, and tasks.
 
-For workspace-wide indexing (Guild v3), use the 'tree' subcommand.`,
+For workspace-wide indexing, use the 'tree' subcommand.`,
 	}
 
 	cmd.AddCommand(newIndexWriteCommand())
@@ -259,7 +259,7 @@ func newIndexTreeCommand() *cobra.Command {
 		Long: `Generate a tree index of all festivals in the workspace.
 
 The tree index groups festivals by status (planning, active, completed, dungeon)
-and provides a complete hierarchical view for Guild v3 integration.`,
+and provides a complete hierarchical view for external tool integration.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cwd, err := os.Getwd()
 			if err != nil {

--- a/internal/commands/parse/parse.go
+++ b/internal/commands/parse/parse.go
@@ -31,7 +31,7 @@ func NewParseCommand() *cobra.Command {
 		Long: `Parse festival documents into structured JSON or YAML output.
 
 This command walks the festival hierarchy and produces structured output
-suitable for external tool integration (e.g., Guild v3, visualization tools).
+suitable for external tool integration (e.g. visualization tools, editors).
 
 Examples:
   fest parse                         # Parse current festival as JSON


### PR DESCRIPTION
## Summary

Tiny salvage from closed [#255](https://github.com/Obedience-Corp/fest/pull/255).

- Reword `fest index` / `fest index tree` Long text to drop Guild / Guild v3 naming
- Same for `fest parse` external-tool example language

**Not** included: any `Hidden` / `Deprecated` surface from #255. That mass zero-usage deprecation was closed as the wrong product call.

## Test plan

- [x] Diff is two help strings only
- [ ] `go test ./internal/commands/navigation/ ./internal/commands/parse/` optional smoke