### PR TITLE
feat(ledger): emit high-intent fest actions to campaign ledger (CA0002)

### DIFF
--- a/internal/campledger/emit.go
+++ b/internal/campledger/emit.go
@@ -1,0 +1,243 @@
+// Package campledger emits high-intent fest state changes into the campaign
+// event ledger via camp's public pkg/ledgerkit (D003/D006 for fest).
+//
+// Emission is best-effort-but-loud: a ledger problem warns and never fails the
+// caller's state change. Outside a campaign workspace emission is a silent
+// no-op (standalone festivals have no campaign ledger).
+//
+// Workflow step noise (wf_step_start/done) stays only in
+// .fest/progress_events.jsonl — this package must not be called from those paths.
+package campledger
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Obedience-Corp/camp/pkg/ledgerkit"
+	"gopkg.in/yaml.v3"
+
+	"github.com/Obedience-Corp/fest/internal/workspace"
+)
+
+// warnMsg matches camp's user-visible ledger warning wording (D003).
+const warnMsg = "warning: campaign ledger not updated: %v\n"
+
+// Emitter appends campaign ledger events for one high-intent fest action.
+type Emitter struct {
+	writer       *ledgerkit.Writer
+	campaignID   string
+	campaignRoot string
+	actionID     string
+	actor        ledgerkit.Actor
+	warn         func(error)
+	disabled     bool
+}
+
+// Option customises an event before append.
+type Option func(*ledgerkit.Event)
+
+// WithWhy sets the human-facing reason (D005).
+func WithWhy(why string) Option {
+	return func(ev *ledgerkit.Event) { ev.Why = why }
+}
+
+// WithPayload sets kind-specific payload fields.
+func WithPayload(p map[string]any) Option {
+	return func(ev *ledgerkit.Event) { ev.Payload = p }
+}
+
+// WithEvidence attaches typed evidence refs.
+func WithEvidence(refs ...ledgerkit.Evidence) Option {
+	return func(ev *ledgerkit.Event) { ev.Evidence = append(ev.Evidence, refs...) }
+}
+
+// WarnTo returns a loud, non-fatal warn function writing to w.
+func WarnTo(w io.Writer) func(error) {
+	return func(err error) {
+		if err == nil {
+			return
+		}
+		_, _ = fmt.Fprintf(w, warnMsg, err)
+	}
+}
+
+// WarnToStderr prints ledger warnings to stderr.
+func WarnToStderr() func(error) { return WarnTo(os.Stderr) }
+
+// NewFromFestival builds an emitter scoped to the campaign that contains
+// festivalPath. Missing campaign context disables emission (silent no-op).
+func NewFromFestival(ctx context.Context, festivalPath string, warn func(error)) *Emitter {
+	if warn == nil {
+		warn = WarnToStderr()
+	}
+	e := &Emitter{
+		actionID: ledgerkit.NewActionID(),
+		actor:    resolveActor(),
+		warn:     warn,
+	}
+	if festivalPath == "" {
+		e.disabled = true
+		return e
+	}
+	root, err := workspace.DetectCampaign(ctx, festivalPath)
+	if err != nil || root == "" {
+		// Standalone festival: no campaign ledger by design.
+		e.disabled = true
+		return e
+	}
+	campaignID := loadCampaignID(root)
+	if campaignID == "" {
+		warn(fmt.Errorf("ledger: missing campaign id in %s", filepath.Join(root, ".campaign", "campaign.yaml")))
+		e.disabled = true
+		return e
+	}
+	writerID, err := ledgerkit.ResolveWriterID(ctx)
+	if err != nil {
+		warn(fmt.Errorf("ledger: resolve writer id: %w", err))
+		e.disabled = true
+		return e
+	}
+	w, err := ledgerkit.NewWriter(root, writerID)
+	if err != nil {
+		warn(fmt.Errorf("ledger: init writer: %w", err))
+		e.disabled = true
+		return e
+	}
+	e.writer = w
+	e.campaignRoot = root
+	e.campaignID = campaignID
+	return e
+}
+
+// Emit appends one command-sourced event. Failure warns; never returns to
+// the caller as a hard error (D003).
+func (e *Emitter) Emit(ctx context.Context, kind ledgerkit.Kind, scope ledgerkit.Scope, opts ...Option) {
+	if e == nil || e.disabled || e.writer == nil {
+		return
+	}
+	if ctx.Err() != nil {
+		e.warn(ctx.Err())
+		return
+	}
+	scope.Campaign = e.campaignID
+	if scope.Festival == "" {
+		// Best-effort: leave empty when caller did not set it.
+	}
+	ev := &ledgerkit.Event{
+		V:      ledgerkit.EnvelopeVersion,
+		ID:     ledgerkit.NewEventID(),
+		TS:     ledgerkit.NowUTC(time.Now()),
+		Kind:   kind,
+		Scope:  scope,
+		Action: e.actionID,
+		Actor:  e.actor,
+		Source: ledgerkit.SourceCommand,
+	}
+	for _, o := range opts {
+		o(ev)
+	}
+	if err := e.writer.Emit(ctx, ev, e.warn); err != nil {
+		// writer.Emit already warns; keep signature symmetric with camp.
+		_ = err
+	}
+}
+
+// FestivalScope builds scope from a festival path and optional task path
+// segments. taskID is the relative task path (phase/seq/task.md) when known.
+func FestivalScope(festivalPath, taskID string) ledgerkit.Scope {
+	scope := ledgerkit.Scope{
+		Festival: festivalIDFromPath(festivalPath),
+	}
+	if taskID == "" {
+		return scope
+	}
+	// taskID forms: "003_IMPLEMENT/05_views/02_graph_ingestion.md" or with fest_id
+	parts := strings.Split(filepath.ToSlash(taskID), "/")
+	switch {
+	case len(parts) >= 3:
+		scope.Phase = parts[0]
+		scope.Sequence = parts[1]
+		scope.Task = parts[len(parts)-1]
+	case len(parts) == 2:
+		scope.Phase = parts[0]
+		scope.Sequence = parts[1]
+	case len(parts) == 1:
+		scope.Task = parts[0]
+	}
+	return scope
+}
+
+func festivalIDFromPath(festivalPath string) string {
+	base := filepath.Base(festivalPath)
+	// Prefer short id suffix when present (…-CA0002).
+	if i := strings.LastIndex(base, "-"); i >= 0 && i < len(base)-1 {
+		suffix := base[i+1:]
+		if looksLikeFestID(suffix) {
+			return suffix
+		}
+	}
+	// Fall back to fest.yaml metadata.id
+	data, err := os.ReadFile(filepath.Join(festivalPath, "fest.yaml"))
+	if err == nil {
+		var doc struct {
+			Metadata struct {
+				ID string `yaml:"id"`
+			} `yaml:"metadata"`
+		}
+		if yaml.Unmarshal(data, &doc) == nil && doc.Metadata.ID != "" {
+			return doc.Metadata.ID
+		}
+	}
+	return base
+}
+
+func looksLikeFestID(s string) bool {
+	if len(s) < 4 || len(s) > 12 {
+		return false
+	}
+	// e.g. CA0002, RI-DR0001
+	for _, r := range s {
+		if (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func loadCampaignID(campaignRoot string) string {
+	path := filepath.Join(campaignRoot, ".campaign", "campaign.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	var doc struct {
+		ID string `yaml:"id"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(doc.ID)
+}
+
+func resolveActor() ledgerkit.Actor {
+	// Prefer USER / LOGNAME; agents often set both.
+	name := os.Getenv("USER")
+	if name == "" {
+		name = os.Getenv("LOGNAME")
+	}
+	actorType := ledgerkit.ActorHuman
+	// Heuristic: common agent env markers.
+	if os.Getenv("OBEY_AGENT") != "" || os.Getenv("CLAUDE_CODE") != "" || os.Getenv("CODEX_TASK") != "" {
+		actorType = ledgerkit.ActorAgent
+	}
+	if name == "" {
+		return ledgerkit.Actor{Type: ledgerkit.ActorUnknown}
+	}
+	return ledgerkit.Actor{Type: actorType, Name: name}
+}

--- a/internal/campledger/emit_test.go
+++ b/internal/campledger/emit_test.go
@@ -1,0 +1,95 @@
+package campledger
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/camp/pkg/ledgerkit"
+)
+
+func TestNewFromFestival_NoCampaignIsNoop(t *testing.T) {
+	// Temp dir with no .campaign marker.
+	root := t.TempDir()
+	fest := filepath.Join(root, "my-fest")
+	if err := os.MkdirAll(fest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var warned error
+	e := NewFromFestival(context.Background(), fest, func(err error) { warned = err })
+	if !e.disabled {
+		t.Fatal("expected disabled emitter outside campaign")
+	}
+	// Emit must not panic or write.
+	e.Emit(context.Background(), ledgerkit.KindCompleted, FestivalScope(fest, "p/s/t.md"))
+	if warned != nil {
+		t.Fatalf("standalone no-op should be silent, got warn %v", warned)
+	}
+}
+
+func TestNewFromFestival_EmitsIntoCampaignLedger(t *testing.T) {
+	camp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(camp, ".campaign"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "id: test-campaign-id\nname: test\n"
+	if err := os.WriteFile(filepath.Join(camp, ".campaign", "campaign.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fest := filepath.Join(camp, "festivals", "active", "demo-fest-DF0001")
+	if err := os.MkdirAll(fest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Pin writer id so we do not depend on global config mutation in unit tests.
+	// ResolveWriterID may still touch ~/.obey; if it fails we skip.
+	e := NewFromFestival(context.Background(), fest, func(error) {})
+	if e.disabled {
+		t.Skip("writer id resolution disabled emitter in this environment")
+	}
+	e.Emit(context.Background(), ledgerkit.KindCompleted, FestivalScope(fest, "003_IMPLEMENT/01_seq/01_task.md"),
+		WithWhy("done"))
+
+	// Find a shard file under .campaign/events
+	eventsRoot := filepath.Join(camp, ".campaign", "events")
+	var found string
+	_ = filepath.Walk(eventsRoot, func(path string, info os.FileInfo, err error) error {
+		if err == nil && !info.IsDir() && strings.HasSuffix(path, ".jsonl") {
+			found = path
+		}
+		return nil
+	})
+	if found == "" {
+		t.Fatal("expected ledger shard to be written")
+	}
+	data, err := os.ReadFile(found)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"kind":"completed"`) {
+		t.Fatalf("shard missing completed event: %s", data)
+	}
+	if !strings.Contains(string(data), "DF0001") && !strings.Contains(string(data), "demo-fest") {
+		t.Fatalf("shard missing festival scope: %s", data)
+	}
+	if !strings.Contains(string(data), "test-campaign-id") {
+		t.Fatalf("shard missing campaign id: %s", data)
+	}
+}
+
+func TestFestivalScopeParsesTaskPath(t *testing.T) {
+	s := FestivalScope("/camp/festivals/active/x-CA0002", "003_IMPLEMENT/05_views/02_graph_ingestion.md")
+	if s.Festival != "CA0002" {
+		t.Fatalf("festival=%q", s.Festival)
+	}
+	if s.Phase != "003_IMPLEMENT" || s.Sequence != "05_views" || s.Task != "02_graph_ingestion.md" {
+		t.Fatalf("scope=%+v", s)
+	}
+}
+
+func TestWarnMsgMatchesCampWording(t *testing.T) {
+	if !strings.Contains(warnMsg, "campaign ledger not updated") {
+		t.Fatalf("warn wording drift: %q", warnMsg)
+	}
+}

--- a/internal/commands/festival/create_festival.go
+++ b/internal/commands/festival/create_festival.go
@@ -12,6 +12,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Obedience-Corp/camp/pkg/ledgerkit"
+
+	"github.com/Obedience-Corp/fest/internal/campledger"
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
 	"github.com/Obedience-Corp/fest/internal/config"
 	festcontract "github.com/Obedience-Corp/fest/internal/contract"
@@ -363,6 +366,17 @@ func RunCreateFestival(ctx context.Context, opts *CreateFestivalOptions) error {
 	// fest init ran before camp init (so .campaign/ didn't exist yet),
 	// or where the contract file was deleted and needs regeneration.
 	writeContractEntries(cfg.campaignRoot)
+
+	// Campaign ledger: festival created (high-intent). Dry-run already returned.
+	if !opts.DryRun && cfg.destDir != "" {
+		emit := campledger.NewFromFestival(ctx, cfg.destDir, campledger.WarnToStderr())
+		emit.Emit(ctx, ledgerkit.KindCreated, campledger.FestivalScope(cfg.destDir, ""),
+			campledger.WithPayload(map[string]any{
+				"status": "created",
+				"type":   "festival",
+			}),
+		)
+	}
 
 	return emitCreateOutput(cfg, res)
 }

--- a/internal/commands/status/atomic.go
+++ b/internal/commands/status/atomic.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Obedience-Corp/camp/pkg/ledgerkit"
+
+	"github.com/Obedience-Corp/fest/internal/campledger"
 	"github.com/Obedience-Corp/fest/internal/id"
 	"github.com/Obedience-Corp/fest/internal/registry"
 )
@@ -60,6 +63,17 @@ func AtomicStatusChange(ctx context.Context, festivalPath, fromStatus, toStatus 
 
 	// Update registry with new path/status
 	updateRegistry(ctx, festivalsRoot, festivalName, toStatus, newPath)
+
+	// Campaign ledger: festival lifecycle transition at the atomic core
+	// success boundary (D003/D006). status_history + dir move already done.
+	emit := campledger.NewFromFestival(ctx, newPath, campledger.WarnToStderr())
+	emit.Emit(ctx, ledgerkit.KindTransitioned, campledger.FestivalScope(newPath, ""),
+		campledger.WithPayload(map[string]any{
+			"from":   fromStatus,
+			"to":     toStatus,
+			"target": "festival",
+		}),
+	)
 
 	return newPath, nil
 }

--- a/internal/commands/workflow/skip.go
+++ b/internal/commands/workflow/skip.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
+	"github.com/Obedience-Corp/camp/pkg/ledgerkit"
+
+	"github.com/Obedience-Corp/fest/internal/campledger"
 	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
 	"github.com/Obedience-Corp/fest/internal/lifecycle"
 	"github.com/Obedience-Corp/fest/internal/scope"
@@ -126,6 +130,26 @@ func runSkip(ctx context.Context, reason string, terminalState wf.StepStatus) er
 	fmt.Printf("%s: %s\n", ui.Label("Terminal State"), terminalState)
 	fmt.Printf("%s: %s\n", ui.Label("Reason"), reason)
 	fmt.Println()
+
+	// Campaign ledger: skip is a high-intent human decision (D005/D006).
+	// One decided event for the whole operator override, not per step.
+	if updatedCount > 0 {
+		phase := ""
+		if nav.Ctx != nil && nav.Ctx.PhasePath != "" {
+			phase = filepath.Base(nav.Ctx.PhasePath)
+		}
+		scope := campledger.FestivalScope(nav.Ctx.FestivalPath, "")
+		scope.Phase = phase
+		emit := campledger.NewFromFestival(ctx, nav.Ctx.FestivalPath, campledger.WarnToStderr())
+		emit.Emit(ctx, ledgerkit.KindDecided, scope,
+			campledger.WithWhy(reason),
+			campledger.WithPayload(map[string]any{
+				"title":          "workflow skip",
+				"terminal_state": string(terminalState),
+				"steps_skipped":  updatedCount,
+			}),
+		)
+	}
 
 	return showNextStep(ctx, nav, steps)
 }

--- a/internal/guidance/workflow/navigator.go
+++ b/internal/guidance/workflow/navigator.go
@@ -7,6 +7,9 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/Obedience-Corp/camp/pkg/ledgerkit"
+
+	"github.com/Obedience-Corp/fest/internal/campledger"
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/guidance"
 )
