### PR TITLE
feat(workflow): clarify judge state and retry commands

### DIFF
--- a/docs/cli-reference/fest-reference.md
+++ b/docs/cli-reference/fest-reference.md
@@ -6832,6 +6832,7 @@ Examples:
   fest workflow advance             # Complete current step and move to next
   fest workflow skip --reason "already completed externally" # Operator override
   fest workflow approve             # Approve a blocking checkpoint
+  fest workflow judge               # Run or re-run the configured approval judge
   fest workflow reject              # Reject checkpoint with feedback
   fest workflow reset               # Reset workflow or gate to step 1
   fest workflow show                # Display the current step details
@@ -6911,8 +6912,8 @@ Auto approval:
 ```bash
   fest next auto-invokes the judge on blocking WORKFLOW.md / GATES.md steps.
 
-  Use --auto to re-run the judge explicitly (for example after a reject or a
-  failed judge invocation). Agents must not clear checkpoints with --as agent;
+  Use 'fest workflow judge' to re-run the judge explicitly after a rejection;
+  '--auto' remains a backwards-compatible alias. Agents must not clear checkpoints with --as agent;
   agent-actor decisions are recorded only via the judge path.
 
   Checkpoint classes:
@@ -6923,7 +6924,7 @@ Auto approval:
   Presentation-like steps require non-empty evidence (e.g. output_specs/PRESENTATION.md)
   before the judge is invoked. Missing evidence blocks deterministically without a model call.
 
-  After a judge reject, re-submit with: fest workflow approve --auto
+  After a judge reject, re-submit with: fest workflow judge
   Operator override (interactive TTY, or --override-judge --summary "..."):
   records decision_actor=user_override.
 
@@ -7057,6 +7058,46 @@ fest workflow init [flags]
       --force                overwrite existing .workflow/workflow.yaml
   -h, --help                 help for init
       --workflow-id string   workflow_id to write into manifest (defaults to wf-<basename>)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --phase string    specify phase directory (e.g., 001_INGEST)
+      --verbose         enable verbose output
+```
+---
+
+## fest workflow judge
+
+Run the approval judge for the current checkpoint
+
+### Synopsis
+
+Run the configured approval judge for the current blocking checkpoint.
+
+Use this after revising evidence following a judge rejection. A judge-owned
+rejection is reopened automatically; ordinary operator rejections still
+require 'fest workflow approve'. By default the judge runs in the background;
+use --wait when this command should wait for the verdict.
+
+The judge command is resolved from --judge-command or the
+hooks.approval_judge.command workspace configuration hook.
+
+```
+fest workflow judge [flags]
+```
+
+### Options
+
+```
+  -h, --help                     help for judge
+      --judge-command string     approval judge command (overrides hooks.approval_judge.command)
+      --judge-timeout duration   maximum time to wait for the approval judge (0 waits until it returns)
+      --wait                     block until the judge returns instead of launching it in the background
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/fest-reference.md
+++ b/docs/cli-reference/fest-reference.md
@@ -4529,6 +4529,7 @@ fest show [festival-name] [flags]
       --inprogress        expand only in-progress phases and sequences
       --json              output in JSON format
       --roadmap           show full execution roadmap with task statuses
+      --show-feedback     show blocked-step feedback
       --summary           show aggregate summary instead of tree view
       --watch             continuously refresh display
 ```
@@ -6635,10 +6636,11 @@ fest watch [festival-selector] [flags]
 ### Options
 
 ```
-      --collapsed   show collapsed tree with counters only
-      --goals       show goals for phases and sequences
-  -h, --help        help for watch
-      --summary     show aggregate summary instead of tree view
+      --collapsed       show collapsed tree with counters only
+      --goals           show goals for phases and sequences
+  -h, --help            help for watch
+      --show-feedback   show blocked-step feedback
+      --summary         show aggregate summary instead of tree view
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/fest_show.md
+++ b/docs/cli-reference/fest_show.md
@@ -41,6 +41,7 @@ fest show [festival-name] [flags]
       --inprogress        expand only in-progress phases and sequences
       --json              output in JSON format
       --roadmap           show full execution roadmap with task statuses
+      --show-feedback     show blocked-step feedback
       --summary           show aggregate summary instead of tree view
       --watch             continuously refresh display
 ```

--- a/docs/cli-reference/fest_watch.md
+++ b/docs/cli-reference/fest_watch.md
@@ -30,10 +30,11 @@ fest watch [festival-selector] [flags]
 ### Options
 
 ```
-      --collapsed   show collapsed tree with counters only
-      --goals       show goals for phases and sequences
-  -h, --help        help for watch
-      --summary     show aggregate summary instead of tree view
+      --collapsed       show collapsed tree with counters only
+      --goals           show goals for phases and sequences
+  -h, --help            help for watch
+      --show-feedback   show blocked-step feedback
+      --summary         show aggregate summary instead of tree view
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/fest_workflow.md
+++ b/docs/cli-reference/fest_workflow.md
@@ -52,6 +52,7 @@ Examples:
   fest workflow advance             # Complete current step and move to next
   fest workflow skip --reason "already completed externally" # Operator override
   fest workflow approve             # Approve a blocking checkpoint
+  fest workflow judge               # Run or re-run the configured approval judge
   fest workflow reject              # Reject checkpoint with feedback
   fest workflow reset               # Reset workflow or gate to step 1
   fest workflow show                # Display the current step details
@@ -80,6 +81,7 @@ Examples:
 * [fest workflow approve](fest_workflow_approve.md)	 - Approve a blocking checkpoint
 * [fest workflow create](fest_workflow_create.md)	 - Scaffold a new standalone WORKFLOW.md (alias of 'fest create workflow')
 * [fest workflow init](fest_workflow_init.md)	 - Initialize standalone workflow runtime
+* [fest workflow judge](fest_workflow_judge.md)	 - Run the approval judge for the current checkpoint
 * [fest workflow reject](fest_workflow_reject.md)	 - Reject checkpoint with feedback
 * [fest workflow renumber](fest_workflow_renumber.md)	 - Renumber step headings in a WORKFLOW.md to a contiguous 1-indexed sequence
 * [fest workflow reset](fest_workflow_reset.md)	 - Reset workflow to step 1

--- a/docs/cli-reference/fest_workflow_approve.md
+++ b/docs/cli-reference/fest_workflow_approve.md
@@ -19,8 +19,8 @@ Auto approval:
 ```bash
   fest next auto-invokes the judge on blocking WORKFLOW.md / GATES.md steps.
 
-  Use --auto to re-run the judge explicitly (for example after a reject or a
-  failed judge invocation). Agents must not clear checkpoints with --as agent;
+  Use 'fest workflow judge' to re-run the judge explicitly after a rejection;
+  '--auto' remains a backwards-compatible alias. Agents must not clear checkpoints with --as agent;
   agent-actor decisions are recorded only via the judge path.
 
   Checkpoint classes:
@@ -31,7 +31,7 @@ Auto approval:
   Presentation-like steps require non-empty evidence (e.g. output_specs/PRESENTATION.md)
   before the judge is invoked. Missing evidence blocks deterministically without a model call.
 
-  After a judge reject, re-submit with: fest workflow approve --auto
+  After a judge reject, re-submit with: fest workflow judge
   Operator override (interactive TTY, or --override-judge --summary "..."):
   records decision_actor=user_override.
 

