### PR TITLE
feat(workflow): async approval judge (fire-and-forget)

### DIFF
--- a/embedded/templates/agent/workflow/checkpoint.tmpl
+++ b/embedded/templates/agent/workflow/checkpoint.tmpl
@@ -43,7 +43,26 @@ Step {{.StepNumber}}: {{.StepName}}
 {{range .Actions}}- {{.}}
 {{end}}
 {{- end}}
-{{- if .JudgeConfigured}}
+{{- if .JudgeWaiting}}
+
+This checkpoint is delegated and a judge is **already running**
+(hooks.approval_judge.command). Do not relaunch it and do not wait in a spin
+loop.
+
+**What you should do:**
+1. Leave the checkpoint blocked. `fest next` / `fest workflow status` report
+   waiting-on-judge while the detached runner is alive.
+2. When the judge returns, run `fest next` again:
+   - Approved: the workflow continues.
+   - Rejected: address the recorded feedback, then
+     `fest workflow advance` to resubmit.
+3. Do **not** run `fest workflow approve --auto` again while the judge is
+   running (duplicate launch is refused).
+
+**Operator commands:**
+- Watch: fest workflow status / fest show
+- Manual override: fest workflow approve / fest workflow reject --reason "..."
+{{- else if .JudgeConfigured}}
 
 This checkpoint is delegated: the operator configured an approval judge
 (hooks.approval_judge.command). `fest next` auto-invokes the judge when it
@@ -52,15 +71,20 @@ lands on a blocking checkpoint; you should not wait for a human.
 **What you should do:**
 1. If you are reading this after `fest next` without an auto-verdict, run:
    fest workflow approve --auto
-2. Wait for it to return. The command blocks until the judge answers and fails
-   closed on timeout or judge errors, leaving the checkpoint unchanged.
-3. Approved: run fest next to continue.
-4. Rejected: address the recorded feedback, then run fest workflow advance to
-   resubmit.
+   (default is fire-and-forget: it launches the judge and returns immediately;
+   use `--wait` only when you need a blocking in-process verdict)
+2. While the judge runs, the checkpoint stays blocked and
+   `fest workflow status` / `fest show` render purple waiting-on-judge.
+3. After the judge returns, run fest next:
+   - Approved: continue.
+   - Rejected: address the recorded feedback, then fest workflow advance to
+     resubmit.
+4. Auto mode fails closed on judge errors (checkpoint unchanged).
 
 **Operator commands:**
 - Manual approve: fest workflow approve
 - Reject with feedback: fest workflow reject --reason "..."
+- Block until verdict: fest workflow approve --auto --wait
 {{- else}}
 
 This step requires explicit operator confirmation before proceeding.

