### PR TITLE
fix: preserve blocked task status in watch

### DIFF
--- a/internal/commands/show/tree.go
+++ b/internal/commands/show/tree.go
@@ -294,8 +294,11 @@ func buildSequenceNode(seqDir string, store *progress.Store, festivalRoot string
 			NodeType: "task",
 			Status:   displayStatus,
 			Stats: StatusCounts{
-				Total:     1,
-				Completed: boolToInt(status == progress.StatusCompleted),
+				Total:      1,
+				Completed:  boolToInt(status == progress.StatusCompleted),
+				InProgress: boolToInt(status == progress.StatusInProgress),
+				Pending:    boolToInt(status == progress.StatusPending),
+				Blocked:    boolToInt(status == progress.StatusBlocked),
 			},
 		}
 		node.Children = append(node.Children, taskNode)
@@ -305,20 +308,22 @@ func buildSequenceNode(seqDir string, store *progress.Store, festivalRoot string
 	return node
 }
 
-// markNextPending walks the tree top-down and marks the first non-completed
+// markNextPending walks the tree top-down and marks the first non-terminal
 // child at each level as IsNextPending, recursing into it. Only one path
 // through the tree gets marked, giving --inprogress a "next up" expansion.
 func markNextPending(node *DisplayNode) {
 	for _, child := range node.Children {
-		if child.Status != "completed" && child.Status != "skipped" {
-			child.IsNextPending = true
-			// Leaf nodes (tasks/steps) show as in_progress to indicate "work here next"
-			if child.NodeType == "task" || child.NodeType == "step" {
-				child.Status = "in_progress"
-			}
-			markNextPending(child)
-			return
+		if child.Status == "completed" || child.Status == "skipped" {
+			continue
 		}
+		child.IsNextPending = true
+		// Highlight an actual pending leaf as the next place to work, but do
+		// not mask an existing in_progress or blocked status.
+		if (child.NodeType == "task" || child.NodeType == "step") && child.Status == "pending" {
+			child.Status = "in_progress"
+		}
+		markNextPending(child)
+		return
 	}
 }
 
@@ -337,6 +342,9 @@ func determineStatus(stats StatusCounts) string {
 	}
 	if stats.Completed == stats.Total {
 		return "completed"
+	}
+	if stats.Blocked > 0 {
+		return "blocked"
 	}
 	if stats.InProgress > 0 || stats.Completed > 0 {
 		return "in_progress"

--- a/internal/commands/show/tree_test.go
+++ b/internal/commands/show/tree_test.go
@@ -359,6 +359,78 @@ func TestRenderTree_Collapsed(t *testing.T) {
 	}
 }
 
+func TestRenderTree_InProgressPreservesBlockedTaskStatus(t *testing.T) {
+	tree := &DisplayNode{
+		Name:   "test-festival",
+		Status: "blocked",
+		Stats:  StatusCounts{Total: 1, Blocked: 1},
+		Children: []*DisplayNode{{
+			Name:   "001_PHASE",
+			Status: "blocked",
+			Stats:  StatusCounts{Total: 1, Blocked: 1},
+			Children: []*DisplayNode{{
+				Name:   "01_sequence",
+				Status: "blocked",
+				Stats:  StatusCounts{Total: 1, Blocked: 1},
+				Children: []*DisplayNode{{
+					Name:     "01_blocked.md",
+					NodeType: "task",
+					Status:   "blocked",
+					Stats:    StatusCounts{Total: 1, Blocked: 1},
+				}},
+			}},
+		}},
+	}
+
+	opts := DefaultTreeOptions()
+	opts.InProgress = true
+	output := RenderTree(tree, opts)
+
+	if tree.Children[0].Children[0].Children[0].Status != "blocked" {
+		t.Fatalf("in-progress rendering changed blocked task status to %q", tree.Children[0].Children[0].Children[0].Status)
+	}
+	if !strings.Contains(output, "■") {
+		t.Errorf("blocked task should render the blocked icon, got %q", output)
+	}
+	if strings.Contains(output, "●") {
+		t.Errorf("blocked task should not render as in_progress, got %q", output)
+	}
+}
+
+func TestRenderTree_InProgressHighlightsPendingTask(t *testing.T) {
+	task := &DisplayNode{
+		Name:     "01_pending.md",
+		NodeType: "task",
+		Status:   "pending",
+		Stats:    StatusCounts{Total: 1, Pending: 1},
+	}
+	tree := &DisplayNode{
+		Name:   "test-festival",
+		Status: "pending",
+		Stats:  StatusCounts{Total: 1, Pending: 1},
+		Children: []*DisplayNode{{
+			Name:   "001_PHASE",
+			Status: "pending",
+			Stats:  StatusCounts{Total: 1, Pending: 1},
+			Children: []*DisplayNode{{
+				Name:     "01_sequence",
+				NodeType: "sequence",
+				Status:   "pending",
+				Stats:    StatusCounts{Total: 1, Pending: 1},
+				Children: []*DisplayNode{task},
+			}},
+		}},
+	}
+
+	opts := DefaultTreeOptions()
+	opts.InProgress = true
+	RenderTree(tree, opts)
+
+	if task.Status != "in_progress" {
+		t.Errorf("next pending task status = %q, want in_progress", task.Status)
+	}
+}
+
 func TestDetermineStatus(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -370,6 +442,7 @@ func TestDetermineStatus(t *testing.T) {
 		{"all completed", StatusCounts{Total: 5, Completed: 5}, "completed"},
 		{"in progress", StatusCounts{Total: 5, Completed: 2, InProgress: 1, Pending: 2}, "in_progress"},
 		{"some completed no in progress", StatusCounts{Total: 5, Completed: 2, Pending: 3}, "in_progress"},
+		{"blocked", StatusCounts{Total: 5, Blocked: 1, Pending: 4}, "blocked"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Preserve blocked and in-progress task statuses in the `fest watch` next-task expansion.
- Report blocked parent aggregates as `blocked` instead of `pending`.
- Add regression coverage for blocked rendering while preserving pending-task highlighting.

## Root cause

`fest watch` enables the in-progress tree view. Its `markNextPending` helper rewrote any non-terminal leaf to `in_progress`, which masked blocked tasks. Aggregate status resolution also ignored the blocked count.

## Validation

- `go test ./internal/commands/show ./internal/commands/watch ./internal/progress -count=1`
- `go vet ./internal/commands/show ./internal/commands/watch ./internal/progress`
- `just lint gopls-tests internal/commands/show`
- `git diff --check`

The full `just test unit` dashboard still reports two unrelated failures in `internal/guidance/workflow` formatting tests (`TestFormatCheckpoint_NoJudgeConfigured` and `TestFormatCheckpoint_JudgeConfigured`).