### PR TITLE
test(list): add containerized integration coverage for fest list --watch

### DIFF
--- a/.justfiles/test.just
+++ b/.justfiles/test.just
@@ -80,6 +80,16 @@ integration-dev-watch:
     echo "Running fest watch dev integration tests..."
     TESTCONTAINERS_RYUK_DISABLED=true go test -v -tags "integration dev" -run TestFestWatch -timeout 5m ./tests/integration/...
 
+# Run dev-profile fest list --watch integration tests through the container harness
+[no-cd]
+integration-dev-list-watch:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Building dev Linux binary..."
+    BUILD_TAGS=dev just build test-binary
+    echo "Running fest list --watch dev integration tests..."
+    TESTCONTAINERS_RYUK_DISABLED=true go test -v -tags "integration dev" -run TestFestListWatch -timeout 5m ./tests/integration/...
+
 # Run all tests directly (fallback)
 [no-cd]
 all-raw: unit-raw integration-raw

--- a/tests/integration/fest_list_watch_test.go
+++ b/tests/integration/fest_list_watch_test.go
@@ -1,0 +1,214 @@
+//go:build integration && dev
+// +build integration,dev
+
+package integration
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	tcexec "github.com/testcontainers/testcontainers-go/exec"
+)
+
+// These tests drive the real `fest list --watch` refresh loop end to end
+// (fixture creation, board rendering, live progress updates). They must stay
+// in the containerized integration harness, not host t.TempDir tests, since
+// they mutate a festivals/ tree and depend on real terminal semantics.
+
+func TestFestListWatchInitialFrameAndCancel(t *testing.T) {
+	container := GetSharedContainer(t)
+	workspaceRoot, _, readyPath := setupListWatchFixture(t, container)
+	readyName := filepath.Base(readyPath)
+
+	output, exitCode := runFestListWatchBounded(t, container, workspaceRoot, 2, "--watch")
+
+	require.Contains(t, []int{124, 143}, exitCode, "list --watch should stay running until the bounded timeout")
+	require.Contains(t, output, "ACTIVE Festivals", "default board should render the active status section")
+	require.Contains(t, output, "READY Festivals", "default board should render the ready status section")
+	require.Contains(t, output, "list-watch-active-LW0001", "default board should include the active fixture festival")
+	require.Contains(t, output, readyName, "default board should include the ready fixture festival")
+	require.Contains(t, output, "watching", "watch footer should announce what is being watched")
+	require.Contains(t, output, "Ctrl+C to quit", "watch footer should document the quit key")
+	require.NotContains(t, output, "unknown command")
+}
+
+func TestFestListWatchFilterPreservesStatusMembership(t *testing.T) {
+	container := GetSharedContainer(t)
+	workspaceRoot, activePath, readyPath := setupListWatchFixture(t, container)
+	activeName := filepath.Base(activePath)
+	readyName := filepath.Base(readyPath)
+
+	output, exitCode := runFestListWatchBounded(t, container, workspaceRoot, 2, "active", "--watch")
+
+	require.Contains(t, []int{124, 143}, exitCode, "filtered list --watch should stay running until the bounded timeout")
+	require.Contains(t, output, activeName, "active filter should include the active fixture festival")
+	require.NotContains(t, output, readyName, "active filter should exclude the ready fixture festival")
+	require.NotContains(t, output, "READY Festivals", "single-status watch should not render other status headers")
+}
+
+func TestFestListWatchRejectsJSON(t *testing.T) {
+	container := GetSharedContainer(t)
+	workspaceRoot, _, _ := setupListWatchFixture(t, container)
+
+	output, err := container.RunFestInDir(workspaceRoot, "list", "--watch", "--json")
+
+	require.Error(t, err, "--watch combined with --json should fail fast")
+	require.Contains(t, output, "--watch cannot be combined with --json")
+}
+
+func TestFestListWatchNonTTYFailsFast(t *testing.T) {
+	container := GetSharedContainer(t)
+	workspaceRoot, _, _ := setupListWatchFixture(t, container)
+
+	output, err := container.RunFestInDir(workspaceRoot, "list", "--watch")
+
+	require.Error(t, err, "--watch on non-TTY stdout should fail fast")
+	require.Contains(t, output, "interactive terminal")
+}
+
+func TestFestListWatchProgressUpdatesBetweenTicks(t *testing.T) {
+	container := GetSharedContainer(t)
+	workspaceRoot, activePath, _ := setupListWatchFixture(t, container)
+
+	script := fmt.Sprintf(
+		"cd %s && timeout 7s /fest list active --watch & watchpid=$!; sleep 3; (cd %s && /fest progress --task 001_IMPLEMENT/01_core/01_first_task.md --complete >/dev/null 2>&1); wait $watchpid",
+		shellQuote(workspaceRoot), shellQuote(activePath),
+	)
+
+	output, exitCode := runContainerScriptTTY(t, container, script)
+
+	require.Contains(t, []int{124, 143}, exitCode, "watch process should be stopped by the bounded timeout")
+	require.Contains(t, output, "[0%]", "initial frame should render 0%% before the task is completed")
+	require.Contains(t, output, "[100%]", "a later frame should render 100%% after fest progress --complete")
+}
+
+// setupListWatchFixture creates a workspace with one active and one ready
+// festival, each with a single task, so watch tests can assert status
+// membership and progress changes without depending on unrelated fixtures.
+func setupListWatchFixture(t *testing.T, tc *TestContainer) (workspaceRoot, activeFestivalPath, readyFestivalPath string) {
+	t.Helper()
+
+	workspaceRoot = "/workspace"
+	festivalsRoot := filepath.Join(workspaceRoot, "festivals")
+	activeFestivalPath = filepath.Join(festivalsRoot, "active", "list-watch-active-LW0001")
+	readyFestivalPath = filepath.Join(festivalsRoot, "ready", "list-watch-ready-LW0002")
+
+	_, err := tc.runCommand([]string{
+		"sh", "-c",
+		fmt.Sprintf(
+			"mkdir -p %[1]s/.campaign %[2]s/.festival/.state %[2]s/planning %[2]s/ritual %[2]s/dungeon/completed %[2]s/dungeon/archived %[2]s/dungeon/someday %[3]s/001_IMPLEMENT/01_core %[4]s/001_IMPLEMENT/01_core",
+			workspaceRoot, festivalsRoot, activeFestivalPath, readyFestivalPath,
+		),
+	})
+	require.NoError(t, err, "should create list watch fixture directories")
+
+	err = writeFileInContainer(tc, filepath.Join(festivalsRoot, ".festival", ".state", ".workspace"), `{"workspace":"workspace","registered":"2024-01-01T00:00:00Z"}`)
+	require.NoError(t, err, "should create workspace marker")
+
+	writeListWatchFestivalFixture(t, tc, activeFestivalPath, "active", "Watch the active board render and refresh correctly.")
+	writeListWatchFestivalFixture(t, tc, readyFestivalPath, "ready", "Confirm ready festivals stay out of the active filter.")
+
+	return workspaceRoot, activeFestivalPath, readyFestivalPath
+}
+
+func writeListWatchFestivalFixture(t *testing.T, tc *TestContainer, festivalPath, status, goalLine string) {
+	t.Helper()
+
+	festivalName := filepath.Base(festivalPath)
+	logicalID := festivalName
+	name := festivalName
+	if idx := strings.LastIndex(festivalName, "-"); idx >= 0 {
+		logicalID = festivalName[idx+1:]
+		name = festivalName[:idx]
+	}
+
+	// status_history is required by the pre-active lifecycle gate that
+	// `fest progress --complete` enforces; without it, status is
+	// undeterminable and the gate fails closed.
+	err := writeFileInContainer(tc, filepath.Join(festivalPath, "fest.yaml"), fmt.Sprintf(`version: "1.0"
+metadata:
+  id: %s
+  name: %s
+  status_history:
+    - status: %s
+      timestamp: 2026-01-01T00:00:00Z
+auto_link:
+  enabled: false
+`, logicalID, name, status))
+	require.NoError(t, err, "should create fest.yaml")
+
+	err = writeFileInContainer(tc, filepath.Join(festivalPath, "FESTIVAL_GOAL.md"), fmt.Sprintf("# %s\n\n## Goal\n\n%s\n", festivalName, goalLine))
+	require.NoError(t, err, "should create festival goal")
+
+	err = writeFileInContainer(tc, filepath.Join(festivalPath, "FESTIVAL_RULES.md"), "# Festival Rules\n\n- Keep list watch tests containerized.\n")
+	require.NoError(t, err, "should create festival rules")
+
+	phasePath := filepath.Join(festivalPath, "001_IMPLEMENT")
+	sequencePath := filepath.Join(phasePath, "01_core")
+
+	err = writeFileInContainer(tc, filepath.Join(phasePath, "PHASE_GOAL.md"), `---
+fest_type: phase
+fest_phase_type: implementation
+---
+
+# Implement Phase
+
+## Objective
+
+Build the list watch board.
+`)
+	require.NoError(t, err, "should create phase goal")
+
+	err = writeFileInContainer(tc, filepath.Join(sequencePath, "SEQUENCE_GOAL.md"), "# Core Sequence\n\nImplement the core list watch flow.\n")
+	require.NoError(t, err, "should create sequence goal")
+
+	err = writeFileInContainer(tc, filepath.Join(sequencePath, "01_first_task.md"), "# First Task\n\n## Definition of Done\n\n- [ ] Board renders the festival.\n")
+	require.NoError(t, err, "should create first task")
+}
+
+// runFestListWatchBounded runs `fest list <args>` from cwd under a real TTY,
+// bounded by an OS-level `timeout` so the watch loop cannot hang the test
+// suite. It mirrors runFestWatchBounded in fest_watch_test.go but allocates
+// a TTY, since list --watch (unlike fest watch) requires an interactive
+// stdout even when a direct context is already resolved.
+func runFestListWatchBounded(t *testing.T, tc *TestContainer, cwd string, timeoutSeconds int, args ...string) (string, int) {
+	t.Helper()
+
+	quotedArgs := make([]string, 0, len(args))
+	for _, arg := range args {
+		quotedArgs = append(quotedArgs, shellQuote(arg))
+	}
+
+	script := fmt.Sprintf("cd %s && timeout %ds /fest list", shellQuote(cwd), timeoutSeconds)
+	if len(quotedArgs) > 0 {
+		script += " " + strings.Join(quotedArgs, " ")
+	}
+
+	return runContainerScriptTTY(t, tc, script)
+}
+
+// runContainerScriptTTY runs an arbitrary shell script inside the container
+// with a pseudo-TTY attached to stdout, returning combined output and the
+// real exit code of the script (unlike tc.runCommand, which discards it).
+func runContainerScriptTTY(t *testing.T, tc *TestContainer, script string) (string, int) {
+	t.Helper()
+
+	options := []tcexec.ProcessOption{
+		tcexec.ProcessOptionFunc(func(opts *tcexec.ProcessOptions) {
+			opts.ExecConfig.TTY = true
+			opts.ExecConfig.AttachStdin = true
+		}),
+	}
+
+	exitCode, reader, err := tc.container.Exec(tc.ctx, []string{"sh", "-c", script}, options...)
+	require.NoError(t, err, "container script should start")
+
+	outputBytes, err := io.ReadAll(reader)
+	require.NoError(t, err, "should read TTY output")
+
+	return string(outputBytes), exitCode
+}