@@ -398,9 +401,17 @@ func (n *Navigator) ApproveWithAudit(ctx context.Context, feedback string, decis
 			n.store.QueueWorkflowEvents(EmitAdvanceEvents(sk, n.workflowState.CurrentStep))
 			n.store.QueueWorkflowEvents(EmitStepStartEvents(sk, n.workflowState.CurrentStep))
 		}
-		return n.store.SaveEvents(ctx)
+		if err := n.store.SaveEvents(ctx); err != nil {
+			return err
+		}
+		n.emitCampaignDecided(ctx, "approve", feedback)
+		return nil
 	}
-	return n.workflowState.Save(ctx, n.festivalPath, sk)
+	if err := n.workflowState.Save(ctx, n.festivalPath, sk); err != nil {
+		return err
+	}
+	n.emitCampaignDecided(ctx, "approve", feedback)
+	return nil
 }
 
 // Reject rejects the current step with feedback.
@@ -435,9 +446,17 @@ func (n *Navigator) RejectWithDecision(ctx context.Context, reason string, decis
 			n.store.QueueWorkflowEvents(EmitJudgeClearedEvents(sk, currentStep, judgeClearRunID))
 		}
 		n.store.QueueWorkflowEvents(EmitStepBlockWithDecisionEvents(sk, currentStep, reason, decision))
