### PR TITLE
fix(workflow): auto-invoke approval judge from fest next

### DIFF
--- a/docs/cli-reference/fest_workflow_approve.md
+++ b/docs/cli-reference/fest_workflow_approve.md
@@ -6,6 +6,10 @@ Approve a blocking checkpoint
 
 Approve a blocking checkpoint and proceed to the next step.
 
+When hooks.approval_judge.command is configured, fest next auto-invokes the
+judge on blocking WORKFLOW.md / GATES.md checkpoints. --auto remains the
+explicit re-run path after a reject or failed judge call.
+
 Some workflow steps require explicit user approval before proceeding.
 This is typically used for review gates or major decision points.
 

--- a/embedded/docs/understand/workflow.txt
+++ b/embedded/docs/understand/workflow.txt
@@ -61,11 +61,18 @@ Common commands:
 Approval Auto Mode
 ------------------
 
-Manual approval is the default. `fest workflow approve --auto` is an explicit
-operator delegation to an external judge command, not an inferred agent
-permission. There is no default judge command: configure one with the
-`hooks.approval_judge.command` hook in `.festival/config.yaml` or pass
-`--judge-command`; otherwise `--auto` fails closed.
+Configuring `hooks.approval_judge.command` in `.festival/config.yaml` is the
+operator opt-in that delegates blocking checkpoints (WORKFLOW.md and GATES.md)
+away from human pings.
+
+When that hook is set:
+
+  • `fest next` auto-invokes the judge on each consecutive blocking checkpoint
+    and continues after approve (or stops after reject / fail-closed errors).
+  • `fest workflow approve --auto` remains available for an explicit re-run.
+
+There is no default judge command: without the hook (or `--judge-command`),
+approval stays manual and fails closed for `--auto`.
 
 The judge command receives JSON on stdin using schema
 `fest.approval.judge/v1` and must return JSON on stdout with decision

--- a/embedded/templates/agent/workflow/checkpoint.tmpl
+++ b/embedded/templates/agent/workflow/checkpoint.tmpl
@@ -46,10 +46,12 @@ Step {{.StepNumber}}: {{.StepName}}
 {{- if .JudgeConfigured}}
 
 This checkpoint is delegated: the operator configured an approval judge
-(hooks.approval_judge.command).
+(hooks.approval_judge.command). `fest next` auto-invokes the judge when it
+lands on a blocking checkpoint; you should not wait for a human.
 
 **What you should do:**
-1. Run: fest workflow approve --auto
+1. If you are reading this after `fest next` without an auto-verdict, run:
+   fest workflow approve --auto
 2. Wait for it to return. The command blocks until the judge answers and fails
    closed on timeout or judge errors, leaving the checkpoint unchanged.
 3. Approved: run fest next to continue.

--- a/internal/commands/next/navigator.go
+++ b/internal/commands/next/navigator.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
+	wfcmd "github.com/Obedience-Corp/fest/internal/commands/workflow"
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/guidance"
 	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
@@ -127,6 +128,14 @@ func runWorkflowModeWithStore(ctx context.Context, festivalPath, phasePath strin
 		return errors.Wrap(err, "initializing workflow navigator")
 	}
 
