### PR TITLE
wip(workflow): early async approval judge prototype (archival)

### DIFF
--- a/internal/commands/workflow/approve.go
+++ b/internal/commands/workflow/approve.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -25,6 +26,7 @@ type approvalJudgeOptions struct {
 	Auto         bool
 	JudgeCommand string
 	Timeout      time.Duration
+	Wait         bool
 }
 
 type approvalJudgeRequest struct {
@@ -88,7 +90,12 @@ Auto approval:
 
       hooks:
         approval_judge:
-          command: ob judge`,
+          command: ob judge
+
+  By default --auto launches the judge in the background and returns
+  immediately; the checkpoint stays blocked until the verdict lands, and
+  'fest show' renders the waiting-on-judge state while it runs. Use --wait
+  to block until the judge returns instead.`,
 		Annotations: map[string]string{
 			"scope": string(scope.Festival),
 		},
@@ -110,6 +117,7 @@ Auto approval:
 	cmd.Flags().BoolVar(&opts.Auto, "auto", false, "delegate this checkpoint decision to the configured approval judge command")
 	cmd.Flags().StringVar(&opts.JudgeCommand, "judge-command", opts.JudgeCommand, "approval judge command for --auto (overrides the .festival/config.yaml hooks.approval_judge.command hook)")
 	cmd.Flags().DurationVar(&opts.Timeout, "judge-timeout", opts.Timeout, "maximum time to wait for the approval judge (0 waits until it returns)")
+	cmd.Flags().BoolVar(&opts.Wait, "wait", false, "block until the judge returns instead of launching it in the background")
 	cmd.MarkFlagsMutuallyExclusive("auto", "as")
 	cmd.MarkFlagsMutuallyExclusive("auto", "summary")
 
@@ -227,25 +235,45 @@ Or pass --judge-command <cmd> for a one-off.`)
 }
 
 func runApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum int, step wf.WorkflowStep, opts approvalJudgeOptions) error {
+	// A judge may already be evaluating this checkpoint from a prior --auto.
+	// Refuse a duplicate launch while it is alive; a running record whose
+	// process died (crash, reboot) is stale and may be relaunched.
+	if ss := nav.GetWorkflowState().GetStepState(currentStepNum); ss != nil && ss.Judge != nil &&
+		ss.Judge.Status == wf.JudgeRunning && judgeProcessAlive(ss.Judge.Pid) {
+		return festerrors.Validation("an approval judge is already evaluating this checkpoint").
+			WithField("judge_command", ss.Judge.Command).
+			WithField("pid", fmt.Sprintf("%d", ss.Judge.Pid)).
+			WithHint("the checkpoint unblocks when the judge returns; watch it with 'fest show' and re-run 'fest next' afterwards")
+	}
+
+	if !opts.Wait {
+		return launchApproveAuto(ctx, nav, currentStepNum, step, opts)
+	}
+
+	// --wait: run the judge in-process and block until the verdict lands.
 	// Record the judge invocation before running it so watchers can render
 	// the waiting-on-judge state and a hung or crashed judge leaves a trace.
-	if err := nav.BeginJudge(ctx, opts.JudgeCommand); err != nil {
+	if err := nav.BeginJudge(ctx, currentStepNum, opts.JudgeCommand, os.Getpid()); err != nil {
 		return festerrors.Wrap(err, "recording judge start")
 	}
 
 	decision, audit, err := judgeApproval(ctx, nav, step, opts)
 	if err != nil {
-		if recErr := nav.RecordJudgeOutcome(ctx, wf.JudgeFailed, err.Error()); recErr != nil {
+		if recErr := nav.RecordJudgeOutcome(ctx, currentStepNum, wf.JudgeFailed, err.Error()); recErr != nil {
 			fmt.Printf("%s failed to record judge outcome: %v\n", ui.Warning("⚠"), recErr)
 		}
 		return err
 	}
 
+	return applyApproveAutoVerdict(ctx, nav, currentStepNum, step, decision, audit)
+}
+
+func applyApproveAutoVerdict(ctx context.Context, nav *wf.Navigator, currentStepNum int, step wf.WorkflowStep, decision *approvalJudgeResponse, audit string) error {
 	judgeDecision := wf.DecisionMetadata{Actor: decisionActorAgent, Summary: decision.Reason}
 
 	switch decision.Decision {
 	case "approve":
-		if err := nav.RecordJudgeOutcome(ctx, wf.JudgeApproved, decision.Reason); err != nil {
+		if err := nav.RecordJudgeOutcome(ctx, currentStepNum, wf.JudgeApproved, decision.Reason); err != nil {
 			return festerrors.Wrap(err, "recording judge outcome")
 		}
 		if err := nav.ApproveWithAudit(ctx, audit, judgeDecision); err != nil {
@@ -255,7 +283,7 @@ func runApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum int, 
 		fmt.Printf("  %s: %s\n", ui.Label("Reason"), decision.Reason)
 		return showNextStep(ctx, nav, nav.GetSteps())
 	case "reject":
-		if err := nav.RecordJudgeOutcome(ctx, wf.JudgeRejected, decision.Reason); err != nil {
+		if err := nav.RecordJudgeOutcome(ctx, currentStepNum, wf.JudgeRejected, decision.Reason); err != nil {
 			return festerrors.Wrap(err, "recording judge outcome")
 		}
 		if err := nav.RejectWithDecision(ctx, audit, judgeDecision); err != nil {
@@ -275,7 +303,7 @@ func runApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum int, 
 		unsupported := festerrors.Validation("approval judge returned unsupported decision").
 			WithField("decision", decision.Decision).
 			WithHint("allowed decisions are approve and reject")
-		if recErr := nav.RecordJudgeOutcome(ctx, wf.JudgeFailed, unsupported.Error()); recErr != nil {
+		if recErr := nav.RecordJudgeOutcome(ctx, currentStepNum, wf.JudgeFailed, unsupported.Error()); recErr != nil {
 			fmt.Printf("%s failed to record judge outcome: %v\n", ui.Warning("⚠"), recErr)
 		}
 		return unsupported

--- a/internal/commands/workflow/judge_exec.go
+++ b/internal/commands/workflow/judge_exec.go
@@ -1,0 +1,205 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+	"github.com/Obedience-Corp/fest/internal/scope"
+	"github.com/Obedience-Corp/fest/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+const judgeExecPayloadSchema = "fest.approval.judge-exec/v1"
+
+// judgeExecPayload is the handoff from 'fest workflow approve --auto' to the
+// detached judge-exec runner. The runner rebuilds the judge request from live
+// workflow state; the payload only pins which checkpoint was delegated and
+// how to run the judge.
+type judgeExecPayload struct {
+	SchemaVersion string `json:"schema_version"`
+	StepNumber    int    `json:"step_number"`
+	StepName      string `json:"step_name"`
+	JudgeCommand  string `json:"judge_command"`
+	Timeout       string `json:"timeout,omitempty"`
+}
+
+// launchJudgeProcess is a seam for tests; production detaches a judge-exec
+// child so approve --auto returns immediately instead of blocking on a
+// potentially long-running judge evaluation.
+var launchJudgeProcess = launchJudgeProcessDefault
+
+// launchApproveAuto starts the judge in the background and returns. The
+// checkpoint stays blocked until the detached runner applies the verdict
+// through the same fail-closed path as --wait; watchers render the
+// waiting-on-judge state in the meantime.
+func launchApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum int, step wf.WorkflowStep, opts approvalJudgeOptions) error {
+	payload := judgeExecPayload{
+		SchemaVersion: judgeExecPayloadSchema,
+		StepNumber:    currentStepNum,
+		StepName:      step.Name,
+		JudgeCommand:  opts.JudgeCommand,
+	}
+	if opts.Timeout > 0 {
+		payload.Timeout = opts.Timeout.String()
+	}
+
+	festDir := filepath.Join(nav.Ctx.PhasePath, ".fest")
+	if err := os.MkdirAll(festDir, 0o755); err != nil {
+		return festerrors.IO("creating .fest directory for judge handoff", err).WithField("path", festDir)
+	}
+	payloadPath := filepath.Join(festDir, fmt.Sprintf("judge-step-%d.json", currentStepNum))
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return festerrors.Wrap(err, "encoding judge-exec payload")
+	}
+	if err := os.WriteFile(payloadPath, data, 0o600); err != nil {
+		return festerrors.IO("writing judge-exec payload", err).WithField("path", payloadPath)
+	}
+
+	pid, err := launchJudgeProcess(payloadPath, nav.Ctx.PhasePath, filepath.Join(festDir, "judge.log"))
+	if err != nil {
+		return festerrors.Wrap(err, "launching approval judge").
+			WithHint("the checkpoint was not approved; fix the judge command or run 'fest workflow approve' manually")
+	}
+
+	if err := nav.BeginJudge(ctx, currentStepNum, opts.JudgeCommand, pid); err != nil {
+		return festerrors.Wrap(err, "recording judge start")
+	}
+
+	fmt.Printf("%s Judge launched: %s (pid %d)\n", ui.Value("⚖", ui.JudgeColor), opts.JudgeCommand, pid)
+	fmt.Println("  The checkpoint stays blocked until the verdict lands.")
+	fmt.Printf("  Watch progress: %s\n", ui.Accent("fest show"))
+	fmt.Printf("  After it returns, run %s — approved continues the workflow;\n", ui.Accent("fest next"))
+	fmt.Printf("  rejected records feedback to address, then %s to resubmit.\n", ui.Accent("fest workflow advance"))
+	return nil
+}
+
+func launchJudgeProcessDefault(payloadPath, phaseDir, logPath string) (int, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return 0, festerrors.Wrap(err, "resolving fest binary for judge runner")
+	}
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return 0, festerrors.IO("opening judge log", err).WithField("path", logPath)
+	}
+	defer func() { _ = logFile.Close() }()
+
+	cmd := exec.Command(exe, "workflow", "judge-exec", "--payload", payloadPath)
+	cmd.Dir = phaseDir
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		return 0, festerrors.Wrap(err, "starting judge runner")
+	}
+	pid := cmd.Process.Pid
+	_ = cmd.Process.Release()
+	return pid, nil
+}
+
+// judgeProcessAlive reports whether the recorded judge runner pid is still
+// running, so a stale running record from a crashed runner does not block
+// relaunching the judge forever.
+func judgeProcessAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}
+
+func newJudgeExecCmd() *cobra.Command {
+	var payloadPath string
+	cmd := &cobra.Command{
+		Use:    "judge-exec",
+		Short:  "Internal: run a delegated approval judge and apply its verdict",
+		Hidden: true,
+		Annotations: map[string]string{
+			"scope": string(scope.Festival),
+		},
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runJudgeExec(cmd.Context(), payloadPath)
+		},
+	}
+	cmd.Flags().StringVar(&payloadPath, "payload", "", "path to the payload written by 'fest workflow approve --auto'")
+	_ = cmd.MarkFlagRequired("payload")
+	return cmd
+}
+
+func runJudgeExec(ctx context.Context, payloadPath string) error {
+	raw, err := os.ReadFile(payloadPath)
+	if err != nil {
+		return festerrors.IO("reading judge-exec payload", err).WithField("path", payloadPath)
+	}
+	var payload judgeExecPayload
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return festerrors.Parse("parsing judge-exec payload", err)
+	}
+	if payload.SchemaVersion != judgeExecPayloadSchema {
+		return festerrors.Validation("unsupported judge-exec payload schema").
+			WithField("schema_version", payload.SchemaVersion)
+	}
+
+	opts := approvalJudgeOptions{Auto: true, Wait: true, JudgeCommand: payload.JudgeCommand}
+	if payload.Timeout != "" {
+		timeout, err := time.ParseDuration(payload.Timeout)
+		if err != nil {
+			return festerrors.Validation("invalid judge-exec timeout").WithField("timeout", payload.Timeout)
+		}
+		opts.Timeout = timeout
+	}
+
+	defer func() { _ = os.Remove(payloadPath) }()
+
+	nav, err := getWorkflowNavigator(ctx)
+	if err != nil {
+		return err
+	}
+	state := nav.GetWorkflowState()
+	if state.CurrentStep != payload.StepNumber {
+		return nav.RecordJudgeOutcome(ctx, payload.StepNumber, wf.JudgeFailed,
+			fmt.Sprintf("checkpoint moved before the judge ran (workflow now on step %d); verdict not applied", state.CurrentStep))
+	}
+	steps := nav.GetSteps()
+	if payload.StepNumber < 1 || payload.StepNumber > len(steps) {
+		return festerrors.Validation("judge-exec payload step out of range").
+			WithField("step", fmt.Sprintf("%d", payload.StepNumber))
+	}
+	step := steps[payload.StepNumber-1]
+
+	decision, audit, err := judgeApproval(ctx, nav, step, opts)
+	if err != nil {
+		if recErr := nav.RecordJudgeOutcome(ctx, payload.StepNumber, wf.JudgeFailed, err.Error()); recErr != nil {
+			fmt.Printf("%s failed to record judge outcome: %v\n", ui.Warning("⚠"), recErr)
+		}
+		return err
+	}
+
+	// The judge may have run for a long time; re-read durable state and only
+	// apply the verdict if the delegated checkpoint is still the current one
+	// (an operator may have approved or reset it manually in the meantime).
+	fresh, err := getWorkflowNavigator(ctx)
+	if err != nil {
+		return err
+	}
+	if fresh.GetWorkflowState().CurrentStep != payload.StepNumber {
+		return fresh.RecordJudgeOutcome(ctx, payload.StepNumber, wf.JudgeFailed,
+			fmt.Sprintf("checkpoint changed while the judge was running (workflow now on step %d); verdict %q discarded",
+				fresh.GetWorkflowState().CurrentStep, decision.Decision))
+	}
+
+	return applyApproveAutoVerdict(ctx, fresh, payload.StepNumber, step, decision, audit)
+}

--- a/internal/commands/workflow/workflow.go
+++ b/internal/commands/workflow/workflow.go
@@ -78,6 +78,7 @@ Examples:
 		newAdvanceCmd(),
 		newSkipCmd(),
 		newApproveCmd(),
+		newJudgeExecCmd(),
 		newRejectCmd(),
 		newResetCmd(),
 		newShowCmd(),

--- a/internal/guidance/workflow/navigator.go
+++ b/internal/guidance/workflow/navigator.go
@@ -268,17 +268,17 @@ func (n *Navigator) GetContextFiles(ctx context.Context) ([]string, error) {
 // the current step, before the judge command executes, so concurrent watchers
 // (fest show --watch, fest progress) can render the waiting-on-judge state
 // and a crashed or timed-out judge still leaves a trace.
-func (n *Navigator) BeginJudge(ctx context.Context, command string) error {
-	return n.recordJudge(ctx, EmitJudgeStartedEvents(n.stateKey(), n.workflowState.CurrentStep, command), func(at time.Time) {
-		n.workflowState.BeginJudge(command, at)
+func (n *Navigator) BeginJudge(ctx context.Context, step int, command string, pid int) error {
+	return n.recordJudge(ctx, EmitJudgeStartedEvents(n.stateKey(), step, command, pid), func(at time.Time) {
+		n.workflowState.BeginJudge(step, command, pid, at)
 	})
 }
 
 // RecordJudgeOutcome durably records how the judge run ended: JudgeApproved,
 // JudgeRejected, or JudgeFailed with the reason or error text in detail.
-func (n *Navigator) RecordJudgeOutcome(ctx context.Context, status, detail string) error {
-	return n.recordJudge(ctx, EmitJudgeReturnedEvents(n.stateKey(), n.workflowState.CurrentStep, status, detail), func(at time.Time) {
-		n.workflowState.RecordJudgeOutcome(status, detail, at)
+func (n *Navigator) RecordJudgeOutcome(ctx context.Context, step int, status, detail string) error {
+	return n.recordJudge(ctx, EmitJudgeReturnedEvents(n.stateKey(), step, status, detail), func(at time.Time) {
+		n.workflowState.RecordJudgeOutcome(step, status, detail, at)
 	})
 }
 

--- a/internal/guidance/workflow/state.go
+++ b/internal/guidance/workflow/state.go
@@ -50,6 +50,7 @@ type WorkflowEvent struct {
 	JudgeStatus      string
 	JudgeCommand     string
 	JudgeDetail      string
+	JudgePid         int
 }
 
 // DecisionMetadata records who made a checkpoint decision and the rationale.
@@ -83,6 +84,10 @@ type JudgeState struct {
 
 	// StartedAt is when the judge command was invoked.
 	StartedAt *time.Time `yaml:"started_at,omitempty" json:"started_at,omitempty"`
+
+	// Pid is the process id of the detached judge runner, used to detect a
+	// stale running record after a crash so the judge can be relaunched.
+	Pid int `yaml:"pid,omitempty" json:"pid,omitempty"`
 
 	// FinishedAt is when the judge outcome was recorded.
 	FinishedAt *time.Time `yaml:"finished_at,omitempty" json:"finished_at,omitempty"`
@@ -338,20 +343,24 @@ func (s *WorkflowState) StartCurrentStep() {
 	}
 }
 
-// BeginJudge records a delegated judge run starting on the current step.
-func (s *WorkflowState) BeginJudge(command string, at time.Time) {
-	state := s.GetOrCreateStepState(s.CurrentStep)
+// BeginJudge records a delegated judge run starting on a step.
+func (s *WorkflowState) BeginJudge(step int, command string, pid int, at time.Time) {
+	state := s.GetOrCreateStepState(step)
 	started := at
 	state.Judge = &JudgeState{
 		Status:    JudgeRunning,
 		Command:   command,
 		StartedAt: &started,
+		Pid:       pid,
 	}
 }
 
-// RecordJudgeOutcome records how the current step's judge run ended.
-func (s *WorkflowState) RecordJudgeOutcome(status, detail string, at time.Time) {
-	state := s.GetOrCreateStepState(s.CurrentStep)
+// RecordJudgeOutcome records how a step's judge run ended. The step is
+// explicit because the detached judge runner may finish after the workflow
+// has moved on; the outcome must land on the step that was judged, never on
+// whatever step is current at completion time.
+func (s *WorkflowState) RecordJudgeOutcome(step int, status, detail string, at time.Time) {
+	state := s.GetOrCreateStepState(step)
 	if state.Judge == nil {
 		state.Judge = &JudgeState{}
 	}
@@ -656,13 +665,14 @@ func EmitResetEvents(phaseName string) []WorkflowEvent {
 
 // EmitJudgeStartedEvents generates events for a delegated judge run starting
 // on a blocking checkpoint.
-func EmitJudgeStartedEvents(phaseName string, step int, command string) []WorkflowEvent {
+func EmitJudgeStartedEvents(phaseName string, step int, command string, pid int) []WorkflowEvent {
 	return []WorkflowEvent{{
 		EventType:    "wf_judge_started",
 		Phase:        phaseName,
 		Step:         step,
 		JudgeStatus:  JudgeRunning,
 		JudgeCommand: command,
+		JudgePid:     pid,
 	}}
 }
 

--- a/internal/progress/events.go
+++ b/internal/progress/events.go
@@ -77,6 +77,7 @@ type ProgressEvent struct {
 	JudgeStatus      string `json:"judge_status,omitempty"`
 	JudgeCommand     string `json:"judge_command,omitempty"`
 	JudgeDetail      string `json:"judge_detail,omitempty"`
+	JudgePid         int    `json:"judge_pid,omitempty"`
 }
 
 // loadFromEvents reads the JSONL file and materializes current state.
@@ -412,6 +413,7 @@ func materializeWorkflowState(events []ProgressEvent) *wf.FestivalWorkflowState 
 				Status:    wf.JudgeRunning,
 				Command:   e.JudgeCommand,
 				StartedAt: &ts,
+				Pid:       e.JudgePid,
 			}
 
 		case EventWorkflowJudgeReturned:

--- a/internal/progress/store.go
+++ b/internal/progress/store.go
@@ -629,6 +629,7 @@ func (s *Store) QueueWorkflowEvents(events []wf.WorkflowEvent) {
 			JudgeStatus:      we.JudgeStatus,
 			JudgeCommand:     we.JudgeCommand,
 			JudgeDetail:      we.JudgeDetail,
+			JudgePid:         we.JudgePid,
 		}
 		s.pendingEvents = append(s.pendingEvents, pe)
 	}


### PR DESCRIPTION
## Summary

**Archival draft** of the original `async-judge` worktree WIP, pushed so the work survives local machine crashes.

This is the earlier prototype of fire-and-forget approval judging. It is **not** the preferred continuation branch.

## Prefer instead

**https://github.com/Obedience-Corp/fest/pull/264** (`fest-async-judge`) — rebased/ported onto current main with:

- test mocks for `launchJudgeProcess`
- hard refuse to re-exec go test binaries (prevents process storms / freezes)
- additional unit coverage

## Why this draft exists

A local session working these branches hit a process storm (`workflow.test` re-exec as `judge-exec` under `go test`) that froze the machine. Opening draft PRs for both worktrees so recovery does not depend on local disk alone.

## Worktree

`fest@async-judge` → `projects/worktrees/fest/async-judge`

## Do not merge as-is

- Branch base is behind `main`
- Missing process-storm safety guard
- Incomplete relative to PR #264

Use this PR only as a backup / diff reference.