-		return n.store.SaveEvents(ctx)
+		if err := n.store.SaveEvents(ctx); err != nil {
+			return err
+		}
+		n.emitCampaignDecided(ctx, "reject", reason)
+		return nil
 	}
-	return n.workflowState.Save(ctx, n.festivalPath, sk)
+	if err := n.workflowState.Save(ctx, n.festivalPath, sk); err != nil {
+		return err
+	}
+	n.emitCampaignDecided(ctx, "reject", reason)
+	return nil
 }
 
 // RejectWithRemediation records the current step as failed with a linked
@@ -475,9 +494,39 @@ func (n *Navigator) RejectWithRemediationDecision(ctx context.Context, reason, r
 			n.store.QueueWorkflowEvents(EmitJudgeClearedEvents(sk, currentStep, judgeClearRunID))
 		}
 		n.store.QueueWorkflowEvents(EmitStepFailRemediationWithDecisionEvents(sk, currentStep, reason, remediationPhase, decision))
-		return n.store.SaveEvents(ctx)
+		if err := n.store.SaveEvents(ctx); err != nil {
+			return err
+		}
+		n.emitCampaignDecided(ctx, "reject_remediation", reason)
+		return nil
 	}
-	return n.workflowState.Save(ctx, n.festivalPath, sk)
+	if err := n.workflowState.Save(ctx, n.festivalPath, sk); err != nil {
+		return err
+	}
+	n.emitCampaignDecided(ctx, "reject_remediation", reason)
+	return nil
+}
+
+// emitCampaignDecided records a gate verdict on the campaign ledger (D005/D006).
+// Best-effort; never blocks the workflow mutation.
+func (n *Navigator) emitCampaignDecided(ctx context.Context, verdict, why string) {
+	if n == nil || n.festivalPath == "" {
+		return
+	}
+	phase := ""
+	if n.Ctx != nil && n.Ctx.PhasePath != "" {
+		phase = filepath.Base(n.Ctx.PhasePath)
+	}
+	scope := campledger.FestivalScope(n.festivalPath, "")
+	scope.Phase = phase
+	emit := campledger.NewFromFestival(ctx, n.festivalPath, campledger.WarnToStderr())
+	emit.Emit(ctx, ledgerkit.KindDecided, scope,
+		campledger.WithWhy(why),
+		campledger.WithPayload(map[string]any{
+			"title":   "gate verdict: " + verdict,
+			"verdict": verdict,
+		}),
+	)
 }
 
 func runningJudgeRunID(state *StepState) string {

--- a/internal/progress/manager.go
+++ b/internal/progress/manager.go
@@ -7,14 +7,18 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Obedience-Corp/camp/pkg/ledgerkit"
+
+	"github.com/Obedience-Corp/fest/internal/campledger"
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/frontmatter"
 )
 
 // Manager handles progress operations for a festival
 type Manager struct {
-	store *Store
-	gate  Gate
+	store        *Store
+	gate         Gate
+	festivalPath string
 }
 
 // NewManager creates a new progress manager with no lifecycle gate.