+	// Operator opt-in via hooks.approval_judge: auto-run the judge on
+	// consecutive blocking checkpoints so fest next does not wait for a human.
+	if wfNav, ok := nav.(*wf.Navigator); ok {
+		if err := wfcmd.AutoDelegateBlockingCheckpoints(ctx, wfNav); err != nil {
+			return err
+		}
+	}
+
 	// Check if we got a valid next step
 	nextStep, err := nav.GetNext(ctx)
 	if err != nil {
@@ -205,6 +214,14 @@ func runPhaseGateMode(ctx context.Context, festivalPath, phasePath string) error
 	// Initialize the navigator
 	if err := nav.Initialize(ctx); err != nil {
 		return errors.Wrap(err, "initializing phase gate navigator")
+	}
+
+	// Operator opt-in via hooks.approval_judge: auto-run the judge on
+	// consecutive blocking gate steps so fest next does not wait for a human.
+	if wfNav, ok := nav.(*wf.Navigator); ok {
+		if err := wfcmd.AutoDelegateBlockingCheckpoints(ctx, wfNav); err != nil {
+			return err
+		}
 	}
 
 	// Check if we got a valid next step

--- a/internal/commands/workflow/approve.go
+++ b/internal/commands/workflow/approve.go
@@ -70,12 +70,13 @@ After approval:
   - The workflow advances to the next step
 
 Auto approval:
-  Manual approval is the default. Use --auto only when an operator has explicitly
-  delegated this checkpoint decision to an external judge command.
+  Configuring hooks.approval_judge.command is the operator opt-in that
+  delegates blocking checkpoints away from human review. With that hook set,
+  fest next auto-invokes the judge on blocking WORKFLOW.md / GATES.md steps.
 
-  Agents must not clear checkpoints themselves: --as agent is rejected. An
-  agent-actor decision is recorded only when the operator delegates via --auto
-  and the judge returns a verdict.
+  Use --auto to re-run the judge explicitly (for example after a reject or a
+  failed judge invocation). Agents must not clear checkpoints with --as agent;
+  agent-actor decisions are recorded only via the judge path.
 
   The judge command receives JSON on stdin using schema fest.approval.judge/v1
   and must return JSON on stdout with decision "approve" or "reject" and a
@@ -164,7 +165,7 @@ func runApproveWithOptions(ctx context.Context, decision wf.DecisionMetadata, op
 	}
 
 	if opts.Auto {
-		judgeCommand, err := resolveApprovalJudgeCommand(ctx, opts.JudgeCommand)
+		judgeCommand, err := resolveApprovalJudgeCommandFor(ctx, nav, opts.JudgeCommand)
 		if err != nil {
 			return err
 		}
@@ -189,9 +190,14 @@ func runApproveWithOptions(ctx context.Context, decision wf.DecisionMetadata, op
 
 // resolveApprovalJudgeCommand resolves the command used for --auto approval.
 // Precedence: the --judge-command flag, then the hooks.approval_judge.command
-// hook in .festival/config.yaml. It fails closed when neither is set so no
-// checkpoint is delegated to an unconfigured (or assumed) command.
+// hook in .festival/config.yaml (via workspace context or navigator festival
+// path). It fails closed when neither is set so no checkpoint is delegated to
+// an unconfigured (or assumed) command.
 func resolveApprovalJudgeCommand(ctx context.Context, flagValue string) (string, error) {
+	return resolveApprovalJudgeCommandFor(ctx, nil, flagValue)
+}
+
+func resolveApprovalJudgeCommandFor(ctx context.Context, nav *wf.Navigator, flagValue string) (string, error) {
 	if cmd := strings.TrimSpace(flagValue); cmd != "" {
 		return cmd, nil
 	}
@@ -202,6 +208,14 @@ func resolveApprovalJudgeCommand(ctx context.Context, flagValue string) (string,
 			return "", festerrors.Wrap(err, "loading approval judge hook")
 		}
 		if cmd := strings.TrimSpace(cfg.Hooks.ApprovalJudge.Command); cmd != "" {
+			return cmd, nil
+		}
+	}
+
+	// fest next is scope.Global and never injects workspace; fall back to the
+	// navigator's festival path (same recovery as ApprovalJudgeCommand).
+	if nav != nil {
+		if cmd := strings.TrimSpace(nav.ApprovalJudgeCommand(ctx)); cmd != "" {
 			return cmd, nil
 		}
 	}
@@ -224,6 +238,80 @@ hooks:
     command: ob judge
 
 Or pass --judge-command <cmd> for a one-off.`)
+}
+
+// AutoDelegateBlockingCheckpoints runs the configured approval judge for each
+// consecutive blocking checkpoint while a judge is configured.
+//
+// This is the fest next integration path: configuring hooks.approval_judge is
+// an operator opt-in to skip human pings on GATES.md / WORKFLOW.md checkpoints.
+// When no judge is configured, this is a no-op and the caller formats the
+// manual checkpoint instructions.
+//
+// Fail-closed: judge errors leave the checkpoint unchanged and return the
+// error. Reject verdicts are recorded by runApproveAuto and return nil so the
+// agent can address feedback.
+func AutoDelegateBlockingCheckpoints(ctx context.Context, nav *wf.Navigator) error {
+	if nav == nil {
+		return nil
+	}
+	if err := nav.EnsureInitialized(); err != nil {
+		return err
+	}
+
+	// Cap iterations so a misbehaving state machine cannot loop forever.
+	const maxAutoSteps = 32
+	for i := 0; i < maxAutoSteps; i++ {
+		state := nav.GetWorkflowState()
+		steps := nav.GetSteps()
+		if state == nil || state.IsComplete() || len(steps) == 0 {
+			return nil
+		}
+		current := state.CurrentStep
+		if current < 1 || current > len(steps) {
+			return nil
+		}
+		step := steps[current-1]
+		stepState := state.GetStepState(current)
+		// Pending or in_progress blocking checkpoints are eligible. fest next
+		// often lands here before GetNext promotes pending → in_progress.
+		if stepState == nil || !step.Checkpoint.IsBlocking() {
+			return nil
+		}
+		switch stepState.Status {
+		case wf.StepStatusInProgress, wf.StepStatusPending:
+			// eligible
+		default:
+			return nil
+		}
+
+		judgeCommand, err := resolveApprovalJudgeCommandFor(ctx, nav, "")
+		if err != nil {
+			// No judge configured — leave checkpoint for manual / agent instruction path.
+			return nil
+		}
+
+		fmt.Printf("%s Checkpoint delegated to approval judge (%s)\n", ui.Info("→"), judgeCommand)
+		fmt.Printf("  Step %d: %s\n", current, step.Name)
+
+		opts := approvalJudgeOptions{Auto: true, JudgeCommand: judgeCommand}
+		if err := runApproveAuto(ctx, nav, current, step, opts); err != nil {
+			return err
+		}
+
+		// Reject or fail-closed leave state non-progressing; stop so the
+		// caller can render the blocked checkpoint / next instructions.
+		nextState := nav.GetWorkflowState()
+		if nextState == nil || nextState.IsComplete() {
+			return nil
+		}
+		if nextState.CurrentStep == current {
+			return nil
+		}
+		// Approved and advanced — continue if the next step is also a
+		// delegated blocking checkpoint.
+	}
+	return nil
 }
 
 func runApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum int, step wf.WorkflowStep, opts approvalJudgeOptions) error {

--- a/internal/commands/workflow/auto_delegate_test.go
+++ b/internal/commands/workflow/auto_delegate_test.go
@@ -1,0 +1,128 @@
+package workflow
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/config"
+	"github.com/Obedience-Corp/fest/internal/guidance"
+	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+	"github.com/Obedience-Corp/fest/internal/progress"
+)
+
+func writeGateFestival(t *testing.T) (festivalPath, phasePath, festivalsRoot string) {
+	t.Helper()
+	root := t.TempDir()
+	festivalsRoot = filepath.Join(root, "festivals")
+	festivalPath = filepath.Join(festivalsRoot, "active", "gate-fest")
+	phasePath = filepath.Join(festivalPath, "001_IMPLEMENT")
+	if err := os.MkdirAll(phasePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(festivalPath, ".fest"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gates := `---
+fest_type: phase_gate
+---
+
+# Gate
+
+## Step 1: PHASE GOAL
+
+**Question:** Is the phase goal met?
+
+**Actions:**
+1. Check deliverables
+
+**Checkpoint:** APPROVAL REQUIRED
+`
+	if err := os.WriteFile(filepath.Join(phasePath, "GATES.md"), []byte(gates), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return festivalPath, phasePath, festivalsRoot
+}
+
+func TestAutoDelegateBlockingCheckpoints_NoJudgeIsNoop(t *testing.T) {
+	festivalPath, phasePath, _ := writeGateFestival(t)
+	gctx := &guidance.GuidanceContext{
+		FestivalPath: festivalPath,
+		PhasePath:    phasePath,
+		PhaseName:    "001_IMPLEMENT",
+		Mode:         guidance.ModeWorkflow,
+	}
+	nav, err := wf.NewNavigator(gctx, guidance.ModeWorkflow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nav.SetDocFilename("GATES.md")
+	nav.SetStateKeyPrefix("gate:")
+	store := progress.NewStore(festivalPath)
+	if err := store.Load(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	nav.SetStateStore(store)
+	if err := nav.Initialize(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := AutoDelegateBlockingCheckpoints(context.Background(), nav); err != nil {
+		t.Fatalf("no-op without judge: %v", err)
+	}
+	// Still on step 1 awaiting human.
+	if nav.GetWorkflowState().CurrentStep != 1 {
+		t.Fatalf("current step = %d, want 1", nav.GetWorkflowState().CurrentStep)
+	}
+}
+
+func TestAutoDelegateBlockingCheckpoints_AutoApprovesWhenJudgeConfigured(t *testing.T) {
+	festivalPath, phasePath, festivalsRoot := writeGateFestival(t)
+	cfg := config.DefaultWorkspaceConfig()
+	cfg.Hooks.ApprovalJudge.Command = "fake-judge"
+	if err := config.SaveWorkspaceConfig(festivalsRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	withApprovalJudgeRunner(t, func(ctx context.Context, command string, stdin []byte) ([]byte, error) {
+		if command != "fake-judge" {
+			t.Fatalf("command = %q", command)
+		}
+		if !strings.Contains(string(stdin), `"document":"GATES.md"`) {
+			t.Fatalf("stdin missing GATES.md document: %s", stdin)
+		}
+		return []byte(`{"schema_version":"fest.approval.judge/v1","decision":"approve","reason":"phase goal satisfied"}`), nil
+	})
+
+	gctx := &guidance.GuidanceContext{
+		FestivalPath: festivalPath,
+		PhasePath:    phasePath,
+		PhaseName:    "001_IMPLEMENT",
+		Mode:         guidance.ModeWorkflow,
+	}
+	nav, err := wf.NewNavigator(gctx, guidance.ModeWorkflow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nav.SetDocFilename("GATES.md")
+	nav.SetStateKeyPrefix("gate:")
+	store := progress.NewStore(festivalPath)
+	if err := store.Load(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	nav.SetStateStore(store)
+	if err := nav.Initialize(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// No workspace in context — same as fest next scope.Global.
+	if err := AutoDelegateBlockingCheckpoints(context.Background(), nav); err != nil {
+		t.Fatalf("AutoDelegateBlockingCheckpoints: %v", err)
+	}
+	// Single-step gate: approve completes the workflow.
+	if !nav.GetWorkflowState().IsComplete() {
+		t.Fatalf("expected gate complete after auto-approve, state=%+v", nav.GetWorkflowState())
+	}
+}

--- a/internal/guidance/workflow/navigator_format.go
+++ b/internal/guidance/workflow/navigator_format.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/config"
 	"github.com/Obedience-Corp/fest/internal/guidance"
 	"github.com/Obedience-Corp/fest/internal/scope"
+	"github.com/Obedience-Corp/fest/internal/workspace"
 )
 
 // FormatInstructions generates agent-friendly workflow instructions using templates.
@@ -104,22 +105,60 @@ func (n *Navigator) formatCheckpoint(ctx context.Context, step WorkflowStep) (st
 }
 
 // approvalJudgeConfigured reports whether the operator has delegated blocking
-// checkpoints to an approval judge via hooks.approval_judge.command. Guidance
-// only advertises 'fest workflow approve --auto' when this returns true, so
-// agents are never handed a delegation affordance the operator did not set up.
+// checkpoints to an approval judge via hooks.approval_judge.command.
+//
+// Detection must not depend solely on scope.WorkspaceFrom(ctx): fest next uses
+// scope.Global and never injects workspace into context, so WorkspaceFrom is
+// empty even when .festival/config.yaml configures the judge. Fall back to
+// resolving the festivals root from the navigator's festival path.
 func (n *Navigator) approvalJudgeConfigured(ctx context.Context) bool {
-	if ctx == nil {
-		return false
+	return strings.TrimSpace(n.ApprovalJudgeCommand(ctx)) != ""
+}
+
+// ApprovalJudgeCommand returns hooks.approval_judge.command when configured.
+// Empty string means no judge is configured (manual approval path).
+func (n *Navigator) ApprovalJudgeCommand(ctx context.Context) string {
+	festivalsRoot := n.festivalsRoot(ctx)
+	if festivalsRoot == "" {
+		return ""
 	}
-	ws, ok := scope.WorkspaceFrom(ctx)
-	if !ok || ws == nil || ws.FestivalsPath == "" {
-		return false
+	cfg, err := config.LoadWorkspaceConfig(festivalsRoot)
+	if err != nil || cfg == nil {
+		return ""
 	}
-	cfg, err := config.LoadWorkspaceConfig(ws.FestivalsPath)
+	return strings.TrimSpace(cfg.Hooks.ApprovalJudge.Command)
+}
+
+// festivalsRoot resolves the campaigns festivals/ directory used for
+// .festival/config.yaml lookup.
+func (n *Navigator) festivalsRoot(ctx context.Context) string {
+	if ctx != nil {
+		if ws, ok := scope.WorkspaceFrom(ctx); ok && ws != nil && ws.FestivalsPath != "" {
+			return ws.FestivalsPath
+		}
+	}
+	// fest next is scope.Global and does not inject workspace; recover from
+	// the festival path the navigator already resolved.
+	start := ""
+	if n != nil && n.BaseNavigator != nil && n.Ctx != nil {
+		if n.Ctx.FestivalPath != "" {
+			start = n.Ctx.FestivalPath
+		} else if n.Ctx.PhasePath != "" {
+			start = n.Ctx.PhasePath
+		}
+	}
+	if start == "" {
+		return ""
+	}
+	lookupCtx := ctx
+	if lookupCtx == nil {
+		lookupCtx = context.Background()
+	}
+	ws, err := workspace.FindWorkspace(lookupCtx, start)
 	if err != nil {
-		return false
+		return ""
 	}
-	return strings.TrimSpace(cfg.Hooks.ApprovalJudge.Command) != ""
+	return ws.FestivalsPath
 }
 
 // formatStep renders the step template for the current workflow step.

--- a/internal/guidance/workflow/navigator_format_judge_test.go
+++ b/internal/guidance/workflow/navigator_format_judge_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/Obedience-Corp/fest/internal/config"
+	"github.com/Obedience-Corp/fest/internal/guidance"
 	"github.com/Obedience-Corp/fest/internal/scope"
 )
 
@@ -56,7 +57,8 @@ func TestFormatCheckpoint_JudgeConfigured(t *testing.T) {
 
 	for _, want := range []string{
 		"This checkpoint is delegated",
-		"Run: fest workflow approve --auto",
+		"fest next` auto-invokes the judge",
+		"fest workflow approve --auto",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("checkpoint output missing %q:\n%s", want, out)
@@ -79,5 +81,37 @@ func TestApprovalJudgeConfigured_NilAndMissing(t *testing.T) {
 	ctx := scope.WithWorkspace(context.Background(), &scope.WorkspaceInfo{FestivalsPath: t.TempDir()})
 	if nav.approvalJudgeConfigured(ctx) {
 		t.Error("workspace without a configured judge should report no judge")
+	}
+}
+
+func TestApprovalJudgeConfigured_FromFestivalPathWithoutWorkspaceCtx(t *testing.T) {
+	// Mirrors fest next: scope.Global so WorkspaceFrom is empty, but the
+	// navigator knows the festival path under festivals/.
+	root := t.TempDir()
+	festivalsRoot := filepath.Join(root, "festivals")
+	festivalPath := filepath.Join(festivalsRoot, "active", "example-fest")
+	if err := os.MkdirAll(festivalPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dotFestival := filepath.Join(festivalsRoot, config.DotFestivalDir)
+	if err := os.MkdirAll(dotFestival, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfgYAML := "version: \"1.0\"\nhooks:\n  approval_judge:\n    command: ob judge\n"
+	if err := os.WriteFile(filepath.Join(dotFestival, config.WorkspaceConfigFileName), []byte(cfgYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	gctx := &guidance.GuidanceContext{FestivalPath: festivalPath}
+	nav, err := NewNavigator(gctx, guidance.ModeWorkflow)
+	if err != nil {
+		t.Fatalf("NewNavigator: %v", err)
+	}
+
+	if !nav.approvalJudgeConfigured(context.Background()) {
+		t.Fatal("judge should be detected from festival path without WorkspaceFrom")
+	}
+	if got := nav.ApprovalJudgeCommand(context.Background()); got != "ob judge" {
+		t.Fatalf("ApprovalJudgeCommand = %q, want %q", got, "ob judge")
 	}
 }


### PR DESCRIPTION
## Summary

Configuring `hooks.approval_judge.command` is supposed to **delegate blocking checkpoints** so humans are not pinged while evaluation still happens. That was broken in two ways:

1. **`fest next` never auto-ran the judge** — it only printed guidance and expected a separate `fest workflow approve --auto`.
2. **Judge detection failed on `fest next`** — next uses `scope.Global`, so `WorkspaceFrom(ctx)` is empty and `JudgeConfigured` was always false. Agents were told to wait for a human even with `ob judge` configured.

### Fixes

- Resolve `hooks.approval_judge.command` from the navigator’s festival path when workspace is not in context (fest next path).
- **`fest next` auto-invokes the judge** on consecutive blocking WORKFLOW.md / GATES.md checkpoints when the hook is set.
- Fail closed on judge errors; reject stays blocked with feedback; approve advances and continues if the next step is also a delegated checkpoint.
- Update agent checkpoint template + understand docs to match.

### Operator model

| Hook set? | Behavior |
|-----------|----------|
| No | Manual: `fest workflow approve` / reject (unchanged) |
| Yes (`ob judge`, etc.) | `fest next` runs the judge; no human ping unless reject/error |

`--auto` remains available for explicit re-runs after reject/failure.

## Test plan

- [x] `go test ./internal/guidance/workflow/ ./internal/commands/workflow/ ./internal/commands/next/ ./internal/e2e/`
- [ ] With campaign hook `command: ob judge`, land on IMPLEMENT `GATES.md` and confirm `fest next` prints “Checkpoint delegated…” and advances or rejects without asking a human first
- [ ] Without hook, confirm manual checkpoint instructions still appear