### PR TITLE
test(workflow): align checkpoint format tests with class semantics

### DIFF
--- a/internal/guidance/workflow/navigator_format_judge_test.go
+++ b/internal/guidance/workflow/navigator_format_judge_test.go
@@ -12,9 +12,43 @@ import (
 	"github.com/Obedience-Corp/fest/internal/scope"
 )
 
-func TestFormatCheckpoint_NoJudgeConfigured(t *testing.T) {
+func TestFormatCheckpoint_NoJudge_OperatorAttestation(t *testing.T) {
+	// Ambiguous legacy steps fail closed as operator_attestation: agents must
+	// hand off to a human and must not be told to configure/run --auto.
 	nav := &Navigator{}
 	step := WorkflowStep{Number: 2, Name: "REVIEW", Goal: "Is the work acceptable?"}
+
+	out, err := nav.formatCheckpoint(context.Background(), step)
+	if err != nil {
+		t.Fatalf("formatCheckpoint() error = %v", err)
+	}
+
+	for _, want := range []string{
+		"Wait for the user's response",
+		"cannot be delegated to a judge",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("checkpoint output missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "fest workflow approve --auto") {
+		t.Errorf("operator_attestation checkpoint must not advertise --auto:\n%s", out)
+	}
+	if strings.Contains(out, "Delegate this decision") {
+		t.Errorf("operator_attestation checkpoint must not suggest configuring a judge:\n%s", out)
+	}
+}
+
+func TestFormatCheckpoint_NoJudge_ArtifactReviewOffersDelegate(t *testing.T) {
+	// Artifact-review checkpoints without a configured judge still stop for a
+	// human, but operators may opt in to auto-judging via hooks.
+	nav := &Navigator{}
+	step := WorkflowStep{
+		Number:          2,
+		Name:            "PRESENT",
+		Goal:            "Present the plan summary",
+		CheckpointClass: CheckpointClassArtifactReview,
+	}
 
 	out, err := nav.formatCheckpoint(context.Background(), step)
 	if err != nil {
@@ -34,7 +68,7 @@ func TestFormatCheckpoint_NoJudgeConfigured(t *testing.T) {
 	}
 }
 
-func TestFormatCheckpoint_JudgeConfigured(t *testing.T) {
+func TestFormatCheckpoint_JudgeConfigured_ArtifactReviewDelegates(t *testing.T) {
 	festivalsRoot := t.TempDir()
 	dotFestival := filepath.Join(festivalsRoot, config.DotFestivalDir)
 	if err := os.MkdirAll(dotFestival, 0o755); err != nil {
@@ -48,7 +82,11 @@ func TestFormatCheckpoint_JudgeConfigured(t *testing.T) {
 	ctx := scope.WithWorkspace(context.Background(), &scope.WorkspaceInfo{FestivalsPath: festivalsRoot})
 
 	nav := &Navigator{}
-	step := WorkflowStep{Number: 2, Name: "REVIEW"}
+	step := WorkflowStep{
+		Number:          2,
+		Name:            "PRESENT",
+		CheckpointClass: CheckpointClassArtifactReview,
+	}
 
 	out, err := nav.formatCheckpoint(ctx, step)
 	if err != nil {
@@ -65,7 +103,51 @@ func TestFormatCheckpoint_JudgeConfigured(t *testing.T) {
 		}
 	}
 	if strings.Contains(out, "Present your work to the user") {
-		t.Errorf("delegated checkpoint should not tell the agent to wait for the user:\n%s", out)
+		t.Errorf("delegated artifact_review checkpoint should not tell the agent to wait for the user:\n%s", out)
+	}
+}
+
+func TestFormatCheckpoint_JudgeConfigured_OperatorAttestationStaysManual(t *testing.T) {
+	// A configured judge must not rewrite operator_attestation gates into the
+	// auto path — those ask whether a human already validated.
+	festivalsRoot := t.TempDir()
+	dotFestival := filepath.Join(festivalsRoot, config.DotFestivalDir)
+	if err := os.MkdirAll(dotFestival, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfgYAML := "version: \"1.0\"\nhooks:\n  approval_judge:\n    command: ob judge\n"
+	if err := os.WriteFile(filepath.Join(dotFestival, config.WorkspaceConfigFileName), []byte(cfgYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	ctx := scope.WithWorkspace(context.Background(), &scope.WorkspaceInfo{FestivalsPath: festivalsRoot})
+
+	nav := &Navigator{}
+	step := WorkflowStep{
+		Number:          2,
+		Name:            "VALIDATE",
+		Goal:            "Did the user explicitly approve the plan?",
+		CheckpointClass: CheckpointClassOperatorAttestation,
+	}
+
+	out, err := nav.formatCheckpoint(ctx, step)
+	if err != nil {
+		t.Fatalf("formatCheckpoint() error = %v", err)
+	}
+
+	for _, want := range []string{
+		"Wait for the user's response",
+		"cannot be delegated to a judge",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("checkpoint output missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "This checkpoint is delegated") {
+		t.Errorf("operator_attestation must not use the delegated judge path:\n%s", out)
+	}
+	if strings.Contains(out, "fest workflow approve --auto") {
+		t.Errorf("operator_attestation must not advertise --auto even when a judge is configured:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up after async judge (#264) and auto-judge hardening (#266).

The #264 review findings (Windows flock/detach/liveness + phase-scoped navigator reload) already landed in the #264 merge (`1e70e68`, `8bc069f`). No further platform/runtime follow-up is needed for those.

This PR fixes the remaining red package tests on `main` after #266:

- Ambiguous checkpoints fail closed as `operator_attestation` and must not advertise `--auto`
- Artifact-review checkpoints without a judge still allow a “configure hooks” delegate hint
- Artifact-review + configured judge uses the delegated path
- Operator attestation stays manual even when a judge hook is configured

## Context

- Parent: #264 (async approval judge), #266 (authority/readiness)
- Worktree: `projects/worktrees/fest/fest-checkpoint-format-fix`

## Test plan

- [x] `go test ./internal/guidance/workflow/`
- [x] `go test ./internal/commands/workflow/ -run 'TestFormat|TestRunApproveAuto|TestApproval'`
- [x] Confirmed Windows build still works on main: `GOOS=windows GOARCH=amd64 go build ./cmd/fest`