### PR DESCRIPTION
## Summary

- `fest list --watch` already shipped and merged via PR #257, covering the CLI surface, flag validation, and unit tests from the design package at `workflow/design/fest-cli-capabilities/fest-list-watch` (originating intent `we-should-add-a-fest-20260711-190301`, workitem `WI-2a7950`).
- The design's acceptance checklist (`04-tests-and-acceptance.md`) also calls for containerized integration coverage matching `fest_watch_test.go`: first frame, filter preservation, cancel behavior, non-TTY/`--json` rejection, and progress updates between polling ticks. That coverage did not exist yet, and PR #257's own test plan left the real-TTY manual check unticked.
- This PR adds that missing integration coverage and a `just` recipe to run it, with no changes to the list command implementation itself.

## Why

Reference: intent `we-should-add-a-fest-20260711-190301`, design package `workflow/design/fest-cli-capabilities/fest-list-watch`. The most recent intent review assumed implementation was still needed; PR #257 (merged 2026-07-12) had already shipped the feature end to end, with full unit coverage in `internal/commands/list/list_test.go`. What was left open, and is closed here, is the containerized integration test matrix the design explicitly required plus the unchecked manual TTY verification from that PR's own test plan.

## What changed

- `tests/integration/fest_list_watch_test.go`: five tests exercising the real `fest` binary in a container.
  - Initial default board render with both active and ready sections and the watch footer.
  - `active` positional filter renders only the active section and excludes the ready festival.
  - `--watch --json` rejected with the mutual exclusion error.
  - `--watch` on non-TTY stdout rejected with the interactive terminal error.
  - Live progress update: renders 0 percent, then after `fest progress --complete` runs against the fixture task, renders 100 percent on a later polling tick, inside one bounded run.