--- a/docs/cli-reference/fest_workflow_judge.md
+++ b/docs/cli-reference/fest_workflow_judge.md
@@ -1,0 +1,42 @@
+## fest workflow judge
+
+Run the approval judge for the current checkpoint
+
+### Synopsis
+
+Run the configured approval judge for the current blocking checkpoint.
+
+Use this after revising evidence following a judge rejection. A judge-owned
+rejection is reopened automatically; ordinary operator rejections still
+require 'fest workflow approve'. By default the judge runs in the background;
+use --wait when this command should wait for the verdict.
+
+The judge command is resolved from --judge-command or the
+hooks.approval_judge.command workspace configuration hook.
+
+```
+fest workflow judge [flags]
+```
+
+### Options
+
+```
+  -h, --help                     help for judge
+      --judge-command string     approval judge command (overrides hooks.approval_judge.command)
+      --judge-timeout duration   maximum time to wait for the approval judge (0 waits until it returns)
+      --wait                     block until the judge returns instead of launching it in the background
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --phase string    specify phase directory (e.g., 001_INGEST)
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest workflow](fest_workflow.md)	 - Manage workflow-based phase execution

--- a/embedded/docs/understand/workflow.txt
+++ b/embedded/docs/understand/workflow.txt
@@ -53,7 +53,7 @@ Common commands:
   fest workflow show
   fest workflow advance
   fest workflow approve
-  fest workflow approve --auto
+  fest workflow judge
   fest workflow reject --reason "..."
   fest workflow reset
   fest workflow skip --reason "already completed externally"
@@ -69,7 +69,9 @@ When that hook is set:
 
   • `fest next` auto-invokes the judge on each consecutive blocking checkpoint
     and continues after approve (or stops after reject / fail-closed errors).
-  • `fest workflow approve --auto` remains available for an explicit re-run.
+  • `fest workflow judge` explicitly runs or re-runs the configured judge after
+    feedback is addressed; `fest workflow approve --auto` remains a compatible
+    alias.
 
 There is no default judge command: without the hook (or `--judge-command`),
 approval stays manual and fails closed for `--auto`.
@@ -80,7 +82,7 @@ The judge command receives JSON on stdin using schema
 non-zero exits, malformed JSON, unknown decisions, and empty reasons fail
 closed: fest does not approve the checkpoint and leaves the workflow state
 unchanged except for valid reject decisions, which block the step with the
-judge reason in the audit text.
+judge reason as concise feedback.
 
 Auto-Routing Rules
 ------------------

--- a/embedded/templates/agent/workflow/checkpoint.tmpl
+++ b/embedded/templates/agent/workflow/checkpoint.tmpl
@@ -54,9 +54,9 @@ loop.
    waiting-on-judge while the detached runner is alive.
 2. When the judge returns, run `fest next` again:
    - Approved: the workflow continues.
-   - Rejected: address the recorded feedback, then
-     `fest workflow approve --auto` to resubmit.
-3. Do **not** run `fest workflow approve --auto` again while the judge is
+   - Rejected: address the recorded feedback, then run
+     `fest workflow judge` to resubmit.
+3. Do **not** run `fest workflow judge` again while the judge is
    running (duplicate launch is refused).
 
 **Operator commands:**
@@ -70,21 +70,21 @@ lands on a blocking checkpoint; you should not wait for a human.
 
 **What you should do:**
 1. If you are reading this after `fest next` without an auto-verdict, run:
-   fest workflow approve --auto
+   fest workflow judge
    (default is fire-and-forget: it launches the judge and returns immediately;
    use `--wait` only when you need a blocking in-process verdict)
 2. While the judge runs, the checkpoint stays blocked and
    `fest workflow status` / `fest show` render purple waiting-on-judge.
 3. After the judge returns, run fest next:
    - Approved: continue.
-   - Rejected: address the recorded feedback, then fest workflow approve --auto to
+   - Rejected: address the recorded feedback, then fest workflow judge to
      resubmit.
 4. Auto mode fails closed on judge errors (checkpoint unchanged).
 
 **Operator commands:**
 - Manual approve: fest workflow approve
 - Reject with feedback: fest workflow reject --reason "..."
-- Block until verdict: fest workflow approve --auto --wait
+- Block until verdict: fest workflow judge --wait
 {{- else}}
 
 This step requires explicit operator confirmation before proceeding.
@@ -102,7 +102,7 @@ This step requires explicit operator confirmation before proceeding.
 - This checkpoint requires human attestation and cannot be delegated to a judge.
 {{- else}}
 - Delegate this decision: configure hooks.approval_judge.command, then
-  fest workflow approve --auto
+  fest workflow judge
 {{- end}}
 {{- end}}
 

--- a/embedded/templates/agent/workflow/step.tmpl
+++ b/embedded/templates/agent/workflow/step.tmpl
@@ -58,13 +58,17 @@ Progress: Step {{.StepNumber}}/{{.TotalSteps}} | Phase: {{.PhaseName}} | Type: {
 This step is BLOCKED: {{.Feedback}}
 
 Address the feedback and try again.
+{{if .JudgeRetryAvailable}}
+When the revised evidence is ready, re-run the approval judge:
+  fest workflow judge
+{{end}}
 {{else if .IsBlocking}}
 When work is complete, submit for review:
   fest workflow advance
 {{if and .JudgeConfigured (not .OperatorAttestation)}}
 This checkpoint is delegated to the operator-configured approval judge. After
 advancing, run:
-  fest workflow approve --auto
+  fest workflow judge
 {{else}}
 This will require operator approval before proceeding. Present the work and
 wait for the operator; do not approve it yourself.

--- a/internal/commands/next/remediation.go
+++ b/internal/commands/next/remediation.go
@@ -98,7 +98,7 @@ func findFailedRemediationGateInStore(ctx context.Context, festivalPath string, 
 		PhasePath:        phasePath,
 		PhaseName:        c.phaseName,
 		Step:             c.stepNum,
-		Reason:           c.stepState.Feedback,
+		Reason:           wf.DisplayFeedback(c.stepState.Feedback),
 		RemediationPhase: c.stepState.RemediationPhase,
 	}
 	if name, err := lookupGateStepName(ctx, phasePath, c.stepNum); err == nil {

--- a/internal/commands/shared/workflow_render.go
+++ b/internal/commands/shared/workflow_render.go
@@ -58,7 +58,7 @@ func RenderWorkflowStepLine(step WorkflowStepView, compact bool) string {
 	var sb strings.Builder
 
 	icon := WorkflowStepIcon(step.Status)
-	if step.JudgeWaiting() && step.Status != wf.StepStatusBlocked {
+	if step.JudgeWaiting() {
 		icon = ui.ColoredText("⚖", ui.JudgeColor)
 	}
 

--- a/internal/commands/shared/workflow_render.go
+++ b/internal/commands/shared/workflow_render.go
@@ -58,7 +58,7 @@ func RenderWorkflowStepLine(step WorkflowStepView, compact bool) string {
 	var sb strings.Builder
 
 	icon := WorkflowStepIcon(step.Status)
-	if step.JudgeWaiting() {
+	if step.JudgeWaiting() && step.Status != wf.StepStatusBlocked {
 		icon = ui.ColoredText("⚖", ui.JudgeColor)
 	}
 
@@ -91,27 +91,28 @@ func RenderWorkflowStepLine(step WorkflowStepView, compact bool) string {
 		fmt.Fprintf(&sb, "     %s: %s\n", ui.Dim("Goal"), step.Goal)
 	}
 
-	if !compact && step.Feedback != "" {
+	feedback := wf.DisplayFeedback(step.Feedback)
+	if !compact && feedback != "" {
 		switch step.Status {
 		case wf.StepStatusBlocked:
-			fmt.Fprintf(&sb, "     %s: %s\n", ui.Error("Feedback"), step.Feedback)
+			fmt.Fprintf(&sb, "     %s: %s\n", ui.Error("Feedback"), feedback)
 		case wf.StepStatusSkipped, wf.StepStatusCompleted:
-			fmt.Fprintf(&sb, "     %s: %s\n", ui.Warning("Note"), step.Feedback)
+			fmt.Fprintf(&sb, "     %s: %s\n", ui.Warning("Note"), feedback)
 		}
 	}
 
 	if !compact && step.Judge != nil {
 		switch step.Judge.Status {
 		case wf.JudgeRunning:
-			started := ""
-			if step.Judge.StartedAt != nil {
-				started = " since " + step.Judge.StartedAt.Local().Format("15:04:05")
-			}
-			fmt.Fprintf(&sb, "     %s\n", ui.ColoredText(fmt.Sprintf("Waiting on judge (%s)%s", step.Judge.Command, started), ui.JudgeColor))
+			fmt.Fprintf(&sb, "     %s\n", ui.ColoredText("Judge: waiting", ui.JudgeColor))
 		case wf.JudgeFailed:
-			fmt.Fprintf(&sb, "     %s: %s\n", ui.Error("Judge failed (fails closed)"), step.Judge.Detail)
+			fmt.Fprintf(&sb, "     %s", ui.Error("Judge: failed (fails closed)"))
+			if detail := wf.DisplayFeedback(step.Judge.Detail); detail != "" {
+				fmt.Fprintf(&sb, ": %s", detail)
+			}
+			sb.WriteByte('\n')
 		case wf.JudgeApproved, wf.JudgeRejected:
-			fmt.Fprintf(&sb, "     %s: %s\n", ui.Dim("Judge "+step.Judge.Status), step.Judge.Detail)
+			fmt.Fprintf(&sb, "     %s\n", ui.Dim("Judge: "+step.Judge.Status))
 		}
 	}
 
@@ -178,7 +179,7 @@ func LoadWorkflowStepsForPhase(ctx context.Context, festivalPath, phasePath stri
 		var judge *wf.JudgeState
 		if stepState != nil {
 			status = stepState.Status
-			feedback = stepState.Feedback
+			feedback = wf.DisplayFeedback(stepState.Feedback)
 			judge = stepState.Judge
 		}
 
@@ -275,7 +276,7 @@ func LoadGateStepsForPhase(ctx context.Context, festivalPath, phasePath string) 
 		var judge *wf.JudgeState
 		if stepState != nil {
 			status = stepState.Status
-			feedback = stepState.Feedback
+			feedback = wf.DisplayFeedback(stepState.Feedback)
 			judge = stepState.Judge
 		}
 

--- a/internal/commands/shared/workflow_render_judge_test.go
+++ b/internal/commands/shared/workflow_render_judge_test.go
@@ -34,6 +34,19 @@ func TestRenderWorkflowStepLine_WaitingOnJudge(t *testing.T) {
 	}
 }
 
+func TestRenderWorkflowStepLine_BlockedWaitingOnJudgeUsesJudgeIcon(t *testing.T) {
+	view := judgeStepView(&wf.JudgeState{Status: wf.JudgeRunning})
+	view.Status = wf.StepStatusBlocked
+	out := RenderWorkflowStepLine(view, false)
+
+	if !strings.Contains(out, "⚖ Step 2: REVIEW") {
+		t.Fatalf("blocked waiting step missing judge icon:\n%s", out)
+	}
+	if !strings.Contains(out, "Judge: waiting") {
+		t.Fatalf("blocked waiting step missing judge state:\n%s", out)
+	}
+}
+
 func TestRenderWorkflowStepLine_JudgeFailed(t *testing.T) {
 	out := RenderWorkflowStepLine(judgeStepView(&wf.JudgeState{
 		Status: wf.JudgeFailed,

--- a/internal/commands/shared/workflow_render_judge_test.go
+++ b/internal/commands/shared/workflow_render_judge_test.go
@@ -27,7 +27,7 @@ func TestRenderWorkflowStepLine_WaitingOnJudge(t *testing.T) {
 		StartedAt: &started,
 	}), false)
 
-	for _, want := range []string{"[waiting on judge]", "Waiting on judge (ob judge)", "⚖"} {
+	for _, want := range []string{"[waiting on judge]", "Judge: waiting", "⚖"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing %q:\n%s", want, out)
 		}
@@ -40,7 +40,7 @@ func TestRenderWorkflowStepLine_JudgeFailed(t *testing.T) {
 		Detail: "judge timed out",
 	}), false)
 
-	if !strings.Contains(out, "Judge failed (fails closed)") || !strings.Contains(out, "judge timed out") {
+	if !strings.Contains(out, "Judge: failed (fails closed)") || !strings.Contains(out, "judge timed out") {
 		t.Errorf("failed judge not surfaced:\n%s", out)
 	}
 	if strings.Contains(out, "[waiting on judge]") {
@@ -54,7 +54,10 @@ func TestRenderWorkflowStepLine_JudgeOutcomeNote(t *testing.T) {
 		Detail: "evidence complete",
 	}), false)
 
-	if !strings.Contains(out, "Judge approved") || !strings.Contains(out, "evidence complete") {
+	if !strings.Contains(out, "Judge: approved") {
 		t.Errorf("judge outcome note missing:\n%s", out)
+	}
+	if strings.Contains(out, "evidence complete") {
+		t.Errorf("judge detail should be rendered as feedback, not metadata:\n%s", out)
 	}
 }

--- a/internal/commands/show/show.go
+++ b/internal/commands/show/show.go
@@ -18,14 +18,15 @@ import (
 )
 
 type showOptions struct {
-	json       bool
-	summary    bool // Show aggregate summary instead of tree view
-	watch      bool // Continuously refresh display
-	goals      bool // Show goals for phases and sequences
-	collapsed  bool // Show collapsed tree with counters only
-	inProgress bool // Expand only in_progress phases/sequences
-	roadmap    bool // Show full execution roadmap with task statuses
-	festival   string
+	json         bool
+	summary      bool // Show aggregate summary instead of tree view
+	watch        bool // Continuously refresh display
+	goals        bool // Show goals for phases and sequences
+	showFeedback bool // Show blocked-step feedback
+	collapsed    bool // Show collapsed tree with counters only
+	inProgress   bool // Expand only in_progress phases/sequences
+	roadmap      bool // Show full execution roadmap with task statuses
+	festival     string
 }
 
 // NewShowCommand creates the show command with all subcommands.
@@ -75,6 +76,7 @@ To list festivals by status, use 'fest list' (e.g. 'fest list active',
 	cmd.Flags().BoolVar(&opts.summary, "summary", false, "show aggregate summary instead of tree view")
 	cmd.Flags().BoolVar(&opts.watch, "watch", false, "continuously refresh display")
 	cmd.Flags().BoolVar(&opts.goals, "goals", false, "show goals for phases and sequences")
+	cmd.Flags().BoolVar(&opts.showFeedback, "show-feedback", false, "show blocked-step feedback")
 	cmd.Flags().BoolVar(&opts.collapsed, "collapsed", false, "show collapsed tree with counters only")
 	cmd.Flags().BoolVar(&opts.inProgress, "inprogress", false, "expand only in-progress phases and sequences")
 	cmd.Flags().BoolVar(&opts.roadmap, "roadmap", false, "show full execution roadmap with task statuses")
@@ -303,6 +305,7 @@ func showCycleWatchOptions(opts *showOptions, cycling bool) WatchOptions {
 	return WatchOptions{
 		Summary:      opts.summary,
 		Goals:        opts.goals,
+		ShowFeedback: opts.showFeedback,
 		Collapsed:    opts.collapsed,
 		InProgress:   opts.inProgress,
 		CycleHint:    true,
@@ -619,10 +622,11 @@ type festivalShowView struct {
 }
 
 type festivalShowViewOptions struct {
-	Summary    bool `json:"summary"`
-	ShowGoals  bool `json:"show_goals"`
-	Collapsed  bool `json:"collapsed"`
-	InProgress bool `json:"in_progress"`
+	Summary      bool `json:"summary"`
+	ShowGoals    bool `json:"show_goals"`
+	ShowFeedback bool `json:"show_feedback"`
+	Collapsed    bool `json:"collapsed"`
+	InProgress   bool `json:"in_progress"`
 }
 
 func emitFestivalJSON(ctx context.Context, festival *FestivalInfo, opts *showOptions, campaignRoot string) error {
@@ -649,10 +653,11 @@ func buildFestivalShowView(ctx context.Context, festival *FestivalInfo, opts *sh
 	view := &festivalShowView{
 		Mode: "tree",
 		Options: festivalShowViewOptions{
-			Summary:    opts.summary,
-			ShowGoals:  opts.goals,
-			Collapsed:  opts.collapsed,
-			InProgress: opts.inProgress,
+			Summary:      opts.summary,
+			ShowGoals:    opts.goals,
+			ShowFeedback: opts.showFeedback,
+			Collapsed:    opts.collapsed,
+			InProgress:   opts.inProgress,
 		},
 	}
 
@@ -671,8 +676,21 @@ func buildFestivalShowView(ctx context.Context, festival *FestivalInfo, opts *sh
 	if opts.inProgress {
 		markNextPending(tree)
 	}
+	if !opts.showFeedback {
+		hideTreeFeedback(tree)
+	}
 	view.Tree = tree
 	return view
+}
+
+func hideTreeFeedback(node *DisplayNode) {
+	if node == nil {
+		return
+	}
+	node.Feedback = ""
+	for _, child := range node.Children {
+		hideTreeFeedback(child)
+	}
 }
 
 func emitFestivalText(festival *FestivalInfo, showOpts *showOptions, campaignRoot string) error {
@@ -694,6 +712,7 @@ func emitFestivalText(festival *FestivalInfo, showOpts *showOptions, campaignRoo
 
 	opts := DefaultTreeOptions()
 	opts.ShowGoals = showOpts.goals
+	opts.ShowFeedback = showOpts.showFeedback
 	opts.Collapsed = showOpts.collapsed
 	opts.InProgress = showOpts.inProgress
 	fmt.Println(RenderTree(tree, opts))

--- a/internal/commands/show/show_command_test.go
+++ b/internal/commands/show/show_command_test.go
@@ -25,6 +25,17 @@ func TestShowCommand_RejectsPositionalWithFestivalFlag(t *testing.T) {
 	}
 }
 
+func TestShowCommand_ProvidesFeedbackOptIn(t *testing.T) {
+	cmd := NewShowCommand()
+	flag := cmd.Flags().Lookup("show-feedback")
+	if flag == nil {
+		t.Fatal("show command missing --show-feedback")
+	}
+	if flag.DefValue != "false" {
+		t.Fatalf("--show-feedback default = %q, want false", flag.DefValue)
+	}
+}
+
 func TestRunShowBySelector_FromProjectDirInCampaign(t *testing.T) {
 	campaignRoot := filepath.Join(t.TempDir(), "campaign")
 	if err := os.MkdirAll(filepath.Join(campaignRoot, ".campaign"), 0755); err != nil {

--- a/internal/commands/show/tree.go
+++ b/internal/commands/show/tree.go
@@ -33,10 +33,11 @@ type DisplayNode struct {
 
 // TreeOptions configures how the tree is rendered.
 type TreeOptions struct {
-	ShowGoals  bool // Show primary goals (default: true)
-	Collapsed  bool // Show only phases with counters, no children
-	InProgress bool // Expand only in_progress phases/sequences, collapse rest
-	Width      int  // Terminal width for alignment (0 = auto)
+	ShowGoals    bool // Show primary goals (default: true)
+	ShowFeedback bool // Show blocked-step feedback
+	Collapsed    bool // Show only phases with counters, no children
+	InProgress   bool // Expand only in_progress phases/sequences, collapse rest
+	Width        int  // Terminal width for alignment (0 = auto)
 }
 
 // DefaultTreeOptions returns sensible defaults for tree rendering.
@@ -509,7 +510,7 @@ func renderStepNode(sb *strings.Builder, node *DisplayNode, prefix string, isLas
 		sb.WriteString(ui.Dim("Goal: " + truncateGoal(node.Goal, opts.Width-len(prefix)-10)))
 		sb.WriteString("\n")
 	}
-	if node.Feedback != "" {
+	if opts.ShowFeedback && node.Feedback != "" {
 		sb.WriteString(prefix)
 		sb.WriteString(ui.Dim(childPrefix))
 		sb.WriteString(ui.Error("Feedback: ") + node.Feedback)

--- a/internal/commands/show/tree.go
+++ b/internal/commands/show/tree.go
@@ -547,6 +547,9 @@ func formatTaskStatus(node *DisplayNode) string {
 
 func formatStepStatus(node *DisplayNode) string {
 	icon := shared.WorkflowStepIcon(wf.StepStatus(node.Status))
+	if node.WaitingOnJudge {
+		icon = ui.ColoredText("⚖", ui.JudgeColor)
+	}
 	return icon + " " + node.Name
 }
 

--- a/internal/commands/show/tree.go
+++ b/internal/commands/show/tree.go
@@ -19,13 +19,16 @@ import (
 
 // DisplayNode represents a node in the festival tree hierarchy.
 type DisplayNode struct {
-	Name          string         `json:"name"`                      // Directory/file name
-	Goal          string         `json:"goal,omitempty"`            // Primary goal from *_GOAL.md
-	Status        string         `json:"status"`                    // pending/in_progress/completed/blocked
-	Stats         StatusCounts   `json:"stats"`                     // Task counts for this level
-	NodeType      string         `json:"node_type"`                 // "festival", "phase", "sequence", "step", "task"
-	Children      []*DisplayNode `json:"children,omitempty"`        // Child phases, sequences, steps, or tasks
-	IsNextPending bool           `json:"is_next_pending,omitempty"` // First incomplete node at this level — expanded by --inprogress
+	Name           string         `json:"name"`                      // Directory/file name
+	Goal           string         `json:"goal,omitempty"`            // Primary goal from *_GOAL.md
+	Status         string         `json:"status"`                    // pending/in_progress/completed/blocked
+	Stats          StatusCounts   `json:"stats"`                     // Task counts for this level
+	NodeType       string         `json:"node_type"`                 // "festival", "phase", "sequence", "step", "task"
+	Children       []*DisplayNode `json:"children,omitempty"`        // Child phases, sequences, steps, or tasks
+	IsNextPending  bool           `json:"is_next_pending,omitempty"` // First incomplete node at this level — expanded by --inprogress
+	Feedback       string         `json:"feedback,omitempty"`        // Concise actionable feedback for blocked steps
+	JudgeStatus    string         `json:"judge_status,omitempty"`    // waiting/approved/rejected/failed
+	WaitingOnJudge bool           `json:"waiting_on_judge,omitempty"`
 }
 
 // TreeOptions configures how the tree is rendered.
@@ -223,6 +226,14 @@ func buildStepNode(step shared.WorkflowStepView) *DisplayNode {
 		Goal:     step.Goal,
 		Status:   status,
 		NodeType: "step",
+		Feedback: wf.DisplayFeedback(step.Feedback),
+		JudgeStatus: func() string {
+			if step.Judge == nil {
+				return ""
+			}
+			return step.Judge.Status
+		}(),
+		WaitingOnJudge: step.JudgeWaiting(),
 		Stats: StatusCounts{
 			Total:     1,
 			Completed: boolToInt(step.Status == wf.StepStatusCompleted || step.Status == wf.StepStatusSkipped),
@@ -496,6 +507,22 @@ func renderStepNode(sb *strings.Builder, node *DisplayNode, prefix string, isLas
 		sb.WriteString(prefix)
 		sb.WriteString(ui.Dim(childPrefix))
 		sb.WriteString(ui.Dim("Goal: " + truncateGoal(node.Goal, opts.Width-len(prefix)-10)))
+		sb.WriteString("\n")
+	}
+	if node.Feedback != "" {
+		sb.WriteString(prefix)
+		sb.WriteString(ui.Dim(childPrefix))
+		sb.WriteString(ui.Error("Feedback: ") + node.Feedback)
+		sb.WriteString("\n")
+	}
+	if node.JudgeStatus != "" {
+		sb.WriteString(prefix)
+		sb.WriteString(ui.Dim(childPrefix))
+		label := "Judge: " + node.JudgeStatus
+		if node.WaitingOnJudge {
+			label = "Judge: waiting"
+		}
+		sb.WriteString(ui.ColoredText(label, ui.JudgeColor))
 		sb.WriteString("\n")
 	}
 }

--- a/internal/commands/show/tree_test.go
+++ b/internal/commands/show/tree_test.go
@@ -145,7 +145,7 @@ func TestRenderTreeStepShowsConciseJudgeFeedback(t *testing.T) {
 		Feedback: `approval auto mode: schema_version=fest.approval.judge/v1 judge_command="ob judge" decision=reject reason="missing acceptance proof"`,
 		Judge:    &wf.JudgeState{Status: wf.JudgeRejected},
 	})
-	output := RenderTree(&DisplayNode{
+	tree := &DisplayNode{
 		Name:     "festival",
 		NodeType: "festival",
 		Children: []*DisplayNode{{
@@ -155,7 +155,14 @@ func TestRenderTreeStepShowsConciseJudgeFeedback(t *testing.T) {
 			Stats:    StatusCounts{Total: 1, Blocked: 1},
 			Children: []*DisplayNode{step},
 		}},
-	}, DefaultTreeOptions())
+	}
+	defaultOutput := RenderTree(tree, DefaultTreeOptions())
+	if strings.Contains(defaultOutput, "Feedback:") {
+		t.Fatalf("tree should hide feedback by default:\n%s", defaultOutput)
+	}
+	opts := DefaultTreeOptions()
+	opts.ShowFeedback = true
+	output := RenderTree(tree, opts)
 
 	if !strings.Contains(output, "Feedback: missing acceptance proof") {
 		t.Fatalf("tree missing concise feedback:\n%s", output)

--- a/internal/commands/show/tree_test.go
+++ b/internal/commands/show/tree_test.go
@@ -168,6 +168,33 @@ func TestRenderTreeStepShowsConciseJudgeFeedback(t *testing.T) {
 	}
 }
 
+func TestRenderTreeStepShowsWaitingJudgeIcon(t *testing.T) {
+	step := buildStepNode(shared.WorkflowStepView{
+		Number: 2,
+		Name:   "REVIEW",
+		Status: wf.StepStatusBlocked,
+		Judge:  &wf.JudgeState{Status: wf.JudgeRunning},
+	})
+	output := RenderTree(&DisplayNode{
+		Name:     "festival",
+		NodeType: "festival",
+		Children: []*DisplayNode{{
+			Name:     "001_PHASE",
+			NodeType: "phase",
+			Status:   "blocked",
+			Stats:    StatusCounts{Total: 1, Blocked: 1},
+			Children: []*DisplayNode{step},
+		}},
+	}, DefaultTreeOptions())
+
+	if !strings.Contains(output, "⚖ Step 2: REVIEW") {
+		t.Fatalf("tree missing purple waiting judge icon:\n%s", output)
+	}
+	if !strings.Contains(output, "Judge: waiting") {
+		t.Fatalf("tree missing waiting judge state:\n%s", output)
+	}
+}
+
 func TestRenderTree(t *testing.T) {
 	// Create a simple tree structure
 	tree := &DisplayNode{

--- a/internal/commands/show/tree_test.go
+++ b/internal/commands/show/tree_test.go
@@ -6,6 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/commands/shared"
+	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
 )
 
 func TestBuildFestivalTree(t *testing.T) {
@@ -131,6 +134,37 @@ fest_tracking: true
 	}
 	if seq.Children[1].Name != "02_task.md" {
 		t.Errorf("expected task name '02_task.md', got '%s'", seq.Children[1].Name)
+	}
+}
+
+func TestRenderTreeStepShowsConciseJudgeFeedback(t *testing.T) {
+	step := buildStepNode(shared.WorkflowStepView{
+		Number:   2,
+		Name:     "REVIEW",
+		Status:   wf.StepStatusBlocked,
+		Feedback: `approval auto mode: schema_version=fest.approval.judge/v1 judge_command="ob judge" decision=reject reason="missing acceptance proof"`,
+		Judge:    &wf.JudgeState{Status: wf.JudgeRejected},
+	})
+	output := RenderTree(&DisplayNode{
+		Name:     "festival",
+		NodeType: "festival",
+		Children: []*DisplayNode{{
+			Name:     "001_PHASE",
+			NodeType: "phase",
+			Status:   "blocked",
+			Stats:    StatusCounts{Total: 1, Blocked: 1},
+			Children: []*DisplayNode{step},
+		}},
+	}, DefaultTreeOptions())
+
+	if !strings.Contains(output, "Feedback: missing acceptance proof") {
+		t.Fatalf("tree missing concise feedback:\n%s", output)
+	}
+	if !strings.Contains(output, "Judge: rejected") {
+		t.Fatalf("tree missing judge status:\n%s", output)
+	}
+	if strings.Contains(output, "schema_version") || strings.Contains(output, "judge_command") {
+		t.Fatalf("tree leaked judge metadata:\n%s", output)
 	}
 }
 

--- a/internal/commands/show/watch.go
+++ b/internal/commands/show/watch.go
@@ -89,12 +89,13 @@ const pollingInterval = 2 * time.Second
 
 // WatchOptions contains the public options needed to run the show watch renderer.
 type WatchOptions struct {
-	Summary    bool
-	Goals      bool
-	Collapsed  bool
-	InProgress bool
-	CycleHint  bool
-	Cycling    bool
+	Summary      bool
+	Goals        bool
+	ShowFeedback bool
+	Collapsed    bool
+	InProgress   bool
+	CycleHint    bool
+	Cycling      bool
 	// CyclePromote controls the cycle footer: when true the "p promote" hint is
 	// shown (watch); when false the footer advertises "q/Ctrl+C" exit instead
 	// (show's cycle has no promote affordance).
@@ -110,11 +111,12 @@ func WatchFestival(ctx context.Context, festival *FestivalInfo, opts WatchOption
 		return errors.Validation("festival is required")
 	}
 	return runWatchMode(ctx, festival, &showOptions{
-		summary:    opts.Summary,
-		watch:      true,
-		goals:      opts.Goals,
-		collapsed:  opts.Collapsed,
-		inProgress: opts.InProgress,
+		summary:      opts.Summary,
+		watch:        true,
+		goals:        opts.Goals,
+		showFeedback: opts.ShowFeedback,
+		collapsed:    opts.Collapsed,
+		inProgress:   opts.InProgress,
 	}, opts.CycleHint, opts.Cycling, opts.CyclePromote, opts.Frame)
 }
 
@@ -364,6 +366,7 @@ func renderFestivalView(ctx context.Context, festival *FestivalInfo, opts *showO
 
 	treeOpts := DefaultTreeOptions()
 	treeOpts.ShowGoals = opts.goals
+	treeOpts.ShowFeedback = opts.showFeedback
 	treeOpts.Collapsed = opts.collapsed
 	treeOpts.InProgress = opts.inProgress
 	_, _ = fmt.Fprintln(out, RenderTree(tree, treeOpts))
@@ -387,4 +390,3 @@ func renderProgressBar(percentage int) string {
 func clearScreen(out io.Writer) {
 	_, _ = fmt.Fprint(out, "\033[H\033[2J")
 }
-

--- a/internal/commands/watch/command.go
+++ b/internal/commands/watch/command.go
@@ -13,9 +13,10 @@ import (
 )
 
 type options struct {
-	goals     bool
-	collapsed bool
-	summary   bool
+	goals        bool
+	showFeedback bool
+	collapsed    bool
+	summary      bool
 }
 
 type commandDeps struct {
@@ -88,6 +89,7 @@ It does not change your shell directory.`,
 	}
 
 	cmd.Flags().BoolVar(&opts.goals, "goals", false, "show goals for phases and sequences")