@@ -41,7 +45,7 @@ func NewManagerWithGate(ctx context.Context, festivalPath string, gate Gate) (*M
 	if err := store.Load(ctx); err != nil {
 		return nil, errors.Wrap(err, "loading progress data")
 	}
-	return &Manager{store: store, gate: gate}, nil
+	return &Manager{store: store, gate: gate, festivalPath: festivalPath}, nil
 }
 
 // NewManagerReadOnly creates a progress manager that never mutates disk while
@@ -56,7 +60,7 @@ func NewManagerReadOnly(ctx context.Context, festivalPath string) (*Manager, err
 	if err := store.LoadReadOnly(ctx); err != nil {
 		return nil, errors.Wrap(err, "loading progress data")
 	}
-	return &Manager{store: store, gate: NoopGate{}}, nil
+	return &Manager{store: store, gate: NoopGate{}, festivalPath: festivalPath}, nil
 }
 
 // UpdateProgress updates the progress percentage for a task
@@ -188,6 +192,11 @@ func (m *Manager) MarkComplete(ctx context.Context, taskID string) error {
 		return err
 	}
 	m.SyncFrontmatterStatus(taskID, task.Status)
+	// Campaign ledger: high-intent task completion (D003/D006). Does not
+	// alter progress_events.jsonl content beyond the save already done.
+	m.emitLedger(ctx, ledgerkit.KindCompleted, taskID, "", map[string]any{
+		"status": "completed",
+	})
 	// Propagation is best-effort: a failure here should not block
 	// the task completion that already succeeded above.
 	_ = m.PropagateCompletion(ctx, taskID)