- `.justfiles/test.just`: added `integration-dev-list-watch`, mirroring the existing `integration-dev-watch` recipe, so this suite is independently runnable.

## Verification

- `just build dashboard`: clean build, no vet errors, 111 packages.
- `just test unit`: 2554 of 2554 tests passed across 97 packages, no failures.
- New integration tests: `TESTCONTAINERS_RYUK_DISABLED=true go test -tags "integration dev" -run TestFestListWatch ./tests/integration/...` then all 5 pass (`TestFestListWatchInitialFrameAndCancel`, `TestFestListWatchFilterPreservesStatusMembership`, `TestFestListWatchRejectsJSON`, `TestFestListWatchNonTTYFailsFast`, `TestFestListWatchProgressUpdatesBetweenTicks`).
- `golangci-lint run ./...`: one pre-existing finding in `internal/campledger/emit.go` (SA9003 empty branch), confirmed present and unmodified on `origin/main`, unrelated to this change.
- Real pty verification (pyte VT100 emulator over a `pty.fork()` child, `HOME` pointed at a throwaway fixture campaign, not a real one) driving the actual built `fest` binary:
  - `fest list --watch`: first paint showed "ALL FESTIVALS", "ACTIVE Festivals (1)" with `list-watch-active-LW0001 [0%]`, "READY Festivals (1)" with `list-watch-ready-LW0002 [0%]`, and the footer "watching festivals, Ctrl+C to quit, Polling every 2s".
  - `fest list active --watch`: rendered only the ACTIVE section, no READY section, no cycling chrome.
  - Live progress: the screen showed `[0%]` before running `fest progress --task 001_IMPLEMENT/01_core/01_first_task.md --complete` against the fixture task; after that command and waiting past the next 2 second poll tick, the same running watch process showed `[100%]` without restarting.
  - Ctrl+C: the process exited and could be waited on cleanly in every run.
  - `fest list` (no `--watch`) and `fest list --json` against the same fixture rendered the same board and JSON structure as before this change.
  - `fest list --watch --json` and `fest list --watch` piped through `cat` both failed fast with the expected error messages and a non-zero exit code.

## Limitations

- This PR does not touch the list command implementation; `fest list --watch` behaves exactly as PR #257 shipped it.
- The `fls --watch` shell alias is personal shell configuration outside this repository and was not separately re-verified; `fest list --watch` itself behaves identically regardless of the invoking alias.
- The pre-existing campledger lint finding is out of scope and was left untouched.