### PR TITLE
fix(workflow): auto-judge legacy phase gates

### DIFF
--- a/internal/commands/workflow/auto_delegate_test.go
+++ b/internal/commands/workflow/auto_delegate_test.go
@@ -66,6 +66,9 @@ func TestAutoDelegateBlockingCheckpoints_NoJudgeIsNoop(t *testing.T) {
 	if err := nav.Initialize(context.Background()); err != nil {
 		t.Fatal(err)
 	}
+	if got := nav.GetSteps()[0].CheckpointClass; got != wf.CheckpointClassArtifactReview {
+		t.Fatalf("legacy GATES.md checkpoint class = %q, want artifact_review", got)
+	}
 
 	if err := AutoDelegateBlockingCheckpoints(context.Background(), nav); err != nil {
 		t.Fatalf("no-op without judge: %v", err)

--- a/internal/guidance/workflow/checkpoint_class_test.go
+++ b/internal/guidance/workflow/checkpoint_class_test.go
@@ -57,6 +57,43 @@ func TestClassifyCheckpoint_AmbiguousHumanGateFailsClosed(t *testing.T) {
 	}
 }
 
+func TestNormalizeLegacyGateCheckpointClasses(t *testing.T) {
+	steps := []WorkflowStep{
+		{
+			Name:       "LEGACY-GATE",
+			Checkpoint: CheckpointUserApproval,
+		},
+		{
+			Name:            "HUMAN-ATTESTATION",
+			Checkpoint:      CheckpointUserApproval,
+			CheckpointClass: CheckpointClassOperatorAttestation,
+		},
+		{
+			Name:            "EXPLICIT-REVIEW",
+			Checkpoint:      CheckpointUserApproval,
+			CheckpointClass: CheckpointClassArtifactReview,
+		},
+		{
+			Name:       "NON-BLOCKING",
+			Checkpoint: CheckpointVerification,
+		},
+	}
+
+	normalizeLegacyGateCheckpointClasses(steps)
+
+	want := []CheckpointClass{
+		CheckpointClassArtifactReview,
+		CheckpointClassOperatorAttestation,
+		CheckpointClassArtifactReview,
+		CheckpointClassUnspecified,
+	}
+	for i, step := range steps {
+		if step.CheckpointClass != want[i] {
+			t.Errorf("step %d CheckpointClass = %q, want %q", i+1, step.CheckpointClass, want[i])
+		}
+	}
+}
+
 func TestParser_CheckpointClassAndEvidence(t *testing.T) {
 	content := `## Step 4: PRESENT — Get User Approval
 

--- a/internal/guidance/workflow/navigator.go
+++ b/internal/guidance/workflow/navigator.go
@@ -132,6 +132,9 @@ func (n *Navigator) Initialize(ctx context.Context) error {
 	if err != nil {
 		return errors.Parse("parsing workflow document", err).WithField("file", n.filename())
 	}
+	if n.IsGate() {
+		normalizeLegacyGateCheckpointClasses(steps)
+	}
 
 	n.steps = steps
 
@@ -170,6 +173,21 @@ func (n *Navigator) Initialize(ctx context.Context) error {
 	n.workflowState = state
 
 	return nil
+}
+
+// normalizeLegacyGateCheckpointClasses preserves auto-judge behavior for
+// phase gates created before checkpoint classes were added to the GATES.md
+// template. Phase gates are artifact-oriented quality checks by convention,
+// so an omitted class on a blocking gate is compatible with artifact_review.
+// Explicit operator_attestation remains human-only, and regular WORKFLOW.md
+// steps continue to fail closed through ClassifyCheckpoint.
+func normalizeLegacyGateCheckpointClasses(steps []WorkflowStep) {
+	for i := range steps {
+		if steps[i].Checkpoint.IsBlocking() &&
+			steps[i].CheckpointClass == CheckpointClassUnspecified {
+			steps[i].CheckpointClass = CheckpointClassArtifactReview
+		}
+	}
 }
 
 // GetNext returns the next workflow step.


### PR DESCRIPTION
## What changed

- Treat blocking checkpoints in legacy `GATES.md` files without a checkpoint class as `artifact_review` during navigator initialization.
- Preserve explicit `operator_attestation` as human-only and leave regular `WORKFLOW.md` ambiguity fail-closed.
- Add regression coverage for the normalization rule and legacy gate loading.

## Why

The workspace approval judge hook was configured, but festivals created before checkpoint classes were added to the gate template had no class annotation. The parser correctly failed closed, so `fest next` silently skipped auto-judging and rendered a manual checkpoint instead.

Phase gates are artifact-oriented quality checks by methodology, so this compatibility normalization restores the intended judge behavior for existing festivals without broadening auto-approval for arbitrary workflow steps.

## Validation

- `go test ./...`
- `go vet ./...`
- `just build quick`

Ready for review.