@@ -279,6 +288,11 @@ func (m *Manager) ReportBlocker(ctx context.Context, taskID, message string) err
 		return err
 	}
 	m.SyncFrontmatterStatus(taskID, task.Status)
+	m.emitLedger(ctx, ledgerkit.KindTransitioned, taskID, message, map[string]any{
+		"from":   string(StatusPending),
+		"to":     "blocked",
+		"target": "blocked",
+	})
 	return nil
 }
 
@@ -320,7 +334,29 @@ func (m *Manager) ResetTask(ctx context.Context, taskID string) error {
 		return err
 	}
 	m.SyncFrontmatterStatus(taskID, task.Status)
+	m.emitLedger(ctx, ledgerkit.KindTransitioned, taskID, "", map[string]any{
+		"to":     "pending",
+		"target": "reset",
+	})
 	return nil
+}
+
+// emitLedger best-effort appends a campaign ledger event for a high-intent
+// task mutation. No-op outside a campaign. Never fails the caller (D003).
+func (m *Manager) emitLedger(ctx context.Context, kind ledgerkit.Kind, taskID, why string, payload map[string]any) {
+	if m == nil || m.festivalPath == "" {
+		return
+	}
+	e := campledger.NewFromFestival(ctx, m.festivalPath, campledger.WarnToStderr())
+	scope := campledger.FestivalScope(m.festivalPath, taskID)
+	opts := []campledger.Option{}
+	if why != "" {
+		opts = append(opts, campledger.WithWhy(why))
+	}
+	if payload != nil {
+		opts = append(opts, campledger.WithPayload(payload))
+	}
+	e.Emit(ctx, kind, scope, opts...)
 }
 
 // ClearBlocker clears a blocker for a task


