### PR TITLE
fix(init): show campaign- or workspace-relative paths in user output

### DIFF
--- a/internal/commands/system/init.go
+++ b/internal/commands/system/init.go
@@ -10,6 +10,7 @@ import (
 	festcontract "github.com/Obedience-Corp/fest/internal/contract"
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/fileops"
+	"github.com/Obedience-Corp/fest/internal/pathutil"
 	"github.com/Obedience-Corp/fest/internal/ui"
 	"github.com/Obedience-Corp/fest/internal/workspace"
 	"github.com/Obedience-Corp/obey-shared/contract"
@@ -84,20 +85,28 @@ func RunInit(ctx context.Context, targetPath string, opts *InitOptions) error {
 		return errors.Wrap(err, "resolving path").WithField("path", targetPath)
 	}
 
+	// Prefer campaign-relative display paths; fall back to the init target
+	// (festival workspace root) when not inside a campaign.
+	campaignRoot, campaignErr := workspace.DetectCampaign(ctx, absPath)
+	displayRoot := resolveDisplayRoot(campaignRoot, campaignErr, absPath)
+	showPath := func(p string) string {
+		return pathutil.DisplayPath(p, displayRoot)
+	}
+
 	// Handle --register flag: register existing festivals directory
 	if opts.Register {
-		return runRegister(absPath, display)
+		return runRegister(ctx, absPath, display)
 	}
 
 	// Handle --unregister flag: remove workspace marker
 	if opts.Unregister {
-		return runUnregister(absPath, display)
+		return runUnregister(ctx, absPath, display)
 	}
 
 	// Check if festival already exists
 	festivalPath := filepath.Join(absPath, "festivals")
 	if fileops.Exists(festivalPath) && !opts.Force {
-		if !display.Confirm("Festival directory already exists at %s. Overwrite?", festivalPath) {
+		if !display.Confirm("Festival directory already exists at %s. Overwrite?", showPath(festivalPath)) {
 			display.Warning("Initialization cancelled")
 			return nil
 		}
@@ -131,7 +140,7 @@ func RunInit(ctx context.Context, targetPath string, opts *InitOptions) error {
 		}
 	}
 
-	display.Info("Initializing festival structure at %s...", festivalPath)
+	display.Info("Initializing festival structure at %s...", showPath(festivalPath))
 
 	// Create festivals directory if it doesn't exist
 	if err := os.MkdirAll(festivalPath, 0755); err != nil {
@@ -182,7 +191,7 @@ func RunInit(ctx context.Context, targetPath string, opts *InitOptions) error {
 			return errors.IO("saving checksums", err).WithField("path", checksumFile)
 		}
 
-		display.Info("Created checksum tracking at %s", checksumFile)
+		display.Info("Created checksum tracking at %s", showPath(checksumFile))
 	}
 
 	// Scaffold a user-owned .festival/config.yaml with a commented hooks example
@@ -208,36 +217,51 @@ func RunInit(ctx context.Context, targetPath string, opts *InitOptions) error {
 	// This declares fest's state files and directories so the daemon knows
 	// what to watch. If no campaign exists (standalone fest workspace),
 	// skip gracefully -- the contract only matters when a daemon is present.
-	campaignRoot, campaignErr := workspace.DetectCampaign(ctx, absPath)
 	if campaignErr == nil {
 		contractPath := contract.ContractPath(campaignRoot)
 		if err := contract.WriteEntries(contractPath, contract.OwnerFest, festcontract.FestEntries()); err != nil {
 			display.Warning("Could not write contract entries: %v", err)
 		} else {
 			if shared.IsVerbose() {
-				display.Info("Wrote fest entries to %s", contractPath)
+				display.Info("Wrote fest entries to %s", showPath(contractPath))
 			}
 		}
 	}
 
-	// Show summary
-	display.Success("Successfully initialized festival structure at %s", festivalPath)
+	// Show summary — user-facing paths stay campaign- or workspace-relative.
+	display.Success("Successfully initialized festival structure at %s", showPath(festivalPath))
 	display.Info("\nNext steps:")
-	display.Info("  1. cd %s", absPath)
+	display.Info("  1. cd %s", showPath(absPath))
 	display.Info("  2. Review festivals/.festival/README.md")
 	display.Info("  3. Start planning your festival in festivals/planning/")
 	display.Info("\nWorkspace navigation:")
-	display.Info("  cd $(fest go)              # Navigate to festivals from anywhere")
+	display.Info("  cd \"$(fest go --print)\"   # Navigate to festivals from anywhere")
 
 	return nil
 }
 
+// resolveDisplayRoot chooses the root used for user-facing path display.
+// Prefer campaign root when present; otherwise the festival workspace root
+// (init target / parent of festivals/).
+func resolveDisplayRoot(campaignRoot string, campaignErr error, festivalWorkspaceRoot string) string {
+	if campaignErr == nil && campaignRoot != "" {
+		return campaignRoot
+	}
+	return festivalWorkspaceRoot
+}
+
 // runRegister registers an existing festivals directory as the active workspace
-func runRegister(targetPath string, display *ui.UI) error {
+func runRegister(ctx context.Context, targetPath string, display *ui.UI) error {
 	// Find the festivals directory
 	festivalsDir, err := findFestivalsDir(targetPath)
 	if err != nil {
 		return err
+	}
+
+	campaignRoot, campaignErr := workspace.DetectCampaign(ctx, festivalsDir)
+	displayRoot := resolveDisplayRoot(campaignRoot, campaignErr, filepath.Dir(festivalsDir))
+	showPath := func(p string) string {
+		return pathutil.DisplayPath(p, displayRoot)
 	}
 
 	// Check if already registered
@@ -260,23 +284,29 @@ func runRegister(targetPath string, display *ui.UI) error {
 		wsName = marker.Workspace
 	}
 
-	display.Success("Registered %s as workspace: %s", festivalsDir, wsName)
-	display.Info("You can now use 'cd $(fest go)' from anywhere in this project")
+	display.Success("Registered %s as workspace: %s", showPath(festivalsDir), wsName)
+	display.Info("You can now use 'cd \"$(fest go --print)\"' from anywhere in this project")
 
 	return nil
 }
 
 // runUnregister removes the workspace marker from a festivals directory
-func runUnregister(targetPath string, display *ui.UI) error {
+func runUnregister(ctx context.Context, targetPath string, display *ui.UI) error {
 	// Find the festivals directory
 	festivalsDir, err := findFestivalsDir(targetPath)
 	if err != nil {
 		return err
 	}
 
+	campaignRoot, campaignErr := workspace.DetectCampaign(ctx, festivalsDir)
+	displayRoot := resolveDisplayRoot(campaignRoot, campaignErr, filepath.Dir(festivalsDir))
+	showPath := func(p string) string {
+		return pathutil.DisplayPath(p, displayRoot)
+	}
+
 	// Check if registered
 	if !workspace.HasMarker(festivalsDir) {
-		display.Info("No workspace marker found at %s", festivalsDir)
+		display.Info("No workspace marker found at %s", showPath(festivalsDir))
 		return nil
 	}
 

--- a/internal/commands/system/init_test.go
+++ b/internal/commands/system/init_test.go
@@ -1,0 +1,147 @@
+package system
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/pathutil"
+	"github.com/Obedience-Corp/fest/internal/workspace"
+)
+
+func TestResolveDisplayRoot(t *testing.T) {
+	campaignRoot := "/home/user/campaigns/my-campaign"
+	workspaceRoot := "/home/user/campaigns/my-campaign/festivals/active/fest-F0001/feedback"
+
+	tests := []struct {
+		name                   string
+		campaignRoot           string
+		campaignErr            error
+		festivalWorkspaceRoot  string
+		want                   string
+	}{
+		{
+			name:                  "prefers campaign root when detected",
+			campaignRoot:          campaignRoot,
+			campaignErr:           nil,
+			festivalWorkspaceRoot: workspaceRoot,
+			want:                  campaignRoot,
+		},
+		{
+			name:                  "falls back to festival workspace root when no campaign",
+			campaignRoot:          "",
+			campaignErr:           workspace.ErrNoCampaign,
+			festivalWorkspaceRoot: workspaceRoot,
+			want:                  workspaceRoot,
+		},
+		{
+			name:                  "falls back when campaign root empty even without error",
+			campaignRoot:          "",
+			campaignErr:           nil,
+			festivalWorkspaceRoot: workspaceRoot,
+			want:                  workspaceRoot,
+		},
+		{
+			name:                  "standalone init target",
+			campaignRoot:          "",
+			campaignErr:           errors.New("no campaign"),
+			festivalWorkspaceRoot: "/tmp/standalone-project",
+			want:                  "/tmp/standalone-project",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveDisplayRoot(tc.campaignRoot, tc.campaignErr, tc.festivalWorkspaceRoot)
+			if got != tc.want {
+				t.Errorf("resolveDisplayRoot() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInitDisplayPaths_CampaignRelative(t *testing.T) {
+	campaignRoot := "/home/lance/campaigns/lance-arch"
+	absPath := filepath.Join(campaignRoot, "festivals", "active", "endeavouros-workstation-setup-EW0001", "feedback")
+	festivalPath := filepath.Join(absPath, "festivals")
+	checksumFile := filepath.Join(festivalPath, ".festival", ".state", ".fest-checksums.json")
+
+	displayRoot := resolveDisplayRoot(campaignRoot, nil, absPath)
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "festivals directory",
+			path: festivalPath,
+			want: "festivals/active/endeavouros-workstation-setup-EW0001/feedback/festivals",
+		},
+		{
+			name: "checksum file",
+			path: checksumFile,
+			want: "festivals/active/endeavouros-workstation-setup-EW0001/feedback/festivals/.festival/.state/.fest-checksums.json",
+		},
+		{
+			name: "init target for cd",
+			path: absPath,
+			want: "festivals/active/endeavouros-workstation-setup-EW0001/feedback",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := pathutil.DisplayPath(tc.path, displayRoot)
+			if got != tc.want {
+				t.Errorf("DisplayPath(%q) = %q, want %q", tc.path, got, tc.want)
+			}
+			if filepath.IsAbs(got) {
+				t.Errorf("DisplayPath(%q) still absolute: %q", tc.path, got)
+			}
+		})
+	}
+}
+
+func TestInitDisplayPaths_StandaloneFestivalRootRelative(t *testing.T) {
+	// No campaign: paths should be relative to the init target (festival workspace root).
+	absPath := "/tmp/my-standalone-project"
+	festivalPath := filepath.Join(absPath, "festivals")
+	checksumFile := filepath.Join(festivalPath, ".festival", ".state", ".fest-checksums.json")
+
+	displayRoot := resolveDisplayRoot("", workspace.ErrNoCampaign, absPath)
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "festivals directory",
+			path: festivalPath,
+			want: "festivals",
+		},
+		{
+			name: "checksum file",
+			path: checksumFile,
+			want: "festivals/.festival/.state/.fest-checksums.json",
+		},
+		{
+			name: "init target for cd",
+			path: absPath,
+			want: ".",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := pathutil.DisplayPath(tc.path, displayRoot)
+			if got != tc.want {
+				t.Errorf("DisplayPath(%q) = %q, want %q", tc.path, got, tc.want)
+			}
+			if filepath.IsAbs(got) {
+				t.Errorf("DisplayPath(%q) still absolute: %q", tc.path, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `fest init` (and register/unregister messages) no longer print absolute system paths in user-facing output.
- Paths are displayed **campaign-root-relative** when a campaign is detected (e.g. `festivals/active/.../feedback/festivals`).
- Outside a campaign, paths are **festival-workspace-relative** (relative to the init target / parent of `festivals/`, e.g. `festivals`, `.`).
- Navigation hint corrected to `cd "$(fest go --print)"` (bare `fest go` prints `cd /path`, which is not shell-safe for command substitution).

## Problem

Nested `fest init feedback` under a festival produced noise like:

```text
Successfully initialized festival structure at /home/lance/campaigns/lance-arch/festivals/active/.../feedback/festivals
  1. cd /home/lance/campaigns/lance-arch/festivals/active/.../feedback
```

## Solution

Reuse existing `pathutil.DisplayPath` with a resolved display root:

1. Campaign root when `DetectCampaign` succeeds
2. Otherwise the festival workspace root (init target)

## Test plan

- [x] `go test ./internal/commands/system/ -run 'TestResolveDisplayRoot|TestInitDisplayPaths'`
- [x] Full `go test ./internal/commands/system/`
- [x] `go build ./cmd/fest`
- [ ] Manual: `fest init` inside a campaign — paths look like `festivals/...`
- [ ] Manual: nested init (e.g. `feedback`) — paths stay campaign-relative, not absolute
- [ ] Manual: standalone (no `.campaign`) — paths relative to init target (`festivals`, `.`)