+	cmd.Flags().BoolVar(&opts.showFeedback, "show-feedback", false, "show blocked-step feedback")
 	cmd.Flags().BoolVar(&opts.collapsed, "collapsed", false, "show collapsed tree with counters only")
 	cmd.Flags().BoolVar(&opts.summary, "summary", false, "show aggregate summary instead of tree view")
 
@@ -166,9 +168,10 @@ func watchStandaloneWorkflow(ctx context.Context, workflow *show.StandaloneWorkf
 
 func showWatchOptions(opts options) show.WatchOptions {
 	return show.WatchOptions{
-		Summary:    opts.summary,
-		Goals:      opts.goals,
-		Collapsed:  opts.collapsed,
-		InProgress: true,
+		Summary:      opts.summary,
+		Goals:        opts.goals,
+		ShowFeedback: opts.showFeedback,
+		Collapsed:    opts.collapsed,
+		InProgress:   true,
 	}
 }

--- a/internal/commands/watch/command_test.go
+++ b/internal/commands/watch/command_test.go
@@ -18,9 +18,10 @@ func TestShowWatchOptionsAlwaysEnableInProgress(t *testing.T) {
 
 func TestShowWatchOptionsMapCommandFlags(t *testing.T) {
 	got := showWatchOptions(options{
-		summary:   true,
-		goals:     true,
-		collapsed: true,
+		summary:      true,
+		goals:        true,
+		showFeedback: true,
+		collapsed:    true,
 	})
 
 	if !got.Summary {
@@ -31,6 +32,9 @@ func TestShowWatchOptionsMapCommandFlags(t *testing.T) {
 	}
 	if !got.Collapsed {
 		t.Fatal("collapsed flag was not mapped")
+	}
+	if !got.ShowFeedback {
+		t.Fatal("show-feedback flag was not mapped")
 	}
 }
 
@@ -59,7 +63,7 @@ func TestWatchCommandDelegatesWithMappedOptions(t *testing.T) {
 			return nil
 		},
 	})
-	cmd.SetArgs([]string{"test-TT0001", "--goals", "--collapsed", "--summary"})
+	cmd.SetArgs([]string{"test-TT0001", "--goals", "--show-feedback", "--collapsed", "--summary"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
@@ -76,7 +80,7 @@ func TestWatchCommandDelegatesWithMappedOptions(t *testing.T) {
 	if !gotOptions.InProgress {
 		t.Fatal("watch options must enable in-progress expansion")
 	}
-	if !gotOptions.Goals || !gotOptions.Collapsed || !gotOptions.Summary {
+	if !gotOptions.Goals || !gotOptions.ShowFeedback || !gotOptions.Collapsed || !gotOptions.Summary {
 		t.Fatalf("watch options did not map flags: %#v", gotOptions)
 	}
 }

--- a/internal/commands/workflow/advance.go
+++ b/internal/commands/workflow/advance.go
@@ -216,8 +216,8 @@ func runAdvance(ctx context.Context) error {
 	// Handle blocked step
 	if stepState != nil && stepState.Status == wf.StepStatusBlocked {
 		feedback := ""
-		if stepState.Feedback != "" {
-			feedback = fmt.Sprintf(": %s", stepState.Feedback)
+		if note := wf.DisplayFeedback(stepState.Feedback); note != "" {
+			feedback = fmt.Sprintf(": %s", note)
 		}
 		return fmt.Errorf("step %d is blocked%s\n\nAddress the feedback, then choose a valid approval route:\n%s\nOr use 'fest workflow reset' to start the phase workflow over", currentStepNum, feedback, approvalRecoveryTextFor(ctx, nav, step))
 	}

--- a/internal/commands/workflow/approval_guidance.go
+++ b/internal/commands/workflow/approval_guidance.go
@@ -32,6 +32,15 @@ func approvalRecoveryLinesFor(ctx context.Context, nav *wf.Navigator, step wf.Wo
 			"To enable auto-judge, configure hooks.approval_judge.command first.",
 		}
 	}
+	if nav != nil {
+		state := nav.GetWorkflowState()
+		stepState := state.GetStepState(step.Number)
+		if stepState != nil && stepState.Status == wf.StepStatusBlocked && !wf.IsJudgeRejection(stepState) {
+			return []string{
+				"Operator override: " + ui.Accent("fest workflow approve") + " (interactive)",
+			}
+		}
+	}
 	return []string{
 		"Operator override:       " + ui.Accent("fest workflow approve") + " (interactive)",
 		"Re-run approval judge:   " + ui.Accent("fest workflow judge"),

--- a/internal/commands/workflow/approval_guidance.go
+++ b/internal/commands/workflow/approval_guidance.go
@@ -33,8 +33,8 @@ func approvalRecoveryLinesFor(ctx context.Context, nav *wf.Navigator, step wf.Wo
 		}
 	}
 	return []string{
-		"Re-submit to the judge: " + ui.Accent("fest workflow approve --auto"),
 		"Operator override:       " + ui.Accent("fest workflow approve") + " (interactive)",
+		"Re-run approval judge:   " + ui.Accent("fest workflow judge"),
 	}
 }
 

--- a/internal/commands/workflow/approval_hardening_test.go
+++ b/internal/commands/workflow/approval_hardening_test.go
@@ -292,8 +292,9 @@ func TestResolveManualApprovalDecision_InteractiveConfirm(t *testing.T) {
 	})
 
 	blocked := &wf.StepState{
-		Status: wf.StepStatusBlocked,
-		Judge:  &wf.JudgeState{Status: wf.JudgeRejected, Detail: "nope"},
+		Status:        wf.StepStatusBlocked,
+		DecisionActor: decisionActorAgent,
+		Judge:         &wf.JudgeState{Status: wf.JudgeRejected, Detail: "nope"},
 	}
 	decision, err := resolveManualApprovalDecision(
 		wf.DecisionMetadata{},

--- a/internal/commands/workflow/approval_hardening_test.go
+++ b/internal/commands/workflow/approval_hardening_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -245,6 +246,31 @@ func TestApprovalRecoveryLines_OnlySuggestValidRoutesWithoutJudge(t *testing.T) 
 	artifactText := strings.Join(artifactLines, "\n")
 	if strings.Contains(artifactText, "approve --auto") || !strings.Contains(artifactText, "configure") {
 		t.Fatalf("unconfigured artifact guidance = %q", artifactText)
+	}
+}
+
+func TestApprovalRecoveryLines_OrdinaryOperatorRejectionOmitsJudgeRetry(t *testing.T) {
+	dir := setupWorkflowFestival(t)
+	cfg := config.DefaultWorkspaceConfig()
+	cfg.Hooks.ApprovalJudge.Command = "configured-judge"
+	if err := config.SaveWorkspaceConfig(dir, cfg); err != nil {
+		t.Fatalf("SaveWorkspaceConfig: %v", err)
+	}
+	ctx := scope.WithWorkspace(context.Background(), &scope.WorkspaceInfo{FestivalsPath: dir})
+	nav := getNavigator(t, filepath.Join(dir, "001_INGEST"))
+	if err := nav.Advance(ctx); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	if err := nav.RejectWithDecision(ctx, "operator review required", wf.DecisionMetadata{Actor: decisionActorUser}); err != nil {
+		t.Fatalf("RejectWithDecision: %v", err)
+	}
+
+	text := strings.Join(approvalRecoveryLinesFor(ctx, nav, nav.GetSteps()[1]), "\n")
+	if strings.Contains(text, "fest workflow judge") {
+		t.Fatalf("ordinary operator rejection should not suggest judge retry: %q", text)
+	}
+	if !strings.Contains(text, "fest workflow approve") {
+		t.Fatalf("operator recovery missing approve route: %q", text)
 	}
 }
 

--- a/internal/commands/workflow/approval_readiness.go
+++ b/internal/commands/workflow/approval_readiness.go
@@ -74,7 +74,7 @@ func checkApprovalReadinessWithInspector(
 			WithField("step", step.Number).
 			WithField("step_name", step.Name).
 			WithField("missing", strings.Join(status.missing, ", ")).
-			WithHint("create every file listed under **Evidence:**, then re-submit with 'fest workflow approve --auto'")
+			WithHint("create every file listed under **Evidence:**, then re-submit with 'fest workflow judge'")
 	}
 
 	if presentationRequired && !status.presentationFound {
@@ -83,7 +83,7 @@ func checkApprovalReadinessWithInspector(
 			WithField("step_name", step.Name).
 			WithField("required", "output_specs/PRESENTATION.md").
 			WithField("missing", strings.Join(status.missing, ", ")).
-			WithHint("write the presentation deliverable, then re-submit with 'fest workflow approve --auto'")
+			WithHint("write the presentation deliverable, then re-submit with 'fest workflow judge'")
 	}
 
 	if status.found == 0 {
@@ -91,7 +91,7 @@ func checkApprovalReadinessWithInspector(
 			WithField("step", step.Number).
 			WithField("step_name", step.Name).
 			WithField("checked", strings.Join(paths, ", ")).
-			WithHint("create the evidence files listed for this step, then re-submit with 'fest workflow approve --auto'")
+			WithHint("create the evidence files listed for this step, then re-submit with 'fest workflow judge'")
 	}
 
 	return nil

--- a/internal/commands/workflow/approve.go
+++ b/internal/commands/workflow/approve.go
@@ -25,6 +25,7 @@ const approvalJudgeSchemaVersion = "fest.approval.judge/v1"
 
 type approvalJudgeOptions struct {
 	Auto          bool
+	Rejudge       bool
 	JudgeCommand  string
 	Timeout       time.Duration
 	WorkDir       string // festival path; set as judge process cwd
@@ -79,8 +80,8 @@ Auto approval:
   delegates blocking checkpoints away from human review. With that hook set,
   fest next auto-invokes the judge on blocking WORKFLOW.md / GATES.md steps.
 
-  Use --auto to re-run the judge explicitly (for example after a reject or a
-  failed judge invocation). Agents must not clear checkpoints with --as agent;
+  Use 'fest workflow judge' to re-run the judge explicitly after a rejection;
+  '--auto' remains a backwards-compatible alias. Agents must not clear checkpoints with --as agent;
   agent-actor decisions are recorded only via the judge path.
 
   Checkpoint classes:
@@ -91,7 +92,7 @@ Auto approval:
   Presentation-like steps require non-empty evidence (e.g. output_specs/PRESENTATION.md)
   before the judge is invoked. Missing evidence blocks deterministically without a model call.
 
-  After a judge reject, re-submit with: fest workflow approve --auto
+  After a judge reject, re-submit with: fest workflow judge
   Operator override (interactive TTY, or --override-judge --summary "..."):
   records decision_actor=user_override.
 
@@ -120,6 +121,7 @@ Auto approval:
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.Auto {
+				opts.Rejudge = true
 				return runApproveWithOptions(cmd.Context(), wf.DecisionMetadata{}, opts)
 			}
 			decision, err := normalizeDecision("approval", actor, opts.Summary)
@@ -502,6 +504,9 @@ func runApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum int, 
 		if fresh.GetWorkflowState().CurrentStep != currentStepNum {
 			return festerrors.Validation("checkpoint changed before approval judge started")
 		}
+		if err := reopenJudgeRejectionIfRequested(ctx, fresh, currentStepNum, opts); err != nil {
+			return err
+		}
 		freshSteps := fresh.GetSteps()
 		if currentStepNum < 1 || currentStepNum > len(freshSteps) {
 			return festerrors.Validation("checkpoint changed before approval judge started")
@@ -542,6 +547,20 @@ func runApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum int, 
 		_, err = applyApproveAutoVerdict(ctx, fresh, currentStepNum, step, runID, decision, audit)
 		return err
 	})
+}
+
+// reopenJudgeRejectionIfRequested clears only a judge-owned blocked state.
+// This keeps re-judging safe: an agent cannot use the judge command to bypass
+// an ordinary operator rejection or an operator-attestation checkpoint.
+func reopenJudgeRejectionIfRequested(ctx context.Context, nav *wf.Navigator, step int, opts approvalJudgeOptions) error {
+	if !opts.Rejudge {
+		return nil
+	}
+	state := nav.GetWorkflowState().GetStepState(step)
+	if state == nil || state.Status != wf.StepStatusBlocked {
+		return nil
+	}
+	return nav.ReopenJudgeRejection(ctx, step)
 }
 
 func applyApproveAutoVerdict(ctx context.Context, nav *wf.Navigator, currentStepNum int, step wf.WorkflowStep, runID string, decision *approvalJudgeResponse, audit string) (bool, error) {

--- a/internal/commands/workflow/approve.go
+++ b/internal/commands/workflow/approve.go
@@ -504,20 +504,23 @@ func runApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum int, 
 		if fresh.GetWorkflowState().CurrentStep != currentStepNum {
 			return festerrors.Validation("checkpoint changed before approval judge started")
 		}
-		if err := reopenJudgeRejectionIfRequested(ctx, fresh, currentStepNum, opts); err != nil {
-			return err
-		}
 		freshSteps := fresh.GetSteps()
 		if currentStepNum < 1 || currentStepNum > len(freshSteps) {
 			return festerrors.Validation("checkpoint changed before approval judge started")
 		}
 		step = freshSteps[currentStepNum-1]
+		rejudgePreflighted, err := reopenJudgeRejectionIfRequested(ctx, fresh, currentStepNum, step, opts)
+		if err != nil {
+			return err
+		}
 		if ss := fresh.GetWorkflowState().GetStepState(currentStepNum); ss != nil && ss.Judge != nil &&
 			ss.Judge.Status == wf.JudgeRunning && judgeLeaseActive(ss.Judge) {
 			return judgeAlreadyRunningError(ss.Judge)
 		}
-		if err := prepareAutoJudgeReadiness(ctx, fresh, currentStepNum, step); err != nil {
-			return err
+		if !rejudgePreflighted {
+			if err := prepareAutoJudgeReadiness(ctx, fresh, currentStepNum, step); err != nil {
+				return err
+			}
 		}
 		if err := fresh.BeginJudge(ctx, currentStepNum, opts.JudgeCommand, runID, os.Getpid()); err != nil {
 			return festerrors.Wrap(err, "recording judge start")
@@ -549,18 +552,24 @@ func runApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum int, 
 	})
 }
 
-// reopenJudgeRejectionIfRequested clears only a judge-owned blocked state.
-// This keeps re-judging safe: an agent cannot use the judge command to bypass
-// an ordinary operator rejection or an operator-attestation checkpoint.
-func reopenJudgeRejectionIfRequested(ctx context.Context, nav *wf.Navigator, step int, opts approvalJudgeOptions) error {
+// reopenJudgeRejectionIfRequested clears only a judge-owned blocked state
+// after the same deterministic preflight used for a fresh auto-judge run.
+// Rejected preflight leaves the original blocked state untouched.
+func reopenJudgeRejectionIfRequested(ctx context.Context, nav *wf.Navigator, stepNum int, step wf.WorkflowStep, opts approvalJudgeOptions) (bool, error) {
 	if !opts.Rejudge {
-		return nil
+		return false, nil
 	}
-	state := nav.GetWorkflowState().GetStepState(step)
+	state := nav.GetWorkflowState().GetStepState(stepNum)
 	if state == nil || state.Status != wf.StepStatusBlocked {
-		return nil
+		return false, nil
 	}
-	return nav.ReopenJudgeRejection(ctx, step)
+	if err := checkAutoJudgePreflight(nav.Ctx.PhasePath, step); err != nil {
+		return false, err
+	}
+	if err := nav.ReopenJudgeRejection(ctx, stepNum); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func applyApproveAutoVerdict(ctx context.Context, nav *wf.Navigator, currentStepNum int, step wf.WorkflowStep, runID string, decision *approvalJudgeResponse, audit string) (bool, error) {

--- a/internal/commands/workflow/approve.go
+++ b/internal/commands/workflow/approve.go
@@ -513,9 +513,8 @@ func runApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum int, 
 		if err != nil {
 			return err
 		}
-		if ss := fresh.GetWorkflowState().GetStepState(currentStepNum); ss != nil && ss.Judge != nil &&
-			ss.Judge.Status == wf.JudgeRunning && judgeLeaseActive(ss.Judge) {
-			return judgeAlreadyRunningError(ss.Judge)
+		if err := reconcileJudgeBeforeLaunch(ctx, fresh, currentStepNum); err != nil {
+			return err
 		}
 		if !rejudgePreflighted {
 			if err := prepareAutoJudgeReadiness(ctx, fresh, currentStepNum, step); err != nil {
@@ -550,6 +549,31 @@ func runApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum int, 
 		_, err = applyApproveAutoVerdict(ctx, fresh, currentStepNum, step, runID, decision, audit)
 		return err
 	})
+}
+
+// reconcileJudgeBeforeLaunch closes a dead detached judge lease before a new
+// run starts. The failure is persisted through the event log so another
+// process cannot continue to render the checkpoint as waiting forever.
+func reconcileJudgeBeforeLaunch(ctx context.Context, nav *wf.Navigator, step int) error {
+	state := nav.GetWorkflowState()
+	stepState := state.GetStepState(step)
+	if stepState == nil || stepState.Judge == nil || stepState.Judge.Status != wf.JudgeRunning {
+		return nil
+	}
+	if judgeLeaseActive(stepState.Judge) {
+		return judgeAlreadyRunningError(stepState.Judge)
+	}
+
+	recorded, err := nav.RecordJudgeFailure(ctx, step, stepState.Judge.RunID,
+		"detached judge process exited before recording a verdict")
+	if err != nil {
+		return festerrors.Wrap(err, "recording stale judge failure")
+	}
+	if !recorded {
+		return festerrors.Validation("approval judge lease changed before stale-run cleanup").
+			WithHint("run fest workflow status, then retry the approval judge")
+	}
+	return nil
 }
 
 // reopenJudgeRejectionIfRequested clears only a judge-owned blocked state

--- a/internal/commands/workflow/approve_auto_test.go
+++ b/internal/commands/workflow/approve_auto_test.go
@@ -442,3 +442,38 @@ func TestRunApproveAuto_RejudgeReopensJudgeRejection(t *testing.T) {
 		t.Fatalf("replayed rejudge status = %s, want completed", got)
 	}
 }
+
+func TestRejudgePreflightFailurePreservesBlockedState(t *testing.T) {
+	dir := setupWorkflowFestival(t)
+	phaseDir := filepath.Join(dir, "001_INGEST")
+	nav := getNavigator(t, phaseDir)
+	ctx := context.Background()
+
+	if err := nav.Advance(ctx); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	state := nav.GetWorkflowState().GetStepState(2)
+	state.Status = wf.StepStatusBlocked
+	state.Feedback = "missing acceptance proof"
+	state.DecisionActor = decisionActorAgent
+	state.Judge = &wf.JudgeState{
+		Status:  wf.JudgeRejected,
+		Detail:  "missing acceptance proof",
+		RunID:   "run-1",
+		Command: "fake judge",
+	}
+
+	operatorStep := wf.WorkflowStep{
+		Number:          2,
+		Name:            "ANALYZE",
+		Checkpoint:      wf.CheckpointUserApproval,
+		CheckpointClass: wf.CheckpointClassOperatorAttestation,
+	}
+	if _, err := reopenJudgeRejectionIfRequested(ctx, nav, 2, operatorStep, approvalJudgeOptions{Rejudge: true}); err == nil {
+		t.Fatal("rejudge should fail closed for operator_attestation")
+	}
+
+	if state.Status != wf.StepStatusBlocked || state.Feedback != "missing acceptance proof" || state.Judge == nil || state.Judge.Status != wf.JudgeRejected {
+		t.Fatalf("preflight failure mutated blocked state: %+v", state)
+	}
+}

--- a/internal/commands/workflow/approve_auto_test.go
+++ b/internal/commands/workflow/approve_auto_test.go
@@ -65,6 +65,16 @@ func TestApproveCommandManualModeDefaultOff(t *testing.T) {
 	}
 }
 
+func TestJudgeCommandUsesAutoRejudgePath(t *testing.T) {
+	cmd := newJudgeCmd()
+	if cmd.Use != "judge" {
+		t.Fatalf("Use = %q, want judge", cmd.Use)
+	}
+	if cmd.Flags().Lookup("wait") == nil || cmd.Flags().Lookup("judge-command") == nil {
+		t.Fatal("judge command missing judge execution flags")
+	}
+}
+
 func TestResolveApprovalJudgeCommand(t *testing.T) {
 	festivalsRoot := t.TempDir()
 	cfg := config.DefaultWorkspaceConfig()
@@ -342,8 +352,8 @@ func TestRunApproveAuto_ApproveAdvancesAndRecordsAudit(t *testing.T) {
 	if step2 == nil || step2.Status != wf.StepStatusCompleted {
 		t.Fatalf("step 2 status = %+v, want completed", step2)
 	}
-	if !strings.Contains(step2.Feedback, "decision=approve") {
-		t.Fatalf("step 2 feedback missing judge audit: %q", step2.Feedback)
+	if step2.Feedback != "evidence complete" {
+		t.Fatalf("step 2 feedback = %q, want concise judge reason", step2.Feedback)
 	}
 }
 
@@ -378,10 +388,57 @@ func TestRunApproveAuto_RejectBlocksStepWithAudit(t *testing.T) {
 	if step2 == nil || step2.Status != wf.StepStatusBlocked {
 		t.Fatalf("step 2 status = %+v, want blocked", step2)
 	}
-	if !strings.Contains(step2.Feedback, "decision=reject") {
-		t.Fatalf("step 2 feedback missing judge audit: %q", step2.Feedback)
+	if step2.Feedback != "missing acceptance proof" {
+		t.Fatalf("step 2 feedback = %q, want concise judge reason", step2.Feedback)
 	}
 	if state.CurrentStep != 2 {
 		t.Fatalf("current step = %d, want 2 (stays on blocked step)", state.CurrentStep)
+	}
+}
+
+func TestRunApproveAuto_RejudgeReopensJudgeRejection(t *testing.T) {
+	dir := setupWorkflowFestival(t)
+	phaseDir := filepath.Join(dir, "001_INGEST")
+	nav := getNavigator(t, phaseDir)
+	ctx := context.Background()
+
+	if err := nav.Advance(ctx); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	steps := nav.GetSteps()
+	responses := [][]byte{
+		[]byte(`{"schema_version":"fest.approval.judge/v1","decision":"reject","reason":"missing acceptance proof"}`),
+		[]byte(`{"schema_version":"fest.approval.judge/v1","decision":"approve","reason":"acceptance proof added"}`),
+	}
+	withApprovalJudgeRunner(t, judgeRunner(func(ctx context.Context, command string, stdin []byte) ([]byte, error) {
+		response := responses[0]
+		responses = responses[1:]
+		return response, nil
+	}))
+
+	if err := runApproveAuto(ctx, nav, 2, steps[1], approvalJudgeOptions{
+		JudgeCommand: "fake judge", Timeout: time.Second, Wait: true,
+	}); err != nil {
+		t.Fatalf("initial runApproveAuto: %v", err)
+	}
+	if got := nav.GetWorkflowState().GetStepState(2).Status; got != wf.StepStatusBlocked {
+		t.Fatalf("first judge status = %s, want blocked", got)
+	}
+
+	if err := runApproveAuto(ctx, nav, 2, steps[1], approvalJudgeOptions{
+		JudgeCommand: "fake judge", Timeout: time.Second, Wait: true, Rejudge: true,
+	}); err != nil {
+		t.Fatalf("rejudge runApproveAuto: %v", err)
+	}
+	state := nav.GetWorkflowState()
+	if got := state.GetStepState(2).Status; got != wf.StepStatusCompleted {
+		t.Fatalf("rejudge status = %s, want completed", got)
+	}
+	if got := state.GetStepState(2).Feedback; got != "acceptance proof added" {
+		t.Fatalf("rejudge feedback = %q, want concise approval reason", got)
+	}
+	reloaded := getNavigator(t, phaseDir)
+	if got := reloaded.GetWorkflowState().GetStepState(2).Status; got != wf.StepStatusCompleted {
+		t.Fatalf("replayed rejudge status = %s, want completed", got)
 	}
 }

--- a/internal/commands/workflow/decision.go
+++ b/internal/commands/workflow/decision.go
@@ -33,7 +33,7 @@ func normalizeDecision(action, actor, summary string) (wf.DecisionMetadata, erro
 	default:
 		return wf.DecisionMetadata{}, festerrors.Validation("invalid decision actor").
 			WithField("actor", actor).
-			WithHint("use --as user; agent-actor decisions are recorded only by 'fest workflow approve --auto' with a configured approval judge")
+			WithHint("use --as user; agent-actor decisions are recorded only by 'fest workflow judge' with a configured approval judge")
 	}
 
 	return wf.DecisionMetadata{
@@ -43,7 +43,7 @@ func normalizeDecision(action, actor, summary string) (wf.DecisionMetadata, erro
 }
 
 func agentActorHint(action string) string {
-	const delegation = "agent-actor decisions enter the audit trail only through 'fest workflow approve --auto' with a configured approval judge (hooks.approval_judge.command)"
+	const delegation = "agent-actor decisions enter the audit trail only through 'fest workflow judge' with a configured approval judge (hooks.approval_judge.command)"
 	switch action {
 	case "approval":
 		return "blocking checkpoints are operator decisions: stop, present the work, and ask the operator to run 'fest workflow approve'; " + delegation

--- a/internal/commands/workflow/decision_test.go
+++ b/internal/commands/workflow/decision_test.go
@@ -48,7 +48,7 @@ func TestNormalizeDecisionDefaultsToUser(t *testing.T) {
 func TestAgentActorHintNamesOperatorPath(t *testing.T) {
 	for _, action := range []string{"approval", "rejection", "other"} {
 		hint := agentActorHint(action)
-		if !strings.Contains(hint, "approve --auto") {
+		if !strings.Contains(hint, "workflow judge") {
 			t.Fatalf("agentActorHint(%q) = %q, want delegation path mentioned", action, hint)
 		}
 	}

--- a/internal/commands/workflow/judge.go
+++ b/internal/commands/workflow/judge.go
@@ -1,0 +1,38 @@
+package workflow
+
+import (
+	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+	"github.com/Obedience-Corp/fest/internal/scope"
+	"github.com/spf13/cobra"
+)
+
+// newJudgeCmd explicitly runs (or re-runs) the configured approval judge for
+// the current blocking checkpoint. It is the agent-facing recovery command
+// after a judge rejection; ordinary operator rejections remain human-owned.
+func newJudgeCmd() *cobra.Command {
+	opts := approvalJudgeOptions{Auto: true, Rejudge: true}
+	cmd := &cobra.Command{
+		Use:   "judge",
+		Short: "Run the approval judge for the current checkpoint",
+		Long: `Run the configured approval judge for the current blocking checkpoint.
+
+Use this after revising evidence following a judge rejection. A judge-owned
+rejection is reopened automatically; ordinary operator rejections still
+require 'fest workflow approve'. By default the judge runs in the background;
+use --wait when this command should wait for the verdict.
+
+The judge command is resolved from --judge-command or the
+hooks.approval_judge.command workspace configuration hook.`,
+		Annotations: map[string]string{
+			"scope": string(scope.Festival),
+		},
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runApproveWithOptions(cmd.Context(), wf.DecisionMetadata{}, opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.JudgeCommand, "judge-command", "", "approval judge command (overrides hooks.approval_judge.command)")
+	cmd.Flags().DurationVar(&opts.Timeout, "judge-timeout", 0, "maximum time to wait for the approval judge (0 waits until it returns)")
+	cmd.Flags().BoolVar(&opts.Wait, "wait", false, "block until the judge returns instead of launching it in the background")
+	return cmd
+}

--- a/internal/commands/workflow/judge_exec.go
+++ b/internal/commands/workflow/judge_exec.go
@@ -65,15 +65,8 @@ func launchApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum in
 		if err != nil {
 			return err
 		}
-		if ss := state.GetStepState(currentStepNum); ss != nil && ss.Judge != nil &&
-			ss.Judge.Status == wf.JudgeRunning {
-			if judgeLeaseActive(ss.Judge) {
-				return judgeAlreadyRunningError(ss.Judge)
-			}
-			if _, err := fresh.RecordJudgeOutcome(ctx, currentStepNum, ss.Judge.RunID, wf.JudgeFailed,
-				"detached judge process exited before recording a verdict"); err != nil {
-				return festerrors.Wrap(err, "recording stale judge failure")
-			}
+		if err := reconcileJudgeBeforeLaunch(ctx, fresh, currentStepNum); err != nil {
+			return err
 		}
 		if !rejudgePreflighted {
 			if err := prepareAutoJudgeReadiness(ctx, fresh, currentStepNum, step); err != nil {
@@ -424,7 +417,7 @@ func recordUnclaimedJudgeFailure(ctx context.Context, nav *wf.Navigator, payload
 		if ss == nil || ss.Judge == nil || ss.Judge.RunID != payload.RunID || ss.Judge.Pid != 0 {
 			return nil
 		}
-		_, err = fresh.RecordJudgeOutcome(ctx, payload.StepNumber, payload.RunID, wf.JudgeFailed, detail)
+		_, err = fresh.RecordJudgeFailure(ctx, payload.StepNumber, payload.RunID, detail)
 		return err
 	})
 }
@@ -435,7 +428,7 @@ func recordJudgeFailureIfOwned(ctx context.Context, nav *wf.Navigator, payload j
 		if err != nil {
 			return err
 		}
-		_, err = fresh.RecordJudgeOutcome(ctx, payload.StepNumber, payload.RunID, wf.JudgeFailed, detail)
+		_, err = fresh.RecordJudgeFailure(ctx, payload.StepNumber, payload.RunID, detail)
 		return err
 	})
 }

--- a/internal/commands/workflow/judge_exec.go
+++ b/internal/commands/workflow/judge_exec.go
@@ -26,7 +26,8 @@ const (
 	judgeLockPoll     = 25 * time.Millisecond
 )
 
-// judgeExecPayload is the handoff from 'fest workflow approve --auto' to the
+// judgeExecPayload is the handoff from 'fest workflow judge' (or the legacy
+// 'fest workflow approve --auto' alias) to the
 // detached judge-exec runner. The runner rebuilds the judge request from live
 // workflow state; the payload only pins which checkpoint was delegated and
 // how to run the judge.
@@ -54,6 +55,9 @@ func launchApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum in
 			return festerrors.Validation("checkpoint changed before approval judge launch").
 				WithField("expected_step", currentStepNum).
 				WithField("current_step", state.CurrentStep)
+		}
+		if err := reopenJudgeRejectionIfRequested(ctx, fresh, currentStepNum, opts); err != nil {
+			return err
 		}
 		if ss := state.GetStepState(currentStepNum); ss != nil && ss.Judge != nil &&
 			ss.Judge.Status == wf.JudgeRunning {
@@ -260,7 +264,7 @@ func newJudgeExecCmd() *cobra.Command {
 			return runJudgeExec(cmd.Context(), payloadPath)
 		},
 	}
-	cmd.Flags().StringVar(&payloadPath, "payload", "", "path to the payload written by 'fest workflow approve --auto'")
+	cmd.Flags().StringVar(&payloadPath, "payload", "", "path to the payload written by 'fest workflow judge'")
 	_ = cmd.MarkFlagRequired("payload")
 	return cmd
 }

--- a/internal/commands/workflow/judge_exec.go
+++ b/internal/commands/workflow/judge_exec.go
@@ -56,7 +56,13 @@ func launchApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum in
 				WithField("expected_step", currentStepNum).
 				WithField("current_step", state.CurrentStep)
 		}
-		if err := reopenJudgeRejectionIfRequested(ctx, fresh, currentStepNum, opts); err != nil {
+		freshSteps := fresh.GetSteps()
+		if currentStepNum < 1 || currentStepNum > len(freshSteps) {
+			return festerrors.Validation("checkpoint changed before approval judge launch")
+		}
+		step = freshSteps[currentStepNum-1]
+		rejudgePreflighted, err := reopenJudgeRejectionIfRequested(ctx, fresh, currentStepNum, step, opts)
+		if err != nil {
 			return err
 		}
 		if ss := state.GetStepState(currentStepNum); ss != nil && ss.Judge != nil &&
@@ -69,13 +75,10 @@ func launchApproveAuto(ctx context.Context, nav *wf.Navigator, currentStepNum in
 				return festerrors.Wrap(err, "recording stale judge failure")
 			}
 		}
-		freshSteps := fresh.GetSteps()
-		if currentStepNum < 1 || currentStepNum > len(freshSteps) {
-			return festerrors.Validation("checkpoint changed before approval judge launch")
-		}
-		step = freshSteps[currentStepNum-1]
-		if err := prepareAutoJudgeReadiness(ctx, fresh, currentStepNum, step); err != nil {
-			return err
+		if !rejudgePreflighted {
+			if err := prepareAutoJudgeReadiness(ctx, fresh, currentStepNum, step); err != nil {
+				return err
+			}
 		}
 
 		runID, err := newJudgeRunID()

--- a/internal/commands/workflow/judge_state_test.go
+++ b/internal/commands/workflow/judge_state_test.go
@@ -178,3 +178,43 @@ func TestOperatorDecisionClearsJudgeAcrossEventReload(t *testing.T) {
 		t.Fatalf("reloaded step = %+v, want blocked operator decision", step)
 	}
 }
+
+func TestOperatorDecisionClearsLegacyEmptyRunIDJudgeAcrossEventReload(t *testing.T) {
+	dir := setupWorkflowFestival(t)
+	phaseDir := filepath.Join(dir, "001_INGEST")
+	ctx := context.Background()
+	gctx := createGuidanceContext(phaseDir)
+	nav, err := wf.NewNavigator(gctx, guidance.ModeWorkflow)
+	if err != nil {
+		t.Fatalf("NewNavigator: %v", err)
+	}
+	store := progress.NewStore(dir)
+	if err := store.Load(ctx); err != nil {
+		t.Fatalf("store.Load: %v", err)
+	}
+	nav.SetStateStore(store)
+	if err := nav.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if err := nav.Advance(ctx); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	if err := nav.BeginJudge(ctx, 2, "legacy judge", "", 123); err != nil {
+		t.Fatalf("BeginJudge: %v", err)
+	}
+	if recorded, err := nav.RecordJudgeOutcome(ctx, 2, "", wf.JudgeRejected, "legacy rejection"); err != nil || !recorded {
+		t.Fatalf("RecordJudgeOutcome: recorded=%v err=%v", recorded, err)
+	}
+	if err := nav.RejectWithDecision(ctx, "operator review required", wf.DecisionMetadata{Actor: decisionActorUser}); err != nil {
+		t.Fatalf("RejectWithDecision: %v", err)
+	}
+
+	reloaded, err := reloadWorkflowNavigator(ctx, nav)
+	if err != nil {
+		t.Fatalf("reloadWorkflowNavigator: %v", err)
+	}
+	step := reloaded.GetWorkflowState().GetStepState(2)
+	if step == nil || step.Judge != nil {
+		t.Fatalf("reloaded step = %+v, want operator block with no legacy judge", step)
+	}
+}

--- a/internal/commands/workflow/judge_state_test.go
+++ b/internal/commands/workflow/judge_state_test.go
@@ -103,3 +103,33 @@ func TestRunApproveAuto_JudgeFailureLeavesDurableTrace(t *testing.T) {
 		t.Fatalf("judge timestamps missing: %+v", judge)
 	}
 }
+
+func TestReconcileJudgeBeforeLaunch_RecordsDeadLease(t *testing.T) {
+	dir := setupWorkflowFestival(t)
+	phaseDir := filepath.Join(dir, "001_INGEST")
+	nav := getNavigator(t, phaseDir)
+	ctx := context.Background()
+	if err := nav.Advance(ctx); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	if err := nav.BeginJudge(ctx, 2, "fake judge", "stale-run", 99999999); err != nil {
+		t.Fatalf("BeginJudge: %v", err)
+	}
+
+	if err := reconcileJudgeBeforeLaunch(ctx, nav, 2); err != nil {
+		t.Fatalf("reconcileJudgeBeforeLaunch: %v", err)
+	}
+	judge := nav.GetWorkflowState().GetStepState(2).Judge
+	if judge == nil || judge.Status != wf.JudgeFailed {
+		t.Fatalf("judge = %+v, want failed stale lease", judge)
+	}
+	if !strings.Contains(judge.Detail, "detached judge process exited") {
+		t.Fatalf("judge detail = %q, want stale-run explanation", judge.Detail)
+	}
+
+	reloaded := getNavigator(t, phaseDir)
+	replayed := reloaded.GetWorkflowState().GetStepState(2).Judge
+	if replayed == nil || replayed.Status != wf.JudgeFailed {
+		t.Fatalf("replayed judge = %+v, want failed stale lease", replayed)
+	}
+}

--- a/internal/commands/workflow/judge_state_test.go
+++ b/internal/commands/workflow/judge_state_test.go
@@ -8,7 +8,9 @@ import (
 	"time"
 
 	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/guidance"
 	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+	"github.com/Obedience-Corp/fest/internal/progress"
 )
 
 func TestRunApproveAuto_RecordsJudgeLifecycle(t *testing.T) {
@@ -131,5 +133,48 @@ func TestReconcileJudgeBeforeLaunch_RecordsDeadLease(t *testing.T) {
 	replayed := reloaded.GetWorkflowState().GetStepState(2).Judge
 	if replayed == nil || replayed.Status != wf.JudgeFailed {
 		t.Fatalf("replayed judge = %+v, want failed stale lease", replayed)
+	}
+}
+
+func TestOperatorDecisionClearsJudgeAcrossEventReload(t *testing.T) {
+	dir := setupWorkflowFestival(t)
+	phaseDir := filepath.Join(dir, "001_INGEST")
+	ctx := context.Background()
+	gctx := createGuidanceContext(phaseDir)
+	nav, err := wf.NewNavigator(gctx, guidance.ModeWorkflow)
+	if err != nil {
+		t.Fatalf("NewNavigator: %v", err)
+	}
+	store := progress.NewStore(dir)
+	if err := store.Load(ctx); err != nil {
+		t.Fatalf("store.Load: %v", err)
+	}
+	nav.SetStateStore(store)
+	if err := nav.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if err := nav.Advance(ctx); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	if err := nav.BeginJudge(ctx, 2, "fake judge", "run-1", 123); err != nil {
+		t.Fatalf("BeginJudge: %v", err)
+	}
+	if recorded, err := nav.RecordJudgeOutcome(ctx, 2, "run-1", wf.JudgeRejected, "missing proof"); err != nil || !recorded {
+		t.Fatalf("RecordJudgeOutcome: recorded=%v err=%v", recorded, err)
+	}
+	if err := nav.RejectWithDecision(ctx, "operator review required", wf.DecisionMetadata{Actor: decisionActorUser}); err != nil {
+		t.Fatalf("RejectWithDecision: %v", err)
+	}
+
+	reloaded, err := reloadWorkflowNavigator(ctx, nav)
+	if err != nil {
+		t.Fatalf("reloadWorkflowNavigator: %v", err)
+	}
+	step := reloaded.GetWorkflowState().GetStepState(2)
+	if step == nil || step.Judge != nil {
+		t.Fatalf("reloaded step = %+v, want operator block with no stale judge", step)
+	}
+	if step.Status != wf.StepStatusBlocked || step.DecisionActor != decisionActorUser {
+		t.Fatalf("reloaded step = %+v, want blocked operator decision", step)
 	}
 }

--- a/internal/commands/workflow/operator_approve.go
+++ b/internal/commands/workflow/operator_approve.go
@@ -39,18 +39,7 @@ func defaultReadOperatorConfirm() (string, error) {
 // stepHasOpenJudgeReject reports whether the current step is blocked after a
 // judge rejection (or readiness block that left agent feedback).
 func stepHasOpenJudgeReject(stepState *wf.StepState) bool {
-	if stepState == nil || stepState.Status != wf.StepStatusBlocked {
-		return false
-	}
-	if stepState.Judge != nil && stepState.Judge.Status == wf.JudgeRejected {
-		return true
-	}
-	// Readiness blocks also set agent decision + blocked without a judge run.
-	if stepState.DecisionActor == decisionActorAgent {
-		return true
-	}
-	return strings.Contains(strings.ToLower(stepState.Feedback), "approval auto mode") ||
-		strings.Contains(strings.ToLower(stepState.Feedback), "approval readiness")
+	return wf.IsJudgeRejection(stepState)
 }
 
 // resolveManualApprovalDecision applies authority rules when auto-judge is configured.
@@ -96,7 +85,7 @@ func resolveManualApprovalDecision(
 	if !stdinIsInteractiveFn() {
 		hint := "run from a terminal and type APPROVE when prompted"
 		if priorReject {
-			hint = "fix evidence and re-submit with 'fest workflow approve --auto', or override interactively / with --override-judge --summary \"...\""
+			hint = "fix evidence and re-submit with 'fest workflow judge', or override interactively / with --override-judge --summary \"...\""
 		}
 		return wf.DecisionMetadata{}, festerrors.Validation("manual approve requires an interactive operator TTY for human attestation, after judge delegation, or when auto-judge is configured").
 			WithField("step", stepNum).
@@ -108,7 +97,7 @@ func resolveManualApprovalDecision(
 	if priorReject {
 		fmt.Fprintf(os.Stderr, "%s This step was previously rejected by the approval judge or readiness check.\n", ui.Label("Note"))
 		if stepState != nil && stepState.Feedback != "" {
-			fmt.Fprintf(os.Stderr, "%s %s\n", ui.Label("Last feedback"), truncateForPrompt(stepState.Feedback, 240))
+			fmt.Fprintf(os.Stderr, "%s %s\n", ui.Label("Last feedback"), truncateForPrompt(wf.DisplayFeedback(stepState.Feedback), 240))
 		}
 		fmt.Fprintf(os.Stderr, "Confirming will record decision_actor=%s (operator override).\n", decisionActorUserOverride)
 	}

--- a/internal/commands/workflow/reject.go
+++ b/internal/commands/workflow/reject.go
@@ -59,7 +59,7 @@ Examples:
 
 	cmd.Flags().StringVarP(&reason, "reason", "r", "", "reason for rejection (required)")
 	cmd.Flags().StringVar(&remediationPhase, "remediation-phase", "", "link a remediation phase for a failed gate (e.g. 005_FIX_PR_302)")
-	cmd.Flags().StringVar(&actor, "as", decisionActorUser, "deprecated: manual rejections are always recorded as the user; agent decisions require 'fest workflow approve --auto' with a configured judge")
+	cmd.Flags().StringVar(&actor, "as", decisionActorUser, "deprecated: manual rejections are always recorded as the user; agent decisions require 'fest workflow judge' with a configured judge")
 	_ = cmd.Flags().MarkHidden("as")
 	cmd.Flags().StringVar(&summary, "summary", "", "decision summary or rationale")
 	_ = cmd.MarkFlagRequired("reason")

--- a/internal/commands/workflow/show.go
+++ b/internal/commands/workflow/show.go
@@ -154,26 +154,15 @@ func runShow(ctx context.Context, stepNum int) error {
 		sb.WriteString(ui.Label("Judge: "))
 		switch stepState.Judge.Status {
 		case wf.JudgeRunning:
-			detail := stepState.Judge.Command
-			if stepState.Judge.Pid > 0 {
-				detail = fmt.Sprintf("%s (pid %d)", detail, stepState.Judge.Pid)
-			}
-			if stepState.Judge.StartedAt != nil {
-				detail = fmt.Sprintf("%s since %s", detail, stepState.Judge.StartedAt.Local().Format("15:04:05"))
-			}
-			sb.WriteString(ui.ColoredText("waiting — "+detail, ui.JudgeColor))
+			sb.WriteString(ui.ColoredText("waiting", ui.JudgeColor))
 		case wf.JudgeFailed:
 			sb.WriteString(ui.Error("failed (fails closed)"))
-			if stepState.Judge.Detail != "" {
+			if detail := wf.DisplayFeedback(stepState.Judge.Detail); detail != "" {
 				sb.WriteString("\n  ")
-				sb.WriteString(stepState.Judge.Detail)
+				sb.WriteString(detail)
 			}
 		case wf.JudgeApproved, wf.JudgeRejected:
 			sb.WriteString(ui.Dim(stepState.Judge.Status))
-			if stepState.Judge.Detail != "" {
-				sb.WriteString("\n  ")
-				sb.WriteString(stepState.Judge.Detail)
-			}
 		default:
 			sb.WriteString(stepState.Judge.Status)
 		}
@@ -182,14 +171,17 @@ func runShow(ctx context.Context, stepNum int) error {
 
 	// Show feedback/note metadata for blocked and skipped/completed-with-note states.
 	if stepState != nil && stepState.Feedback != "" {
-		label := ui.Error("Rejection Feedback:")
+		feedback := wf.DisplayFeedback(stepState.Feedback)
+		label := ui.Error("Feedback:")
 		if stepState.Status == wf.StepStatusSkipped || stepState.Status == wf.StepStatusCompleted {
 			label = ui.Warning("Operator Note:")
 		}
-		sb.WriteString(label)
-		sb.WriteString("\n  ")
-		sb.WriteString(stepState.Feedback)
-		sb.WriteString("\n\n")
+		if feedback != "" {
+			sb.WriteString(label)
+			sb.WriteString("\n  ")
+			sb.WriteString(feedback)
+			sb.WriteString("\n\n")
+		}
 	}
 
 	// Navigation hint

--- a/internal/commands/workflow/status.go
+++ b/internal/commands/workflow/status.go
@@ -79,7 +79,7 @@ func runStatus(ctx context.Context, jsonOutput bool) error {
 		var judge *wf.JudgeState
 		if stepState != nil {
 			status = stepState.Status
-			feedback = stepState.Feedback
+			feedback = wf.DisplayFeedback(stepState.Feedback)
 			judge = stepState.Judge
 			if stepState.Status == wf.StepStatusFailedRemediation {
 				failedRemediation[i] = stepState
@@ -142,8 +142,8 @@ func runStatus(ctx context.Context, jsonOutput bool) error {
 		sb.WriteString(ui.Warning("⚠ Failed gate (remediation linked)"))
 		sb.WriteString("\n")
 		fmt.Fprintf(&sb, "  Step %d: %s\n", steps[i].Number, steps[i].Name)
-		if ss.Feedback != "" {
-			fmt.Fprintf(&sb, "  Reason: %s\n", ss.Feedback)
+		if feedback := wf.DisplayFeedback(ss.Feedback); feedback != "" {
+			fmt.Fprintf(&sb, "  Reason: %s\n", feedback)
 		}
 		if ss.RemediationPhase != "" {
 			fmt.Fprintf(&sb, "  Remediation phase: %s\n", ss.RemediationPhase)

--- a/internal/commands/workflow/status_json.go
+++ b/internal/commands/workflow/status_json.go
@@ -44,10 +44,6 @@ type workflowStatusStepJSON struct {
 	// WaitingOnJudge is true when a detached approval judge is still running.
 	WaitingOnJudge bool   `json:"waiting_on_judge,omitempty"`
 	JudgeStatus    string `json:"judge_status,omitempty"`
-	JudgeCommand   string `json:"judge_command,omitempty"`
-	JudgePid       int    `json:"judge_pid,omitempty"`
-	JudgeRunID     string `json:"judge_run_id,omitempty"`
-	JudgeDetail    string `json:"judge_detail,omitempty"`
 }
 
 // collectWorkflowStatus builds the structured snapshot from navigator state.
@@ -98,14 +94,10 @@ func collectWorkflowStatus(nav *wf.Navigator) workflowStatusJSON {
 		}
 		if stepState := state.GetStepState(step.Number); stepState != nil {
 			status = stepState.Status
-			feedback = stepState.Feedback
+			feedback = wf.DisplayFeedback(stepState.Feedback)
 			remediation = stepState.RemediationPhase
 			if stepState.Judge != nil {
 				entry.JudgeStatus = stepState.Judge.Status
-				entry.JudgeCommand = stepState.Judge.Command
-				entry.JudgePid = stepState.Judge.Pid
-				entry.JudgeRunID = stepState.Judge.RunID
-				entry.JudgeDetail = stepState.Judge.Detail
 				entry.WaitingOnJudge = stepState.Judge.Status == wf.JudgeRunning
 			}
 		}

--- a/internal/commands/workflow/status_json.go
+++ b/internal/commands/workflow/status_json.go
@@ -44,6 +44,12 @@ type workflowStatusStepJSON struct {
 	// WaitingOnJudge is true when a detached approval judge is still running.
 	WaitingOnJudge bool   `json:"waiting_on_judge,omitempty"`
 	JudgeStatus    string `json:"judge_status,omitempty"`
+	// These judge fields are retained for fest.workflow.status/v1 consumers.
+	// Human renderers intentionally keep this metadata out of normal output.
+	JudgeCommand string `json:"judge_command,omitempty"`
+	JudgePid     int    `json:"judge_pid,omitempty"`
+	JudgeRunID   string `json:"judge_run_id,omitempty"`
+	JudgeDetail  string `json:"judge_detail,omitempty"`
 }
 
 // collectWorkflowStatus builds the structured snapshot from navigator state.
@@ -99,6 +105,10 @@ func collectWorkflowStatus(nav *wf.Navigator) workflowStatusJSON {
 			if stepState.Judge != nil {
 				entry.JudgeStatus = stepState.Judge.Status
 				entry.WaitingOnJudge = stepState.Judge.Status == wf.JudgeRunning
+				entry.JudgeCommand = stepState.Judge.Command
+				entry.JudgePid = stepState.Judge.Pid
+				entry.JudgeRunID = stepState.Judge.RunID
+				entry.JudgeDetail = wf.DisplayFeedback(stepState.Judge.Detail)
 			}
 		}
 		isCurrent := step.Number == state.CurrentStep && !out.Complete

--- a/internal/commands/workflow/status_json_test.go
+++ b/internal/commands/workflow/status_json_test.go
@@ -204,9 +204,9 @@ func TestWorkflowStatusJSON_ConciseJudgeFeedback(t *testing.T) {
 	if !strings.Contains(out, `"feedback": "missing acceptance proof"`) {
 		t.Fatalf("JSON missing concise feedback:\n%s", out)
 	}
-	for _, noisy := range []string{"judge_command", "judge_detail", "judge_pid", "judge_run_id"} {
-		if strings.Contains(out, noisy) {
-			t.Fatalf("JSON leaked %q:\n%s", noisy, out)
+	for _, want := range []string{`"judge_command": "ob judge"`, `"judge_pid": 42`, `"judge_run_id": "run-1"`, `"judge_detail": "missing acceptance proof"`} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("JSON missing v1 compatibility field %q:\n%s", want, out)
 		}
 	}
 }

--- a/internal/commands/workflow/status_json_test.go
+++ b/internal/commands/workflow/status_json_test.go
@@ -185,6 +185,32 @@ func TestWorkflowStatusJSON_EmptyStepsSerializesArray(t *testing.T) {
 	}
 }
 
+func TestWorkflowStatusJSON_ConciseJudgeFeedback(t *testing.T) {
+	dir := setupWorkflowFestival(t)
+	phaseDir := filepath.Join(dir, "001_INGEST")
+	nav := getNavigator(t, phaseDir)
+	if err := nav.Advance(context.Background()); err != nil {
+		t.Fatalf("advance: %v", err)
+	}
+	step := nav.GetWorkflowState().GetStepState(2)
+	step.Status = wf.StepStatusBlocked
+	step.Feedback = `approval auto mode: schema_version=fest.approval.judge/v1 judge_command="ob judge" decision=reject reason="missing acceptance proof"`
+	step.Judge = &wf.JudgeState{Status: wf.JudgeRejected, Command: "ob judge", Detail: "missing acceptance proof", Pid: 42, RunID: "run-1"}
+
+	out, err := renderWorkflowStatusJSON(nav)
+	if err != nil {
+		t.Fatalf("renderWorkflowStatusJSON: %v", err)
+	}
+	if !strings.Contains(out, `"feedback": "missing acceptance proof"`) {
+		t.Fatalf("JSON missing concise feedback:\n%s", out)
+	}
+	for _, noisy := range []string{"judge_command", "judge_detail", "judge_pid", "judge_run_id"} {
+		if strings.Contains(out, noisy) {
+			t.Fatalf("JSON leaked %q:\n%s", noisy, out)
+		}
+	}
+}
+
 // TestRunStatus_JSONAndText exercises the real command entrypoint for both
 // modes: --json emits parseable structured output and default text mode still
 // renders the human-readable status without leaking JSON.

--- a/internal/commands/workflow/workflow.go
+++ b/internal/commands/workflow/workflow.go
@@ -64,6 +64,7 @@ Examples:
   fest workflow advance             # Complete current step and move to next
   fest workflow skip --reason "already completed externally" # Operator override
   fest workflow approve             # Approve a blocking checkpoint
+  fest workflow judge               # Run or re-run the configured approval judge
   fest workflow reject              # Reject checkpoint with feedback
   fest workflow reset               # Reset workflow or gate to step 1
   fest workflow show                # Display the current step details`,
@@ -78,6 +79,7 @@ Examples:
 		newAdvanceCmd(),
 		newSkipCmd(),
 		newApproveCmd(),
+		newJudgeCmd(),
 		newJudgeExecCmd(),
 		newRejectCmd(),
 		newResetCmd(),

--- a/internal/config/workspace_config.go
+++ b/internal/config/workspace_config.go
@@ -27,7 +27,7 @@ type WorkspaceConfig struct {
 // .festival/config.yaml. fest reads these directly so it stays usable on its
 // own, without the camp CLI.
 type HooksConfig struct {
-	// ApprovalJudge configures the command run by `fest workflow approve --auto`.
+	// ApprovalJudge configures the command run by `fest workflow judge`.
 	ApprovalJudge ApprovalJudgeHookConfig `yaml:"approval_judge,omitempty"`
 }
 
@@ -97,7 +97,7 @@ func SaveWorkspaceConfig(festivalsRoot string, cfg *WorkspaceConfig) error {
 	}
 
 	// Surface the hooks option as a discoverable commented block when none is
-	// configured, so users can opt into approve --auto without reading docs.
+	// configured, so users can opt into the approval judge without reading docs.
 	if (cfg.Hooks == HooksConfig{}) {
 		data = append(data, commentedHooksPlaceholder()...)
 	}
@@ -118,7 +118,7 @@ func commentedHooksPlaceholder() []byte {
 	return []byte(`
 # hooks:
 #   approval_judge:
-#     # Command run by 'fest workflow approve --auto'. It receives the approval
+#     # Command run by 'fest workflow judge'. It receives the approval
 #     # request as JSON on stdin and must print a JSON verdict on stdout
 #     # (schema fest.approval.judge/v1). Any tool works; 'ob judge' is one example.
 #     command: ob judge

--- a/internal/guidance/workflow/feedback_test.go
+++ b/internal/guidance/workflow/feedback_test.go
@@ -1,0 +1,51 @@
+package workflow
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDisplayFeedbackStripsLegacyJudgeAudit(t *testing.T) {
+	got := DisplayFeedback(`approval auto mode: schema_version=fest.approval.judge/v1 judge_command="ob judge" decision=reject reason="missing \"proof\""`)
+	if got != `missing "proof"` {
+		t.Fatalf("DisplayFeedback() = %q, want concise reason", got)
+	}
+}
+
+func TestDisplayFeedbackLeavesNormalReasonUntouched(t *testing.T) {
+	if got := DisplayFeedback("missing acceptance proof"); got != "missing acceptance proof" {
+		t.Fatalf("DisplayFeedback() = %q", got)
+	}
+}
+
+func TestWorkflowStateReopenJudgeRejection(t *testing.T) {
+	state := NewWorkflowState(1)
+	state.StartCurrentStep()
+	now := time.Now().UTC()
+	state.BeginJudge(1, "ob judge", "run-1", 123, now)
+	if !state.RecordJudgeOutcome(1, "run-1", JudgeRejected, "missing proof", now) {
+		t.Fatal("RecordJudgeOutcome() did not record rejection")
+	}
+	state.RejectWithDecision("missing proof", DecisionMetadata{Actor: "agent", Summary: "missing proof"})
+
+	if !state.ReopenJudgeRejection(1) {
+		t.Fatal("ReopenJudgeRejection() = false, want true")
+	}
+	step := state.GetStepState(1)
+	if step.Status != StepStatusInProgress || step.Feedback != "" || step.Judge != nil {
+		t.Fatalf("reopened step = %+v, want in-progress with cleared active judge state", step)
+	}
+}
+
+func TestWorkflowStateReopenJudgeRejectionDoesNotBypassOperator(t *testing.T) {
+	state := NewWorkflowState(1)
+	state.StartCurrentStep()
+	state.RejectWithDecision("operator review required", DecisionMetadata{Actor: "user"})
+
+	if state.ReopenJudgeRejection(1) {
+		t.Fatal("ReopenJudgeRejection() = true for ordinary operator rejection")
+	}
+	if state.GetStepState(1).Status != StepStatusBlocked {
+		t.Fatal("operator rejection was reopened")
+	}
+}

--- a/internal/guidance/workflow/feedback_test.go
+++ b/internal/guidance/workflow/feedback_test.go
@@ -12,6 +12,13 @@ func TestDisplayFeedbackStripsLegacyJudgeAudit(t *testing.T) {
 	}
 }
 
+func TestDisplayFeedbackPreservesReasonTextContainingReasonField(t *testing.T) {
+	got := DisplayFeedback(`approval auto mode: schema_version=fest.approval.judge/v1 judge_command="ob judge" decision=reject reason="the note says reason=needs more evidence"`)
+	if got != `the note says reason=needs more evidence` {
+		t.Fatalf("DisplayFeedback() = %q, want complete reason", got)
+	}
+}
+
 func TestDisplayFeedbackLeavesNormalReasonUntouched(t *testing.T) {
 	if got := DisplayFeedback("missing acceptance proof"); got != "missing acceptance proof" {
 		t.Fatalf("DisplayFeedback() = %q", got)
@@ -47,5 +54,24 @@ func TestWorkflowStateReopenJudgeRejectionDoesNotBypassOperator(t *testing.T) {
 	}
 	if state.GetStepState(1).Status != StepStatusBlocked {
 		t.Fatal("operator rejection was reopened")
+	}
+}
+
+func TestWorkflowStateReopenJudgeRejectionDoesNotBypassLaterOperatorDecision(t *testing.T) {
+	state := NewWorkflowState(1)
+	state.StartCurrentStep()
+	now := time.Now().UTC()
+	state.BeginJudge(1, "ob judge", "run-1", 123, now)
+	if !state.RecordJudgeOutcome(1, "run-1", JudgeRejected, "judge feedback", now) {
+		t.Fatal("RecordJudgeOutcome() did not record rejection")
+	}
+	state.RejectWithDecision("approval auto mode: operator feedback", DecisionMetadata{Actor: "user"})
+
+	if state.ReopenJudgeRejection(1) {
+		t.Fatal("ReopenJudgeRejection() = true after later operator rejection")
+	}
+	step := state.GetStepState(1)
+	if step.Status != StepStatusBlocked || step.Feedback != "approval auto mode: operator feedback" {
+		t.Fatalf("operator decision was not preserved: %+v", step)
 	}
 }

--- a/internal/guidance/workflow/feedback_test.go
+++ b/internal/guidance/workflow/feedback_test.go
@@ -75,3 +75,19 @@ func TestWorkflowStateReopenJudgeRejectionDoesNotBypassLaterOperatorDecision(t *
 		t.Fatalf("operator decision was not preserved: %+v", step)
 	}
 }
+
+func TestWorkflowStateRecordJudgeFailureAllowsBlockedStaleLease(t *testing.T) {
+	state := NewWorkflowState(1)
+	state.StartCurrentStep()
+	now := time.Now().UTC()
+	state.BeginJudge(1, "ob judge", "run-1", 123, now)
+	state.GetStepState(1).Status = StepStatusBlocked
+
+	if !state.RecordJudgeFailure(1, "run-1", "detached runner exited", now.Add(time.Second)) {
+		t.Fatal("RecordJudgeFailure() = false, want stale lease to be recorded")
+	}
+	judge := state.GetStepState(1).Judge
+	if judge == nil || judge.Status != JudgeFailed || judge.Detail != "detached runner exited" {
+		t.Fatalf("judge = %+v, want failed stale lease", judge)
+	}
+}

--- a/internal/guidance/workflow/navigator.go
+++ b/internal/guidance/workflow/navigator.go
@@ -380,7 +380,7 @@ func (n *Navigator) ApproveWithAudit(ctx context.Context, feedback string, decis
 	currentStep := n.workflowState.CurrentStep
 	stepState := n.workflowState.GetStepState(currentStep)
 	judgeRunID := runningJudgeRunID(stepState)
-	judgeClearRunID := terminalJudgeRunID(stepState, decision)
+	judgeClearRunID, shouldClearJudge := terminalJudgeRunID(stepState, decision)
 	if err := n.workflowState.ApproveWithAudit(feedback, decision); err != nil {
 		return err
 	}
@@ -390,7 +390,7 @@ func (n *Navigator) ApproveWithAudit(ctx context.Context, feedback string, decis
 		if judgeRunID != "" {
 			n.store.QueueWorkflowEvents(EmitJudgeReturnedEvents(sk, currentStep, judgeRunID, JudgeCanceled, "superseded by manual approval"))
 		}
-		if judgeClearRunID != "" {
+		if shouldClearJudge {
 			n.store.QueueWorkflowEvents(EmitJudgeClearedEvents(sk, currentStep, judgeClearRunID))
 		}
 		n.store.QueueWorkflowEvents(EmitStepDoneWithDecisionEvents(sk, currentStep, feedback, decision))
@@ -423,7 +423,7 @@ func (n *Navigator) RejectWithDecision(ctx context.Context, reason string, decis
 	currentStep := n.workflowState.CurrentStep
 	stepState := n.workflowState.GetStepState(currentStep)
 	judgeRunID := runningJudgeRunID(stepState)
-	judgeClearRunID := terminalJudgeRunID(stepState, decision)
+	judgeClearRunID, shouldClearJudge := terminalJudgeRunID(stepState, decision)
 	n.workflowState.RejectWithDecision(reason, decision)
 
 	sk := n.stateKey()
@@ -431,7 +431,7 @@ func (n *Navigator) RejectWithDecision(ctx context.Context, reason string, decis
 		if judgeRunID != "" {
 			n.store.QueueWorkflowEvents(EmitJudgeReturnedEvents(sk, currentStep, judgeRunID, JudgeCanceled, "superseded by manual rejection"))
 		}
-		if judgeClearRunID != "" {
+		if shouldClearJudge {
 			n.store.QueueWorkflowEvents(EmitJudgeClearedEvents(sk, currentStep, judgeClearRunID))
 		}
 		n.store.QueueWorkflowEvents(EmitStepBlockWithDecisionEvents(sk, currentStep, reason, decision))
@@ -463,7 +463,7 @@ func (n *Navigator) RejectWithRemediationDecision(ctx context.Context, reason, r
 	currentStep := n.workflowState.CurrentStep
 	stepState := n.workflowState.GetStepState(currentStep)
 	judgeRunID := runningJudgeRunID(stepState)
-	judgeClearRunID := terminalJudgeRunID(stepState, decision)
+	judgeClearRunID, shouldClearJudge := terminalJudgeRunID(stepState, decision)
 	n.workflowState.RejectWithRemediationDecision(reason, remediationPhase, decision)
 
 	sk := n.stateKey()
@@ -471,7 +471,7 @@ func (n *Navigator) RejectWithRemediationDecision(ctx context.Context, reason, r
 		if judgeRunID != "" {
 			n.store.QueueWorkflowEvents(EmitJudgeReturnedEvents(sk, currentStep, judgeRunID, JudgeCanceled, "superseded by manual remediation decision"))
 		}
-		if judgeClearRunID != "" {
+		if shouldClearJudge {
 			n.store.QueueWorkflowEvents(EmitJudgeClearedEvents(sk, currentStep, judgeClearRunID))
 		}
 		n.store.QueueWorkflowEvents(EmitStepFailRemediationWithDecisionEvents(sk, currentStep, reason, remediationPhase, decision))
@@ -487,12 +487,12 @@ func runningJudgeRunID(state *StepState) string {
 	return state.Judge.RunID
 }
 
-func terminalJudgeRunID(state *StepState, decision DecisionMetadata) string {
+func terminalJudgeRunID(state *StepState, decision DecisionMetadata) (string, bool) {
 	if decision.Actor == "agent" || state == nil || state.Judge == nil ||
 		state.Judge.Status == JudgeRunning || state.Judge.Status == JudgeCanceled {
-		return ""
+		return "", false
 	}
-	return state.Judge.RunID
+	return state.Judge.RunID, true
 }
 
 // ApplyJudgeApproval atomically records an owned verdict and advances the

--- a/internal/guidance/workflow/navigator.go
+++ b/internal/guidance/workflow/navigator.go
@@ -322,6 +322,17 @@ func (n *Navigator) RecordJudgeOutcome(ctx context.Context, step int, runID, sta
 	return recorded, err
 }
 
+// RecordJudgeFailure durably marks an owned judge lease as failed. Unlike a
+// normal verdict, stale-run cleanup remains valid after the step is blocked.
+func (n *Navigator) RecordJudgeFailure(ctx context.Context, step int, runID, detail string) (bool, error) {
+	recorded := false
+	err := n.recordJudge(ctx, EmitJudgeReturnedEvents(n.stateKey(), step, runID, JudgeFailed, detail), func(at time.Time) bool {
+		recorded = n.workflowState.RecordJudgeFailure(step, runID, detail, at)
+		return recorded
+	})
+	return recorded, err
+}
+
 func (n *Navigator) recordJudge(ctx context.Context, events []WorkflowEvent, apply func(at time.Time) bool) error {
 	if err := n.EnsureInitialized(); err != nil {
 		return err
@@ -367,7 +378,9 @@ func (n *Navigator) ApproveWithAudit(ctx context.Context, feedback string, decis
 	}
 
 	currentStep := n.workflowState.CurrentStep
-	judgeRunID := runningJudgeRunID(n.workflowState.GetStepState(currentStep))
+	stepState := n.workflowState.GetStepState(currentStep)
+	judgeRunID := runningJudgeRunID(stepState)
+	judgeClearRunID := terminalJudgeRunID(stepState, decision)
 	if err := n.workflowState.ApproveWithAudit(feedback, decision); err != nil {
 		return err
 	}
@@ -376,6 +389,9 @@ func (n *Navigator) ApproveWithAudit(ctx context.Context, feedback string, decis
 	if n.store != nil {
 		if judgeRunID != "" {
 			n.store.QueueWorkflowEvents(EmitJudgeReturnedEvents(sk, currentStep, judgeRunID, JudgeCanceled, "superseded by manual approval"))
+		}
+		if judgeClearRunID != "" {
+			n.store.QueueWorkflowEvents(EmitJudgeClearedEvents(sk, currentStep, judgeClearRunID))
 		}
 		n.store.QueueWorkflowEvents(EmitStepDoneWithDecisionEvents(sk, currentStep, feedback, decision))
 		if n.workflowState.CurrentStep > currentStep {
@@ -405,13 +421,18 @@ func (n *Navigator) RejectWithDecision(ctx context.Context, reason string, decis
 	}
 
 	currentStep := n.workflowState.CurrentStep
-	judgeRunID := runningJudgeRunID(n.workflowState.GetStepState(currentStep))
+	stepState := n.workflowState.GetStepState(currentStep)
+	judgeRunID := runningJudgeRunID(stepState)
+	judgeClearRunID := terminalJudgeRunID(stepState, decision)
 	n.workflowState.RejectWithDecision(reason, decision)
 
 	sk := n.stateKey()
 	if n.store != nil {
 		if judgeRunID != "" {
 			n.store.QueueWorkflowEvents(EmitJudgeReturnedEvents(sk, currentStep, judgeRunID, JudgeCanceled, "superseded by manual rejection"))
+		}
+		if judgeClearRunID != "" {
+			n.store.QueueWorkflowEvents(EmitJudgeClearedEvents(sk, currentStep, judgeClearRunID))
 		}
 		n.store.QueueWorkflowEvents(EmitStepBlockWithDecisionEvents(sk, currentStep, reason, decision))
 		return n.store.SaveEvents(ctx)
@@ -440,13 +461,18 @@ func (n *Navigator) RejectWithRemediationDecision(ctx context.Context, reason, r
 	}
 
 	currentStep := n.workflowState.CurrentStep
-	judgeRunID := runningJudgeRunID(n.workflowState.GetStepState(currentStep))
+	stepState := n.workflowState.GetStepState(currentStep)
+	judgeRunID := runningJudgeRunID(stepState)
+	judgeClearRunID := terminalJudgeRunID(stepState, decision)
 	n.workflowState.RejectWithRemediationDecision(reason, remediationPhase, decision)
 
 	sk := n.stateKey()
 	if n.store != nil {
 		if judgeRunID != "" {
 			n.store.QueueWorkflowEvents(EmitJudgeReturnedEvents(sk, currentStep, judgeRunID, JudgeCanceled, "superseded by manual remediation decision"))
+		}
+		if judgeClearRunID != "" {
+			n.store.QueueWorkflowEvents(EmitJudgeClearedEvents(sk, currentStep, judgeClearRunID))
 		}
 		n.store.QueueWorkflowEvents(EmitStepFailRemediationWithDecisionEvents(sk, currentStep, reason, remediationPhase, decision))
 		return n.store.SaveEvents(ctx)
@@ -456,6 +482,14 @@ func (n *Navigator) RejectWithRemediationDecision(ctx context.Context, reason, r
 
 func runningJudgeRunID(state *StepState) string {
 	if state == nil || state.Judge == nil || state.Judge.Status != JudgeRunning {
+		return ""
+	}
+	return state.Judge.RunID
+}
+
+func terminalJudgeRunID(state *StepState, decision DecisionMetadata) string {
+	if decision.Actor == "agent" || state == nil || state.Judge == nil ||
+		state.Judge.Status == JudgeRunning || state.Judge.Status == JudgeCanceled {
 		return ""
 	}
 	return state.Judge.RunID

--- a/internal/guidance/workflow/navigator.go
+++ b/internal/guidance/workflow/navigator.go
@@ -474,14 +474,14 @@ func (n *Navigator) ApplyJudgeApproval(ctx context.Context, step int, runID, aud
 	if !n.workflowState.RecordJudgeOutcome(step, runID, JudgeApproved, decision.Summary, now) {
 		return false, nil
 	}
-	if err := n.workflowState.ApproveWithAudit(audit, decision); err != nil {
+	if err := n.workflowState.ApproveWithAudit(decision.Summary, decision); err != nil {
 		return false, err
 	}
 
 	sk := n.stateKey()
 	if n.store != nil {
 		n.store.QueueWorkflowEvents(EmitJudgeReturnedEvents(sk, step, runID, JudgeApproved, decision.Summary))
-		n.store.QueueWorkflowEvents(EmitStepDoneWithDecisionEvents(sk, step, audit, decision))
+		n.store.QueueWorkflowEvents(EmitStepDoneWithDecisionEvents(sk, step, decision.Summary, decision))
 		if n.workflowState.CurrentStep > step {
 			n.store.QueueWorkflowEvents(EmitAdvanceEvents(sk, n.workflowState.CurrentStep))
 			n.store.QueueWorkflowEvents(EmitStepStartEvents(sk, n.workflowState.CurrentStep))
@@ -504,12 +504,12 @@ func (n *Navigator) ApplyJudgeRejection(ctx context.Context, step int, runID, au
 	if !n.workflowState.RecordJudgeOutcome(step, runID, JudgeRejected, decision.Summary, now) {
 		return false, nil
 	}
-	n.workflowState.RejectWithDecision(audit, decision)
+	n.workflowState.RejectWithDecision(decision.Summary, decision)
 
 	sk := n.stateKey()
 	if n.store != nil {
 		n.store.QueueWorkflowEvents(EmitJudgeReturnedEvents(sk, step, runID, JudgeRejected, decision.Summary))
-		n.store.QueueWorkflowEvents(EmitStepBlockWithDecisionEvents(sk, step, audit, decision))
+		n.store.QueueWorkflowEvents(EmitStepBlockWithDecisionEvents(sk, step, decision.Summary, decision))
 		return true, n.store.SaveEvents(ctx)
 	}
 	return true, n.workflowState.Save(ctx, n.festivalPath, sk)
@@ -534,6 +534,36 @@ func (n *Navigator) Recheck(ctx context.Context) error {
 	sk := n.stateKey()
 	if n.store != nil {
 		n.store.QueueWorkflowEvents(EmitStepRecheckEvents(sk, n.workflowState.CurrentStep))
+		return n.store.SaveEvents(ctx)
+	}
+	return n.workflowState.Save(ctx, n.festivalPath, sk)
+}
+
+// ReopenJudgeRejection moves the current judge-owned rejection back to
+// in-progress so revised evidence can be submitted with the approval judge.
+// Ordinary operator rejections are intentionally left untouched.
+func (n *Navigator) ReopenJudgeRejection(ctx context.Context, step int) error {
+	if err := n.EnsureInitialized(); err != nil {
+		return err
+	}
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+	if n.workflowState.CurrentStep != step {
+		return errors.Validation("approval judge can only re-run the current step").
+			WithField("expected_step", n.workflowState.CurrentStep).
+			WithField("step", step)
+	}
+	if !n.workflowState.ReopenJudgeRejection(step) {
+		return errors.Validation("current step is not blocked by an approval judge rejection").
+			WithHint("address the current feedback first, then run 'fest workflow judge'; ordinary operator rejections require 'fest workflow approve'")
+	}
+
+	sk := n.stateKey()
+	if n.store != nil {
+		n.store.QueueWorkflowEvents(EmitJudgeRecheckEvents(sk, step))
 		return n.store.SaveEvents(ctx)
 	}
 	return n.workflowState.Save(ctx, n.festivalPath, sk)

--- a/internal/guidance/workflow/navigator_format.go
+++ b/internal/guidance/workflow/navigator_format.go
@@ -172,7 +172,7 @@ func (n *Navigator) festivalsRoot(ctx context.Context) string {
 // formatStep renders the step template for the current workflow step.
 func (n *Navigator) formatStep(ctx context.Context, step WorkflowStep, stepState *StepState) (string, error) {
 	status := string(stepState.Status)
-	feedback := stepState.Feedback
+	feedback := DisplayFeedback(stepState.Feedback)
 
 	isGate := n.docFilename == "GATES.md"
 	phaseType := n.displayPhaseType()
@@ -197,6 +197,9 @@ func (n *Navigator) formatStep(ctx context.Context, step WorkflowStep, stepState
 		"IsGate":              isGate,
 		"JudgeConfigured":     n.approvalJudgeConfigured(ctx),
 		"OperatorAttestation": ClassifyCheckpoint(step) == CheckpointClassOperatorAttestation,
+		"JudgeRetryAvailable": stepState.Status == StepStatusBlocked &&
+			ClassifyCheckpoint(step) != CheckpointClassOperatorAttestation &&
+			IsJudgeRejection(stepState) && n.approvalJudgeConfigured(ctx),
 	}
 
 	return agent.Render("workflow/step", data)

--- a/internal/guidance/workflow/navigator_format_judge_test.go
+++ b/internal/guidance/workflow/navigator_format_judge_test.go
@@ -96,7 +96,7 @@ func TestFormatCheckpoint_JudgeConfigured_ArtifactReviewDelegates(t *testing.T) 
 	for _, want := range []string{
 		"This checkpoint is delegated",
 		"fest next` auto-invokes the judge",
-		"fest workflow approve --auto",
+		"fest workflow judge",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("checkpoint output missing %q:\n%s", want, out)

--- a/internal/guidance/workflow/state.go
+++ b/internal/guidance/workflow/state.go
@@ -112,8 +112,7 @@ func DisplayFeedback(feedback string) string {
 	}
 
 	if strings.HasPrefix(feedback, "approval auto mode:") {
-		if idx := strings.LastIndex(feedback, " reason="); idx >= 0 {
-			rawReason := strings.TrimSpace(feedback[idx+len(" reason="):])
+		if rawReason, ok := legacyJudgeReason(feedback); ok {
 			if reason, err := strconv.Unquote(rawReason); err == nil {
 				return reason
 			}
@@ -129,6 +128,39 @@ func DisplayFeedback(feedback string) string {
 	return feedback
 }
 
+// legacyJudgeReason finds the final, unquoted reason field in the legacy
+// approval audit format. A plain LastIndex is unsafe because free-form reason
+// text can itself contain "reason=".
+func legacyJudgeReason(audit string) (string, bool) {
+	const delimiter = " reason="
+	inQuote := false
+	escaped := false
+	for i := 0; i < len(audit); i++ {
+		if inQuote {
+			if escaped {
+				escaped = false
+				continue
+			}
+			switch audit[i] {
+			case '\\':
+				escaped = true
+			case '"':
+				inQuote = false
+			}
+			continue
+		}
+
+		if audit[i] == '"' {
+			inQuote = true
+			continue
+		}
+		if strings.HasPrefix(audit[i:], delimiter) {
+			return strings.TrimSpace(audit[i+len(delimiter):]), true
+		}
+	}
+	return "", false
+}
+
 // IsJudgeRejection reports whether a blocked step was produced by an approval
 // judge or by the deterministic readiness checks that precede one. Ordinary
 // operator rejections intentionally return false and cannot be reopened by
@@ -138,10 +170,16 @@ func IsJudgeRejection(stepState *StepState) bool {
 		return false
 	}
 	if stepState.Judge != nil && stepState.Judge.Status == JudgeRejected {
-		return true
+		// A manual rejection can leave an older terminal judge record in
+		// append-only history. The current decision actor is authoritative;
+		// only an agent-owned decision may be reopened by the judge command.
+		return stepState.DecisionActor == "agent"
 	}
 	if stepState.DecisionActor == "agent" {
 		return true
+	}
+	if stepState.DecisionActor != "" {
+		return false
 	}
 	feedback := strings.ToLower(stepState.Feedback)
 	return strings.Contains(feedback, "approval auto mode") ||
@@ -518,6 +556,11 @@ func (s *WorkflowState) RejectWithDecision(feedback string, decision DecisionMet
 	state.Status = StepStatusBlocked
 	state.Feedback = feedback
 	state.RemediationPhase = ""
+	if decision.Actor != "agent" && state.Judge != nil && state.Judge.Status != JudgeCanceled {
+		// Replace any prior terminal judge outcome so a later judge command
+		// cannot reopen a checkpoint after an operator has taken ownership.
+		state.Judge = nil
+	}
 	s.recordDecision(s.CurrentStep, decision)
 }
 

--- a/internal/guidance/workflow/state.go
+++ b/internal/guidance/workflow/state.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -97,6 +99,54 @@ type JudgeState struct {
 
 	// FinishedAt is when the judge outcome was recorded.
 	FinishedAt *time.Time `yaml:"finished_at,omitempty" json:"finished_at,omitempty"`
+}
+
+// DisplayFeedback removes implementation details from approval-judge feedback
+// before it is shown in normal command output. Older event logs stored the
+// complete judge audit string; keep accepting those records while presenting
+// only the actionable reason to users and agents.
+func DisplayFeedback(feedback string) string {
+	feedback = strings.TrimSpace(feedback)
+	if feedback == "" {
+		return ""
+	}
+
+	if strings.HasPrefix(feedback, "approval auto mode:") {
+		if idx := strings.LastIndex(feedback, " reason="); idx >= 0 {
+			rawReason := strings.TrimSpace(feedback[idx+len(" reason="):])
+			if reason, err := strconv.Unquote(rawReason); err == nil {
+				return reason
+			}
+			return strings.Trim(rawReason, "\"")
+		}
+	}
+
+	const preflightPrefix = "detached approval judge preflight rejected:"
+	if strings.HasPrefix(feedback, preflightPrefix) {
+		return strings.TrimSpace(strings.TrimPrefix(feedback, preflightPrefix))
+	}
+
+	return feedback
+}
+
+// IsJudgeRejection reports whether a blocked step was produced by an approval
+// judge or by the deterministic readiness checks that precede one. Ordinary
+// operator rejections intentionally return false and cannot be reopened by
+// the agent-facing judge command.
+func IsJudgeRejection(stepState *StepState) bool {
+	if stepState == nil || stepState.Status != StepStatusBlocked {
+		return false
+	}
+	if stepState.Judge != nil && stepState.Judge.Status == JudgeRejected {
+		return true
+	}
+	if stepState.DecisionActor == "agent" {
+		return true
+	}
+	feedback := strings.ToLower(stepState.Feedback)
+	return strings.Contains(feedback, "approval auto mode") ||
+		strings.Contains(feedback, "approval readiness") ||
+		strings.Contains(feedback, "detached approval judge preflight rejected")
 }
 
 // StepState tracks the state of a single workflow step.
@@ -527,6 +577,26 @@ func (s *WorkflowState) ClearFailedRemediation() {
 	state.DecisionAt = nil
 }
 
+// ReopenJudgeRejection moves a judge-owned blocked step back to in-progress
+// so the approval judge can evaluate the revised evidence. The prior rejection
+// remains in the append-only event log; the active state is cleared for the
+// new judge run.
+func (s *WorkflowState) ReopenJudgeRejection(step int) bool {
+	if s.CurrentStep != step || !IsJudgeRejection(s.GetStepState(step)) {
+		return false
+	}
+	state := s.GetOrCreateStepState(step)
+	state.Status = StepStatusInProgress
+	state.Feedback = ""
+	state.RemediationPhase = ""
+	state.DecisionActor = ""
+	state.DecisionSummary = ""
+	state.DecisionAt = nil
+	state.Judge = nil
+	s.UpdatedAt = time.Now().UTC()
+	return true
+}
+
 // Reset resets the workflow to step 1 and clears all step states.
 func (s *WorkflowState) Reset() {
 	s.CurrentStep = 1
@@ -688,6 +758,16 @@ func EmitStepFailRemediationWithDecisionEvents(phaseName string, step int, feedb
 func EmitStepRecheckEvents(phaseName string, step int) []WorkflowEvent {
 	return []WorkflowEvent{{
 		EventType: "wf_step_recheck",
+		Phase:     phaseName,
+		Step:      step,
+	}}
+}
+
+// EmitJudgeRecheckEvents generates an event for reopening a judge-owned
+// rejection before submitting revised evidence to the judge again.
+func EmitJudgeRecheckEvents(phaseName string, step int) []WorkflowEvent {
+	return []WorkflowEvent{{
+		EventType: "wf_judge_recheck",
 		Phase:     phaseName,
 		Step:      step,
 	}}

--- a/internal/guidance/workflow/state.go
+++ b/internal/guidance/workflow/state.go
@@ -465,11 +465,21 @@ func (s *WorkflowState) ClaimJudge(step int, runID string, pid int) bool {
 	return true
 }
 
+// JudgeRunOwned reports whether a running judge still owns the current step.
+// Unlike JudgeOwned, this does not require the step to remain pending or
+// in-progress. A dead detached runner may need to be marked failed after a
+// concurrent transition has blocked the step.
+func (s *WorkflowState) JudgeRunOwned(step int, runID string) bool {
+	state := s.GetStepState(step)
+	return state != nil && state.Judge != nil && state.Judge.Status == JudgeRunning &&
+		state.Judge.RunID == runID && s.CurrentStep == step
+}
+
 // JudgeOwned reports whether a running judge still owns the current decision.
 func (s *WorkflowState) JudgeOwned(step int, runID string) bool {
 	state := s.GetStepState(step)
-	return state != nil && state.Judge != nil && state.Judge.Status == JudgeRunning &&
-		state.Judge.RunID == runID && s.CurrentStep == step &&
+	return s.JudgeRunOwned(step, runID) &&
+		state != nil &&
 		(state.Status == StepStatusPending || state.Status == StepStatusInProgress)
 }
 
@@ -486,6 +496,24 @@ func (s *WorkflowState) RecordJudgeOutcome(step int, runID, status, detail strin
 	}
 	finished := at
 	state.Judge.Status = status
+	state.Judge.Detail = detail
+	state.Judge.FinishedAt = &finished
+	return true
+}
+
+// RecordJudgeFailure records a failure for an owned judge lease. This is
+// intentionally allowed after a step becomes blocked so a stale detached
+// runner cannot leave the durable state looking permanently "waiting".
+func (s *WorkflowState) RecordJudgeFailure(step int, runID, detail string, at time.Time) bool {
+	if runID != "" && !s.JudgeRunOwned(step, runID) {
+		return false
+	}
+	state := s.GetOrCreateStepState(step)
+	if state.Judge == nil {
+		state.Judge = &JudgeState{}
+	}
+	finished := at
+	state.Judge.Status = JudgeFailed
 	state.Judge.Detail = detail
 	state.Judge.FinishedAt = &finished
 	return true
@@ -535,7 +563,11 @@ func (s *WorkflowState) ApproveWithDecision(decision DecisionMetadata) error {
 // ApproveWithAudit approves a blocking checkpoint, recording durable audit
 // text and decision metadata, then advances to the next step.
 func (s *WorkflowState) ApproveWithAudit(feedback string, decision DecisionMetadata) error {
+	state := s.GetOrCreateStepState(s.CurrentStep)
 	s.cancelCurrentJudge("superseded by manual approval")
+	if decision.Actor != "agent" && state.Judge != nil && state.Judge.Status != JudgeCanceled {
+		state.Judge = nil
+	}
 	s.MarkCurrentStep(StepStatusCompleted, feedback)
 	s.recordDecision(s.CurrentStep, decision)
 	if s.CurrentStep < s.TotalSteps {
@@ -579,6 +611,9 @@ func (s *WorkflowState) RejectWithRemediationDecision(feedback, remediationPhase
 	state.Status = StepStatusFailedRemediation
 	state.Feedback = feedback
 	state.RemediationPhase = remediationPhase
+	if decision.Actor != "agent" && state.Judge != nil && state.Judge.Status != JudgeCanceled {
+		state.Judge = nil
+	}
 	s.recordDecision(s.CurrentStep, decision)
 }
 
@@ -870,5 +905,16 @@ func EmitJudgeReturnedEvents(phaseName string, step int, runID, status, detail s
 		JudgeStatus: status,
 		JudgeDetail: detail,
 		JudgeRunID:  runID,
+	}}
+}
+
+// EmitJudgeClearedEvents generates an event that removes a prior terminal
+// judge outcome after an operator takes ownership of the checkpoint.
+func EmitJudgeClearedEvents(phaseName string, step int, runID string) []WorkflowEvent {
+	return []WorkflowEvent{{
+		EventType:  "wf_judge_cleared",
+		Phase:      phaseName,
+		Step:       step,
+		JudgeRunID: runID,
 	}}
 }

--- a/internal/progress/events.go
+++ b/internal/progress/events.go
@@ -59,6 +59,10 @@ const (
 	// EventWorkflowJudgeReturned records how a delegated judge run ended:
 	// approved, rejected, or failed (timeout, missing command, bad verdict).
 	EventWorkflowJudgeReturned EventType = "wf_judge_returned"
+
+	// EventWorkflowJudgeCleared removes a prior terminal judge outcome after
+	// an operator takes ownership of the checkpoint.
+	EventWorkflowJudgeCleared EventType = "wf_judge_cleared"
 )
 
 // ProgressEvent represents a single progress event in JSONL format.
@@ -447,19 +451,27 @@ func materializeWorkflowState(events []ProgressEvent) *wf.FestivalWorkflowState 
 
 		case EventWorkflowJudgeReturned:
 			ss := phaseState.GetOrCreateStepState(e.Step)
-			if ss.Judge == nil {
-				ss.Judge = &wf.JudgeState{}
-			}
 			// Run IDs make late events from superseded detached processes inert.
 			// Empty IDs remain compatible with events written before leases existed.
-			if e.JudgeRunID != "" && (ss.Judge.Status != wf.JudgeRunning ||
+			if e.JudgeRunID != "" && (ss.Judge == nil || ss.Judge.Status != wf.JudgeRunning ||
 				ss.Judge.RunID != e.JudgeRunID) {
 				continue
+			}
+			if ss.Judge == nil {
+				ss.Judge = &wf.JudgeState{}
 			}
 			ts := e.Timestamp
 			ss.Judge.Status = e.JudgeStatus
 			ss.Judge.Detail = e.JudgeDetail
 			ss.Judge.FinishedAt = &ts
+
+		case EventWorkflowJudgeCleared:
+			ss := phaseState.GetOrCreateStepState(e.Step)
+			// A run ID prevents an older operator cleanup from clearing a
+			// newer judge lease that started before the event was replayed.
+			if e.JudgeRunID == "" || (ss.Judge != nil && ss.Judge.RunID == e.JudgeRunID) {
+				ss.Judge = nil
+			}
 
 		case EventWorkflowAdvance:
 			phaseState.CurrentStep = e.Step

--- a/internal/progress/events.go
+++ b/internal/progress/events.go
@@ -44,6 +44,10 @@ const (
 	// previously failed remediation step for re-evaluation.
 	EventWorkflowStepRecheck EventType = "wf_step_recheck"
 
+	// EventWorkflowJudgeRecheck records that a judge-owned rejection is being
+	// reopened for a new approval-judge evaluation.
+	EventWorkflowJudgeRecheck EventType = "wf_judge_recheck"
+
 	// EventWorkflowJudgeStarted records that a delegated approval judge run
 	// was invoked on a blocking checkpoint via 'fest workflow approve --auto'.
 	EventWorkflowJudgeStarted EventType = "wf_judge_started"
@@ -404,6 +408,18 @@ func materializeWorkflowState(events []ProgressEvent) *wf.FestivalWorkflowState 
 			ss := phaseState.GetOrCreateStepState(e.Step)
 			if ss.Status == wf.StepStatusFailedRemediation {
 				ss.Status = wf.StepStatusInProgress
+				ss.RemediationPhase = ""
+				ss.DecisionActor = ""
+				ss.DecisionSummary = ""
+				ss.DecisionAt = nil
+				ss.Judge = nil
+			}
+
+		case EventWorkflowJudgeRecheck:
+			ss := phaseState.GetOrCreateStepState(e.Step)
+			if wf.IsJudgeRejection(ss) {
+				ss.Status = wf.StepStatusInProgress
+				ss.Feedback = ""
 				ss.RemediationPhase = ""
 				ss.DecisionActor = ""
 				ss.DecisionSummary = ""

--- a/internal/progress/workflow_events_test.go
+++ b/internal/progress/workflow_events_test.go
@@ -94,6 +94,31 @@ func TestMaterializeWorkflowState_IgnoresSupersededJudgeEvents(t *testing.T) {
 	}
 }
 
+func TestMaterializeWorkflowState_ClearsJudgeAfterOperatorDecision(t *testing.T) {
+	now := time.Now().UTC()
+	events := []ProgressEvent{
+		{Timestamp: now, Event: EventWorkflowInit, Phase: "001_INGEST", TotalSteps: 1},
+		{Timestamp: now.Add(time.Second), Event: EventWorkflowStepStart, Phase: "001_INGEST", Step: 1},
+		{Timestamp: now.Add(2 * time.Second), Event: EventWorkflowJudgeStarted, Phase: "001_INGEST", Step: 1, JudgeCommand: "ob judge", JudgeRunID: "run-1"},
+		{Timestamp: now.Add(3 * time.Second), Event: EventWorkflowJudgeReturned, Phase: "001_INGEST", Step: 1, JudgeStatus: wf.JudgeRejected, JudgeDetail: "missing proof", JudgeRunID: "run-1"},
+		{Timestamp: now.Add(4 * time.Second), Event: EventWorkflowStepBlock, Phase: "001_INGEST", Step: 1, Feedback: "operator review required", DecisionActor: "user", DecisionSummary: "manual decision"},
+		{Timestamp: now.Add(5 * time.Second), Event: EventWorkflowJudgeCleared, Phase: "001_INGEST", Step: 1, JudgeRunID: "run-1"},
+		// A late detached verdict must not recreate the cleared judge state.
+		{Timestamp: now.Add(6 * time.Second), Event: EventWorkflowJudgeReturned, Phase: "001_INGEST", Step: 1, JudgeStatus: wf.JudgeApproved, JudgeDetail: "late verdict", JudgeRunID: "run-1"},
+	}
+
+	step := materializeWorkflowState(events).Phases["001_INGEST"].GetStepState(1)
+	if step == nil {
+		t.Fatal("expected step state")
+	}
+	if step.Judge != nil {
+		t.Fatalf("judge state = %+v, want nil after operator decision", step.Judge)
+	}
+	if step.Status != wf.StepStatusBlocked || step.DecisionActor != "user" {
+		t.Fatalf("step = %+v, want blocked operator decision", step)
+	}
+}
+
 func TestGenerateWorkflowEventsFromYAML_EmitsStepSkip(t *testing.T) {
 	now := time.Now().UTC()
 	phaseState := wf.NewWorkflowState(2)


### PR DESCRIPTION
## Summary

- add `fest workflow judge` for explicit approval-judge runs and safe rejudging after judge-owned rejection
- show judge status and concise feedback consistently in `fest workflow status`, `fest show`, and `fest watch`
- remove judge command/PID/run/audit metadata from routine status payloads and normalize legacy feedback
- end blocked `fest next` instructions with the rejudge command when auto-judge recovery is available

## Behavior

A judge rejection remains blocked until the agent addresses the feedback. `fest workflow judge` reopens only judge-owned/readiness blocks, records a `wf_judge_recheck` event, and then runs the configured judge. Ordinary operator rejections and operator-attestation checkpoints remain human-owned. `fest workflow approve --auto` remains a backwards-compatible alias.

The machine-readable workflow status contract keeps its top-level `schema_version`; only noisy per-step judge execution metadata was removed.

## Validation

- `go test ./...`
- `go vet ./...`
- `just docs`
- `just build quick`
- visually checked the real blocked tcount gate with `workflow status`, `workflow show`, `show --inprogress`, and `workflow status --json`

Ready for review.