### PR DESCRIPTION
## Summary

Fest now emits high-intent state changes into the campaign event ledger via public `camp/pkg/ledgerkit` (`v0.3.0-rc.2`, no replace directives).

### Package `internal/campledger`
- Best-effort-but-loud emission (D003; warning wording matches camp)
- Silent no-op outside a campaign (standalone festivals)
- Scope helpers for festival id + task path segments

### Wired capture points
| Verb | Kind |
|------|------|
| `fest task completed` | `completed` |
| `fest task blocked` / `reset` | `transitioned` |
| `AtomicStatusChange` (promote/status) | `transitioned` |
| `fest workflow skip` | `decided` |
| gate approve / reject / remediation | `decided` |

### Unchanged
- `.fest/progress_events.jsonl` write path and step-level events (D006)
- `status_history.json` still written by AtomicStatusChange

### Follow-ups
- `fest create *` created events
- workflow advance phase-completion completed
- `fest commit` evidence_attached (sequence task 02)

## Test plan
- [x] `go test ./internal/campledger/ ./internal/progress/ ./internal/commands/status/ ./internal/commands/workflow/ ./internal/guidance/workflow/`
- [ ] CI green
- [ ] Manual: `fest task completed` inside a campaign festival appends to `.campaign/events/**/*.jsonl`

Festival: CA0002 `003_IMPLEMENT/06_capture_fest/01_fest_ledger_emission`