### PR TITLE
chore(deps): bump camp to v0.3.0-rc.2 for ledgerkit (CA0002)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.6
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0
-	github.com/Obedience-Corp/camp v0.2.16
+	github.com/Obedience-Corp/camp v0.3.0-rc.2
 	github.com/Obedience-Corp/obey-shared v0.4.4
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/Obedience-Corp/camp v0.2.16 h1:usid1pX8sW6PdYp/CKsEVu730KjOgEThyhP+Nru3oKU=
-github.com/Obedience-Corp/camp v0.2.16/go.mod h1:0K3f98p4IDeC1IFZoX0g7k3aGr1LAy5rF2SYA6iwMxc=
+github.com/Obedience-Corp/camp v0.3.0-rc.2 h1:a0GCh/E69AlvDmsE14zcXmcB31rGtq3Zf7IQjmuPJuI=
+github.com/Obedience-Corp/camp v0.3.0-rc.2/go.mod h1:0K3f98p4IDeC1IFZoX0g7k3aGr1LAy5rF2SYA6iwMxc=
 github.com/Obedience-Corp/obey-shared v0.4.4 h1:BLsOvnvZ0ViHLFVOQ5i1zC3+sa+XLMXhsX67ueMTGpY=
 github.com/Obedience-Corp/obey-shared v0.4.4/go.mod h1:X7xXZJ/S8Ek7s6dsihrnpFLnBykOkv2dQnHv+sRHx/Q=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=


### PR DESCRIPTION
## What

Bump `github.com/Obedience-Corp/camp` from `v0.2.16` to `v0.3.0-rc.2`.

## Why

Unblocks CA0002 (campaign audit trail) sequence 06 `capture_fest`: fest needs to
import `camp/pkg/ledgerkit` for live ledger emission. `ledgerkit` only exists in
camp `v0.3.0-rc.x` (merged via camp PRs #402/#403/#404); the previously pinned
`v0.2.16` predates it. Per project rules this is a real tag bump via `go get`, no
`replace` directive.

## Version note

Pinned to the `v0.3.0-rc.2` prerelease because that is the earliest tagged camp
release containing `ledgerkit`. Re-pin to stable `v0.3.0` once it ships.

## Verification

Against `v0.3.0-rc.2` in this branch:

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./... -count=1` — all 97 packages pass

Only `go.mod` / `go.sum` change; no functional code in this PR (the ledgerkit
import lands with the `capture_fest` implementation).
