### PR TITLE
fix(workflow): send deliverable evidence to the approval judge

### DIFF
--- a/internal/commands/workflow/approval_hardening_test.go
+++ b/internal/commands/workflow/approval_hardening_test.go
@@ -2,7 +2,9 @@ package workflow
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -331,6 +333,112 @@ func TestResolveManualApprovalDecision_InteractiveConfirm(t *testing.T) {
 	}
 	if decision.Actor != decisionActorUserOverride {
 		t.Fatalf("actor = %q after prior reject, want user_override", decision.Actor)
+	}
+}
+
+func TestResolveExistingEvidencePaths_ReturnsPresentDeliverables(t *testing.T) {
+	step := wf.WorkflowStep{Number: 4, Name: "PRESENT", Checkpoint: wf.CheckpointUserApproval}
+	present := map[string]bool{
+		"output_specs/PRESENTATION.md": true,
+		"output_specs/purpose.md":      true,
+	}
+	got := resolveExistingEvidencePathsWithInspector("/phase", step, func(_, path string) (bool, error) {
+		return present[path], nil
+	})
+	want := []string{"output_specs/PRESENTATION.md", "output_specs/purpose.md"}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Fatalf("evidence = %v, want %v", got, want)
+	}
+}
+
+func TestResolveExistingEvidencePaths_SkipsMissingAndErrors(t *testing.T) {
+	step := wf.WorkflowStep{Number: 4, Name: "PRESENT", Checkpoint: wf.CheckpointUserApproval}
+	got := resolveExistingEvidencePathsWithInspector("/phase", step, func(_, _ string) (bool, error) {
+		return false, errors.New("containment failed")
+	})
+	if len(got) != 0 {
+		t.Fatalf("evidence = %v, want empty when nothing is present", got)
+	}
+}
+
+func TestResolveExistingEvidencePaths_NilWhenNoConventionalPaths(t *testing.T) {
+	// A non-presentation step with no explicit evidence has no conventional
+	// deliverable set; the judge receives no evidence files, only the document.
+	step := wf.WorkflowStep{Number: 2, Name: "ANALYZE", Checkpoint: wf.CheckpointUserApproval}
+	got := resolveExistingEvidencePathsWithInspector("/phase", step, func(_, _ string) (bool, error) {
+		t.Fatal("a step with no conventional evidence paths must not inspect files")
+		return false, nil
+	})
+	if got != nil {
+		t.Fatalf("evidence = %v, want nil", got)
+	}
+}
+
+func TestResolveExistingEvidencePaths_HonorsExplicitEvidence(t *testing.T) {
+	step := wf.WorkflowStep{
+		Number:        2,
+		Name:          "REVIEW",
+		Checkpoint:    wf.CheckpointUserApproval,
+		EvidencePaths: []string{"output_specs/review.md", "output_specs/demo.txt"},
+	}
+	got := resolveExistingEvidencePathsWithInspector("/phase", step, func(_, path string) (bool, error) {
+		return path == "output_specs/review.md", nil
+	})
+	if len(got) != 1 || got[0] != "output_specs/review.md" {
+		t.Fatalf("evidence = %v, want [output_specs/review.md]", got)
+	}
+}
+
+func TestJudgeApproval_AttachesDeliverableEvidenceToRequest(t *testing.T) {
+	dir := setupWorkflowFestival(t)
+	phaseDir := filepath.Join(dir, "001_INGEST")
+
+	// Write the deliverables a PRESENT step is expected to produce.
+	specs := filepath.Join(phaseDir, "output_specs")
+	if err := os.MkdirAll(specs, 0o755); err != nil {
+		t.Fatalf("mkdir output_specs: %v", err)
+	}
+	for name, body := range map[string]string{
+		"PRESENTATION.md": "# Presentation\n\nThe user wants a chat TUI.\n",
+		"purpose.md":      "# Purpose\n\nReduce onboarding friction.\n",
+	} {
+		if err := os.WriteFile(filepath.Join(specs, name), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	nav := getNavigator(t, phaseDir)
+	step := wf.WorkflowStep{
+		Number:     4,
+		Name:       "PRESENT",
+		Goal:       "Verify the structured output captures the user's intent.",
+		Output:     "Summary presented to user",
+		Checkpoint: wf.CheckpointUserApproval,
+	}
+
+	var captured approvalJudgeRequest
+	withApprovalJudgeRunner(t, func(_ context.Context, _ string, stdin []byte, _ string) ([]byte, error) {
+		if err := json.Unmarshal(stdin, &captured); err != nil {
+			t.Fatalf("unmarshal judge request: %v", err)
+		}
+		return []byte(`{"schema_version":"fest.approval.judge/v1","decision":"approve","reason":"ok"}`), nil
+	})
+
+	if _, _, err := judgeApproval(context.Background(), nav, step, approvalJudgeOptions{JudgeCommand: "fake"}); err != nil {
+		t.Fatalf("judgeApproval: %v", err)
+	}
+
+	want := map[string]bool{
+		"output_specs/PRESENTATION.md": true,
+		"output_specs/purpose.md":      true,
+	}
+	if len(captured.Evidence) != len(want) {
+		t.Fatalf("evidence = %v, want the two existing deliverables", captured.Evidence)
+	}
+	for _, got := range captured.Evidence {
+		if !want[got] {
+			t.Fatalf("unexpected evidence path %q in %v", got, captured.Evidence)
+		}
 	}
 }
 

--- a/internal/commands/workflow/approval_readiness.go
+++ b/internal/commands/workflow/approval_readiness.go
@@ -83,7 +83,8 @@ func checkApprovalReadinessWithInspector(
 			WithField("step_name", step.Name).
 			WithField("required", "output_specs/PRESENTATION.md").
 			WithField("missing", strings.Join(status.missing, ", ")).
-			WithHint("write the presentation deliverable, then re-submit with 'fest workflow judge'")
+			WithHint("write output_specs/PRESENTATION.md relative to the phase directory " +
+				"(e.g. <phase>/output_specs/PRESENTATION.md), then re-submit with 'fest workflow judge'")
 	}
 
 	if status.found == 0 {
@@ -91,7 +92,8 @@ func checkApprovalReadinessWithInspector(
 			WithField("step", step.Number).
 			WithField("step_name", step.Name).
 			WithField("checked", strings.Join(paths, ", ")).
-			WithHint("create the evidence files listed for this step, then re-submit with 'fest workflow judge'")
+			WithHint("create at least one of these files relative to the phase directory, then " +
+				"re-submit with 'fest workflow judge': " + strings.Join(paths, ", "))
 	}
 
 	return nil
@@ -122,6 +124,45 @@ func inspectApprovalEvidencePaths(
 		}
 	}
 	return status, nil
+}
+
+// resolveExistingEvidencePaths returns the step's phase-relative deliverable
+// paths that exist as non-empty regular files. It reuses the same path
+// resolution and inspection the readiness gate applies, so the judge receives
+// exactly the evidence set readiness considered present. Missing or empty
+// candidates are dropped rather than surfaced; the judge is handed only files
+// it can actually read. Returns nil when the step has no conventional evidence.
+func resolveExistingEvidencePaths(phasePath string, step wf.WorkflowStep) []string {
+	return resolveExistingEvidencePathsWithInspector(phasePath, step, inspectApprovalEvidence)
+}
+
+func resolveExistingEvidencePathsWithInspector(
+	phasePath string,
+	step wf.WorkflowStep,
+	inspect approvalEvidenceInspector,
+) []string {
+	paths := wf.DefaultEvidencePaths(step)
+	if len(paths) == 0 {
+		return nil
+	}
+	var present []string
+	seen := make(map[string]struct{}, len(paths))
+	for _, rawPath := range paths {
+		rel, err := normalizeEvidencePath(rawPath)
+		if err != nil {
+			continue
+		}
+		if _, dup := seen[rel]; dup {
+			continue
+		}
+		ok, err := inspect(phasePath, rel)
+		if err != nil || !ok {
+			continue
+		}
+		seen[rel] = struct{}{}
+		present = append(present, rel)
+	}
+	return present
 }
 
 func normalizeEvidencePath(path string) (string, error) {

--- a/internal/commands/workflow/approve.go
+++ b/internal/commands/workflow/approve.go
@@ -45,6 +45,12 @@ type approvalJudgeRequest struct {
 	Actions       []string `json:"actions,omitempty"`
 	Output        string   `json:"output,omitempty"`
 	Checkpoint    string   `json:"checkpoint"`
+	// Evidence lists phase-relative deliverable files the judge should read as
+	// evidence, beyond Document (which is only the step definition for a
+	// WORKFLOW.md checkpoint). These are the same existing, non-empty artifacts
+	// the readiness gate validated. Additive to fest.approval.judge/v1: an older
+	// judge ignores it and sees only Document, as before.
+	Evidence []string `json:"evidence,omitempty"`
 }
 
 type approvalJudgeResponse struct {
@@ -660,6 +666,10 @@ func judgeApproval(ctx context.Context, nav *wf.Navigator, step wf.WorkflowStep,
 	if text := strings.TrimSpace(step.CheckpointText); text != "" {
 		req.Checkpoint = text
 	}
+	// Attach the step's deliverable files so the judge reads the actual work,
+	// not just the step definition. Without this the judge sees only Document
+	// and rejects (no evidence) or approves on the agent's self-report.
+	req.Evidence = resolveExistingEvidencePaths(nav.Ctx.PhasePath, step)
 
 	return evaluateApprovalJudge(ctx, req, opts)
 }


### PR DESCRIPTION
## Problem

The approval judge rules on evidence it never receives. `judgeApproval` built a `fest.approval.judge/v1` request carrying only `document` (`WORKFLOW.md` / `GATES.md`), which for a `PRESENT` step is just the step definition. The actual deliverables live in `output_specs/`, so the judge (`ob judge`) read a template:

- rejected real work as *"no evidence, only the workflow definition"* even though the files existed, or
- approved on claims it read from the agent-authored document and could not verify.

`fest` already resolves and validates those deliverable paths in the `--auto` readiness gate (`checkApprovalReadiness`), then threw them away: the request struct had no evidence field.

## Fix

- Add an additive `evidence []string` (phase-relative paths) to `approvalJudgeRequest`. Populated in `judgeApproval` from `resolveExistingEvidencePaths`, which reuses the same `DefaultEvidencePaths` + `inspectApprovalEvidence` the readiness gate uses, so the judge receives exactly the existing, non-empty files readiness confirmed.
- The field is additive to the versioned protocol: an older judge ignores it and sees only `document`, exactly as before. The paired judge-side change is `Obedience-Corp/obey#182`.

## Secondary: readiness hint named the path

The `presentation artifact missing or empty` and `no non-empty evidence files` hints never stated the path they required; it was discoverable only by running `strings` on the binary (`output_specs/PRESENTATION.md`, phase-relative). Both hints now name the expected path(s).

## Tests

- `resolveExistingEvidencePaths` returns present deliverables, skips missing/errored, is nil when a step has no conventional evidence, and honors explicit `**Evidence:**`.
- End-to-end: `judgeApproval` over a real navigator + temp phase captures the request the judge receives and asserts `evidence` carries the two existing `output_specs/` files.
- Full `go test ./...` green; `golangci-lint` clean on the touched package.

## Notes

Scope was deliberately the evidence-bundle fix, not giving the judge live read-tools. That larger direction (a phase-scoped tool source + judge session plumbing in `ob`) is tracked as a follow-up; this closes the live gate failure with a minimal, backward-compatible protocol addition.