--- a/internal/commands/workflow/approve.go
+++ b/internal/commands/workflow/approve.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -25,6 +26,7 @@ type approvalJudgeOptions struct {
 	Auto         bool
 	JudgeCommand string
 	Timeout      time.Duration
+	Wait         bool
 }
 
 type approvalJudgeRequest struct {
@@ -89,7 +91,12 @@ Auto approval:
 
       hooks:
         approval_judge:
-          command: ob judge`,
+          command: ob judge
+
+  By default --auto launches the judge in the background and returns
+  immediately; the checkpoint stays blocked until the verdict lands, and
+  'fest show' renders the waiting-on-judge state while it runs. Use --wait
+  to block until the judge returns instead.`,
 		Annotations: map[string]string{
 			"scope": string(scope.Festival),
 		},
@@ -111,6 +118,7 @@ Auto approval:
 	cmd.Flags().BoolVar(&opts.Auto, "auto", false, "delegate this checkpoint decision to the configured approval judge command")
 	cmd.Flags().StringVar(&opts.JudgeCommand, "judge-command", opts.JudgeCommand, "approval judge command for --auto (overrides the .festival/config.yaml hooks.approval_judge.command hook)")
 	cmd.Flags().DurationVar(&opts.Timeout, "judge-timeout", opts.Timeout, "maximum time to wait for the approval judge (0 waits until it returns)")
+	cmd.Flags().BoolVar(&opts.Wait, "wait", false, "block until the judge returns instead of launching it in the background")
 	cmd.MarkFlagsMutuallyExclusive("auto", "as")
 	cmd.MarkFlagsMutuallyExclusive("auto", "summary")
 
@@ -315,25 +323,45 @@ func AutoDelegateBlockingCheckpoints(ctx context.Context, nav *wf.Navigator) err
 }
 
 func runApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum int, step wf.WorkflowStep, opts approvalJudgeOptions) error {
+	// A judge may already be evaluating this checkpoint from a prior --auto.
+	// Refuse a duplicate launch while it is alive; a running record whose
+	// process died (crash, reboot) is stale and may be relaunched.
+	if ss := nav.GetWorkflowState().GetStepState(currentStepNum); ss != nil && ss.Judge != nil &&
+		ss.Judge.Status == wf.JudgeRunning && judgeProcessAlive(ss.Judge.Pid) {
+		return festerrors.Validation("an approval judge is already evaluating this checkpoint").
+			WithField("judge_command", ss.Judge.Command).
+			WithField("pid", fmt.Sprintf("%d", ss.Judge.Pid)).
+			WithHint("the checkpoint unblocks when the judge returns; watch it with 'fest show' and re-run 'fest next' afterwards")
+	}
+
+	if !opts.Wait {
+		return launchApproveAuto(ctx, nav, currentStepNum, step, opts)
+	}
+
+	// --wait: run the judge in-process and block until the verdict lands.
 	// Record the judge invocation before running it so watchers can render
 	// the waiting-on-judge state and a hung or crashed judge leaves a trace.
-	if err := nav.BeginJudge(ctx, opts.JudgeCommand); err != nil {
+	if err := nav.BeginJudge(ctx, currentStepNum, opts.JudgeCommand, os.Getpid()); err != nil {
 		return festerrors.Wrap(err, "recording judge start")
 	}
 
 	decision, audit, err := judgeApproval(ctx, nav, step, opts)
 	if err != nil {
-		if recErr := nav.RecordJudgeOutcome(ctx, wf.JudgeFailed, err.Error()); recErr != nil {
+		if recErr := nav.RecordJudgeOutcome(ctx, currentStepNum, wf.JudgeFailed, err.Error()); recErr != nil {
 			fmt.Printf("%s failed to record judge outcome: %v\n", ui.Warning("⚠"), recErr)
 		}
 		return err
 	}
 
+	return applyApproveAutoVerdict(ctx, nav, currentStepNum, step, decision, audit)
+}
+
+func applyApproveAutoVerdict(ctx context.Context, nav *wf.Navigator, currentStepNum int, step wf.WorkflowStep, decision *approvalJudgeResponse, audit string) error {
 	judgeDecision := wf.DecisionMetadata{Actor: decisionActorAgent, Summary: decision.Reason}
 
 	switch decision.Decision {
 	case "approve":
-		if err := nav.RecordJudgeOutcome(ctx, wf.JudgeApproved, decision.Reason); err != nil {
+		if err := nav.RecordJudgeOutcome(ctx, currentStepNum, wf.JudgeApproved, decision.Reason); err != nil {
 			return festerrors.Wrap(err, "recording judge outcome")
 		}
 		if err := nav.ApproveWithAudit(ctx, audit, judgeDecision); err != nil {
@@ -343,7 +371,7 @@ func runApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum int, 
 		fmt.Printf("  %s: %s\n", ui.Label("Reason"), decision.Reason)
 		return showNextStep(ctx, nav, nav.GetSteps())
 	case "reject":
-		if err := nav.RecordJudgeOutcome(ctx, wf.JudgeRejected, decision.Reason); err != nil {
+		if err := nav.RecordJudgeOutcome(ctx, currentStepNum, wf.JudgeRejected, decision.Reason); err != nil {
 			return festerrors.Wrap(err, "recording judge outcome")
 		}
 		if err := nav.RejectWithDecision(ctx, audit, judgeDecision); err != nil {
@@ -363,7 +391,7 @@ func runApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum int, 
 		unsupported := festerrors.Validation("approval judge returned unsupported decision").
 			WithField("decision", decision.Decision).
 			WithHint("allowed decisions are approve and reject")
-		if recErr := nav.RecordJudgeOutcome(ctx, wf.JudgeFailed, unsupported.Error()); recErr != nil {
+		if recErr := nav.RecordJudgeOutcome(ctx, currentStepNum, wf.JudgeFailed, unsupported.Error()); recErr != nil {
 			fmt.Printf("%s failed to record judge outcome: %v\n", ui.Warning("⚠"), recErr)
 		}
 		return unsupported

--- a/internal/commands/workflow/approve.go
+++ b/internal/commands/workflow/approve.go
@@ -299,6 +299,22 @@ func AutoDelegateBlockingCheckpoints(ctx context.Context, nav *wf.Navigator) err
 			return nil
 		}
 
+		// fest next must not error while a prior fire-and-forget judge is still
+		// alive — report waiting-on-judge and leave the checkpoint blocked.
+		if stepState.Judge != nil && stepState.Judge.Status == wf.JudgeRunning &&
+			judgeProcessAlive(stepState.Judge.Pid) {
+			cmd := stepState.Judge.Command
+			if cmd == "" {
+				cmd = judgeCommand
+			}
+			fmt.Printf("%s Approval judge still running: %s (pid %d)\n",
+				ui.Value("⚖", ui.JudgeColor), cmd, stepState.Judge.Pid)
+			fmt.Println("  Checkpoint stays blocked until the verdict lands.")
+			fmt.Printf("  Watch progress: %s\n", ui.Accent("fest workflow status"))
+			fmt.Printf("  After it returns, run %s again.\n", ui.Accent("fest next"))
+			return nil
+		}
+
 		fmt.Printf("%s Checkpoint delegated to approval judge (%s)\n", ui.Info("→"), judgeCommand)
 		fmt.Printf("  Step %d: %s\n", current, step.Name)
 

--- a/internal/commands/workflow/approve.go
+++ b/internal/commands/workflow/approve.go
@@ -182,7 +182,7 @@ func runApproveWithOptions(ctx context.Context, decision wf.DecisionMetadata, op
 	}
 
 	return withJudgeStepLock(ctx, nav.Ctx.PhasePath, currentStepNum, func() error {
-		fresh, err := getWorkflowNavigator(ctx)
+		fresh, err := reloadWorkflowNavigator(ctx, nav)
 		if err != nil {
 			return err
 		}
@@ -359,7 +359,7 @@ func runApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum int, 
 		return err
 	}
 	err = withJudgeStepLock(ctx, nav.Ctx.PhasePath, currentStepNum, func() error {
-		fresh, err := getWorkflowNavigator(ctx)
+		fresh, err := reloadWorkflowNavigator(ctx, nav)
 		if err != nil {
 			return err
 		}
@@ -382,7 +382,7 @@ func runApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum int, 
 
 	decision, audit, err := judgeApproval(ctx, nav, step, opts)
 	if err != nil {
-		if recErr := recordJudgeFailureIfOwned(ctx, nav.Ctx.PhasePath, judgeExecPayload{
+		if recErr := recordJudgeFailureIfOwned(ctx, nav, judgeExecPayload{
 			StepNumber: currentStepNum, RunID: runID,
 		}, err.Error()); recErr != nil {
 			fmt.Printf("%s failed to record judge outcome: %v\n", ui.Warning("⚠"), recErr)
@@ -391,7 +391,7 @@ func runApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum int, 
 	}
 
 	return withJudgeStepLock(ctx, nav.Ctx.PhasePath, currentStepNum, func() error {
-		fresh, err := getWorkflowNavigator(ctx)
+		fresh, err := reloadWorkflowNavigator(ctx, nav)
 		if err != nil {
 			return err
 		}

--- a/internal/commands/workflow/approve.go
+++ b/internal/commands/workflow/approve.go
@@ -181,19 +181,30 @@ func runApproveWithOptions(ctx context.Context, decision wf.DecisionMetadata, op
 		return runApproveAuto(ctx, nav, currentStepNum, step, opts)
 	}
 
-	// Approve and advance
-	if err := nav.ApproveWithDecision(ctx, decision); err != nil {
-		return festerrors.Wrap(err, "approving checkpoint")
-	}
+	return withJudgeStepLock(ctx, nav.Ctx.PhasePath, currentStepNum, func() error {
+		fresh, err := getWorkflowNavigator(ctx)
+		if err != nil {
+			return err
+		}
+		freshState := fresh.GetWorkflowState()
+		if freshState.CurrentStep != currentStepNum {
+			return festerrors.Validation("checkpoint changed before approval").
+				WithField("expected_step", currentStepNum).
+				WithField("current_step", freshState.CurrentStep)
+		}
+		if err := fresh.ApproveWithDecision(ctx, decision); err != nil {
+			return festerrors.Wrap(err, "approving checkpoint")
+		}
 
-	fmt.Printf("%s Step %d: %s approved\n", ui.Success("✓"), currentStepNum, step.Name)
-	if decision.Actor != "" {
-		fmt.Printf("  %s: %s\n", ui.Label("Approved by"), decision.Actor)
-	}
-	if decision.Summary != "" {
-		fmt.Printf("  %s: %s\n", ui.Label("Summary"), decision.Summary)
-	}
-	return showNextStep(ctx, nav, steps)
+		fmt.Printf("%s Step %d: %s approved\n", ui.Success("✓"), currentStepNum, step.Name)
+		if decision.Actor != "" {
+			fmt.Printf("  %s: %s\n", ui.Label("Approved by"), decision.Actor)
+		}
+		if decision.Summary != "" {
+			fmt.Printf("  %s: %s\n", ui.Label("Summary"), decision.Summary)
+		}
+		return showNextStep(ctx, fresh, fresh.GetSteps())
+	})
 }
 
 // resolveApprovalJudgeCommand resolves the command used for --auto approval.
@@ -302,7 +313,7 @@ func AutoDelegateBlockingCheckpoints(ctx context.Context, nav *wf.Navigator) err
 		// fest next must not error while a prior fire-and-forget judge is still
 		// alive — report waiting-on-judge and leave the checkpoint blocked.
 		if stepState.Judge != nil && stepState.Judge.Status == wf.JudgeRunning &&
-			judgeProcessAlive(stepState.Judge.Pid) {
+			judgeLeaseActive(stepState.Judge) {
 			cmd := stepState.Judge.Command
 			if cmd == "" {
 				cmd = judgeCommand
@@ -339,65 +350,84 @@ func AutoDelegateBlockingCheckpoints(ctx context.Context, nav *wf.Navigator) err
 }
 
 func runApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum int, step wf.WorkflowStep, opts approvalJudgeOptions) error {
-	// A judge may already be evaluating this checkpoint from a prior --auto.
-	// Refuse a duplicate launch while it is alive; a running record whose
-	// process died (crash, reboot) is stale and may be relaunched.
-	if ss := nav.GetWorkflowState().GetStepState(currentStepNum); ss != nil && ss.Judge != nil &&
-		ss.Judge.Status == wf.JudgeRunning && judgeProcessAlive(ss.Judge.Pid) {
-		return festerrors.Validation("an approval judge is already evaluating this checkpoint").
-			WithField("judge_command", ss.Judge.Command).
-			WithField("pid", fmt.Sprintf("%d", ss.Judge.Pid)).
-			WithHint("the checkpoint unblocks when the judge returns; watch it with 'fest show' and re-run 'fest next' afterwards")
-	}
-
 	if !opts.Wait {
 		return launchApproveAuto(ctx, nav, currentStepNum, step, opts)
 	}
 
-	// --wait: run the judge in-process and block until the verdict lands.
-	// Record the judge invocation before running it so watchers can render
-	// the waiting-on-judge state and a hung or crashed judge leaves a trace.
-	if err := nav.BeginJudge(ctx, currentStepNum, opts.JudgeCommand, os.Getpid()); err != nil {
-		return festerrors.Wrap(err, "recording judge start")
+	runID, err := newJudgeRunID()
+	if err != nil {
+		return err
+	}
+	err = withJudgeStepLock(ctx, nav.Ctx.PhasePath, currentStepNum, func() error {
+		fresh, err := getWorkflowNavigator(ctx)
+		if err != nil {
+			return err
+		}
+		if fresh.GetWorkflowState().CurrentStep != currentStepNum {
+			return festerrors.Validation("checkpoint changed before approval judge started")
+		}
+		if ss := fresh.GetWorkflowState().GetStepState(currentStepNum); ss != nil && ss.Judge != nil &&
+			ss.Judge.Status == wf.JudgeRunning && judgeLeaseActive(ss.Judge) {
+			return judgeAlreadyRunningError(ss.Judge)
+		}
+		if err := fresh.BeginJudge(ctx, currentStepNum, opts.JudgeCommand, runID, os.Getpid()); err != nil {
+			return festerrors.Wrap(err, "recording judge start")
+		}
+		nav = fresh
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	decision, audit, err := judgeApproval(ctx, nav, step, opts)
 	if err != nil {
-		if recErr := nav.RecordJudgeOutcome(ctx, currentStepNum, wf.JudgeFailed, err.Error()); recErr != nil {
+		if recErr := recordJudgeFailureIfOwned(ctx, nav.Ctx.PhasePath, judgeExecPayload{
+			StepNumber: currentStepNum, RunID: runID,
+		}, err.Error()); recErr != nil {
 			fmt.Printf("%s failed to record judge outcome: %v\n", ui.Warning("⚠"), recErr)
 		}
 		return err
 	}
 
-	return applyApproveAutoVerdict(ctx, nav, currentStepNum, step, decision, audit)
+	return withJudgeStepLock(ctx, nav.Ctx.PhasePath, currentStepNum, func() error {
+		fresh, err := getWorkflowNavigator(ctx)
+		if err != nil {
+			return err
+		}
+		_, err = applyApproveAutoVerdict(ctx, fresh, currentStepNum, step, runID, decision, audit)
+		return err
+	})
 }
 
-func applyApproveAutoVerdict(ctx context.Context, nav *wf.Navigator, currentStepNum int, step wf.WorkflowStep, decision *approvalJudgeResponse, audit string) error {
+func applyApproveAutoVerdict(ctx context.Context, nav *wf.Navigator, currentStepNum int, step wf.WorkflowStep, runID string, decision *approvalJudgeResponse, audit string) (bool, error) {
 	judgeDecision := wf.DecisionMetadata{Actor: decisionActorAgent, Summary: decision.Reason}
 
 	switch decision.Decision {
 	case "approve":
-		if err := nav.RecordJudgeOutcome(ctx, currentStepNum, wf.JudgeApproved, decision.Reason); err != nil {
-			return festerrors.Wrap(err, "recording judge outcome")
+		applied, err := nav.ApplyJudgeApproval(ctx, currentStepNum, runID, audit, judgeDecision)
+		if err != nil {
+			return false, festerrors.Wrap(err, "approving checkpoint from judge decision")
 		}
-		if err := nav.ApproveWithAudit(ctx, audit, judgeDecision); err != nil {
-			return festerrors.Wrap(err, "approving checkpoint from judge decision")
+		if !applied {
+			return false, nil
 		}
 		fmt.Printf("%s Step %d: %s auto-approved\n", ui.Success("✓"), currentStepNum, step.Name)
 		fmt.Printf("  %s: %s\n", ui.Label("Reason"), decision.Reason)
-		return showNextStep(ctx, nav, nav.GetSteps())
+		return true, showNextStep(ctx, nav, nav.GetSteps())
 	case "reject":
-		if err := nav.RecordJudgeOutcome(ctx, currentStepNum, wf.JudgeRejected, decision.Reason); err != nil {
-			return festerrors.Wrap(err, "recording judge outcome")
+		applied, err := nav.ApplyJudgeRejection(ctx, currentStepNum, runID, audit, judgeDecision)
+		if err != nil {
+			return false, festerrors.Wrap(err, "recording judge rejection")
 		}
-		if err := nav.RejectWithDecision(ctx, audit, judgeDecision); err != nil {
-			return festerrors.Wrap(err, "recording judge rejection")
+		if !applied {
+			return false, nil
 		}
 		fmt.Printf("%s Step %d: %s auto-rejected\n", ui.Warning("⚠"), currentStepNum, step.Name)
 		fmt.Printf("  %s: %s\n\n", ui.Label("Reason"), decision.Reason)
 		fmt.Println("The step is now blocked. Address the feedback and revise the work.")
 		fmt.Println("When ready, run " + ui.Accent("fest workflow advance") + " to resubmit.")
-		return nil
+		return true, nil
 	default:
 		// Unreachable today: parseApprovalJudgeResponse already rejects any
 		// decision outside {approve, reject} (that path records JudgeFailed via
@@ -407,10 +437,10 @@ func applyApproveAutoVerdict(ctx context.Context, nav *wf.Navigator, currentStep
 		unsupported := festerrors.Validation("approval judge returned unsupported decision").
 			WithField("decision", decision.Decision).
 			WithHint("allowed decisions are approve and reject")
-		if recErr := nav.RecordJudgeOutcome(ctx, currentStepNum, wf.JudgeFailed, unsupported.Error()); recErr != nil {
+		if _, recErr := nav.RecordJudgeOutcome(ctx, currentStepNum, runID, wf.JudgeFailed, unsupported.Error()); recErr != nil {
 			fmt.Printf("%s failed to record judge outcome: %v\n", ui.Warning("⚠"), recErr)
 		}
-		return unsupported
+		return false, unsupported
 	}
 }
 

--- a/internal/commands/workflow/approve_auto_test.go
+++ b/internal/commands/workflow/approve_auto_test.go
@@ -315,8 +315,11 @@ func TestRunApproveAuto_ApproveAdvancesAndRecordsAudit(t *testing.T) {
 		return []byte(`{"schema_version":"fest.approval.judge/v1","decision":"approve","reason":"evidence complete"}`), nil
 	})
 
+	// Wait:true = in-process verdict path (mocked runner). Default --auto is async.
 	out := captureStdout(t, func() {
-		if err := runApproveAuto(ctx, nav, 2, steps[1], approvalJudgeOptions{JudgeCommand: "fake judge", Timeout: time.Second}); err != nil {
+		if err := runApproveAuto(ctx, nav, 2, steps[1], approvalJudgeOptions{
+			JudgeCommand: "fake judge", Timeout: time.Second, Wait: true,
+		}); err != nil {
 			t.Fatalf("runApproveAuto: %v", err)
 		}
 	})
@@ -353,7 +356,9 @@ func TestRunApproveAuto_RejectBlocksStepWithAudit(t *testing.T) {
 	})
 
 	out := captureStdout(t, func() {
-		if err := runApproveAuto(ctx, nav, 2, steps[1], approvalJudgeOptions{JudgeCommand: "fake judge", Timeout: time.Second}); err != nil {
+		if err := runApproveAuto(ctx, nav, 2, steps[1], approvalJudgeOptions{
+			JudgeCommand: "fake judge", Timeout: time.Second, Wait: true,
+		}); err != nil {
 			t.Fatalf("runApproveAuto: %v", err)
 		}
 	})

--- a/internal/commands/workflow/auto_delegate_test.go
+++ b/internal/commands/workflow/auto_delegate_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/Obedience-Corp/fest/internal/config"
@@ -78,7 +77,7 @@ func TestAutoDelegateBlockingCheckpoints_NoJudgeIsNoop(t *testing.T) {
 	}
 }
 
-func TestAutoDelegateBlockingCheckpoints_AutoApprovesWhenJudgeConfigured(t *testing.T) {
+func TestAutoDelegateBlockingCheckpoints_LaunchesJudgeWhenConfigured(t *testing.T) {
 	festivalPath, phasePath, festivalsRoot := writeGateFestival(t)
 	cfg := config.DefaultWorkspaceConfig()
 	cfg.Hooks.ApprovalJudge.Command = "fake-judge"
@@ -86,14 +85,17 @@ func TestAutoDelegateBlockingCheckpoints_AutoApprovesWhenJudgeConfigured(t *test
 		t.Fatal(err)
 	}
 
-	withApprovalJudgeRunner(t, func(ctx context.Context, command string, stdin []byte) ([]byte, error) {
-		if command != "fake-judge" {
-			t.Fatalf("command = %q", command)
+	// fest next auto-delegate is fire-and-forget: mock launch, never spawn.
+	var launchedPayload string
+	withMockedJudgeLaunch(t, func(payloadPath, phaseDir, logPath string) (int, error) {
+		launchedPayload = payloadPath
+		if phaseDir != phasePath {
+			t.Fatalf("phaseDir = %q, want %q", phaseDir, phasePath)
 		}
-		if !strings.Contains(string(stdin), `"document":"GATES.md"`) {
-			t.Fatalf("stdin missing GATES.md document: %s", stdin)
+		if logPath == "" {
+			t.Fatal("expected judge log path")
 		}
-		return []byte(`{"schema_version":"fest.approval.judge/v1","decision":"approve","reason":"phase goal satisfied"}`), nil
+		return 4242, nil
 	})
 
 	gctx := &guidance.GuidanceContext{
@@ -121,8 +123,28 @@ func TestAutoDelegateBlockingCheckpoints_AutoApprovesWhenJudgeConfigured(t *test
 	if err := AutoDelegateBlockingCheckpoints(context.Background(), nav); err != nil {
 		t.Fatalf("AutoDelegateBlockingCheckpoints: %v", err)
 	}
-	// Single-step gate: approve completes the workflow.
-	if !nav.GetWorkflowState().IsComplete() {
-		t.Fatalf("expected gate complete after auto-approve, state=%+v", nav.GetWorkflowState())
+	// Async: checkpoint stays open; durable "running" record for show/watch.
+	state := nav.GetWorkflowState()
+	if state.IsComplete() {
+		t.Fatal("async launch must not complete the gate before the verdict")
+	}
+	if state.CurrentStep != 1 {
+		t.Fatalf("current step = %d, want 1 (still waiting on judge)", state.CurrentStep)
+	}
+	judge := state.GetStepState(1).Judge
+	if judge == nil || judge.Status != wf.JudgeRunning {
+		t.Fatalf("judge state = %+v, want running", judge)
+	}
+	if judge.Pid != 4242 {
+		t.Fatalf("judge pid = %d, want 4242", judge.Pid)
+	}
+	if judge.Command != "fake-judge" {
+		t.Fatalf("judge command = %q, want fake-judge", judge.Command)
+	}
+	if launchedPayload == "" {
+		t.Fatal("expected launchJudgeProcess to be called with a payload path")
+	}
+	if _, err := os.Stat(launchedPayload); err != nil {
+		t.Fatalf("payload file missing: %v", err)
 	}
 }

--- a/internal/commands/workflow/auto_delegate_test.go
+++ b/internal/commands/workflow/auto_delegate_test.go
@@ -1,5 +1,8 @@
 package workflow
 
+// Host unit tests mock launchJudgeProcess. Real fest next → detached judge
+// re-exec coverage lives in tests/integration/async_judge_test.go.
+
 import (
 	"context"
 	"os"

--- a/internal/commands/workflow/auto_delegate_test.go
+++ b/internal/commands/workflow/auto_delegate_test.go
@@ -1,15 +1,11 @@
 package workflow
 
-// Host unit tests mock launchJudgeProcess. Real fest next → detached judge
-// re-exec coverage lives in tests/integration/async_judge_test.go.
-
 import (
 	"context"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/Obedience-Corp/fest/internal/config"
 	"github.com/Obedience-Corp/fest/internal/guidance"
 	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
 	"github.com/Obedience-Corp/fest/internal/progress"
@@ -77,77 +73,5 @@ func TestAutoDelegateBlockingCheckpoints_NoJudgeIsNoop(t *testing.T) {
 	// Still on step 1 awaiting human.
 	if nav.GetWorkflowState().CurrentStep != 1 {
 		t.Fatalf("current step = %d, want 1", nav.GetWorkflowState().CurrentStep)
-	}
-}
-
-func TestAutoDelegateBlockingCheckpoints_LaunchesJudgeWhenConfigured(t *testing.T) {
-	festivalPath, phasePath, festivalsRoot := writeGateFestival(t)
-	cfg := config.DefaultWorkspaceConfig()
-	cfg.Hooks.ApprovalJudge.Command = "fake-judge"
-	if err := config.SaveWorkspaceConfig(festivalsRoot, cfg); err != nil {
-		t.Fatal(err)
-	}
-
-	// fest next auto-delegate is fire-and-forget: mock launch, never spawn.
-	var launchedPayload string
-	withMockedJudgeLaunch(t, func(payloadPath, phaseDir, logPath string) (int, error) {
-		launchedPayload = payloadPath
-		if phaseDir != phasePath {
-			t.Fatalf("phaseDir = %q, want %q", phaseDir, phasePath)
-		}
-		if logPath == "" {
-			t.Fatal("expected judge log path")
-		}
-		return 4242, nil
-	})
-
-	gctx := &guidance.GuidanceContext{
-		FestivalPath: festivalPath,
-		PhasePath:    phasePath,
-		PhaseName:    "001_IMPLEMENT",
-		Mode:         guidance.ModeWorkflow,
-	}
-	nav, err := wf.NewNavigator(gctx, guidance.ModeWorkflow)
-	if err != nil {
-		t.Fatal(err)
-	}
-	nav.SetDocFilename("GATES.md")
-	nav.SetStateKeyPrefix("gate:")
-	store := progress.NewStore(festivalPath)
-	if err := store.Load(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-	nav.SetStateStore(store)
-	if err := nav.Initialize(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-
-	// No workspace in context — same as fest next scope.Global.
-	if err := AutoDelegateBlockingCheckpoints(context.Background(), nav); err != nil {
-		t.Fatalf("AutoDelegateBlockingCheckpoints: %v", err)
-	}
-	// Async: checkpoint stays open; durable "running" record for show/watch.
-	state := nav.GetWorkflowState()
-	if state.IsComplete() {
-		t.Fatal("async launch must not complete the gate before the verdict")
-	}
-	if state.CurrentStep != 1 {
-		t.Fatalf("current step = %d, want 1 (still waiting on judge)", state.CurrentStep)
-	}
-	judge := state.GetStepState(1).Judge
-	if judge == nil || judge.Status != wf.JudgeRunning {
-		t.Fatalf("judge state = %+v, want running", judge)
-	}
-	if judge.Pid != 4242 {
-		t.Fatalf("judge pid = %d, want 4242", judge.Pid)
-	}
-	if judge.Command != "fake-judge" {
-		t.Fatalf("judge command = %q, want fake-judge", judge.Command)
-	}
-	if launchedPayload == "" {
-		t.Fatal("expected launchJudgeProcess to be called with a payload path")
-	}
-	if _, err := os.Stat(launchedPayload); err != nil {
-		t.Fatalf("payload file missing: %v", err)
 	}
 }

--- a/internal/commands/workflow/judge_exec.go
+++ b/internal/commands/workflow/judge_exec.go
@@ -1,0 +1,227 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+	"github.com/Obedience-Corp/fest/internal/scope"
+	"github.com/Obedience-Corp/fest/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+const judgeExecPayloadSchema = "fest.approval.judge-exec/v1"
+
+// judgeExecPayload is the handoff from 'fest workflow approve --auto' to the
+// detached judge-exec runner. The runner rebuilds the judge request from live
+// workflow state; the payload only pins which checkpoint was delegated and
+// how to run the judge.
+type judgeExecPayload struct {
+	SchemaVersion string `json:"schema_version"`
+	StepNumber    int    `json:"step_number"`
+	StepName      string `json:"step_name"`
+	JudgeCommand  string `json:"judge_command"`
+	Timeout       string `json:"timeout,omitempty"`
+}
+
+// launchJudgeProcess is a seam for tests; production detaches a judge-exec
+// child so approve --auto returns immediately instead of blocking on a
+// potentially long-running judge evaluation.
+var launchJudgeProcess = launchJudgeProcessDefault
+
+// launchApproveAuto starts the judge in the background and returns. The
+// checkpoint stays blocked until the detached runner applies the verdict
+// through the same fail-closed path as --wait; watchers render the
+// waiting-on-judge state in the meantime.
+func launchApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum int, step wf.WorkflowStep, opts approvalJudgeOptions) error {
+	payload := judgeExecPayload{
+		SchemaVersion: judgeExecPayloadSchema,
+		StepNumber:    currentStepNum,
+		StepName:      step.Name,
+		JudgeCommand:  opts.JudgeCommand,
+	}
+	if opts.Timeout > 0 {
+		payload.Timeout = opts.Timeout.String()
+	}
+
+	festDir := filepath.Join(nav.Ctx.PhasePath, ".fest")
+	if err := os.MkdirAll(festDir, 0o755); err != nil {
+		return festerrors.IO("creating .fest directory for judge handoff", err).WithField("path", festDir)
+	}
+	payloadPath := filepath.Join(festDir, fmt.Sprintf("judge-step-%d.json", currentStepNum))
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return festerrors.Wrap(err, "encoding judge-exec payload")
+	}
+	if err := os.WriteFile(payloadPath, data, 0o600); err != nil {
+		return festerrors.IO("writing judge-exec payload", err).WithField("path", payloadPath)
+	}
+
+	pid, err := launchJudgeProcess(payloadPath, nav.Ctx.PhasePath, filepath.Join(festDir, "judge.log"))
+	if err != nil {
+		return festerrors.Wrap(err, "launching approval judge").
+			WithHint("the checkpoint was not approved; fix the judge command or run 'fest workflow approve' manually")
+	}
+
+	if err := nav.BeginJudge(ctx, currentStepNum, opts.JudgeCommand, pid); err != nil {
+		return festerrors.Wrap(err, "recording judge start")
+	}
+
+	fmt.Printf("%s Judge launched: %s (pid %d)\n", ui.Value("⚖", ui.JudgeColor), opts.JudgeCommand, pid)
+	fmt.Println("  The checkpoint stays blocked until the verdict lands.")
+	fmt.Printf("  Watch progress: %s\n", ui.Accent("fest show"))
+	fmt.Printf("  After it returns, run %s — approved continues the workflow;\n", ui.Accent("fest next"))
+	fmt.Printf("  rejected records feedback to address, then %s to resubmit.\n", ui.Accent("fest workflow advance"))
+	return nil
+}
+
+func launchJudgeProcessDefault(payloadPath, phaseDir, logPath string) (int, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return 0, festerrors.Wrap(err, "resolving fest binary for judge runner")
+	}
+	// Hard safety: go test package binaries are named "<pkg>.test". Re-execing
+	// them with "workflow judge-exec ..." does NOT run the hidden command —
+	// it re-enters the test harness, re-runs every Test*, and each auto-approve
+	// test detaches another child → process storm / machine freeze.
+	// Tests must mock launchJudgeProcess; production always uses the fest binary.
+	if looksLikeGoTestBinary(exe) {
+		return 0, festerrors.Validation("refusing to detach judge-exec from a go test binary").
+			WithField("executable", exe).
+			WithHint("tests must mock launchJudgeProcess; never call the default launcher under go test")
+	}
+
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return 0, festerrors.IO("opening judge log", err).WithField("path", logPath)
+	}
+	defer func() { _ = logFile.Close() }()
+
+	cmd := exec.Command(exe, "workflow", "judge-exec", "--payload", payloadPath)
+	cmd.Dir = phaseDir
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	// New session so the runner outlives the parent fest process (fire-and-forget).
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		return 0, festerrors.Wrap(err, "starting judge runner")
+	}
+	pid := cmd.Process.Pid
+	// Detach: do not Wait; the parent returns after logging BeginJudge.
+	_ = cmd.Process.Release()
+	return pid, nil
+}
+
+// looksLikeGoTestBinary reports whether exe is a `go test` package binary.
+// Those binaries re-run the test suite when invoked with extra argv, so they
+// must never be used as the judge-exec re-exec target.
+func looksLikeGoTestBinary(exe string) bool {
+	base := filepath.Base(exe)
+	return strings.HasSuffix(base, ".test") || strings.HasSuffix(base, ".test.exe")
+}
+
+// judgeProcessAlive reports whether the recorded judge runner pid is still
+// running, so a stale running record from a crashed runner does not block
+// relaunching the judge forever.
+func judgeProcessAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}
+
+func newJudgeExecCmd() *cobra.Command {
+	var payloadPath string
+	cmd := &cobra.Command{
+		Use:    "judge-exec",
+		Short:  "Internal: run a delegated approval judge and apply its verdict",
+		Hidden: true,
+		Annotations: map[string]string{
+			"scope": string(scope.Festival),
+		},
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runJudgeExec(cmd.Context(), payloadPath)
+		},
+	}
+	cmd.Flags().StringVar(&payloadPath, "payload", "", "path to the payload written by 'fest workflow approve --auto'")
+	_ = cmd.MarkFlagRequired("payload")
+	return cmd
+}
+
+func runJudgeExec(ctx context.Context, payloadPath string) error {
+	raw, err := os.ReadFile(payloadPath)
+	if err != nil {
+		return festerrors.IO("reading judge-exec payload", err).WithField("path", payloadPath)
+	}
+	var payload judgeExecPayload
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return festerrors.Parse("parsing judge-exec payload", err)
+	}
+	if payload.SchemaVersion != judgeExecPayloadSchema {
+		return festerrors.Validation("unsupported judge-exec payload schema").
+			WithField("schema_version", payload.SchemaVersion)
+	}
+
+	opts := approvalJudgeOptions{Auto: true, Wait: true, JudgeCommand: payload.JudgeCommand}
+	if payload.Timeout != "" {
+		timeout, err := time.ParseDuration(payload.Timeout)
+		if err != nil {
+			return festerrors.Validation("invalid judge-exec timeout").WithField("timeout", payload.Timeout)
+		}
+		opts.Timeout = timeout
+	}
+
+	defer func() { _ = os.Remove(payloadPath) }()
+
+	nav, err := getWorkflowNavigator(ctx)
+	if err != nil {
+		return err
+	}
+	state := nav.GetWorkflowState()
+	if state.CurrentStep != payload.StepNumber {
+		return nav.RecordJudgeOutcome(ctx, payload.StepNumber, wf.JudgeFailed,
+			fmt.Sprintf("checkpoint moved before the judge ran (workflow now on step %d); verdict not applied", state.CurrentStep))
+	}
+	steps := nav.GetSteps()
+	if payload.StepNumber < 1 || payload.StepNumber > len(steps) {
+		return festerrors.Validation("judge-exec payload step out of range").
+			WithField("step", fmt.Sprintf("%d", payload.StepNumber))
+	}
+	step := steps[payload.StepNumber-1]
+
+	decision, audit, err := judgeApproval(ctx, nav, step, opts)
+	if err != nil {
+		if recErr := nav.RecordJudgeOutcome(ctx, payload.StepNumber, wf.JudgeFailed, err.Error()); recErr != nil {
+			fmt.Printf("%s failed to record judge outcome: %v\n", ui.Warning("⚠"), recErr)
+		}
+		return err
+	}
+
+	// The judge may have run for a long time; re-read durable state and only
+	// apply the verdict if the delegated checkpoint is still the current one
+	// (an operator may have approved or reset it manually in the meantime).
+	fresh, err := getWorkflowNavigator(ctx)
+	if err != nil {
+		return err
+	}
+	if fresh.GetWorkflowState().CurrentStep != payload.StepNumber {
+		return fresh.RecordJudgeOutcome(ctx, payload.StepNumber, wf.JudgeFailed,
+			fmt.Sprintf("checkpoint changed while the judge was running (workflow now on step %d); verdict %q discarded",
+				fresh.GetWorkflowState().CurrentStep, decision.Decision))
+	}
+
+	return applyApproveAutoVerdict(ctx, fresh, payload.StepNumber, step, decision, audit)
+}

--- a/internal/commands/workflow/judge_exec.go
+++ b/internal/commands/workflow/judge_exec.go
@@ -45,7 +45,7 @@ type judgeExecPayload struct {
 // waiting-on-judge state in the meantime.
 func launchApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum int, step wf.WorkflowStep, opts approvalJudgeOptions) error {
 	return withJudgeStepLock(ctx, nav.Ctx.PhasePath, currentStepNum, func() error {
-		fresh, err := getWorkflowNavigator(ctx)
+		fresh, err := reloadWorkflowNavigator(ctx, nav)
 		if err != nil {
 			return err
 		}
@@ -297,7 +297,7 @@ func runJudgeExec(ctx context.Context, payloadPath string) error {
 	if payload.StepNumber < 1 || payload.StepNumber > len(steps) {
 		err := festerrors.Validation("judge-exec payload step out of range").
 			WithField("step", fmt.Sprintf("%d", payload.StepNumber))
-		if recErr := recordJudgeFailureIfOwned(ctx, nav.Ctx.PhasePath, payload, err.Error()); recErr != nil {
+		if recErr := recordJudgeFailureIfOwned(ctx, nav, payload, err.Error()); recErr != nil {
 			fmt.Printf("%s failed to record judge outcome: %v\n", ui.Warning("⚠"), recErr)
 		}
 		return err
@@ -306,14 +306,14 @@ func runJudgeExec(ctx context.Context, payloadPath string) error {
 
 	decision, audit, err := judgeApproval(ctx, nav, step, opts)
 	if err != nil {
-		if recErr := recordJudgeFailureIfOwned(ctx, nav.Ctx.PhasePath, payload, err.Error()); recErr != nil {
+		if recErr := recordJudgeFailureIfOwned(ctx, nav, payload, err.Error()); recErr != nil {
 			fmt.Printf("%s failed to record judge outcome: %v\n", ui.Warning("⚠"), recErr)
 		}
 		return err
 	}
 
 	return withJudgeStepLock(ctx, nav.Ctx.PhasePath, payload.StepNumber, func() error {
-		fresh, err := getWorkflowNavigator(ctx)
+		fresh, err := reloadWorkflowNavigator(ctx, nav)
 		if err != nil {
 			return err
 		}
@@ -331,11 +331,11 @@ func runJudgeExec(ctx context.Context, payloadPath string) error {
 
 func waitForJudgeClaim(ctx context.Context, payload judgeExecPayload) (*wf.Navigator, bool, error) {
 	deadline := time.Now().Add(judgeClaimTimeout)
+	nav, err := getWorkflowNavigator(ctx)
+	if err != nil {
+		return nil, false, err
+	}
 	for {
-		nav, err := getWorkflowNavigator(ctx)
-		if err != nil {
-			return nil, false, err
-		}
 		state := nav.GetWorkflowState()
 		ss := state.GetStepState(payload.StepNumber)
 		if state.CurrentStep != payload.StepNumber || ss == nil || ss.Judge == nil ||
@@ -347,7 +347,7 @@ func waitForJudgeClaim(ctx context.Context, payload judgeExecPayload) (*wf.Navig
 		}
 		if ss.Judge.Pid != 0 || time.Now().After(deadline) {
 			detail := "judge runner never received its durable PID claim"
-			if err := recordUnclaimedJudgeFailure(ctx, nav.Ctx.PhasePath, payload, detail); err != nil {
+			if err := recordUnclaimedJudgeFailure(ctx, nav, payload, detail); err != nil {
 				return nil, false, err
 			}
 			return nav, false, nil
@@ -357,12 +357,16 @@ func waitForJudgeClaim(ctx context.Context, payload judgeExecPayload) (*wf.Navig
 			return nil, false, ctx.Err()
 		case <-time.After(judgeLockPoll):
 		}
+		nav, err = reloadWorkflowNavigator(ctx, nav)
+		if err != nil {
+			return nil, false, err
+		}
 	}
 }
 
-func recordUnclaimedJudgeFailure(ctx context.Context, phasePath string, payload judgeExecPayload, detail string) error {
-	return withJudgeStepLock(ctx, phasePath, payload.StepNumber, func() error {
-		fresh, err := getWorkflowNavigator(ctx)
+func recordUnclaimedJudgeFailure(ctx context.Context, nav *wf.Navigator, payload judgeExecPayload, detail string) error {
+	return withJudgeStepLock(ctx, nav.Ctx.PhasePath, payload.StepNumber, func() error {
+		fresh, err := reloadWorkflowNavigator(ctx, nav)
 		if err != nil {
 			return err
 		}
@@ -375,9 +379,9 @@ func recordUnclaimedJudgeFailure(ctx context.Context, phasePath string, payload 
 	})
 }
 
-func recordJudgeFailureIfOwned(ctx context.Context, phasePath string, payload judgeExecPayload, detail string) error {
-	return withJudgeStepLock(ctx, phasePath, payload.StepNumber, func() error {
-		fresh, err := getWorkflowNavigator(ctx)
+func recordJudgeFailureIfOwned(ctx context.Context, nav *wf.Navigator, payload judgeExecPayload, detail string) error {
+	return withJudgeStepLock(ctx, nav.Ctx.PhasePath, payload.StepNumber, func() error {
+		fresh, err := reloadWorkflowNavigator(ctx, nav)
 		if err != nil {
 			return err
 		}

--- a/internal/commands/workflow/judge_exec.go
+++ b/internal/commands/workflow/judge_exec.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"time"
 
 	festerrors "github.com/Obedience-Corp/fest/internal/errors"
@@ -182,27 +182,14 @@ func withJudgeStepLock(ctx context.Context, phasePath string, step int, fn func(
 		return festerrors.IO("creating judge lock directory", err).WithField("path", lockDir)
 	}
 	lockPath := filepath.Join(lockDir, fmt.Sprintf("judge-step-%d.lock", step))
-	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	release, err := acquireJudgeStepLock(ctx, lockPath)
 	if err != nil {
-		return festerrors.IO("opening judge step lock", err).WithField("path", lockPath)
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return festerrors.Wrap(err, "waiting for judge step lock").WithField("path", lockPath)
+		}
+		return festerrors.IO("acquiring judge step lock", err).WithField("path", lockPath)
 	}
-	defer func() { _ = lockFile.Close() }()
-
-	for {
-		err = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
-		if err == nil {
-			break
-		}
-		if err != syscall.EWOULDBLOCK && err != syscall.EAGAIN {
-			return festerrors.IO("acquiring judge step lock", err).WithField("path", lockPath)
-		}
-		select {
-		case <-ctx.Done():
-			return festerrors.Wrap(ctx.Err(), "waiting for judge step lock")
-		case <-time.After(judgeLockPoll):
-		}
-	}
-	defer func() { _ = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN) }()
+	defer release()
 	return fn()
 }
 
@@ -215,11 +202,12 @@ func launchJudgeProcessDefault(payloadPath, phaseDir, logPath string) (int, erro
 	// them with "workflow judge-exec ..." does NOT run the hidden command —
 	// it re-enters the test harness, re-runs every Test*, and each auto-approve
 	// test detaches another child → process storm / machine freeze.
-	// Tests must mock launchJudgeProcess; production always uses the fest binary.
+	// Host tests exercise this refusal only; real launches run in the container
+	// integration harness. Production always uses the fest binary.
 	if looksLikeGoTestBinary(exe) {
 		return 0, festerrors.Validation("refusing to detach judge-exec from a go test binary").
 			WithField("executable", exe).
-			WithHint("tests must mock launchJudgeProcess; never call the default launcher under go test")
+			WithHint("real judge launches must run in the container integration harness, never under go test")
 	}
 
 	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
@@ -232,8 +220,7 @@ func launchJudgeProcessDefault(payloadPath, phaseDir, logPath string) (int, erro
 	cmd.Dir = phaseDir
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
-	// New session so the runner outlives the parent fest process (fire-and-forget).
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	configureDetachedJudgeProcess(cmd)
 	if err := cmd.Start(); err != nil {
 		return 0, festerrors.Wrap(err, "starting judge runner")
 	}
@@ -249,20 +236,6 @@ func launchJudgeProcessDefault(payloadPath, phaseDir, logPath string) (int, erro
 func looksLikeGoTestBinary(exe string) bool {
 	base := filepath.Base(exe)
 	return strings.HasSuffix(base, ".test") || strings.HasSuffix(base, ".test.exe")
-}
-
-// judgeProcessAlive reports whether the recorded judge runner pid is still
-// running, so a stale running record from a crashed runner does not block
-// relaunching the judge forever.
-func judgeProcessAlive(pid int) bool {
-	if pid <= 0 {
-		return false
-	}
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		return false
-	}
-	return proc.Signal(syscall.Signal(0)) == nil
 }
 
 func newJudgeExecCmd() *cobra.Command {

--- a/internal/commands/workflow/judge_exec.go
+++ b/internal/commands/workflow/judge_exec.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -20,6 +21,11 @@ import (
 
 const judgeExecPayloadSchema = "fest.approval.judge-exec/v1"
 
+const (
+	judgeClaimTimeout = 5 * time.Second
+	judgeLockPoll     = 25 * time.Millisecond
+)
+
 // judgeExecPayload is the handoff from 'fest workflow approve --auto' to the
 // detached judge-exec runner. The runner rebuilds the judge request from live
 // workflow state; the payload only pins which checkpoint was delegated and
@@ -30,23 +36,51 @@ type judgeExecPayload struct {
 	StepName      string `json:"step_name"`
 	JudgeCommand  string `json:"judge_command"`
 	Timeout       string `json:"timeout,omitempty"`
+	RunID         string `json:"run_id"`
 }
-
-// launchJudgeProcess is a seam for tests; production detaches a judge-exec
-// child so approve --auto returns immediately instead of blocking on a
-// potentially long-running judge evaluation.
-var launchJudgeProcess = launchJudgeProcessDefault
 
 // launchApproveAuto starts the judge in the background and returns. The
 // checkpoint stays blocked until the detached runner applies the verdict
 // through the same fail-closed path as --wait; watchers render the
 // waiting-on-judge state in the meantime.
 func launchApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum int, step wf.WorkflowStep, opts approvalJudgeOptions) error {
+	return withJudgeStepLock(ctx, nav.Ctx.PhasePath, currentStepNum, func() error {
+		fresh, err := getWorkflowNavigator(ctx)
+		if err != nil {
+			return err
+		}
+		state := fresh.GetWorkflowState()
+		if state.CurrentStep != currentStepNum {
+			return festerrors.Validation("checkpoint changed before approval judge launch").
+				WithField("expected_step", currentStepNum).
+				WithField("current_step", state.CurrentStep)
+		}
+		if ss := state.GetStepState(currentStepNum); ss != nil && ss.Judge != nil &&
+			ss.Judge.Status == wf.JudgeRunning {
+			if judgeLeaseActive(ss.Judge) {
+				return judgeAlreadyRunningError(ss.Judge)
+			}
+			if _, err := fresh.RecordJudgeOutcome(ctx, currentStepNum, ss.Judge.RunID, wf.JudgeFailed,
+				"detached judge process exited before recording a verdict"); err != nil {
+				return festerrors.Wrap(err, "recording stale judge failure")
+			}
+		}
+
+		runID, err := newJudgeRunID()
+		if err != nil {
+			return err
+		}
+		return launchApproveAutoLocked(ctx, fresh, currentStepNum, step, opts, runID)
+	})
+}
+
+func launchApproveAutoLocked(ctx context.Context, nav *wf.Navigator, currentStepNum int, step wf.WorkflowStep, opts approvalJudgeOptions, runID string) error {
 	payload := judgeExecPayload{
 		SchemaVersion: judgeExecPayloadSchema,
 		StepNumber:    currentStepNum,
 		StepName:      step.Name,
 		JudgeCommand:  opts.JudgeCommand,
+		RunID:         runID,
 	}
 	if opts.Timeout > 0 {
 		payload.Timeout = opts.Timeout.String()
@@ -56,7 +90,7 @@ func launchApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum in
 	if err := os.MkdirAll(festDir, 0o755); err != nil {
 		return festerrors.IO("creating .fest directory for judge handoff", err).WithField("path", festDir)
 	}
-	payloadPath := filepath.Join(festDir, fmt.Sprintf("judge-step-%d.json", currentStepNum))
+	payloadPath := filepath.Join(festDir, fmt.Sprintf("judge-step-%d-%s.json", currentStepNum, runID))
 	data, err := json.Marshal(payload)
 	if err != nil {
 		return festerrors.Wrap(err, "encoding judge-exec payload")
@@ -65,14 +99,36 @@ func launchApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum in
 		return festerrors.IO("writing judge-exec payload", err).WithField("path", payloadPath)
 	}
 
-	pid, err := launchJudgeProcess(payloadPath, nav.Ctx.PhasePath, filepath.Join(festDir, "judge.log"))
+	// Persist the run lease before starting a child. The child will not evaluate
+	// until the parent durably claims this lease with its PID.
+	if err := nav.BeginJudge(ctx, currentStepNum, opts.JudgeCommand, runID, 0); err != nil {
+		_ = os.Remove(payloadPath)
+		return festerrors.Wrap(err, "recording judge lease")
+	}
+
+	pid, err := launchJudgeProcessDefault(payloadPath, nav.Ctx.PhasePath, filepath.Join(festDir, "judge.log"))
 	if err != nil {
+		_, recErr := nav.RecordJudgeOutcome(ctx, currentStepNum, runID, wf.JudgeFailed, err.Error())
+		_ = os.Remove(payloadPath)
+		if recErr != nil {
+			return festerrors.Wrap(recErr, "recording judge launch failure")
+		}
 		return festerrors.Wrap(err, "launching approval judge").
 			WithHint("the checkpoint was not approved; fix the judge command or run 'fest workflow approve' manually")
 	}
 
-	if err := nav.BeginJudge(ctx, currentStepNum, opts.JudgeCommand, pid); err != nil {
-		return festerrors.Wrap(err, "recording judge start")
+	claimed, err := nav.ClaimJudge(ctx, currentStepNum, runID, pid)
+	if err != nil || !claimed {
+		_ = terminateJudgeProcess(pid)
+		detail := "judge process was terminated because its durable PID claim failed"
+		_, recErr := nav.RecordJudgeOutcome(ctx, currentStepNum, runID, wf.JudgeFailed, detail)
+		if err != nil {
+			return festerrors.Wrap(err, "claiming judge process")
+		}
+		if recErr != nil {
+			return festerrors.Wrap(recErr, "recording judge claim failure")
+		}
+		return festerrors.Validation("approval judge lease was superseded before launch completed")
 	}
 
 	fmt.Printf("%s Judge launched: %s (pid %d)\n", ui.Value("⚖", ui.JudgeColor), opts.JudgeCommand, pid)
@@ -81,6 +137,73 @@ func launchApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum in
 	fmt.Printf("  After it returns, run %s — approved continues the workflow;\n", ui.Accent("fest next"))
 	fmt.Printf("  rejected records feedback to address, then %s to resubmit.\n", ui.Accent("fest workflow advance"))
 	return nil
+}
+
+func newJudgeRunID() (string, error) {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", festerrors.Wrap(err, "generating approval judge run id")
+	}
+	return fmt.Sprintf("%x", raw[:]), nil
+}
+
+func judgeAlreadyRunningError(judge *wf.JudgeState) error {
+	return festerrors.Validation("an approval judge is already evaluating this checkpoint").
+		WithField("judge_command", judge.Command).
+		WithField("pid", fmt.Sprintf("%d", judge.Pid)).
+		WithField("run_id", judge.RunID).
+		WithHint("the checkpoint unblocks when the judge returns; watch it with 'fest show' and re-run 'fest next' afterwards")
+}
+
+func judgeLeaseActive(judge *wf.JudgeState) bool {
+	if judge == nil || judge.Status != wf.JudgeRunning {
+		return false
+	}
+	if judge.Pid > 0 {
+		return judgeProcessAlive(judge.Pid)
+	}
+	return judge.StartedAt != nil && time.Since(*judge.StartedAt) < 2*judgeClaimTimeout
+}
+
+func terminateJudgeProcess(pid int) error {
+	if pid <= 0 {
+		return nil
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return proc.Kill()
+}
+
+func withJudgeStepLock(ctx context.Context, phasePath string, step int, fn func() error) error {
+	lockDir := filepath.Join(phasePath, ".fest")
+	if err := os.MkdirAll(lockDir, 0o755); err != nil {
+		return festerrors.IO("creating judge lock directory", err).WithField("path", lockDir)
+	}
+	lockPath := filepath.Join(lockDir, fmt.Sprintf("judge-step-%d.lock", step))
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return festerrors.IO("opening judge step lock", err).WithField("path", lockPath)
+	}
+	defer func() { _ = lockFile.Close() }()
+
+	for {
+		err = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			break
+		}
+		if err != syscall.EWOULDBLOCK && err != syscall.EAGAIN {
+			return festerrors.IO("acquiring judge step lock", err).WithField("path", lockPath)
+		}
+		select {
+		case <-ctx.Done():
+			return festerrors.Wrap(ctx.Err(), "waiting for judge step lock")
+		case <-time.After(judgeLockPoll):
+		}
+	}
+	defer func() { _ = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN) }()
+	return fn()
 }
 
 func launchJudgeProcessDefault(payloadPath, phaseDir, logPath string) (int, error) {
@@ -174,6 +297,10 @@ func runJudgeExec(ctx context.Context, payloadPath string) error {
 		return festerrors.Validation("unsupported judge-exec payload schema").
 			WithField("schema_version", payload.SchemaVersion)
 	}
+	if payload.RunID == "" {
+		return festerrors.Validation("judge-exec payload is missing run ownership").
+			WithField("payload", payloadPath)
+	}
 
 	opts := approvalJudgeOptions{Auto: true, Wait: true, JudgeCommand: payload.JudgeCommand}
 	if payload.Timeout != "" {
@@ -186,42 +313,102 @@ func runJudgeExec(ctx context.Context, payloadPath string) error {
 
 	defer func() { _ = os.Remove(payloadPath) }()
 
-	nav, err := getWorkflowNavigator(ctx)
+	nav, owned, err := waitForJudgeClaim(ctx, payload)
 	if err != nil {
 		return err
 	}
-	state := nav.GetWorkflowState()
-	if state.CurrentStep != payload.StepNumber {
-		return nav.RecordJudgeOutcome(ctx, payload.StepNumber, wf.JudgeFailed,
-			fmt.Sprintf("checkpoint moved before the judge ran (workflow now on step %d); verdict not applied", state.CurrentStep))
+	if !owned {
+		return nil
 	}
 	steps := nav.GetSteps()
 	if payload.StepNumber < 1 || payload.StepNumber > len(steps) {
-		return festerrors.Validation("judge-exec payload step out of range").
+		err := festerrors.Validation("judge-exec payload step out of range").
 			WithField("step", fmt.Sprintf("%d", payload.StepNumber))
+		if recErr := recordJudgeFailureIfOwned(ctx, nav.Ctx.PhasePath, payload, err.Error()); recErr != nil {
+			fmt.Printf("%s failed to record judge outcome: %v\n", ui.Warning("⚠"), recErr)
+		}
+		return err
 	}
 	step := steps[payload.StepNumber-1]
 
 	decision, audit, err := judgeApproval(ctx, nav, step, opts)
 	if err != nil {
-		if recErr := nav.RecordJudgeOutcome(ctx, payload.StepNumber, wf.JudgeFailed, err.Error()); recErr != nil {
+		if recErr := recordJudgeFailureIfOwned(ctx, nav.Ctx.PhasePath, payload, err.Error()); recErr != nil {
 			fmt.Printf("%s failed to record judge outcome: %v\n", ui.Warning("⚠"), recErr)
 		}
 		return err
 	}
 
-	// The judge may have run for a long time; re-read durable state and only
-	// apply the verdict if the delegated checkpoint is still the current one
-	// (an operator may have approved or reset it manually in the meantime).
-	fresh, err := getWorkflowNavigator(ctx)
-	if err != nil {
-		return err
-	}
-	if fresh.GetWorkflowState().CurrentStep != payload.StepNumber {
-		return fresh.RecordJudgeOutcome(ctx, payload.StepNumber, wf.JudgeFailed,
-			fmt.Sprintf("checkpoint changed while the judge was running (workflow now on step %d); verdict %q discarded",
-				fresh.GetWorkflowState().CurrentStep, decision.Decision))
-	}
+	return withJudgeStepLock(ctx, nav.Ctx.PhasePath, payload.StepNumber, func() error {
+		fresh, err := getWorkflowNavigator(ctx)
+		if err != nil {
+			return err
+		}
+		applied, err := applyApproveAutoVerdict(ctx, fresh, payload.StepNumber, step, payload.RunID, decision, audit)
+		if err != nil {
+			return err
+		}
+		if !applied {
+			fmt.Printf("%s judge run %s was superseded; verdict %q discarded\n",
+				ui.Warning("⚠"), payload.RunID, decision.Decision)
+		}
+		return nil
+	})
+}
 
-	return applyApproveAutoVerdict(ctx, fresh, payload.StepNumber, step, decision, audit)
+func waitForJudgeClaim(ctx context.Context, payload judgeExecPayload) (*wf.Navigator, bool, error) {
+	deadline := time.Now().Add(judgeClaimTimeout)
+	for {
+		nav, err := getWorkflowNavigator(ctx)
+		if err != nil {
+			return nil, false, err
+		}
+		state := nav.GetWorkflowState()
+		ss := state.GetStepState(payload.StepNumber)
+		if state.CurrentStep != payload.StepNumber || ss == nil || ss.Judge == nil ||
+			ss.Judge.Status != wf.JudgeRunning || ss.Judge.RunID != payload.RunID {
+			return nav, false, nil
+		}
+		if ss.Judge.Pid == os.Getpid() {
+			return nav, true, nil
+		}
+		if ss.Judge.Pid != 0 || time.Now().After(deadline) {
+			detail := "judge runner never received its durable PID claim"
+			if err := recordUnclaimedJudgeFailure(ctx, nav.Ctx.PhasePath, payload, detail); err != nil {
+				return nil, false, err
+			}
+			return nav, false, nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil, false, ctx.Err()
+		case <-time.After(judgeLockPoll):
+		}
+	}
+}
+
+func recordUnclaimedJudgeFailure(ctx context.Context, phasePath string, payload judgeExecPayload, detail string) error {
+	return withJudgeStepLock(ctx, phasePath, payload.StepNumber, func() error {
+		fresh, err := getWorkflowNavigator(ctx)
+		if err != nil {
+			return err
+		}
+		ss := fresh.GetWorkflowState().GetStepState(payload.StepNumber)
+		if ss == nil || ss.Judge == nil || ss.Judge.RunID != payload.RunID || ss.Judge.Pid != 0 {
+			return nil
+		}
+		_, err = fresh.RecordJudgeOutcome(ctx, payload.StepNumber, payload.RunID, wf.JudgeFailed, detail)
+		return err
+	})
+}
+
+func recordJudgeFailureIfOwned(ctx context.Context, phasePath string, payload judgeExecPayload, detail string) error {
+	return withJudgeStepLock(ctx, phasePath, payload.StepNumber, func() error {
+		fresh, err := getWorkflowNavigator(ctx)
+		if err != nil {
+			return err
+		}
+		_, err = fresh.RecordJudgeOutcome(ctx, payload.StepNumber, payload.RunID, wf.JudgeFailed, detail)
+		return err
+	})
 }

--- a/internal/commands/workflow/judge_exec_test.go
+++ b/internal/commands/workflow/judge_exec_test.go
@@ -1,0 +1,160 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+)
+
+// withMockedJudgeLaunch installs a fake launchJudgeProcess for the duration of
+// the test. Production code must never detach under go test — this is the
+// only safe way to exercise the async --auto path in unit tests.
+func withMockedJudgeLaunch(t *testing.T, fn func(payloadPath, phaseDir, logPath string) (int, error)) {
+	t.Helper()
+	orig := launchJudgeProcess
+	launchJudgeProcess = fn
+	t.Cleanup(func() { launchJudgeProcess = orig })
+}
+
+func TestLooksLikeGoTestBinary(t *testing.T) {
+	cases := []struct {
+		exe  string
+		want bool
+	}{
+		{"/tmp/go-build123/b001/workflow.test", true},
+		{`C:\Users\x\go-build\workflow.test.exe`, true},
+		{"/usr/local/bin/fest", false},
+		{"/Users/me/bin/fest", false},
+		{"workflow.test.backup", false},
+	}
+	for _, tc := range cases {
+		if got := looksLikeGoTestBinary(tc.exe); got != tc.want {
+			t.Fatalf("looksLikeGoTestBinary(%q) = %v, want %v", tc.exe, got, tc.want)
+		}
+	}
+}
+
+func TestLaunchJudgeProcessDefault_RefusesGoTestBinary(t *testing.T) {
+	// The process under test IS a go test binary, so the default launcher must
+	// refuse rather than re-exec and fork-bomb the machine.
+	_, err := launchJudgeProcessDefault("/tmp/payload.json", t.TempDir(), filepath.Join(t.TempDir(), "judge.log"))
+	if err == nil {
+		t.Fatal("expected refusal when executable is a go test binary")
+	}
+	if !strings.Contains(err.Error(), "go test binary") {
+		t.Fatalf("error = %v, want go test binary refusal", err)
+	}
+}
+
+func TestRunApproveAuto_AsyncFireAndForget(t *testing.T) {
+	dir := setupWorkflowFestival(t)
+	phaseDir := filepath.Join(dir, "001_INGEST")
+	nav := getNavigator(t, phaseDir)
+	ctx := context.Background()
+
+	if err := nav.Advance(ctx); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	steps := nav.GetSteps()
+
+	var gotPayload, gotPhase, gotLog string
+	withMockedJudgeLaunch(t, func(payloadPath, phaseDirArg, logPath string) (int, error) {
+		gotPayload = payloadPath
+		gotPhase = phaseDirArg
+		gotLog = logPath
+		return 9991, nil
+	})
+
+	// Default async path: Wait=false (zero value).
+	out := captureStdout(t, func() {
+		if err := runApproveAuto(ctx, nav, 2, steps[1], approvalJudgeOptions{
+			JudgeCommand: "ob judge",
+			Timeout:      30 * time.Second,
+		}); err != nil {
+			t.Fatalf("runApproveAuto: %v", err)
+		}
+	})
+	if !strings.Contains(out, "Judge launched") {
+		t.Fatalf("output missing launch notice: %q", out)
+	}
+	if !strings.Contains(out, "pid 9991") {
+		t.Fatalf("output missing pid: %q", out)
+	}
+
+	// Checkpoint still open — fest does not wait for the verdict.
+	state := nav.GetWorkflowState()
+	if state.CurrentStep != 2 {
+		t.Fatalf("current step = %d, want 2", state.CurrentStep)
+	}
+	judge := state.GetStepState(2).Judge
+	if judge == nil || judge.Status != wf.JudgeRunning {
+		t.Fatalf("judge = %+v, want running", judge)
+	}
+	if judge.Pid != 9991 {
+		t.Fatalf("pid = %d, want 9991", judge.Pid)
+	}
+	if judge.FinishedAt != nil {
+		t.Fatalf("async launch must not set FinishedAt: %+v", judge)
+	}
+
+	if gotPhase != phaseDir {
+		t.Fatalf("phaseDir = %q, want %q", gotPhase, phaseDir)
+	}
+	if !strings.HasSuffix(gotLog, "judge.log") {
+		t.Fatalf("log path = %q, want .../judge.log", gotLog)
+	}
+
+	raw, err := os.ReadFile(gotPayload)
+	if err != nil {
+		t.Fatalf("read payload: %v", err)
+	}
+	var payload judgeExecPayload
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("parse payload: %v", err)
+	}
+	if payload.SchemaVersion != judgeExecPayloadSchema {
+		t.Fatalf("schema = %q", payload.SchemaVersion)
+	}
+	if payload.StepNumber != 2 || payload.JudgeCommand != "ob judge" {
+		t.Fatalf("payload = %+v", payload)
+	}
+	if payload.Timeout != (30 * time.Second).String() {
+		t.Fatalf("timeout = %q, want %s", payload.Timeout, 30*time.Second)
+	}
+}
+
+func TestRunApproveAuto_AsyncRefusesDuplicateWhileAlive(t *testing.T) {
+	dir := setupWorkflowFestival(t)
+	phaseDir := filepath.Join(dir, "001_INGEST")
+	nav := getNavigator(t, phaseDir)
+	ctx := context.Background()
+
+	if err := nav.Advance(ctx); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	steps := nav.GetSteps()
+
+	// Use this test process's own pid so judgeProcessAlive reports true.
+	self := os.Getpid()
+	withMockedJudgeLaunch(t, func(payloadPath, phaseDir, logPath string) (int, error) {
+		return self, nil
+	})
+
+	if err := runApproveAuto(ctx, nav, 2, steps[1], approvalJudgeOptions{JudgeCommand: "ob judge"}); err != nil {
+		t.Fatalf("first launch: %v", err)
+	}
+
+	err := runApproveAuto(ctx, nav, 2, steps[1], approvalJudgeOptions{JudgeCommand: "ob judge"})
+	if err == nil {
+		t.Fatal("expected duplicate-launch refusal while judge pid is alive")
+	}
+	if !strings.Contains(err.Error(), "already evaluating") {
+		t.Fatalf("error = %v, want already evaluating", err)
+	}
+}

--- a/internal/commands/workflow/judge_exec_test.go
+++ b/internal/commands/workflow/judge_exec_test.go
@@ -1,5 +1,17 @@
 package workflow
 
+// Host unit tests for the async judge path.
+//
+// RULE: never call launchJudgeProcessDefault in a way that can re-exec a real
+// fest binary or leave detached children on the host. The only allowed use of
+// the default launcher under go test is the refusal test
+// (TestLaunchJudgeProcessDefault_RefusesGoTestBinary), which asserts that
+// go-test binaries are rejected before Start.
+//
+// Real process launch, Setsid detach, judge-exec re-exec, waiting-on-judge
+// visibility while a child is alive, and orphan cleanup belong in
+// tests/integration/async_judge_test.go (container harness).
+
 import (
 	"context"
 	"encoding/json"
@@ -14,9 +26,12 @@ import (
 
 // withMockedJudgeLaunch installs a fake launchJudgeProcess for the duration of
 // the test. Production code must never detach under go test — this is the
-// only safe way to exercise the async --auto path in unit tests.
+// only safe way to exercise the async --auto path in unit tests on the host.
 func withMockedJudgeLaunch(t *testing.T, fn func(payloadPath, phaseDir, logPath string) (int, error)) {
 	t.Helper()
+	if fn == nil {
+		t.Fatal("withMockedJudgeLaunch requires a mock; real launches must use the container integration harness")
+	}
 	orig := launchJudgeProcess
 	launchJudgeProcess = fn
 	t.Cleanup(func() { launchJudgeProcess = orig })

--- a/internal/commands/workflow/judge_exec_test.go
+++ b/internal/commands/workflow/judge_exec_test.go
@@ -1,42 +1,12 @@
 package workflow
 
-// Host unit tests for the async judge path.
-//
-// RULE: never call launchJudgeProcessDefault in a way that can re-exec a real
-// fest binary or leave detached children on the host. The only allowed use of
-// the default launcher under go test is the refusal test
-// (TestLaunchJudgeProcessDefault_RefusesGoTestBinary), which asserts that
-// go-test binaries are rejected before Start.
-//
-// Real process launch, Setsid detach, judge-exec re-exec, waiting-on-judge
-// visibility while a child is alive, and orphan cleanup belong in
-// tests/integration/async_judge_test.go (container harness).
-
 import (
-	"context"
-	"encoding/json"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
-	"time"
-
-	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
 )
 
-// withMockedJudgeLaunch installs a fake launchJudgeProcess for the duration of
-// the test. Production code must never detach under go test — this is the
-// only safe way to exercise the async --auto path in unit tests on the host.
-func withMockedJudgeLaunch(t *testing.T, fn func(payloadPath, phaseDir, logPath string) (int, error)) {
-	t.Helper()
-	if fn == nil {
-		t.Fatal("withMockedJudgeLaunch requires a mock; real launches must use the container integration harness")
-	}
-	orig := launchJudgeProcess
-	launchJudgeProcess = fn
-	t.Cleanup(func() { launchJudgeProcess = orig })
-}
-
+// Keep host coverage pure. Real payload/state writes and process launch live
+// in tests/integration/async_judge_test.go's container boundary.
 func TestLooksLikeGoTestBinary(t *testing.T) {
 	cases := []struct {
 		exe  string
@@ -56,120 +26,13 @@ func TestLooksLikeGoTestBinary(t *testing.T) {
 }
 
 func TestLaunchJudgeProcessDefault_RefusesGoTestBinary(t *testing.T) {
-	// The process under test IS a go test binary, so the default launcher must
-	// refuse rather than re-exec and fork-bomb the machine.
-	_, err := launchJudgeProcessDefault("/tmp/payload.json", t.TempDir(), filepath.Join(t.TempDir(), "judge.log"))
+	// Static paths are intentional: the guard must return before performing
+	// any filesystem mutation.
+	_, err := launchJudgeProcessDefault("/nonexistent/payload.json", "/nonexistent", "/nonexistent/judge.log")
 	if err == nil {
 		t.Fatal("expected refusal when executable is a go test binary")
 	}
 	if !strings.Contains(err.Error(), "go test binary") {
 		t.Fatalf("error = %v, want go test binary refusal", err)
-	}
-}
-
-func TestRunApproveAuto_AsyncFireAndForget(t *testing.T) {
-	dir := setupWorkflowFestival(t)
-	phaseDir := filepath.Join(dir, "001_INGEST")
-	nav := getNavigator(t, phaseDir)
-	ctx := context.Background()
-
-	if err := nav.Advance(ctx); err != nil {
-		t.Fatalf("Advance: %v", err)
-	}
-	steps := nav.GetSteps()
-
-	var gotPayload, gotPhase, gotLog string
-	withMockedJudgeLaunch(t, func(payloadPath, phaseDirArg, logPath string) (int, error) {
-		gotPayload = payloadPath
-		gotPhase = phaseDirArg
-		gotLog = logPath
-		return 9991, nil
-	})
-
-	// Default async path: Wait=false (zero value).
-	out := captureStdout(t, func() {
-		if err := runApproveAuto(ctx, nav, 2, steps[1], approvalJudgeOptions{
-			JudgeCommand: "ob judge",
-			Timeout:      30 * time.Second,
-		}); err != nil {
-			t.Fatalf("runApproveAuto: %v", err)
-		}
-	})
-	if !strings.Contains(out, "Judge launched") {
-		t.Fatalf("output missing launch notice: %q", out)
-	}
-	if !strings.Contains(out, "pid 9991") {
-		t.Fatalf("output missing pid: %q", out)
-	}
-
-	// Checkpoint still open — fest does not wait for the verdict.
-	state := nav.GetWorkflowState()
-	if state.CurrentStep != 2 {
-		t.Fatalf("current step = %d, want 2", state.CurrentStep)
-	}
-	judge := state.GetStepState(2).Judge
-	if judge == nil || judge.Status != wf.JudgeRunning {
-		t.Fatalf("judge = %+v, want running", judge)
-	}
-	if judge.Pid != 9991 {
-		t.Fatalf("pid = %d, want 9991", judge.Pid)
-	}
-	if judge.FinishedAt != nil {
-		t.Fatalf("async launch must not set FinishedAt: %+v", judge)
-	}
-
-	if gotPhase != phaseDir {
-		t.Fatalf("phaseDir = %q, want %q", gotPhase, phaseDir)
-	}
-	if !strings.HasSuffix(gotLog, "judge.log") {
-		t.Fatalf("log path = %q, want .../judge.log", gotLog)
-	}
-
-	raw, err := os.ReadFile(gotPayload)
-	if err != nil {
-		t.Fatalf("read payload: %v", err)
-	}
-	var payload judgeExecPayload
-	if err := json.Unmarshal(raw, &payload); err != nil {
-		t.Fatalf("parse payload: %v", err)
-	}
-	if payload.SchemaVersion != judgeExecPayloadSchema {
-		t.Fatalf("schema = %q", payload.SchemaVersion)
-	}
-	if payload.StepNumber != 2 || payload.JudgeCommand != "ob judge" {
-		t.Fatalf("payload = %+v", payload)
-	}
-	if payload.Timeout != (30 * time.Second).String() {
-		t.Fatalf("timeout = %q, want %s", payload.Timeout, 30*time.Second)
-	}
-}
-
-func TestRunApproveAuto_AsyncRefusesDuplicateWhileAlive(t *testing.T) {
-	dir := setupWorkflowFestival(t)
-	phaseDir := filepath.Join(dir, "001_INGEST")
-	nav := getNavigator(t, phaseDir)
-	ctx := context.Background()
-
-	if err := nav.Advance(ctx); err != nil {
-		t.Fatalf("Advance: %v", err)
-	}
-	steps := nav.GetSteps()
-
-	// Use this test process's own pid so judgeProcessAlive reports true.
-	self := os.Getpid()
-	withMockedJudgeLaunch(t, func(payloadPath, phaseDir, logPath string) (int, error) {
-		return self, nil
-	})
-
-	if err := runApproveAuto(ctx, nav, 2, steps[1], approvalJudgeOptions{JudgeCommand: "ob judge"}); err != nil {
-		t.Fatalf("first launch: %v", err)
-	}
-
-	err := runApproveAuto(ctx, nav, 2, steps[1], approvalJudgeOptions{JudgeCommand: "ob judge"})
-	if err == nil {
-		t.Fatal("expected duplicate-launch refusal while judge pid is alive")
-	}
-	if !strings.Contains(err.Error(), "already evaluating") {
-		t.Fatalf("error = %v, want already evaluating", err)
 	}
 }

--- a/internal/commands/workflow/judge_platform_test.go
+++ b/internal/commands/workflow/judge_platform_test.go
@@ -1,0 +1,18 @@
+package workflow
+
+import (
+	"os"
+	"testing"
+)
+
+func TestJudgeProcessAlive_CurrentProcess(t *testing.T) {
+	if !judgeProcessAlive(os.Getpid()) {
+		t.Fatal("current process must be reported alive")
+	}
+}
+
+func TestJudgeProcessAlive_InvalidPID(t *testing.T) {
+	if judgeProcessAlive(0) || judgeProcessAlive(-1) {
+		t.Fatal("non-positive PIDs must not be reported alive")
+	}
+}

--- a/internal/commands/workflow/judge_platform_unix.go
+++ b/internal/commands/workflow/judge_platform_unix.go
@@ -1,0 +1,52 @@
+//go:build unix
+
+package workflow
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func acquireJudgeStepLock(ctx context.Context, lockPath string) (func(), error) {
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		err = unix.Flock(int(lockFile.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+		if err == nil {
+			break
+		}
+		if err != unix.EWOULDBLOCK && err != unix.EAGAIN {
+			_ = lockFile.Close()
+			return nil, err
+		}
+		select {
+		case <-ctx.Done():
+			_ = lockFile.Close()
+			return nil, ctx.Err()
+		case <-time.After(judgeLockPoll):
+		}
+	}
+
+	return func() {
+		_ = unix.Flock(int(lockFile.Fd()), unix.LOCK_UN)
+		_ = lockFile.Close()
+	}, nil
+}
+
+func configureDetachedJudgeProcess(cmd *exec.Cmd) {
+	// A new session lets the runner outlive the parent fest process.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}
+
+// judgeProcessAlive reports whether the recorded judge PID still exists.
+func judgeProcessAlive(pid int) bool {
+	return pid > 0 && unix.Kill(pid, 0) == nil
+}

--- a/internal/commands/workflow/judge_platform_unix_test.go
+++ b/internal/commands/workflow/judge_platform_unix_test.go
@@ -1,0 +1,16 @@
+//go:build unix
+
+package workflow
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestConfigureDetachedJudgeProcessUnix(t *testing.T) {
+	cmd := exec.Command("fest")
+	configureDetachedJudgeProcess(cmd)
+	if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setsid {
+		t.Fatal("Unix judge runner must start in a new session")
+	}
+}

--- a/internal/commands/workflow/judge_platform_windows.go
+++ b/internal/commands/workflow/judge_platform_windows.go
@@ -1,0 +1,68 @@
+//go:build windows
+
+package workflow
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+func acquireJudgeStepLock(ctx context.Context, lockPath string) (func(), error) {
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+
+	handle := windows.Handle(lockFile.Fd())
+	overlapped := new(windows.Overlapped)
+	flags := uint32(windows.LOCKFILE_EXCLUSIVE_LOCK | windows.LOCKFILE_FAIL_IMMEDIATELY)
+	for {
+		err = windows.LockFileEx(handle, flags, 0, 1, 0, overlapped)
+		if err == nil {
+			break
+		}
+		if err != windows.ERROR_LOCK_VIOLATION {
+			_ = lockFile.Close()
+			return nil, err
+		}
+		select {
+		case <-ctx.Done():
+			_ = lockFile.Close()
+			return nil, ctx.Err()
+		case <-time.After(judgeLockPoll):
+		}
+	}
+
+	return func() {
+		_ = windows.UnlockFileEx(handle, 0, 1, 0, overlapped)
+		_ = lockFile.Close()
+	}, nil
+}
+
+func configureDetachedJudgeProcess(cmd *exec.Cmd) {
+	// Windows processes normally survive their parent. A detached process group
+	// also prevents console control events from coupling the judge to fest.
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windows.CREATE_NEW_PROCESS_GROUP | windows.DETACHED_PROCESS,
+		HideWindow:    true,
+	}
+}
+
+func judgeProcessAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	handle, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer func() { _ = windows.CloseHandle(handle) }()
+
+	result, err := windows.WaitForSingleObject(handle, 0)
+	return err == nil && result == uint32(windows.WAIT_TIMEOUT)
+}

--- a/internal/commands/workflow/judge_platform_windows_test.go
+++ b/internal/commands/workflow/judge_platform_windows_test.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+package workflow
+
+import (
+	"os/exec"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestConfigureDetachedJudgeProcessWindows(t *testing.T) {
+	cmd := exec.Command("fest.exe")
+	configureDetachedJudgeProcess(cmd)
+	if cmd.SysProcAttr == nil {
+		t.Fatal("Windows judge runner requires process attributes")
+	}
+	want := uint32(windows.CREATE_NEW_PROCESS_GROUP | windows.DETACHED_PROCESS)
+	if cmd.SysProcAttr.CreationFlags&want != want {
+		t.Fatalf("creation flags = %#x, want detached process group bits %#x", cmd.SysProcAttr.CreationFlags, want)
+	}
+	if !cmd.SysProcAttr.HideWindow {
+		t.Fatal("detached Windows judge runner must not create a visible console window")
+	}
+}

--- a/internal/commands/workflow/judge_state_test.go
+++ b/internal/commands/workflow/judge_state_test.go
@@ -26,8 +26,12 @@ func TestRunApproveAuto_RecordsJudgeLifecycle(t *testing.T) {
 		return []byte(`{"schema_version":"fest.approval.judge/v1","decision":"approve","reason":"evidence complete"}`), nil
 	})
 
+	// Wait:true exercises the in-process path with a mocked judge runner.
+	// Default async launch must never run under go test (see launchJudgeProcessDefault).
 	_ = captureStdout(t, func() {
-		if err := runApproveAuto(ctx, nav, 2, steps[1], approvalJudgeOptions{JudgeCommand: "fake judge", Timeout: time.Second}); err != nil {
+		if err := runApproveAuto(ctx, nav, 2, steps[1], approvalJudgeOptions{
+			JudgeCommand: "fake judge", Timeout: time.Second, Wait: true,
+		}); err != nil {
 			t.Fatalf("runApproveAuto: %v", err)
 		}
 	})
@@ -70,7 +74,9 @@ func TestRunApproveAuto_JudgeFailureLeavesDurableTrace(t *testing.T) {
 		return nil, festerrors.Validation("judge exploded")
 	})
 
-	err := runApproveAuto(ctx, nav, 2, steps[1], approvalJudgeOptions{JudgeCommand: "fake judge", Timeout: time.Second})
+	err := runApproveAuto(ctx, nav, 2, steps[1], approvalJudgeOptions{
+		JudgeCommand: "fake judge", Timeout: time.Second, Wait: true,
+	})
 	if err == nil {
 		t.Fatal("runApproveAuto should fail when the judge fails")
 	}

--- a/internal/commands/workflow/lifecycle_gate_test.go
+++ b/internal/commands/workflow/lifecycle_gate_test.go
@@ -19,9 +19,7 @@ func TestWorkflowGate_BlocksImplPhaseInPlanningFestival(t *testing.T) {
 	festDir := setupImplWorkflowFestival(t, "planning")
 	ctx := scope.WithFestival(context.Background(), festDir)
 	t.Setenv("PWD", festDir)
-	if err := os.Chdir(festDir); err != nil {
-		t.Fatalf("chdir festival: %v", err)
-	}
+	t.Chdir(festDir)
 
 	cases := []struct {
 		name string
@@ -48,9 +46,7 @@ func TestWorkflowGate_BlocksImplPhaseInPlanningFestival(t *testing.T) {
 func TestWorkflowGate_AllowsImplPhaseInActiveFestival(t *testing.T) {
 	festDir := setupImplWorkflowFestival(t, "active")
 	ctx := scope.WithFestival(context.Background(), festDir)
-	if err := os.Chdir(festDir); err != nil {
-		t.Fatalf("chdir festival: %v", err)
-	}
+	t.Chdir(festDir)
 
 	// runAdvance against an empty workflow state should not be blocked by
 	// the lifecycle gate. (It may fail later for other reasons; we only

--- a/internal/commands/workflow/reject.go
+++ b/internal/commands/workflow/reject.go
@@ -110,6 +110,21 @@ func runRejectWithRemediationDecision(ctx context.Context, reason, remediationPh
 			WithHint("Reject is only for checkpoint steps")
 	}
 
+	return withJudgeStepLock(ctx, nav.Ctx.PhasePath, currentStepNum, func() error {
+		fresh, err := getWorkflowNavigator(ctx)
+		if err != nil {
+			return err
+		}
+		if fresh.GetWorkflowState().CurrentStep != currentStepNum {
+			return festerrors.Validation("checkpoint changed before rejection").
+				WithField("expected_step", currentStepNum).
+				WithField("current_step", fresh.GetWorkflowState().CurrentStep)
+		}
+		return applyRejectDecision(ctx, fresh, currentStepNum, step, reason, remediationPhase, decision)
+	})
+}
+
+func applyRejectDecision(ctx context.Context, nav *wf.Navigator, currentStepNum int, step wf.WorkflowStep, reason, remediationPhase string, decision wf.DecisionMetadata) error {
 	if remediationPhase != "" {
 		if !nav.IsGate() {
 			return festerrors.Validation("--remediation-phase is only valid for phase gates").

--- a/internal/commands/workflow/reject.go
+++ b/internal/commands/workflow/reject.go
@@ -111,7 +111,7 @@ func runRejectWithRemediationDecision(ctx context.Context, reason, remediationPh
 	}
 
 	return withJudgeStepLock(ctx, nav.Ctx.PhasePath, currentStepNum, func() error {
-		fresh, err := getWorkflowNavigator(ctx)
+		fresh, err := reloadWorkflowNavigator(ctx, nav)
 		if err != nil {
 			return err
 		}

--- a/internal/commands/workflow/reject_remediation_test.go
+++ b/internal/commands/workflow/reject_remediation_test.go
@@ -14,9 +14,7 @@ import (
 func TestRunRejectWithRemediation_RecordsFailedGate(t *testing.T) {
 	festDir := setupGateRemediationFestival(t)
 	ctx := scope.WithFestival(context.Background(), festDir)
-	if err := os.Chdir(festDir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
+	t.Chdir(festDir)
 
 	if err := runRejectWithRemediation(ctx, "blockers found", "005_FIX_PR_302"); err != nil {
 		t.Fatalf("runRejectWithRemediation: %v", err)
@@ -48,9 +46,7 @@ func TestRunRejectWithRemediation_RecordsFailedGate(t *testing.T) {
 func TestRunRejectWithRemediation_ValidatesPhaseExists(t *testing.T) {
 	festDir := setupGateRemediationFestival(t)
 	ctx := scope.WithFestival(context.Background(), festDir)
-	if err := os.Chdir(festDir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
+	t.Chdir(festDir)
 
 	err := runRejectWithRemediation(ctx, "x", "999_DOES_NOT_EXIST")
 	if err == nil {
@@ -68,9 +64,7 @@ func TestRunRejectWithRemediation_ValidatesPhaseNameFormat(t *testing.T) {
 		t.Fatalf("mkdir: %v", err)
 	}
 	ctx := scope.WithFestival(context.Background(), festDir)
-	if err := os.Chdir(festDir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
+	t.Chdir(festDir)
 
 	err := runRejectWithRemediation(ctx, "x", "BAD_NAME_NO_NUMBER")
 	if err == nil {
@@ -81,9 +75,7 @@ func TestRunRejectWithRemediation_ValidatesPhaseNameFormat(t *testing.T) {
 func TestRunRejectWithRemediation_RejectsNonGateNavigator(t *testing.T) {
 	festDir := setupWorkflowCheckpointFestival(t)
 	ctx := scope.WithFestival(context.Background(), festDir)
-	if err := os.Chdir(festDir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
+	t.Chdir(festDir)
 
 	err := runRejectWithRemediation(ctx, "blockers", "005_FIX_PR_302")
 	if err == nil {
@@ -136,9 +128,7 @@ func TestValidateRemediationPhase_AcceptsSequenceDirs(t *testing.T) {
 func TestRunReject_DefaultBehaviorUnchanged(t *testing.T) {
 	festDir := setupGateRemediationFestival(t)
 	ctx := scope.WithFestival(context.Background(), festDir)
-	if err := os.Chdir(festDir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
+	t.Chdir(festDir)
 
 	if err := runReject(ctx, "needs revision"); err != nil {
 		t.Fatalf("runReject: %v", err)

--- a/internal/commands/workflow/reset.go
+++ b/internal/commands/workflow/reset.go
@@ -73,7 +73,7 @@ func runReset(ctx context.Context, force bool) error {
 
 	currentStep := state.CurrentStep
 	if err := withJudgeStepLock(ctx, nav.Ctx.PhasePath, currentStep, func() error {
-		fresh, err := getWorkflowNavigator(ctx)
+		fresh, err := reloadWorkflowNavigator(ctx, nav)
 		if err != nil {
 			return err
 		}

--- a/internal/commands/workflow/reset.go
+++ b/internal/commands/workflow/reset.go
@@ -71,7 +71,14 @@ func runReset(ctx context.Context, force bool) error {
 		}
 	}
 
-	if err := nav.Reset(ctx); err != nil {
+	currentStep := state.CurrentStep
+	if err := withJudgeStepLock(ctx, nav.Ctx.PhasePath, currentStep, func() error {
+		fresh, err := getWorkflowNavigator(ctx)
+		if err != nil {
+			return err
+		}
+		return fresh.Reset(ctx)
+	}); err != nil {
 		return fmt.Errorf("resetting workflow: %w", err)
 	}
 

--- a/internal/commands/workflow/show.go
+++ b/internal/commands/workflow/show.go
@@ -149,6 +149,37 @@ func runShow(ctx context.Context, stepNum int) error {
 		sb.WriteString("\n\n")
 	}
 
+	// Delegated judge lifecycle (purple waiting-on-judge while running).
+	if stepState != nil && stepState.Judge != nil {
+		sb.WriteString(ui.Label("Judge: "))
+		switch stepState.Judge.Status {
+		case wf.JudgeRunning:
+			detail := stepState.Judge.Command
+			if stepState.Judge.Pid > 0 {
+				detail = fmt.Sprintf("%s (pid %d)", detail, stepState.Judge.Pid)
+			}
+			if stepState.Judge.StartedAt != nil {
+				detail = fmt.Sprintf("%s since %s", detail, stepState.Judge.StartedAt.Local().Format("15:04:05"))
+			}
+			sb.WriteString(ui.ColoredText("waiting — "+detail, ui.JudgeColor))
+		case wf.JudgeFailed:
+			sb.WriteString(ui.Error("failed (fails closed)"))
+			if stepState.Judge.Detail != "" {
+				sb.WriteString("\n  ")
+				sb.WriteString(stepState.Judge.Detail)
+			}
+		case wf.JudgeApproved, wf.JudgeRejected:
+			sb.WriteString(ui.Dim(stepState.Judge.Status))
+			if stepState.Judge.Detail != "" {
+				sb.WriteString("\n  ")
+				sb.WriteString(stepState.Judge.Detail)
+			}
+		default:
+			sb.WriteString(stepState.Judge.Status)
+		}
+		sb.WriteString("\n\n")
+	}
+
 	// Show feedback/note metadata for blocked and skipped/completed-with-note states.
 	if stepState != nil && stepState.Feedback != "" {
 		label := ui.Error("Rejection Feedback:")
@@ -163,8 +194,13 @@ func runShow(ctx context.Context, stepNum int) error {
 
 	// Navigation hint
 	if isCurrent {
+		waitingOnJudge := stepState != nil && stepState.Judge != nil &&
+			stepState.Judge.Status == wf.JudgeRunning
 		sb.WriteString(ui.Dim("When complete: "))
-		if step.Checkpoint.IsBlocking() {
+		if waitingOnJudge {
+			sb.WriteString(ui.Accent("fest next"))
+			sb.WriteString(ui.Dim(" after the judge returns"))
+		} else if step.Checkpoint.IsBlocking() {
 			sb.WriteString(ui.Accent("fest workflow approve"))
 		} else {
 			sb.WriteString(ui.Accent("fest workflow advance"))

--- a/internal/commands/workflow/status.go
+++ b/internal/commands/workflow/status.go
@@ -76,9 +76,11 @@ func runStatus(ctx context.Context, jsonOutput bool) error {
 		stepState := state.GetStepState(step.Number)
 		status := wf.StepStatusPending
 		feedback := ""
+		var judge *wf.JudgeState
 		if stepState != nil {
 			status = stepState.Status
 			feedback = stepState.Feedback
+			judge = stepState.Judge
 			if stepState.Status == wf.StepStatusFailedRemediation {
 				failedRemediation[i] = stepState
 			}
@@ -92,6 +94,7 @@ func runStatus(ctx context.Context, jsonOutput bool) error {
 			HasCheckpoint: step.HasCheckpoint(),
 			Goal:          step.Goal,
 			Feedback:      feedback,
+			Judge:         judge,
 		}
 	}
 

--- a/internal/commands/workflow/status.go
+++ b/internal/commands/workflow/status.go
@@ -259,6 +259,43 @@ func getWorkflowNavigator(ctx context.Context) (*wf.Navigator, error) {
 	return nav, nil
 }
 
+// reloadWorkflowNavigator rebuilds a navigator from an already-resolved
+// workflow context. Mutating commands use this after acquiring a step lock so
+// they observe durable state without re-resolving the festival or phase from
+// ambient process state such as the current working directory or --phase.
+func reloadWorkflowNavigator(ctx context.Context, current *wf.Navigator) (*wf.Navigator, error) {
+	if current == nil || current.Ctx == nil {
+		return nil, fmt.Errorf("reloading workflow navigator: resolved context is unavailable")
+	}
+
+	gctx := *current.Ctx
+	nav, err := wf.NewNavigator(&gctx, gctx.Mode)
+	if err != nil {
+		return nil, fmt.Errorf("creating navigator: %w", err)
+	}
+	if current.IsGate() {
+		nav.SetDocFilename("GATES.md")
+		nav.SetStateKeyPrefix("gate:")
+	}
+
+	if current.HasStateStore() {
+		store := progress.NewStore(gctx.FestivalPath)
+		if err := store.Load(ctx); err != nil {
+			return nil, fmt.Errorf("loading progress store: %w", err)
+		}
+		nav.SetStateStore(store)
+	}
+	if err := nav.Initialize(ctx); err != nil {
+		return nil, fmt.Errorf("initializing navigator: %w", err)
+	}
+
+	// Preserve the injected navigator's identity so callers that retain it
+	// (notably fest next and in-process approval flows) observe every state
+	// transition applied after the reload.
+	*current = *nav
+	return current, nil
+}
+
 // resolveNavigationMode determines whether workflow commands should target WORKFLOW.md or GATES.md.
 // Returns the document filename, state key prefix, and an optional not-ready message.
 // Returns empty filename if phase has neither document or if gate is not yet eligible.

--- a/internal/commands/workflow/status_json.go
+++ b/internal/commands/workflow/status_json.go
@@ -46,6 +46,7 @@ type workflowStatusStepJSON struct {
 	JudgeStatus    string `json:"judge_status,omitempty"`
 	JudgeCommand   string `json:"judge_command,omitempty"`
 	JudgePid       int    `json:"judge_pid,omitempty"`
+	JudgeRunID     string `json:"judge_run_id,omitempty"`
 	JudgeDetail    string `json:"judge_detail,omitempty"`
 }
 
@@ -103,6 +104,7 @@ func collectWorkflowStatus(nav *wf.Navigator) workflowStatusJSON {
 				entry.JudgeStatus = stepState.Judge.Status
 				entry.JudgeCommand = stepState.Judge.Command
 				entry.JudgePid = stepState.Judge.Pid
+				entry.JudgeRunID = stepState.Judge.RunID
 				entry.JudgeDetail = stepState.Judge.Detail
 				entry.WaitingOnJudge = stepState.Judge.Status == wf.JudgeRunning
 			}

--- a/internal/commands/workflow/status_json.go
+++ b/internal/commands/workflow/status_json.go
@@ -41,6 +41,12 @@ type workflowStatusStepJSON struct {
 	Goal             string `json:"goal"`
 	Feedback         string `json:"feedback,omitempty"`
 	RemediationPhase string `json:"remediation_phase,omitempty"`
+	// WaitingOnJudge is true when a detached approval judge is still running.
+	WaitingOnJudge bool   `json:"waiting_on_judge,omitempty"`
+	JudgeStatus    string `json:"judge_status,omitempty"`
+	JudgeCommand   string `json:"judge_command,omitempty"`
+	JudgePid       int    `json:"judge_pid,omitempty"`
+	JudgeDetail    string `json:"judge_detail,omitempty"`
 }
 
 // collectWorkflowStatus builds the structured snapshot from navigator state.
@@ -83,23 +89,31 @@ func collectWorkflowStatus(nav *wf.Navigator) workflowStatusJSON {
 		status := wf.StepStatusPending
 		feedback := ""
 		remediation := ""
+		entry := workflowStatusStepJSON{
+			Number:        step.Number,
+			Name:          step.Name,
+			HasCheckpoint: step.HasCheckpoint(),
+			Goal:          step.Goal,
+		}
 		if stepState := state.GetStepState(step.Number); stepState != nil {
 			status = stepState.Status
 			feedback = stepState.Feedback
 			remediation = stepState.RemediationPhase
+			if stepState.Judge != nil {
+				entry.JudgeStatus = stepState.Judge.Status
+				entry.JudgeCommand = stepState.Judge.Command
+				entry.JudgePid = stepState.Judge.Pid
+				entry.JudgeDetail = stepState.Judge.Detail
+				entry.WaitingOnJudge = stepState.Judge.Status == wf.JudgeRunning
+			}
 		}
 		isCurrent := step.Number == state.CurrentStep && !out.Complete
+		entry.Status = string(status)
+		entry.IsCurrent = isCurrent
+		entry.Feedback = feedback
+		entry.RemediationPhase = remediation
 
-		out.Steps = append(out.Steps, workflowStatusStepJSON{
-			Number:           step.Number,
-			Name:             step.Name,
-			Status:           string(status),
-			IsCurrent:        isCurrent,
-			HasCheckpoint:    step.HasCheckpoint(),
-			Goal:             step.Goal,
-			Feedback:         feedback,
-			RemediationPhase: remediation,
-		})
+		out.Steps = append(out.Steps, entry)
 
 		if isCurrent {
 			name := step.Name

--- a/internal/commands/workflow/workflow.go
+++ b/internal/commands/workflow/workflow.go
@@ -78,6 +78,7 @@ Examples:
 		newAdvanceCmd(),
 		newSkipCmd(),
 		newApproveCmd(),
+		newJudgeExecCmd(),
 		newRejectCmd(),
 		newResetCmd(),
 		newShowCmd(),

--- a/internal/guidance/workflow/navigator.go
+++ b/internal/guidance/workflow/navigator.go
@@ -54,6 +54,13 @@ func (n *Navigator) SetStateStore(store StateStore) {
 	n.store = store
 }
 
+// HasStateStore reports whether workflow state is backed by an injected event
+// store instead of the legacy YAML state file. Reloading must preserve this
+// persistence mode so injected navigators do not silently change backends.
+func (n *Navigator) HasStateStore() bool {
+	return n.store != nil
+}
+
 // SetDocFilename overrides the document filename to parse (default: "WORKFLOW.md").
 // Use "GATES.md" for phase-level gates.
 func (n *Navigator) SetDocFilename(name string) {

--- a/internal/guidance/workflow/navigator.go
+++ b/internal/guidance/workflow/navigator.go
@@ -2,10 +2,10 @@ package workflow
 
 import (
 	"context"
-	"time"
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/guidance"
@@ -268,21 +268,36 @@ func (n *Navigator) GetContextFiles(ctx context.Context) ([]string, error) {
 // the current step, before the judge command executes, so concurrent watchers
 // (fest show --watch, fest progress) can render the waiting-on-judge state
 // and a crashed or timed-out judge still leaves a trace.
-func (n *Navigator) BeginJudge(ctx context.Context, step int, command string, pid int) error {
-	return n.recordJudge(ctx, EmitJudgeStartedEvents(n.stateKey(), step, command, pid), func(at time.Time) {
-		n.workflowState.BeginJudge(step, command, pid, at)
+func (n *Navigator) BeginJudge(ctx context.Context, step int, command, runID string, pid int) error {
+	return n.recordJudge(ctx, EmitJudgeStartedEvents(n.stateKey(), step, command, runID, pid), func(at time.Time) bool {
+		n.workflowState.BeginJudge(step, command, runID, pid, at)
+		return true
 	})
+}
+
+// ClaimJudge binds a previously persisted run lease to its detached process.
+// It returns false when another transition superseded the run first.
+func (n *Navigator) ClaimJudge(ctx context.Context, step int, runID string, pid int) (bool, error) {
+	claimed := false
+	err := n.recordJudge(ctx, EmitJudgeClaimedEvents(n.stateKey(), step, runID, pid), func(_ time.Time) bool {
+		claimed = n.workflowState.ClaimJudge(step, runID, pid)
+		return claimed
+	})
+	return claimed, err
 }
 
 // RecordJudgeOutcome durably records how the judge run ended: JudgeApproved,
 // JudgeRejected, or JudgeFailed with the reason or error text in detail.
-func (n *Navigator) RecordJudgeOutcome(ctx context.Context, step int, status, detail string) error {
-	return n.recordJudge(ctx, EmitJudgeReturnedEvents(n.stateKey(), step, status, detail), func(at time.Time) {
-		n.workflowState.RecordJudgeOutcome(step, status, detail, at)
+func (n *Navigator) RecordJudgeOutcome(ctx context.Context, step int, runID, status, detail string) (bool, error) {
+	recorded := false
+	err := n.recordJudge(ctx, EmitJudgeReturnedEvents(n.stateKey(), step, runID, status, detail), func(at time.Time) bool {
+		recorded = n.workflowState.RecordJudgeOutcome(step, runID, status, detail, at)
+		return recorded
 	})
+	return recorded, err
 }
 
-func (n *Navigator) recordJudge(ctx context.Context, events []WorkflowEvent, apply func(at time.Time)) error {
+func (n *Navigator) recordJudge(ctx context.Context, events []WorkflowEvent, apply func(at time.Time) bool) error {
 	if err := n.EnsureInitialized(); err != nil {
 		return err
 	}
@@ -292,7 +307,9 @@ func (n *Navigator) recordJudge(ctx context.Context, events []WorkflowEvent, app
 		}
 	}
 
-	apply(time.Now().UTC())
+	if !apply(time.Now().UTC()) {
+		return nil
+	}
 
 	if n.store != nil {
 		n.store.QueueWorkflowEvents(events)
@@ -325,12 +342,16 @@ func (n *Navigator) ApproveWithAudit(ctx context.Context, feedback string, decis
 	}
 
 	currentStep := n.workflowState.CurrentStep
+	judgeRunID := runningJudgeRunID(n.workflowState.GetStepState(currentStep))
 	if err := n.workflowState.ApproveWithAudit(feedback, decision); err != nil {
 		return err
 	}
 
 	sk := n.stateKey()
 	if n.store != nil {
+		if judgeRunID != "" {
+			n.store.QueueWorkflowEvents(EmitJudgeReturnedEvents(sk, currentStep, judgeRunID, JudgeCanceled, "superseded by manual approval"))
+		}
 		n.store.QueueWorkflowEvents(EmitStepDoneWithDecisionEvents(sk, currentStep, feedback, decision))
 		if n.workflowState.CurrentStep > currentStep {
 			n.store.QueueWorkflowEvents(EmitAdvanceEvents(sk, n.workflowState.CurrentStep))
@@ -358,11 +379,16 @@ func (n *Navigator) RejectWithDecision(ctx context.Context, reason string, decis
 		}
 	}
 
+	currentStep := n.workflowState.CurrentStep
+	judgeRunID := runningJudgeRunID(n.workflowState.GetStepState(currentStep))
 	n.workflowState.RejectWithDecision(reason, decision)
 
 	sk := n.stateKey()
 	if n.store != nil {
-		n.store.QueueWorkflowEvents(EmitStepBlockWithDecisionEvents(sk, n.workflowState.CurrentStep, reason, decision))
+		if judgeRunID != "" {
+			n.store.QueueWorkflowEvents(EmitJudgeReturnedEvents(sk, currentStep, judgeRunID, JudgeCanceled, "superseded by manual rejection"))
+		}
+		n.store.QueueWorkflowEvents(EmitStepBlockWithDecisionEvents(sk, currentStep, reason, decision))
 		return n.store.SaveEvents(ctx)
 	}
 	return n.workflowState.Save(ctx, n.festivalPath, sk)
@@ -388,14 +414,80 @@ func (n *Navigator) RejectWithRemediationDecision(ctx context.Context, reason, r
 		}
 	}
 
+	currentStep := n.workflowState.CurrentStep
+	judgeRunID := runningJudgeRunID(n.workflowState.GetStepState(currentStep))
 	n.workflowState.RejectWithRemediationDecision(reason, remediationPhase, decision)
 
 	sk := n.stateKey()
 	if n.store != nil {
-		n.store.QueueWorkflowEvents(EmitStepFailRemediationWithDecisionEvents(sk, n.workflowState.CurrentStep, reason, remediationPhase, decision))
+		if judgeRunID != "" {
+			n.store.QueueWorkflowEvents(EmitJudgeReturnedEvents(sk, currentStep, judgeRunID, JudgeCanceled, "superseded by manual remediation decision"))
+		}
+		n.store.QueueWorkflowEvents(EmitStepFailRemediationWithDecisionEvents(sk, currentStep, reason, remediationPhase, decision))
 		return n.store.SaveEvents(ctx)
 	}
 	return n.workflowState.Save(ctx, n.festivalPath, sk)
+}
+
+func runningJudgeRunID(state *StepState) string {
+	if state == nil || state.Judge == nil || state.Judge.Status != JudgeRunning {
+		return ""
+	}
+	return state.Judge.RunID
+}
+
+// ApplyJudgeApproval atomically records an owned verdict and advances the
+// checkpoint. The caller must hold the checkpoint's cross-process lock.
+func (n *Navigator) ApplyJudgeApproval(ctx context.Context, step int, runID, audit string, decision DecisionMetadata) (bool, error) {
+	if err := n.EnsureInitialized(); err != nil {
+		return false, err
+	}
+	if !n.workflowState.JudgeOwned(step, runID) {
+		return false, nil
+	}
+	now := time.Now().UTC()
+	if !n.workflowState.RecordJudgeOutcome(step, runID, JudgeApproved, decision.Summary, now) {
+		return false, nil
+	}
+	if err := n.workflowState.ApproveWithAudit(audit, decision); err != nil {
+		return false, err
+	}
+
+	sk := n.stateKey()
+	if n.store != nil {
+		n.store.QueueWorkflowEvents(EmitJudgeReturnedEvents(sk, step, runID, JudgeApproved, decision.Summary))
+		n.store.QueueWorkflowEvents(EmitStepDoneWithDecisionEvents(sk, step, audit, decision))
+		if n.workflowState.CurrentStep > step {
+			n.store.QueueWorkflowEvents(EmitAdvanceEvents(sk, n.workflowState.CurrentStep))
+			n.store.QueueWorkflowEvents(EmitStepStartEvents(sk, n.workflowState.CurrentStep))
+		}
+		return true, n.store.SaveEvents(ctx)
+	}
+	return true, n.workflowState.Save(ctx, n.festivalPath, sk)
+}
+
+// ApplyJudgeRejection atomically records an owned verdict and blocks the
+// checkpoint. The caller must hold the checkpoint's cross-process lock.
+func (n *Navigator) ApplyJudgeRejection(ctx context.Context, step int, runID, audit string, decision DecisionMetadata) (bool, error) {
+	if err := n.EnsureInitialized(); err != nil {
+		return false, err
+	}
+	if !n.workflowState.JudgeOwned(step, runID) {
+		return false, nil
+	}
+	now := time.Now().UTC()
+	if !n.workflowState.RecordJudgeOutcome(step, runID, JudgeRejected, decision.Summary, now) {
+		return false, nil
+	}
+	n.workflowState.RejectWithDecision(audit, decision)
+
+	sk := n.stateKey()
+	if n.store != nil {
+		n.store.QueueWorkflowEvents(EmitJudgeReturnedEvents(sk, step, runID, JudgeRejected, decision.Summary))
+		n.store.QueueWorkflowEvents(EmitStepBlockWithDecisionEvents(sk, step, audit, decision))
+		return true, n.store.SaveEvents(ctx)
+	}
+	return true, n.workflowState.Save(ctx, n.festivalPath, sk)
 }
 
 // Recheck transitions the current step out of failed_with_remediation back

--- a/internal/guidance/workflow/navigator.go
+++ b/internal/guidance/workflow/navigator.go
@@ -268,17 +268,17 @@ func (n *Navigator) GetContextFiles(ctx context.Context) ([]string, error) {
 // the current step, before the judge command executes, so concurrent watchers
 // (fest show --watch, fest progress) can render the waiting-on-judge state
 // and a crashed or timed-out judge still leaves a trace.
-func (n *Navigator) BeginJudge(ctx context.Context, command string) error {
-	return n.recordJudge(ctx, EmitJudgeStartedEvents(n.stateKey(), n.workflowState.CurrentStep, command), func(at time.Time) {
-		n.workflowState.BeginJudge(command, at)
+func (n *Navigator) BeginJudge(ctx context.Context, step int, command string, pid int) error {
+	return n.recordJudge(ctx, EmitJudgeStartedEvents(n.stateKey(), step, command, pid), func(at time.Time) {
+		n.workflowState.BeginJudge(step, command, pid, at)
 	})
 }
 
 // RecordJudgeOutcome durably records how the judge run ended: JudgeApproved,
 // JudgeRejected, or JudgeFailed with the reason or error text in detail.
-func (n *Navigator) RecordJudgeOutcome(ctx context.Context, status, detail string) error {
-	return n.recordJudge(ctx, EmitJudgeReturnedEvents(n.stateKey(), n.workflowState.CurrentStep, status, detail), func(at time.Time) {
-		n.workflowState.RecordJudgeOutcome(status, detail, at)
+func (n *Navigator) RecordJudgeOutcome(ctx context.Context, step int, status, detail string) error {
+	return n.recordJudge(ctx, EmitJudgeReturnedEvents(n.stateKey(), step, status, detail), func(at time.Time) {
+		n.workflowState.RecordJudgeOutcome(step, status, detail, at)
 	})
 }
 

--- a/internal/guidance/workflow/navigator_format.go
+++ b/internal/guidance/workflow/navigator_format.go
@@ -92,6 +92,12 @@ func (n *Navigator) formatComplete() string {
 
 // formatCheckpoint renders the checkpoint template for blocking steps.
 func (n *Navigator) formatCheckpoint(ctx context.Context, step WorkflowStep) (string, error) {
+	judgeWaiting := false
+	if n.workflowState != nil {
+		if ss := n.workflowState.GetStepState(step.Number); ss != nil && ss.Judge != nil {
+			judgeWaiting = ss.Judge.Status == JudgeRunning
+		}
+	}
 	data := map[string]any{
 		"InstructionHeader": guidance.InstructionHeader,
 		"StepNumber":        step.Number,
@@ -99,6 +105,7 @@ func (n *Navigator) formatCheckpoint(ctx context.Context, step WorkflowStep) (st
 		"Goal":              step.Goal,
 		"Actions":           step.Actions,
 		"JudgeConfigured":   n.approvalJudgeConfigured(ctx),
+		"JudgeWaiting":      judgeWaiting,
 	}
 
 	return agent.Render("workflow/checkpoint", data)

--- a/internal/guidance/workflow/state.go
+++ b/internal/guidance/workflow/state.go
@@ -51,6 +51,7 @@ type WorkflowEvent struct {
 	JudgeCommand     string
 	JudgeDetail      string
 	JudgePid         int
+	JudgeRunID       string
 }
 
 // DecisionMetadata records who made a checkpoint decision and the rationale.
@@ -65,6 +66,7 @@ const (
 	JudgeApproved = "approved"
 	JudgeRejected = "rejected"
 	JudgeFailed   = "failed"
+	JudgeCanceled = "canceled"
 )
 
 // JudgeState tracks the lifecycle of a delegated approval judge run for a
@@ -88,6 +90,10 @@ type JudgeState struct {
 	// Pid is the process id of the detached judge runner, used to detect a
 	// stale running record after a crash so the judge can be relaunched.
 	Pid int `yaml:"pid,omitempty" json:"pid,omitempty"`
+
+	// RunID uniquely identifies one delegated evaluation. Detached runners
+	// must still own this ID before they may update or decide the checkpoint.
+	RunID string `yaml:"run_id,omitempty" json:"run_id,omitempty"`
 
 	// FinishedAt is when the judge outcome was recorded.
 	FinishedAt *time.Time `yaml:"finished_at,omitempty" json:"finished_at,omitempty"`
@@ -344,7 +350,7 @@ func (s *WorkflowState) StartCurrentStep() {
 }
 
 // BeginJudge records a delegated judge run starting on a step.
-func (s *WorkflowState) BeginJudge(step int, command string, pid int, at time.Time) {
+func (s *WorkflowState) BeginJudge(step int, command, runID string, pid int, at time.Time) {
 	state := s.GetOrCreateStepState(step)
 	started := at
 	state.Judge = &JudgeState{
@@ -352,14 +358,40 @@ func (s *WorkflowState) BeginJudge(step int, command string, pid int, at time.Ti
 		Command:   command,
 		StartedAt: &started,
 		Pid:       pid,
+		RunID:     runID,
 	}
 }
 
-// RecordJudgeOutcome records how a step's judge run ended. The step is
-// explicit because the detached judge runner may finish after the workflow
-// has moved on; the outcome must land on the step that was judged, never on
-// whatever step is current at completion time.
-func (s *WorkflowState) RecordJudgeOutcome(step int, status, detail string, at time.Time) {
+// ClaimJudge records the detached runner PID only while the supplied run still
+// owns the checkpoint. Repeating the same claim is idempotent.
+func (s *WorkflowState) ClaimJudge(step int, runID string, pid int) bool {
+	state := s.GetStepState(step)
+	if state == nil || state.Judge == nil || state.Judge.Status != JudgeRunning ||
+		state.Judge.RunID != runID {
+		return false
+	}
+	if state.Judge.Pid != 0 && state.Judge.Pid != pid {
+		return false
+	}
+	state.Judge.Pid = pid
+	return true
+}
+
+// JudgeOwned reports whether a running judge still owns the current decision.
+func (s *WorkflowState) JudgeOwned(step int, runID string) bool {
+	state := s.GetStepState(step)
+	return state != nil && state.Judge != nil && state.Judge.Status == JudgeRunning &&
+		state.Judge.RunID == runID && s.CurrentStep == step &&
+		(state.Status == StepStatusPending || state.Status == StepStatusInProgress)
+}
+
+// RecordJudgeOutcome records how an owned judge run ended. It returns false
+// without changing state when a manual decision, reset, or newer run has
+// superseded the caller.
+func (s *WorkflowState) RecordJudgeOutcome(step int, runID, status, detail string, at time.Time) bool {
+	if runID != "" && !s.JudgeOwned(step, runID) {
+		return false
+	}
 	state := s.GetOrCreateStepState(step)
 	if state.Judge == nil {
 		state.Judge = &JudgeState{}
@@ -368,6 +400,7 @@ func (s *WorkflowState) RecordJudgeOutcome(step int, status, detail string, at t
 	state.Judge.Status = status
 	state.Judge.Detail = detail
 	state.Judge.FinishedAt = &finished
+	return true
 }
 
 // CompleteCurrentStep marks the current step as completed.
@@ -414,6 +447,7 @@ func (s *WorkflowState) ApproveWithDecision(decision DecisionMetadata) error {
 // ApproveWithAudit approves a blocking checkpoint, recording durable audit
 // text and decision metadata, then advances to the next step.
 func (s *WorkflowState) ApproveWithAudit(feedback string, decision DecisionMetadata) error {
+	s.cancelCurrentJudge("superseded by manual approval")
 	s.MarkCurrentStep(StepStatusCompleted, feedback)
 	s.recordDecision(s.CurrentStep, decision)
 	if s.CurrentStep < s.TotalSteps {
@@ -430,6 +464,7 @@ func (s *WorkflowState) Reject(feedback string) {
 // RejectWithDecision rejects the current step with feedback and decision metadata.
 func (s *WorkflowState) RejectWithDecision(feedback string, decision DecisionMetadata) {
 	state := s.GetOrCreateStepState(s.CurrentStep)
+	s.cancelCurrentJudge("superseded by manual rejection")
 	state.Status = StepStatusBlocked
 	state.Feedback = feedback
 	state.RemediationPhase = ""
@@ -447,10 +482,22 @@ func (s *WorkflowState) RejectWithRemediation(feedback, remediationPhase string)
 // RejectWithRemediationDecision records a non-passing gate decision with metadata.
 func (s *WorkflowState) RejectWithRemediationDecision(feedback, remediationPhase string, decision DecisionMetadata) {
 	state := s.GetOrCreateStepState(s.CurrentStep)
+	s.cancelCurrentJudge("superseded by manual remediation decision")
 	state.Status = StepStatusFailedRemediation
 	state.Feedback = feedback
 	state.RemediationPhase = remediationPhase
 	s.recordDecision(s.CurrentStep, decision)
+}
+
+func (s *WorkflowState) cancelCurrentJudge(detail string) {
+	state := s.GetOrCreateStepState(s.CurrentStep)
+	if state.Judge == nil || state.Judge.Status != JudgeRunning {
+		return
+	}
+	now := time.Now().UTC()
+	state.Judge.Status = JudgeCanceled
+	state.Judge.Detail = detail
+	state.Judge.FinishedAt = &now
 }
 
 func (s *WorkflowState) recordDecision(step int, decision DecisionMetadata) {
@@ -665,7 +712,7 @@ func EmitResetEvents(phaseName string) []WorkflowEvent {
 
 // EmitJudgeStartedEvents generates events for a delegated judge run starting
 // on a blocking checkpoint.
-func EmitJudgeStartedEvents(phaseName string, step int, command string, pid int) []WorkflowEvent {
+func EmitJudgeStartedEvents(phaseName string, step int, command, runID string, pid int) []WorkflowEvent {
 	return []WorkflowEvent{{
 		EventType:    "wf_judge_started",
 		Phase:        phaseName,
@@ -673,18 +720,32 @@ func EmitJudgeStartedEvents(phaseName string, step int, command string, pid int)
 		JudgeStatus:  JudgeRunning,
 		JudgeCommand: command,
 		JudgePid:     pid,
+		JudgeRunID:   runID,
+	}}
+}
+
+// EmitJudgeClaimedEvents binds a durable judge lease to the detached process
+// that may evaluate it.
+func EmitJudgeClaimedEvents(phaseName string, step int, runID string, pid int) []WorkflowEvent {
+	return []WorkflowEvent{{
+		EventType:  "wf_judge_claimed",
+		Phase:      phaseName,
+		Step:       step,
+		JudgePid:   pid,
+		JudgeRunID: runID,
 	}}
 }
 
 // EmitJudgeReturnedEvents generates events recording how a delegated judge
 // run ended: approved, rejected, or failed (timeout, missing command,
 // malformed verdict).
-func EmitJudgeReturnedEvents(phaseName string, step int, status, detail string) []WorkflowEvent {
+func EmitJudgeReturnedEvents(phaseName string, step int, runID, status, detail string) []WorkflowEvent {
 	return []WorkflowEvent{{
 		EventType:   "wf_judge_returned",
 		Phase:       phaseName,
 		Step:        step,
 		JudgeStatus: status,
 		JudgeDetail: detail,
+		JudgeRunID:  runID,
 	}}
 }

--- a/internal/guidance/workflow/state.go
+++ b/internal/guidance/workflow/state.go
@@ -50,6 +50,7 @@ type WorkflowEvent struct {
 	JudgeStatus      string
 	JudgeCommand     string
 	JudgeDetail      string
+	JudgePid         int
 }
 
 // DecisionMetadata records who made a checkpoint decision and the rationale.
@@ -83,6 +84,10 @@ type JudgeState struct {
 
 	// StartedAt is when the judge command was invoked.
 	StartedAt *time.Time `yaml:"started_at,omitempty" json:"started_at,omitempty"`
+
+	// Pid is the process id of the detached judge runner, used to detect a
+	// stale running record after a crash so the judge can be relaunched.
+	Pid int `yaml:"pid,omitempty" json:"pid,omitempty"`
 
 	// FinishedAt is when the judge outcome was recorded.
 	FinishedAt *time.Time `yaml:"finished_at,omitempty" json:"finished_at,omitempty"`
@@ -338,20 +343,24 @@ func (s *WorkflowState) StartCurrentStep() {
 	}
 }
 
-// BeginJudge records a delegated judge run starting on the current step.
-func (s *WorkflowState) BeginJudge(command string, at time.Time) {
-	state := s.GetOrCreateStepState(s.CurrentStep)
+// BeginJudge records a delegated judge run starting on a step.
+func (s *WorkflowState) BeginJudge(step int, command string, pid int, at time.Time) {
+	state := s.GetOrCreateStepState(step)
 	started := at
 	state.Judge = &JudgeState{
 		Status:    JudgeRunning,
 		Command:   command,
 		StartedAt: &started,
+		Pid:       pid,
 	}
 }
 
-// RecordJudgeOutcome records how the current step's judge run ended.
-func (s *WorkflowState) RecordJudgeOutcome(status, detail string, at time.Time) {
-	state := s.GetOrCreateStepState(s.CurrentStep)
+// RecordJudgeOutcome records how a step's judge run ended. The step is
+// explicit because the detached judge runner may finish after the workflow
+// has moved on; the outcome must land on the step that was judged, never on
+// whatever step is current at completion time.
+func (s *WorkflowState) RecordJudgeOutcome(step int, status, detail string, at time.Time) {
+	state := s.GetOrCreateStepState(step)
 	if state.Judge == nil {
 		state.Judge = &JudgeState{}
 	}
@@ -656,13 +665,14 @@ func EmitResetEvents(phaseName string) []WorkflowEvent {
 
 // EmitJudgeStartedEvents generates events for a delegated judge run starting
 // on a blocking checkpoint.
-func EmitJudgeStartedEvents(phaseName string, step int, command string) []WorkflowEvent {
+func EmitJudgeStartedEvents(phaseName string, step int, command string, pid int) []WorkflowEvent {
 	return []WorkflowEvent{{
 		EventType:    "wf_judge_started",
 		Phase:        phaseName,
 		Step:         step,
 		JudgeStatus:  JudgeRunning,
 		JudgeCommand: command,
+		JudgePid:     pid,
 	}}
 }
 

--- a/internal/guidance/workflow/state_test.go
+++ b/internal/guidance/workflow/state_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestNewWorkflowState(t *testing.T) {
@@ -346,6 +347,22 @@ func TestWorkflowState_Reject(t *testing.T) {
 
 	if current.Feedback != "needs more detail" {
 		t.Errorf("Feedback = %q, want 'needs more detail'", current.Feedback)
+	}
+}
+
+func TestWorkflowState_RejectCancelsRunningJudge(t *testing.T) {
+	state := NewWorkflowState(1)
+	state.StartCurrentStep()
+	state.BeginJudge(1, "ob judge", "run-1", 42, time.Now().UTC())
+
+	state.Reject("operator override")
+
+	judge := state.GetStepState(1).Judge
+	if judge == nil || judge.Status != JudgeCanceled || judge.RunID != "run-1" {
+		t.Fatalf("manual rejection did not cancel judge lease: %+v", judge)
+	}
+	if state.JudgeOwned(1, "run-1") {
+		t.Fatal("canceled judge must not retain decision ownership")
 	}
 }
 

--- a/internal/progress/events.go
+++ b/internal/progress/events.go
@@ -77,6 +77,7 @@ type ProgressEvent struct {
 	JudgeStatus      string `json:"judge_status,omitempty"`
 	JudgeCommand     string `json:"judge_command,omitempty"`
 	JudgeDetail      string `json:"judge_detail,omitempty"`
+	JudgePid         int    `json:"judge_pid,omitempty"`
 }
 
 // loadFromEvents reads the JSONL file and materializes current state.
@@ -412,6 +413,7 @@ func materializeWorkflowState(events []ProgressEvent) *wf.FestivalWorkflowState 
 				Status:    wf.JudgeRunning,
 				Command:   e.JudgeCommand,
 				StartedAt: &ts,
+				Pid:       e.JudgePid,
 			}
 
 		case EventWorkflowJudgeReturned:

--- a/internal/progress/events.go
+++ b/internal/progress/events.go
@@ -48,6 +48,10 @@ const (
 	// was invoked on a blocking checkpoint via 'fest workflow approve --auto'.
 	EventWorkflowJudgeStarted EventType = "wf_judge_started"
 
+	// EventWorkflowJudgeClaimed binds a started judge run to the detached PID
+	// that is allowed to evaluate it.
+	EventWorkflowJudgeClaimed EventType = "wf_judge_claimed"
+
 	// EventWorkflowJudgeReturned records how a delegated judge run ended:
 	// approved, rejected, or failed (timeout, missing command, bad verdict).
 	EventWorkflowJudgeReturned EventType = "wf_judge_returned"
@@ -78,6 +82,7 @@ type ProgressEvent struct {
 	JudgeCommand     string `json:"judge_command,omitempty"`
 	JudgeDetail      string `json:"judge_detail,omitempty"`
 	JudgePid         int    `json:"judge_pid,omitempty"`
+	JudgeRunID       string `json:"judge_run_id,omitempty"`
 }
 
 // loadFromEvents reads the JSONL file and materializes current state.
@@ -414,12 +419,26 @@ func materializeWorkflowState(events []ProgressEvent) *wf.FestivalWorkflowState 
 				Command:   e.JudgeCommand,
 				StartedAt: &ts,
 				Pid:       e.JudgePid,
+				RunID:     e.JudgeRunID,
+			}
+
+		case EventWorkflowJudgeClaimed:
+			ss := phaseState.GetOrCreateStepState(e.Step)
+			if ss.Judge != nil && ss.Judge.Status == wf.JudgeRunning &&
+				ss.Judge.RunID == e.JudgeRunID {
+				ss.Judge.Pid = e.JudgePid
 			}
 
 		case EventWorkflowJudgeReturned:
 			ss := phaseState.GetOrCreateStepState(e.Step)
 			if ss.Judge == nil {
 				ss.Judge = &wf.JudgeState{}
+			}
+			// Run IDs make late events from superseded detached processes inert.
+			// Empty IDs remain compatible with events written before leases existed.
+			if e.JudgeRunID != "" && (ss.Judge.Status != wf.JudgeRunning ||
+				ss.Judge.RunID != e.JudgeRunID) {
+				continue
 			}
 			ts := e.Timestamp
 			ss.Judge.Status = e.JudgeStatus

--- a/internal/progress/store.go
+++ b/internal/progress/store.go
@@ -629,6 +629,7 @@ func (s *Store) QueueWorkflowEvents(events []wf.WorkflowEvent) {
 			JudgeStatus:      we.JudgeStatus,
 			JudgeCommand:     we.JudgeCommand,
 			JudgeDetail:      we.JudgeDetail,
+			JudgePid:         we.JudgePid,
 		}
 		s.pendingEvents = append(s.pendingEvents, pe)
 	}

--- a/internal/progress/store.go
+++ b/internal/progress/store.go
@@ -630,6 +630,7 @@ func (s *Store) QueueWorkflowEvents(events []wf.WorkflowEvent) {
 			JudgeCommand:     we.JudgeCommand,
 			JudgeDetail:      we.JudgeDetail,
 			JudgePid:         we.JudgePid,
+			JudgeRunID:       we.JudgeRunID,
 		}
 		s.pendingEvents = append(s.pendingEvents, pe)
 	}

--- a/internal/progress/workflow_events_test.go
+++ b/internal/progress/workflow_events_test.go
@@ -76,6 +76,24 @@ func TestMaterializeWorkflowState_ResetClearsJudge(t *testing.T) {
 	}
 }
 
+func TestMaterializeWorkflowState_IgnoresSupersededJudgeEvents(t *testing.T) {
+	now := time.Now().UTC()
+	events := []ProgressEvent{
+		{Timestamp: now, Event: EventWorkflowInit, Phase: "001_INGEST", TotalSteps: 1},
+		{Timestamp: now.Add(time.Second), Event: EventWorkflowJudgeStarted, Phase: "001_INGEST", Step: 1, JudgeCommand: "old", JudgeRunID: "run-old"},
+		{Timestamp: now.Add(2 * time.Second), Event: EventWorkflowJudgeClaimed, Phase: "001_INGEST", Step: 1, JudgePid: 100, JudgeRunID: "run-old"},
+		{Timestamp: now.Add(3 * time.Second), Event: EventWorkflowJudgeStarted, Phase: "001_INGEST", Step: 1, JudgeCommand: "new", JudgeRunID: "run-new"},
+		{Timestamp: now.Add(4 * time.Second), Event: EventWorkflowJudgeClaimed, Phase: "001_INGEST", Step: 1, JudgePid: 200, JudgeRunID: "run-new"},
+		{Timestamp: now.Add(5 * time.Second), Event: EventWorkflowJudgeReturned, Phase: "001_INGEST", Step: 1, JudgeStatus: wf.JudgeApproved, JudgeDetail: "stale", JudgeRunID: "run-old"},
+	}
+
+	state := materializeWorkflowState(events).Phases["001_INGEST"]
+	judge := state.GetStepState(1).Judge
+	if judge == nil || judge.Status != wf.JudgeRunning || judge.RunID != "run-new" || judge.Pid != 200 {
+		t.Fatalf("stale event changed active lease: %+v", judge)
+	}
+}
+
 func TestGenerateWorkflowEventsFromYAML_EmitsStepSkip(t *testing.T) {
 	now := time.Now().UTC()
 	phaseState := wf.NewWorkflowState(2)

--- a/tests/integration/async_judge_test.go
+++ b/tests/integration/async_judge_test.go
@@ -1,0 +1,375 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Async approval-judge coverage that exercises real process launch, re-exec of
+// the fest binary as `workflow judge-exec`, and durable waiting-on-judge state
+// MUST run in this container harness — never as host `go test` unit tests.
+//
+// The host process-storm that froze operator machines was caused by unit tests
+// re-execing `workflow.test` as judge-exec under go test. Container isolation
+// keeps any runaway children off the host.
+
+const (
+	asyncJudgeFestival = "/festivals/async-judge-test"
+	asyncJudgePhase    = "/festivals/async-judge-test/001_INGEST"
+	asyncJudgeBinDir   = "/opt/async-judge"
+)
+
+func TestAsyncJudge_ApproveAutoFireAndForgetCompletes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	container := GetSharedContainer(t)
+	setupAsyncJudgeFestival(t, container, "instant-approve")
+
+	// Fire-and-forget: parent returns while detached judge-exec runs.
+	out, err := container.RunFestInDir(asyncJudgePhase, "workflow", "approve", "--auto")
+	require.NoError(t, err, "approve --auto should launch: %s", out)
+	require.Contains(t, out, "Judge launched", "expected async launch notice, got: %s", out)
+	// Parent must not apply the verdict (only the detached runner does).
+	require.NotContains(t, out, "Reason:",
+		"async --auto must not print in-process verdict reason in the parent: %s", out)
+
+	// Detached runner should finish quickly with the instant-approve judge.
+	waitForJudgeSettled(t, container, 15*time.Second)
+
+	jsonOut, err := container.RunFestInDir(asyncJudgePhase, "workflow", "status", "--json")
+	require.NoError(t, err, "status after judge: %s", jsonOut)
+	require.NotContains(t, jsonOut, `"waiting_on_judge": true`,
+		"judge should have finished; still waiting: %s", jsonOut)
+	require.Contains(t, jsonOut, `"judge_status": "approved"`,
+		"expected approved judge outcome: %s", jsonOut)
+
+	// No leftover judge-exec children from the detached path.
+	assertNoOrphanJudgeExec(t, container)
+}
+
+func TestAsyncJudge_WaitingOnJudgeSurfacedWhileRunning(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	container := GetSharedContainer(t)
+	setupAsyncJudgeFestival(t, container, "slow-approve")
+
+	out, err := container.RunFestInDir(asyncJudgePhase, "workflow", "approve", "--auto")
+	require.NoError(t, err, "approve --auto should launch: %s", out)
+	require.Contains(t, out, "Judge launched", out)
+
+	// While the slow judge sleeps, status/show/json must report waiting-on-judge.
+	status, err := container.RunFestInDir(asyncJudgePhase, "workflow", "status")
+	require.NoError(t, err, status)
+	require.Contains(t, strings.ToLower(status), "waiting on judge",
+		"text status should show purple waiting-on-judge while runner alive: %s", status)
+
+	show, err := container.RunFestInDir(asyncJudgePhase, "workflow", "show")
+	require.NoError(t, err, show)
+	require.Contains(t, strings.ToLower(show), "waiting",
+		"show should surface judge waiting state: %s", show)
+
+	jsonOut, err := container.RunFestInDir(asyncJudgePhase, "workflow", "status", "--json")
+	require.NoError(t, err, jsonOut)
+	require.Contains(t, jsonOut, `"waiting_on_judge": true`,
+		"json status should set waiting_on_judge: %s", jsonOut)
+	require.Contains(t, jsonOut, `"judge_status": "running"`, jsonOut)
+
+	// fest workflow approve --auto must refuse a duplicate launch while alive.
+	// (fest next may still hit festival validation before auto-delegate; the
+	// approve path is the direct contract for duplicate refusal vs soft wait.)
+	dupOut, dupErr := container.RunFestInDir(asyncJudgePhase, "workflow", "approve", "--auto")
+	require.Error(t, dupErr, "duplicate approve --auto should fail while judge is alive: %s", dupOut)
+	require.Contains(t, strings.ToLower(dupOut+errString(dupErr)), "already evaluating",
+		"expected duplicate-launch refusal: %s / %v", dupOut, dupErr)
+
+	// Soft waiting report is emitted by AutoDelegate on fest next when the
+	// festival is valid; re-check after ensuring docs exist (setup already does).
+	nextOut, nextErr := container.RunFestInDir(asyncJudgePhase, "next")
+	combinedNext := strings.ToLower(nextOut + errString(nextErr))
+	require.True(t,
+		strings.Contains(combinedNext, "still running") ||
+			strings.Contains(combinedNext, "waiting") ||
+			strings.Contains(nextOut, "⚖") ||
+			strings.Contains(combinedNext, "already evaluating"),
+		"fest next should acknowledge an in-flight judge: %s / %v", nextOut, nextErr)
+
+	waitForJudgeSettled(t, container, 20*time.Second)
+	assertNoOrphanJudgeExec(t, container)
+}
+
+func TestAsyncJudge_WaitFlagBlocksUntilVerdict(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	container := GetSharedContainer(t)
+	setupAsyncJudgeFestival(t, container, "instant-approve")
+
+	out, err := container.RunFestInDir(asyncJudgePhase, "workflow", "approve", "--auto", "--wait")
+	require.NoError(t, err, "approve --auto --wait: %s", out)
+	// Blocking path applies the verdict in-process.
+	require.True(t,
+		strings.Contains(strings.ToLower(out), "approved") ||
+			strings.Contains(strings.ToLower(out), "reason"),
+		"wait path should report the verdict: %s", out)
+	require.NotContains(t, out, "Judge launched",
+		"--wait must not take the detached launch path: %s", out)
+
+	assertNoOrphanJudgeExec(t, container)
+}
+
+func TestAsyncJudge_NextAutoDelegatesFireAndForget(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	container := GetSharedContainer(t)
+	// Step 1 is the blocking checkpoint so fest next auto-delegates immediately.
+	setupAsyncJudgeFestivalAtStep(t, container, "instant-approve", true)
+
+	out, err := container.RunFestInDir(asyncJudgePhase, "next")
+	// Auto-delegate launches and returns; checkpoint may still be open briefly.
+	combined := out + errString(err)
+	require.True(t,
+		strings.Contains(combined, "Judge launched") ||
+			strings.Contains(combined, "Checkpoint delegated") ||
+			strings.Contains(strings.ToLower(combined), "approval judge"),
+		"fest next should auto-delegate to the judge: %s", combined)
+
+	waitForJudgeSettled(t, container, 15*time.Second)
+	assertNoOrphanJudgeExec(t, container)
+}
+
+// --- helpers ---
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func setupAsyncJudgeFestival(t *testing.T, container *TestContainer, judgeKind string) {
+	t.Helper()
+	setupAsyncJudgeFestivalAtStep(t, container, judgeKind, false)
+}
+
+// setupAsyncJudgeFestivalAtStep builds a minimal active festival under
+// /festivals with workspace marker + approval_judge hook. When checkpointFirst
+// is false, step 1 is non-blocking and step 2 is the approval checkpoint
+// (matches the unit-test fixture); the helper advances to step 2.
+func setupAsyncJudgeFestivalAtStep(t *testing.T, container *TestContainer, judgeKind string, checkpointFirst bool) {
+	t.Helper()
+
+	// Kill any leftover judge-exec / judge children from a prior test in this
+	// shared container before rebuilding fixtures.
+	killAsyncJudgeProcesses(t, container)
+	installAsyncJudgeScripts(t, container)
+
+	judgeCmd := asyncJudgeBinDir + "/" + judgeKind
+	// Advance to checkpoint step when it is step 2.
+	checkpointStep1 := `**Checkpoint:** APPROVAL REQUIRED — Wait for user`
+	checkpointStep2 := `**Checkpoint:** None`
+	if !checkpointFirst {
+		checkpointStep1 = `**Checkpoint:** None`
+		checkpointStep2 = `**Checkpoint:** APPROVAL REQUIRED — Wait for user`
+	}
+
+	script := fmt.Sprintf(`
+set -eu
+mkdir -p /festivals/.festival/.state /festivals/active
+mkdir -p "%[1]s"
+
+# Workspace marker so festivalsRoot / hooks resolve from the phase path.
+cat > /festivals/.festival/.state/.workspace <<'EOF'
+{"workspace": "/", "registered": "2026-01-01T00:00:00Z"}
+EOF
+
+cat > /festivals/.festival/config.yaml <<EOF
+version: "1.0"
+hooks:
+  approval_judge:
+    command: %[2]s
+EOF
+
+cat > "%[1]s/fest.yaml" <<'EOF'
+version: "1.0"
+name: async-judge-test
+id: AJ-001
+metadata:
+  id: AJ-001
+  status_history:
+    - status: active
+      timestamp: 2026-02-10T00:00:00Z
+EOF
+
+cat > "%[1]s/FESTIVAL_OVERVIEW.md" <<'EOF'
+# Overview
+Async judge integration fixture festival.
+EOF
+
+cat > "%[1]s/FESTIVAL_RULES.md" <<'EOF'
+# Rules
+Integration-only fixture.
+EOF
+
+mkdir -p "%[3]s"
+cat > "%[3]s/PHASE_GOAL.md" <<'EOF'
+---
+fest_type: phase_goal
+fest_id: 001_INGEST
+fest_mode: ingest
+fest_phase_type: ingest
+---
+
+# Phase Goal
+Async judge integration fixture.
+EOF
+
+cat > "%[3]s/WORKFLOW.md" <<EOF
+---
+fest_type: workflow
+fest_id: AJ-WF
+fest_parent: 001_INGEST
+---
+
+# Async Judge Workflow
+
+## Step 1: PREP — Prepare
+
+**Goal:** Prepare for the gate.
+
+**Actions:**
+1. Prep work
+
+**Output:** Prep notes
+
+%[4]s
+
+---
+
+## Step 2: GATE — Approval gate
+
+**Goal:** Judge the checkpoint.
+
+**Actions:**
+1. Review evidence
+
+**Output:** Decision
+
+%[5]s
+
+---
+
+## Step 3: COMPLETE — Done
+
+**Goal:** Finish.
+
+**Actions:**
+1. Wrap up
+
+**Output:** Done
+
+**Checkpoint:** None
+EOF
+`, asyncJudgeFestival, judgeCmd, asyncJudgePhase, checkpointStep1, checkpointStep2)
+
+	_, err := container.runCommand([]string{"sh", "-c", script})
+	require.NoError(t, err, "setup async judge festival")
+
+	// Ensure workflow state exists and current step is the blocking checkpoint.
+	// Initializing via status is enough to load/create state at step 1.
+	_, _ = container.RunFestInDir(asyncJudgePhase, "workflow", "status")
+
+	if !checkpointFirst {
+		// Advance past the non-blocking prep step onto the approval checkpoint.
+		out, err := container.RunFestInDir(asyncJudgePhase, "workflow", "advance")
+		require.NoError(t, err, "advance to checkpoint: %s", out)
+	}
+}
+
+func installAsyncJudgeScripts(t *testing.T, container *TestContainer) {
+	t.Helper()
+	// Reset wipes /tmp and /festivals but not /opt — reinstall scripts each test
+	// for hermetic commands.
+	script := `
+set -eu
+mkdir -p ` + asyncJudgeBinDir + `
+cat > ` + asyncJudgeBinDir + `/instant-approve <<'EOF'
+#!/bin/sh
+# Drain stdin (judge request JSON) and approve immediately.
+cat >/dev/null
+printf '%s\n' '{"schema_version":"fest.approval.judge/v1","decision":"approve","reason":"container instant approve"}'
+EOF
+cat > ` + asyncJudgeBinDir + `/slow-approve <<'EOF'
+#!/bin/sh
+# Hold the checkpoint in waiting-on-judge long enough for status assertions.
+cat >/dev/null
+sleep 4
+printf '%s\n' '{"schema_version":"fest.approval.judge/v1","decision":"approve","reason":"container slow approve"}'
+EOF
+chmod 755 ` + asyncJudgeBinDir + `/instant-approve ` + asyncJudgeBinDir + `/slow-approve
+`
+	_, err := container.runCommand([]string{"sh", "-c", script})
+	require.NoError(t, err, "install judge scripts")
+}
+
+func waitForJudgeSettled(t *testing.T, container *TestContainer, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last string
+	for time.Now().Before(deadline) {
+		// Prefer JSON for a stable signal.
+		out, err := container.RunFestInDir(asyncJudgePhase, "workflow", "status", "--json")
+		last = out + errString(err)
+		if err == nil && !strings.Contains(out, `"waiting_on_judge": true`) {
+			// Either finished (no waiting flag) or never started — acceptable once launch completed.
+			if strings.Contains(out, `"judge_status": "approved"`) ||
+				strings.Contains(out, `"judge_status": "failed"`) ||
+				strings.Contains(out, `"judge_status": "rejected"`) ||
+				!strings.Contains(out, `"judge_status": "running"`) {
+				return
+			}
+		}
+		// Also treat absence of running judge processes as settled after a grace period.
+		ps, _ := container.Exec("sh", "-c", "ps w 2>/dev/null | grep -E 'judge-exec|slow-approve|instant-approve' | grep -v grep || true")
+		if strings.TrimSpace(ps) == "" && time.Now().After(deadline.Add(-timeout+2*time.Second)) {
+			// processes gone; re-check once more after brief settle
+			time.Sleep(200 * time.Millisecond)
+			out, err := container.RunFestInDir(asyncJudgePhase, "workflow", "status", "--json")
+			last = out + errString(err)
+			if err == nil && !strings.Contains(out, `"waiting_on_judge": true`) {
+				return
+			}
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	t.Fatalf("judge did not settle within %s; last status: %s", timeout, last)
+}
+
+func assertNoOrphanJudgeExec(t *testing.T, container *TestContainer) {
+	t.Helper()
+	// Give the process table a moment to reap zombies.
+	time.Sleep(200 * time.Millisecond)
+	ps, err := container.Exec("sh", "-c", "ps w 2>/dev/null | grep -E '[j]udge-exec|[s]low-approve|[i]nstant-approve' || true")
+	require.NoError(t, err)
+	require.Empty(t, strings.TrimSpace(ps), "orphan judge processes left in container:\n%s", ps)
+}
+
+func killAsyncJudgeProcesses(t *testing.T, container *TestContainer) {
+	t.Helper()
+	// Best-effort cleanup of prior detached runners in the shared container.
+	// Isolation boundary is the container; still keep each test hermetic.
+	_, _ = container.Exec("sh", "-c", `
+pkill -f 'workflow judge-exec' 2>/dev/null || true
+pkill -f '/opt/async-judge/' 2>/dev/null || true
+sleep 0.2
+`)
+}

--- a/tests/integration/async_judge_test.go
+++ b/tests/integration/async_judge_test.go
@@ -51,7 +51,70 @@ func TestAsyncJudge_ApproveAutoFireAndForgetCompletes(t *testing.T) {
 	require.Contains(t, jsonOut, `"judge_status": "approved"`,
 		"expected approved judge outcome: %s", jsonOut)
 
+	// The durable lease and PID claim must precede the verdict even when the
+	// judge answers immediately. This is the fast-child interleaving contract.
+	events, err := container.ReadFile(asyncJudgeFestival + "/.fest/progress_events.jsonl")
+	require.NoError(t, err)
+	startedAt := strings.Index(events, `"event":"wf_judge_started"`)
+	claimedAt := strings.Index(events, `"event":"wf_judge_claimed"`)
+	returnedAt := strings.Index(events, `"event":"wf_judge_returned"`)
+	require.GreaterOrEqual(t, startedAt, 0, "missing judge start event: %s", events)
+	require.Greater(t, claimedAt, startedAt, "PID claim must follow durable lease: %s", events)
+	require.Greater(t, returnedAt, claimedAt, "verdict must follow PID claim: %s", events)
+
 	// No leftover judge-exec children from the detached path.
+	assertNoOrphanJudgeExec(t, container)
+}
+
+func TestAsyncJudge_ConcurrentLaunchCreatesSingleRunner(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	container := GetSharedContainer(t)
+	setupAsyncJudgeFestival(t, container, "slow-approve")
+
+	out, err := container.Exec("sh", "-c", `
+cd `+asyncJudgePhase+`
+/fest workflow approve --auto >/tmp/judge-a.out 2>&1 & a=$!
+/fest workflow approve --auto >/tmp/judge-b.out 2>&1 & b=$!
+wait "$a"; sa=$?
+wait "$b"; sb=$?
+printf 'status-a=%s\nstatus-b=%s\n' "$sa" "$sb"
+cat /tmp/judge-a.out /tmp/judge-b.out
+`)
+	require.NoError(t, err, out)
+	require.True(t,
+		strings.Contains(out, "status-a=0\nstatus-b=1") || strings.Contains(out, "status-a=1\nstatus-b=0"),
+		"exactly one concurrent launch must succeed: %s", out)
+	require.Equal(t, 1, strings.Count(out, "Judge launched"), "only one detached runner may launch: %s", out)
+	require.Contains(t, strings.ToLower(out), "already evaluating", out)
+
+	waitForJudgeSettled(t, container, 20*time.Second)
+	assertNoOrphanJudgeExec(t, container)
+}
+
+func TestAsyncJudge_ManualRejectSupersedesRunningVerdict(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	container := GetSharedContainer(t)
+	setupAsyncJudgeFestival(t, container, "slow-approve")
+
+	out, err := container.RunFestInDir(asyncJudgePhase, "workflow", "approve", "--auto")
+	require.NoError(t, err, out)
+	require.Contains(t, out, "Judge launched")
+
+	rejectOut, err := container.RunFestInDir(asyncJudgePhase, "workflow", "reject", "--reason", "operator-override")
+	require.NoError(t, err, rejectOut)
+	require.Contains(t, rejectOut, "operator-override")
+
+	waitForJudgeSettled(t, container, 20*time.Second)
+	jsonOut, err := container.RunFestInDir(asyncJudgePhase, "workflow", "status", "--json")
+	require.NoError(t, err, jsonOut)
+	require.Contains(t, jsonOut, `"status": "blocked"`, "manual rejection must remain authoritative: %s", jsonOut)
+	require.Contains(t, jsonOut, `"feedback": "operator-override"`, jsonOut)
+	require.Contains(t, jsonOut, `"judge_status": "canceled"`, jsonOut)
+	require.NotContains(t, jsonOut, `"judge_status": "approved"`, "stale approval overwrote operator decision: %s", jsonOut)
 	assertNoOrphanJudgeExec(t, container)
 }
 
@@ -330,11 +393,13 @@ func waitForJudgeSettled(t *testing.T, container *TestContainer, timeout time.Du
 		out, err := container.RunFestInDir(asyncJudgePhase, "workflow", "status", "--json")
 		last = out + errString(err)
 		if err == nil && !strings.Contains(out, `"waiting_on_judge": true`) {
-			// Either finished (no waiting flag) or never started — acceptable once launch completed.
+			// A canceled run may still be winding down after an operator override;
+			// do not return until its detached process has actually exited.
+			canceled := strings.Contains(out, `"judge_status": "canceled"`)
 			if strings.Contains(out, `"judge_status": "approved"`) ||
 				strings.Contains(out, `"judge_status": "failed"`) ||
 				strings.Contains(out, `"judge_status": "rejected"`) ||
-				!strings.Contains(out, `"judge_status": "running"`) {
+				(!canceled && !strings.Contains(out, `"judge_status": "running"`)) {
 				return
 			}
 		}


### PR DESCRIPTION
## Summary

Fire-and-forget auto-judge so `fest next` / `fest workflow approve --auto` does not block the TTY while a long-running judge evaluates a checkpoint.

- Default `--auto` launches a detached `workflow judge-exec` runner, records `BeginJudge` with PID, and returns immediately
- Checkpoint stays blocked; `fest show` / watchers can render **waiting-on-judge**
- New `--wait` flag restores the previous blocking path
- Duplicate launch while the recorded judge PID is still alive is rejected; stale PIDs (crash/reboot) can relaunch
- **Safety:** refuse to re-exec `*.test` / go test package binaries as the judge runner (this path previously fork-bombed machines under `go test`)
- Unit tests mock `launchJudgeProcess` so package tests never spawn real detached judges

## Worktree

`fest@fest-async-judge` → `projects/worktrees/fest/fest-async-judge`

## Test plan

- [ ] `go test` only with mocked launch paths (do **not** run unmocked auto-judge tests on older WIP without the go-test binary guard)
- [ ] Manual: `fest workflow approve --auto` on a gate → returns immediately, progress shows judge running
- [ ] Manual: `fest show` / waiting-on-judge UI while runner alive
- [ ] Manual: judge completes → `fest next` continues or stays blocked on reject
- [ ] Manual: `--wait` still blocks until verdict
- [ ] Confirm no orphan `workflow.test` / `judge-exec` processes after tests

## Notes / risk

This is a **draft** backup of in-progress work recovered after a machine freeze caused by process storms from detached `workflow.test` re-exec under `go test`. Review carefully before merge.