### PR TITLE
feat(task): non-interactive task mutations, make fest progress read-only

### DIFF
--- a/docs/cli-reference/fest-reference.md
+++ b/docs/cli-reference/fest-reference.md
@@ -3404,25 +3404,25 @@ Track and display festival execution progress
 
 Track and display progress for festival execution.
 
-When run without flags, shows an overview of festival progress.
-Use flags to update task progress, report blockers, or mark tasks complete.
+When run without flags, shows an overview of festival progress. 'fest progress'
+is the display surface; task state mutations live under 'fest task'.
 
 PROGRESS OVERVIEW:
 ```bash
   fest progress              Show festival progress summary
   fest progress --json       Output progress in JSON format
+  fest progress --watch      Continuously refresh the display
 ```
 
-TASK UPDATES:
+DEPRECATED TASK MUTATIONS (use 'fest task' instead):
 ```bash
-  fest progress --task <id> --update 50%     Update task progress
-  fest progress --task <id> --complete       Mark task as complete
-  fest progress --task <id> --in-progress    Mark task as in progress
-  fest progress --task <id> --blocker "msg"  Report a blocker
-  fest progress --task <id> --clear          Clear blocker
-  fest progress --path <task_path> --complete
-  fest progress --phase <phase> --sequence <seq> --task <id> --complete
+  fest progress --task <id> --complete   -> fest task completed --yes
+  fest progress --task <id> --update 50% -> fest task update 50%
+  fest progress --task <id> --blocker "msg" -> fest task blocked --reason "msg" --yes
+  fest progress --task <id> --clear      -> fest task unblock
 ```
+
+These flags still work for one release and print a deprecation notice.
 
 Task IDs can be festival-relative paths (e.g. 002_FOUNDATION/01_project_scaffold/01_design.md)
 or absolute paths. Use --path or --phase/--sequence to disambiguate duplicates.
@@ -3436,12 +3436,9 @@ fest progress [flags]
 
 ```
   fest progress                          # Show overall progress
-  fest progress --task 01_setup.md --update 75%
-  fest progress --path 002_FOUNDATION/01_project_scaffold/01_design.md --complete
-  fest progress --phase 002_FOUNDATION --sequence 01_project_scaffold --task 01_design.md --complete
-  fest progress --festival festivals/active/guild-chat-GC0001 --task 01_setup.md --update 75%
-  fest progress --task 02_impl.md --blocker "Waiting on API spec"
-  fest progress --task 02_impl.md --clear
+  fest progress --json                   # Overall progress as JSON
+  fest progress --watch                  # Live-refreshing progress display
+  fest progress --task 01_setup.md       # Show a single task's progress
 ```
 
 ### Options
@@ -4976,9 +4973,11 @@ Manage task status (show, edit, complete, block, reset)
 
 Commands for managing individual task status within a festival.
 
-These commands provide a simpler interface for viewing, editing, marking
-tasks complete, blocked, or resetting them. Each mutation requires
-interactive confirmation to ensure agents verify their work before proceeding.
+This is the single home for task state mutations. Consequential changes
+(completed, blocked, reset) prompt for confirmation to ensure agents verify
+their work; pass --yes to skip the prompt for non-interactive or agent use, and
+--json to emit a structured result (--json requires --yes). Progress signals
+(update, unblock) are frictionless and never prompt.
 
 Task Resolution:
   When [task] is omitted, the command auto-detects the current task:
@@ -4996,8 +4995,12 @@ Examples:
   fest task show 01_design.md             # Show specific task
   fest task edit                          # Open current task in editor
   fest task completed                     # Mark current task complete (Y/n)
+  fest task completed --yes               # Mark complete, no prompt (agents)
+  fest task completed --yes --json        # Mark complete, structured output
   fest task blocked --reason "need API"   # Mark task blocked (Y/n)
   fest task reset                         # Reset task to pending (Y/n)
+  fest task update 50%                    # Set progress to 50%
+  fest task unblock                       # Clear a blocker, resume work
 ```
 
 ### Options
@@ -5018,7 +5021,15 @@ Examples:
 
 ## fest task blocked
 
-Mark a task as blocked (requires confirmation)
+Mark a task as blocked
+
+### Synopsis
+
+Mark a task as blocked, pausing work and notifying the user.
+
+By default a confirmation prompt is shown; pass --yes to skip it for
+non-interactive or agent use. --json emits a structured result and requires
+--yes.
 
 ```
 fest task blocked [task] [flags]
@@ -5028,8 +5039,9 @@ fest task blocked [task] [flags]
 
 ```
   -h, --help            help for blocked
-      --json            output as JSON (blocks: interactive confirmation required)
+      --json            output as JSON (requires --yes)
       --reason string   reason for the blocker (required)
+  -y, --yes             skip the interactive confirmation prompt
 ```
 
 ### Options inherited from parent commands
@@ -5044,7 +5056,15 @@ fest task blocked [task] [flags]
 
 ## fest task completed
 
-Mark a task as complete (requires confirmation)
+Mark a task as complete
+
+### Synopsis
+
+Mark a task as complete.
+
+Quality gates are evaluated first and block completion on failure. By default a
+confirmation prompt is shown; pass --yes to skip it for non-interactive or agent
+use. --json emits a structured result and requires --yes.
 
 ```
 fest task completed [task] [flags]
@@ -5054,7 +5074,8 @@ fest task completed [task] [flags]
 
 ```
   -h, --help   help for completed
-      --json   output as JSON (blocks: interactive confirmation required)
+      --json   output as JSON (requires --yes)
+  -y, --yes    skip the interactive confirmation prompt
 ```
 
 ### Options inherited from parent commands
@@ -5093,7 +5114,15 @@ fest task edit [task] [flags]
 
 ## fest task reset
 
-Reset a task to pending (requires confirmation)
+Reset a task to pending
+
+### Synopsis
+
+Reset a task to pending, clearing all progress, time, and blocker data.
+
+By default a confirmation prompt is shown; pass --yes to skip it for
+non-interactive or agent use. --json emits a structured result and requires
+--yes.
 
 ```
 fest task reset [task] [flags]
@@ -5103,7 +5132,8 @@ fest task reset [task] [flags]
 
 ```
   -h, --help   help for reset
-      --json   output as JSON (blocks: interactive confirmation required)
+      --json   output as JSON (requires --yes)
+  -y, --yes    skip the interactive confirmation prompt
 ```
 
 ### Options inherited from parent commands
@@ -5130,6 +5160,70 @@ fest task show [task] [flags]
   -h, --help         help for show
       --json         output as JSON
       --no-context   hide task markdown content
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## fest task unblock
+
+Clear a task's blocker and resume work
+
+### Synopsis
+
+Clear a task's blocker, returning it to in_progress.
+
+This is a frictionless forward-motion signal and does not prompt for
+confirmation. When [task] is omitted the current task is auto-detected.
+
+```
+fest task unblock [task] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for unblock
+      --json   output as JSON
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## fest task update
+
+Update a task's progress percentage
+
+### Synopsis
+
+Update a task's progress percentage (0-100).
+
+This is a frictionless forward-motion signal and does not prompt for
+confirmation. When [task] is omitted the current task is auto-detected.
+
+```
+fest task update [task] <percent> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for update
+      --json   output as JSON
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/fest-reference.md
+++ b/docs/cli-reference/fest-reference.md
@@ -5213,7 +5213,9 @@ Update a task's progress percentage
 Update a task's progress percentage (0-100).
 
 This is a frictionless forward-motion signal and does not prompt for
-confirmation. When [task] is omitted the current task is auto-detected.
+confirmation. Progress must stay below 100%; use 'fest task completed' at
+100% so quality gates are evaluated. When [task] is omitted the current task
+is auto-detected.
 
 ```
 fest task update [task] <percent> [flags]

--- a/docs/cli-reference/fest_progress.md
+++ b/docs/cli-reference/fest_progress.md
@@ -6,25 +6,25 @@ Track and display festival execution progress
 
 Track and display progress for festival execution.
 
-When run without flags, shows an overview of festival progress.
-Use flags to update task progress, report blockers, or mark tasks complete.
+When run without flags, shows an overview of festival progress. 'fest progress'
+is the display surface; task state mutations live under 'fest task'.
 
 PROGRESS OVERVIEW:
 ```bash
   fest progress              Show festival progress summary
   fest progress --json       Output progress in JSON format
+  fest progress --watch      Continuously refresh the display
 ```
 
-TASK UPDATES:
+DEPRECATED TASK MUTATIONS (use 'fest task' instead):
 ```bash
-  fest progress --task <id> --update 50%     Update task progress
-  fest progress --task <id> --complete       Mark task as complete
-  fest progress --task <id> --in-progress    Mark task as in progress
-  fest progress --task <id> --blocker "msg"  Report a blocker
-  fest progress --task <id> --clear          Clear blocker
-  fest progress --path <task_path> --complete
-  fest progress --phase <phase> --sequence <seq> --task <id> --complete
+  fest progress --task <id> --complete   -> fest task completed --yes
+  fest progress --task <id> --update 50% -> fest task update 50%
+  fest progress --task <id> --blocker "msg" -> fest task blocked --reason "msg" --yes
+  fest progress --task <id> --clear      -> fest task unblock
 ```
+
+These flags still work for one release and print a deprecation notice.
 
 Task IDs can be festival-relative paths (e.g. 002_FOUNDATION/01_project_scaffold/01_design.md)
 or absolute paths. Use --path or --phase/--sequence to disambiguate duplicates.
@@ -38,12 +38,9 @@ fest progress [flags]
 
 ```
   fest progress                          # Show overall progress
-  fest progress --task 01_setup.md --update 75%
-  fest progress --path 002_FOUNDATION/01_project_scaffold/01_design.md --complete
-  fest progress --phase 002_FOUNDATION --sequence 01_project_scaffold --task 01_design.md --complete
-  fest progress --festival festivals/active/guild-chat-GC0001 --task 01_setup.md --update 75%
-  fest progress --task 02_impl.md --blocker "Waiting on API spec"
-  fest progress --task 02_impl.md --clear
+  fest progress --json                   # Overall progress as JSON
+  fest progress --watch                  # Live-refreshing progress display
+  fest progress --task 01_setup.md       # Show a single task's progress
 ```
 
 ### Options

--- a/docs/cli-reference/fest_task.md
+++ b/docs/cli-reference/fest_task.md
@@ -6,9 +6,11 @@ Manage task status (show, edit, complete, block, reset)
 
 Commands for managing individual task status within a festival.
 
-These commands provide a simpler interface for viewing, editing, marking
-tasks complete, blocked, or resetting them. Each mutation requires
-interactive confirmation to ensure agents verify their work before proceeding.
+This is the single home for task state mutations. Consequential changes
+(completed, blocked, reset) prompt for confirmation to ensure agents verify
+their work; pass --yes to skip the prompt for non-interactive or agent use, and
+--json to emit a structured result (--json requires --yes). Progress signals
+(update, unblock) are frictionless and never prompt.
 
 Task Resolution:
   When [task] is omitted, the command auto-detects the current task:
@@ -26,8 +28,12 @@ Examples:
   fest task show 01_design.md             # Show specific task
   fest task edit                          # Open current task in editor
   fest task completed                     # Mark current task complete (Y/n)
+  fest task completed --yes               # Mark complete, no prompt (agents)
+  fest task completed --yes --json        # Mark complete, structured output
   fest task blocked --reason "need API"   # Mark task blocked (Y/n)
   fest task reset                         # Reset task to pending (Y/n)
+  fest task update 50%                    # Set progress to 50%
+  fest task unblock                       # Clear a blocker, resume work
 ```
 
 ### Options
@@ -48,8 +54,10 @@ Examples:
 ### SEE ALSO
 
 * [fest](fest.md)	 - Festival Methodology CLI - goal-oriented project management for AI agents
-* [fest task blocked](fest_task_blocked.md)	 - Mark a task as blocked (requires confirmation)
-* [fest task completed](fest_task_completed.md)	 - Mark a task as complete (requires confirmation)
+* [fest task blocked](fest_task_blocked.md)	 - Mark a task as blocked
+* [fest task completed](fest_task_completed.md)	 - Mark a task as complete
 * [fest task edit](fest_task_edit.md)	 - Open the current task in your editor
-* [fest task reset](fest_task_reset.md)	 - Reset a task to pending (requires confirmation)
+* [fest task reset](fest_task_reset.md)	 - Reset a task to pending
 * [fest task show](fest_task_show.md)	 - Show task details and status
+* [fest task unblock](fest_task_unblock.md)	 - Clear a task's blocker and resume work
+* [fest task update](fest_task_update.md)	 - Update a task's progress percentage

--- a/docs/cli-reference/fest_task_blocked.md
+++ b/docs/cli-reference/fest_task_blocked.md
@@ -1,6 +1,14 @@
 ## fest task blocked
 
-Mark a task as blocked (requires confirmation)
+Mark a task as blocked
+
+### Synopsis
+
+Mark a task as blocked, pausing work and notifying the user.
+
+By default a confirmation prompt is shown; pass --yes to skip it for
+non-interactive or agent use. --json emits a structured result and requires
+--yes.
 
 ```
 fest task blocked [task] [flags]
@@ -10,8 +18,9 @@ fest task blocked [task] [flags]
 
 ```
   -h, --help            help for blocked
-      --json            output as JSON (blocks: interactive confirmation required)
+      --json            output as JSON (requires --yes)
       --reason string   reason for the blocker (required)
+  -y, --yes             skip the interactive confirmation prompt
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/fest_task_completed.md
+++ b/docs/cli-reference/fest_task_completed.md
@@ -1,6 +1,14 @@
 ## fest task completed
 
-Mark a task as complete (requires confirmation)
+Mark a task as complete
+
+### Synopsis
+
+Mark a task as complete.
+
+Quality gates are evaluated first and block completion on failure. By default a
+confirmation prompt is shown; pass --yes to skip it for non-interactive or agent
+use. --json emits a structured result and requires --yes.
 
 ```
 fest task completed [task] [flags]
@@ -10,7 +18,8 @@ fest task completed [task] [flags]
 
 ```
   -h, --help   help for completed
-      --json   output as JSON (blocks: interactive confirmation required)
+      --json   output as JSON (requires --yes)
+  -y, --yes    skip the interactive confirmation prompt
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/fest_task_reset.md
+++ b/docs/cli-reference/fest_task_reset.md
@@ -1,6 +1,14 @@
 ## fest task reset
 
-Reset a task to pending (requires confirmation)
+Reset a task to pending
+
+### Synopsis
+
+Reset a task to pending, clearing all progress, time, and blocker data.
+
+By default a confirmation prompt is shown; pass --yes to skip it for
+non-interactive or agent use. --json emits a structured result and requires
+--yes.
 
 ```
 fest task reset [task] [flags]
@@ -10,7 +18,8 @@ fest task reset [task] [flags]
 
 ```
   -h, --help   help for reset
-      --json   output as JSON (blocks: interactive confirmation required)
+      --json   output as JSON (requires --yes)
+  -y, --yes    skip the interactive confirmation prompt
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/fest_task_unblock.md
+++ b/docs/cli-reference/fest_task_unblock.md
@@ -1,0 +1,34 @@
+## fest task unblock
+
+Clear a task's blocker and resume work
+
+### Synopsis
+
+Clear a task's blocker, returning it to in_progress.
+
+This is a frictionless forward-motion signal and does not prompt for
+confirmation. When [task] is omitted the current task is auto-detected.
+
+```
+fest task unblock [task] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for unblock
+      --json   output as JSON
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest task](fest_task.md)	 - Manage task status (show, edit, complete, block, reset)

--- a/docs/cli-reference/fest_task_update.md
+++ b/docs/cli-reference/fest_task_update.md
@@ -7,7 +7,9 @@ Update a task's progress percentage
 Update a task's progress percentage (0-100).
 
 This is a frictionless forward-motion signal and does not prompt for
-confirmation. When [task] is omitted the current task is auto-detected.
+confirmation. Progress must stay below 100%; use 'fest task completed' at
+100% so quality gates are evaluated. When [task] is omitted the current task
+is auto-detected.
 
 ```
 fest task update [task] <percent> [flags]

--- a/docs/cli-reference/fest_task_update.md
+++ b/docs/cli-reference/fest_task_update.md
@@ -1,0 +1,34 @@
+## fest task update
+
+Update a task's progress percentage
+
+### Synopsis
+
+Update a task's progress percentage (0-100).
+
+This is a frictionless forward-motion signal and does not prompt for
+confirmation. When [task] is omitted the current task is auto-detected.
+
+```
+fest task update [task] <percent> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for update
+      --json   output as JSON
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest task](fest_task.md)	 - Manage task status (show, edit, complete, block, reset)

--- a/embedded/templates/agent/registry_test.go
+++ b/embedded/templates/agent/registry_test.go
@@ -107,7 +107,7 @@ func minimalTestData(templateName string) any {
 		"ProgressLine":      "Progress: 50%",
 		"PositionSection":   "Position: Phase 1, Sequence 1",
 		"ContextSection":    "Context: test-festival",
-		"ProgressCmd":       "fest progress --complete",
+		"ProgressCmd":       "fest task completed",
 		"Message":           "Test message",
 		"ActionInstruction": "Follow the instructions",
 	}

--- a/internal/commands/progress/deprecation_test.go
+++ b/internal/commands/progress/deprecation_test.go
@@ -1,0 +1,42 @@
+package progress
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestWarnProgressDeprecation(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     *progressOptions
+		wantWarn bool
+		wantHas  string
+	}{
+		{name: "complete_redirects_to_task_completed", opts: &progressOptions{complete: true}, wantWarn: true, wantHas: "fest task completed --yes"},
+		{name: "update_redirects_to_task_update", opts: &progressOptions{update: "50%"}, wantWarn: true, wantHas: "fest task update"},
+		{name: "blocker_redirects_to_task_blocked", opts: &progressOptions{blocker: "stuck"}, wantWarn: true, wantHas: "fest task blocked"},
+		{name: "clear_redirects_to_task_unblock", opts: &progressOptions{clear: true}, wantWarn: true, wantHas: "fest task unblock"},
+		{name: "in_progress_not_deprecated", opts: &progressOptions{inProgress: true}, wantWarn: false},
+		{name: "read_only_not_deprecated", opts: &progressOptions{}, wantWarn: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			warnProgressDeprecation(&buf, tt.opts)
+			got := buf.String()
+
+			if tt.wantWarn {
+				if !strings.Contains(got, "deprecated") {
+					t.Errorf("expected a deprecation warning, got %q", got)
+				}
+				if !strings.Contains(got, tt.wantHas) {
+					t.Errorf("warning = %q, want it to name %q", got, tt.wantHas)
+				}
+			} else if got != "" {
+				t.Errorf("expected no warning, got %q", got)
+			}
+		})
+	}
+}

--- a/internal/commands/progress/gate_shim_test.go
+++ b/internal/commands/progress/gate_shim_test.go
@@ -1,0 +1,118 @@
+package progress
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/lifecycle"
+	progresspkg "github.com/Obedience-Corp/fest/internal/progress"
+)
+
+// setupActiveFestivalForProgress builds an active-status festival with one
+// implementation task and returns the festival dir plus the absolute task path,
+// mirroring the task package's setupActiveFestival so the deprecated
+// `fest progress` mutation shim can be exercised through handleTaskUpdate.
+func setupActiveFestivalForProgress(t *testing.T) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	festYAML := "version: \"1.0\"\nname: prog-shim-test\nid: PST-001\nmetadata:\n  id: PST-001\n  status_history:\n    - status: active\n      timestamp: 2026-02-10T00:00:00Z\n"
+	if err := os.WriteFile(filepath.Join(dir, "fest.yaml"), []byte(festYAML), 0o644); err != nil {
+		t.Fatalf("write fest.yaml: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".fest"), 0o755); err != nil {
+		t.Fatalf("mkdir .fest: %v", err)
+	}
+
+	seqDir := filepath.Join(dir, "001_PHASE", "01_seq")
+	if err := os.MkdirAll(seqDir, 0o755); err != nil {
+		t.Fatalf("mkdir sequence: %v", err)
+	}
+	phaseGoal := "---\nfest_type: phase_goal\nfest_id: 001_PHASE\nfest_phase_type: implementation\n---\n# Phase Goal\n"
+	if err := os.WriteFile(filepath.Join(dir, "001_PHASE", "PHASE_GOAL.md"), []byte(phaseGoal), 0o644); err != nil {
+		t.Fatalf("write phase goal: %v", err)
+	}
+	seqGoal := "---\nfest_type: sequence_goal\nfest_id: 01_seq\n---\n# Sequence Goal\n"
+	if err := os.WriteFile(filepath.Join(seqDir, "SEQUENCE_GOAL.md"), []byte(seqGoal), 0o644); err != nil {
+		t.Fatalf("write sequence goal: %v", err)
+	}
+	taskBody := "---\nfest_type: task\nfest_id: 01_task\n---\n# Task body\n"
+	taskPath := filepath.Join(seqDir, "01_task.md")
+	if err := os.WriteFile(taskPath, []byte(taskBody), 0o644); err != nil {
+		t.Fatalf("write task: %v", err)
+	}
+	return dir, taskPath
+}
+
+// TestHandleTaskUpdate_100PercentRefusedOnDeprecatedShim locks the fest#280
+// parity fix: the deprecated `fest progress --update 100%` path must refuse the
+// ungated completion the same way `fest task update 100` does, pointing the
+// caller at `fest task completed --yes` instead of silently completing the task
+// without quality-gate evaluation during the deprecation window.
+func TestHandleTaskUpdate_100PercentRefusedOnDeprecatedShim(t *testing.T) {
+	festDir, taskPath := setupActiveFestivalForProgress(t)
+	ctx := context.Background()
+
+	mgr, err := progresspkg.NewManagerWithGate(ctx, festDir,
+		lifecycle.NewGateWithReason(festDir, "fest progress"))
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+
+	opts := &progressOptions{taskPath: taskPath, update: "100"}
+	err = handleTaskUpdate(ctx, mgr, festDir, opts)
+	if err == nil {
+		t.Fatal("progress --update 100 unexpectedly succeeded; ungated completion side-door is open")
+	}
+	if !strings.Contains(err.Error(), "fest task completed") {
+		t.Fatalf("error = %v, want a pointer to gated completion (fest task completed)", err)
+	}
+
+	// The task must not have been completed through the shim.
+	taskID, rErr := resolveTaskID(festDir, opts)
+	if rErr != nil {
+		t.Fatalf("resolve task id: %v", rErr)
+	}
+	if task, ok := mgr.GetTaskProgress(taskID); ok && task != nil {
+		if task.Status == progresspkg.StatusCompleted {
+			t.Error("task must not be completed via progress --update 100")
+		}
+		if task.Progress == 100 {
+			t.Error("task progress must not reach 100 via progress --update")
+		}
+	}
+}
+
+// TestHandleTaskUpdate_SubHundredStillUpdates guards against over-rejecting: a
+// non-terminal percentage on the deprecated shim keeps working for the
+// compatibility window.
+func TestHandleTaskUpdate_SubHundredStillUpdates(t *testing.T) {
+	festDir, taskPath := setupActiveFestivalForProgress(t)
+	ctx := context.Background()
+
+	mgr, err := progresspkg.NewManagerWithGate(ctx, festDir,
+		lifecycle.NewGateWithReason(festDir, "fest progress"))
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+
+	opts := &progressOptions{taskPath: taskPath, update: "50"}
+	if err := handleTaskUpdate(ctx, mgr, festDir, opts); err != nil {
+		t.Fatalf("progress --update 50 should still succeed on the shim: %v", err)
+	}
+
+	taskID, rErr := resolveTaskID(festDir, opts)
+	if rErr != nil {
+		t.Fatalf("resolve task id: %v", rErr)
+	}
+	task, ok := mgr.GetTaskProgress(taskID)
+	if !ok || task == nil {
+		t.Fatal("expected a progress entry after a sub-100 update")
+	}
+	if task.Progress != 50 {
+		t.Errorf("progress = %d, want 50", task.Progress)
+	}
+}

--- a/internal/commands/progress/progress.go
+++ b/internal/commands/progress/progress.go
@@ -53,32 +53,29 @@ func NewProgressCommand() *cobra.Command {
 		},
 		Long: `Track and display progress for festival execution.
 
-When run without flags, shows an overview of festival progress.
-Use flags to update task progress, report blockers, or mark tasks complete.
+When run without flags, shows an overview of festival progress. 'fest progress'
+is the display surface; task state mutations live under 'fest task'.
 
 PROGRESS OVERVIEW:
   fest progress              Show festival progress summary
   fest progress --json       Output progress in JSON format
+  fest progress --watch      Continuously refresh the display
 
-TASK UPDATES:
-  fest progress --task <id> --update 50%     Update task progress
-  fest progress --task <id> --complete       Mark task as complete
-  fest progress --task <id> --in-progress    Mark task as in progress
-  fest progress --task <id> --blocker "msg"  Report a blocker
-  fest progress --task <id> --clear          Clear blocker
-  fest progress --path <task_path> --complete
-  fest progress --phase <phase> --sequence <seq> --task <id> --complete
+DEPRECATED TASK MUTATIONS (use 'fest task' instead):
+  fest progress --task <id> --complete   -> fest task completed --yes
+  fest progress --task <id> --update 50% -> fest task update 50%
+  fest progress --task <id> --blocker "msg" -> fest task blocked --reason "msg" --yes
+  fest progress --task <id> --clear      -> fest task unblock
+
+These flags still work for one release and print a deprecation notice.
 
 Task IDs can be festival-relative paths (e.g. 002_FOUNDATION/01_project_scaffold/01_design.md)
 or absolute paths. Use --path or --phase/--sequence to disambiguate duplicates.
 Use --festival to run outside a festival directory.`,
 		Example: `  fest progress                          # Show overall progress
-  fest progress --task 01_setup.md --update 75%
-  fest progress --path 002_FOUNDATION/01_project_scaffold/01_design.md --complete
-  fest progress --phase 002_FOUNDATION --sequence 01_project_scaffold --task 01_design.md --complete
-  fest progress --festival festivals/active/guild-chat-GC0001 --task 01_setup.md --update 75%
-  fest progress --task 02_impl.md --blocker "Waiting on API spec"
-  fest progress --task 02_impl.md --clear`,
+  fest progress --json                   # Overall progress as JSON
+  fest progress --watch                  # Live-refreshing progress display
+  fest progress --task 01_setup.md       # Show a single task's progress`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runProgress(cmd.Context(), opts)
 		},

--- a/internal/commands/progress/task_update.go
+++ b/internal/commands/progress/task_update.go
@@ -4,6 +4,7 @@ package progress
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -23,6 +24,8 @@ func handleTaskUpdate(ctx context.Context, mgr *progress.Manager, festivalPath s
 	if err != nil {
 		return err
 	}
+
+	warnProgressDeprecation(os.Stderr, opts)
 
 	if err := lifecycle.EnforcePreActive(ctx, festivalPath, lifecycle.EnforceOptions{
 		TaskID: taskID,
@@ -295,6 +298,29 @@ func statusForProgress(progressPct int) string {
 	default:
 		return progress.StatusPending
 	}
+}
+
+// warnProgressDeprecation prints a one-line deprecation notice to w when a
+// task-mutating progress flag is used. Task mutations now live under
+// 'fest task'; 'fest progress' is display-only. The action still runs for one
+// release so existing callers keep working. --in-progress is intentionally not
+// deprecated: it stays with the progress display surface.
+func warnProgressDeprecation(w io.Writer, opts *progressOptions) {
+	var replacement string
+	switch {
+	case opts.complete:
+		replacement = "fest task completed --yes"
+	case opts.update != "":
+		replacement = "fest task update <percent>"
+	case opts.blocker != "":
+		replacement = "fest task blocked --reason <msg> --yes"
+	case opts.clear:
+		replacement = "fest task unblock"
+	default:
+		return
+	}
+	_, _ = fmt.Fprintf(w, "%s this 'fest progress' task mutation is deprecated; use '%s' instead. It will be removed in a future release.\n",
+		ui.Warning("Warning:"), replacement)
 }
 
 // progressReasonFor returns a label for the lifecycle gate based on the

--- a/internal/commands/progress/task_update.go
+++ b/internal/commands/progress/task_update.go
@@ -186,6 +186,15 @@ func handleTaskUpdate(ctx context.Context, mgr *progress.Manager, festivalPath s
 		if err != nil {
 			return err
 		}
+		// Mirror `fest task update`: 100% must run through the gated completion
+		// path, not this deprecated shim. Without this, an agent still on the
+		// old flag could complete a task without quality-gate evaluation for the
+		// whole deprecation window, re-opening the ungated completion side-door
+		// that `fest task completed` exists to close.
+		if pct == 100 {
+			return errors.Validation("100% progress must be finalized with 'fest task completed'").
+				WithHint("run 'fest task completed --yes' to evaluate quality gates and complete the task")
+		}
 		if err := mgr.UpdateProgress(ctx, taskID, pct); err != nil {
 			return err
 		}

--- a/internal/commands/task/blocked.go
+++ b/internal/commands/task/blocked.go
@@ -16,13 +16,19 @@ import (
 var (
 	blockedReason string
 	blockedJSON   bool
+	blockedYes    bool
 )
 
 func newBlockedCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "blocked [task]",
-		Short: "Mark a task as blocked (requires confirmation)",
-		Args:  cobra.MaximumNArgs(1),
+		Short: "Mark a task as blocked",
+		Long: `Mark a task as blocked, pausing work and notifying the user.
+
+By default a confirmation prompt is shown; pass --yes to skip it for
+non-interactive or agent use. --json emits a structured result and requires
+--yes.`,
+		Args: cobra.MaximumNArgs(1),
 		Annotations: map[string]string{
 			"scope": string(scope.Festival),
 		},
@@ -30,7 +36,8 @@ func newBlockedCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&blockedReason, "reason", "", "reason for the blocker (required)")
-	cmd.Flags().BoolVar(&blockedJSON, "json", false, "output as JSON (blocks: interactive confirmation required)")
+	cmd.Flags().BoolVar(&blockedJSON, "json", false, "output as JSON (requires --yes)")
+	cmd.Flags().BoolVarP(&blockedYes, "yes", "y", false, "skip the interactive confirmation prompt")
 	_ = cmd.MarkFlagRequired("reason")
 
 	return cmd
@@ -61,17 +68,11 @@ func runBlocked(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Require interactive mode
-	if blockedJSON {
-		result := map[string]any{
-			"error":   "interactive confirmation required",
-			"task":    taskID,
-			"message": "Use 'fest task blocked' without --json to report a blocker interactively",
-		}
-		if encErr := shared.EncodeJSON(os.Stdout, result); encErr != nil {
-			return errors.Wrap(encErr, "encoding JSON output")
-		}
-		return errors.Validation("interactive confirmation required for reporting blockers")
+	// Refuse before doing any work when confirmation cannot be obtained.
+	needPrompt, err := resolveConfirmation(blockedYes, blockedJSON, taskID,
+		"report a blocker", "fest task blocked --reason <msg> --yes")
+	if err != nil {
+		return err
 	}
 
 	mgr, err := progress.NewManagerWithGate(ctx, festivalPath,
@@ -80,24 +81,33 @@ func runBlocked(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "loading progress")
 	}
 
-	// Show current status
-	task, _ := mgr.GetTaskProgress(taskID)
-	if task != nil {
+	if !blockedJSON {
+		task, _ := mgr.GetTaskProgress(taskID)
+		status := progress.StatusPending
+		if task != nil {
+			status = task.Status
+		}
 		fmt.Printf("%s %s (%s)\n", ui.Label("Task"), ui.Value(taskID, ui.TaskColor),
-			ui.GetStateStyle(task.Status).Render(task.Status))
-	} else {
-		fmt.Printf("%s %s (%s)\n", ui.Label("Task"), ui.Value(taskID, ui.TaskColor),
-			ui.GetStateStyle(progress.StatusPending).Render(progress.StatusPending))
+			ui.GetStateStyle(status).Render(status))
 	}
 
-	// Interactive confirmation
-	if !confirmBlocked(taskID, blockedReason) {
+	if needPrompt && !confirmBlocked(taskID, blockedReason) {
 		fmt.Println(ui.Info("Cancelled."))
 		return nil
 	}
 
 	if err := mgr.ReportBlocker(ctx, taskID, blockedReason); err != nil {
 		return err
+	}
+
+	if blockedJSON {
+		result := map[string]any{
+			"success": true,
+			"task":    taskID,
+			"status":  progress.StatusBlocked,
+			"blocker": blockedReason,
+		}
+		return shared.EncodeJSON(os.Stdout, result)
 	}
 
 	fmt.Println()

--- a/internal/commands/task/completed.go
+++ b/internal/commands/task/completed.go
@@ -15,20 +15,29 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var completedJSON bool
+var (
+	completedJSON bool
+	completedYes  bool
+)
 
 func newCompletedCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "completed [task]",
-		Short: "Mark a task as complete (requires confirmation)",
-		Args:  cobra.MaximumNArgs(1),
+		Short: "Mark a task as complete",
+		Long: `Mark a task as complete.
+
+Quality gates are evaluated first and block completion on failure. By default a
+confirmation prompt is shown; pass --yes to skip it for non-interactive or agent
+use. --json emits a structured result and requires --yes.`,
+		Args: cobra.MaximumNArgs(1),
 		Annotations: map[string]string{
 			"scope": string(scope.Festival),
 		},
 		RunE: runCompleted,
 	}
 
-	cmd.Flags().BoolVar(&completedJSON, "json", false, "output as JSON (blocks: interactive confirmation required)")
+	cmd.Flags().BoolVar(&completedJSON, "json", false, "output as JSON (requires --yes)")
+	cmd.Flags().BoolVarP(&completedYes, "yes", "y", false, "skip the interactive confirmation prompt")
 
 	return cmd
 }
@@ -58,17 +67,11 @@ func runCompleted(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Require interactive mode - no --json bypass for mutations
-	if completedJSON {
-		result := map[string]any{
-			"error":   "interactive confirmation required",
-			"task":    taskID,
-			"message": "Use 'fest task completed' without --json to complete a task interactively",
-		}
-		if encErr := shared.EncodeJSON(os.Stdout, result); encErr != nil {
-			return errors.Wrap(encErr, "encoding JSON output")
-		}
-		return errors.Validation("interactive confirmation required for task completion")
+	// Refuse before doing any work when confirmation cannot be obtained.
+	needPrompt, err := resolveConfirmation(completedYes, completedJSON, taskID,
+		"complete this task", "fest task completed --yes")
+	if err != nil {
+		return err
 	}
 
 	mgr, err := progress.NewManagerWithGate(ctx, festivalPath,
@@ -77,21 +80,20 @@ func runCompleted(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "loading progress")
 	}
 
-	// Show current status
-	task, _ := mgr.GetTaskProgress(taskID)
-	if task != nil {
+	if !completedJSON {
+		task, _ := mgr.GetTaskProgress(taskID)
+		status := progress.StatusPending
+		if task != nil {
+			status = task.Status
+		}
 		fmt.Printf("%s %s (%s)\n", ui.Label("Task"), ui.Value(taskID, ui.TaskColor),
-			ui.GetStateStyle(task.Status).Render(task.Status))
-	} else {
-		fmt.Printf("%s %s (%s)\n", ui.Label("Task"), ui.Value(taskID, ui.TaskColor),
-			ui.GetStateStyle(progress.StatusPending).Render(progress.StatusPending))
+			ui.GetStateStyle(status).Render(status))
 	}
 
-	// Evaluate quality gates
+	// Evaluate quality gates - these BLOCK completion if they fail.
 	if !strings.HasSuffix(taskFilePath, ".md") {
 		taskFilePath += ".md"
 	}
-
 	phasePath, sequencePath := resolveTaskLocationPaths(festivalPath, taskID)
 	evaluator := gates.NewGateEvaluator(festivalPath, phasePath, sequencePath)
 	gateResult, gateErr := evaluator.EvaluateForTask(ctx, taskFilePath)
@@ -100,20 +102,47 @@ func runCompleted(cmd *cobra.Command, args []string) error {
 	}
 
 	if !gateResult.Passed {
-		printGateFailures(gateResult)
+		if completedJSON {
+			result := map[string]any{
+				"success":      false,
+				"task":         taskID,
+				"blocked":      true,
+				"failed_gates": gateResult.FailedGates,
+				"message":      "Task completion blocked by quality gates",
+			}
+			if encErr := shared.EncodeJSON(os.Stdout, result); encErr != nil {
+				return errors.Wrap(encErr, "encoding JSON output")
+			}
+		} else {
+			printGateFailures(gateResult)
+		}
 		return errors.Validation("task completion blocked by quality gates").
 			WithField("task", taskID).
 			WithField("failed_gates", len(gateResult.FailedGates))
 	}
 
-	// Interactive confirmation
-	if !confirmCompletion(taskID) {
+	if needPrompt && !confirmCompletion(taskID) {
 		fmt.Println(ui.Info("Cancelled."))
 		return nil
 	}
 
 	if err := mgr.MarkComplete(ctx, taskID); err != nil {
 		return err
+	}
+
+	if completedJSON {
+		task, _ := mgr.GetTaskProgress(taskID)
+		timeSpent := 0
+		if task != nil {
+			timeSpent = task.TimeSpentMinutes
+		}
+		result := map[string]any{
+			"success":            true,
+			"task":               taskID,
+			"status":             progress.StatusCompleted,
+			"time_spent_minutes": timeSpent,
+		}
+		return shared.EncodeJSON(os.Stdout, result)
 	}
 
 	fmt.Println()

--- a/internal/commands/task/confirm.go
+++ b/internal/commands/task/confirm.go
@@ -6,8 +6,51 @@ import (
 	"os"
 	"strings"
 
+	"github.com/Obedience-Corp/fest/internal/commands/shared"
+	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/ui"
+	"golang.org/x/term"
 )
+
+// resolveConfirmation decides how a consequential task mutation should proceed
+// given the --yes and --json flags and whether stdin is an interactive terminal.
+//
+// It returns needPrompt=true only when the caller must run its own interactive
+// Y/n prompt (no --yes, not JSON, stdin is a TTY). When yes is set it returns
+// needPrompt=false with no error so the caller proceeds directly.
+//
+// When confirmation cannot be obtained it returns an error the caller must
+// propagate: in JSON mode it first emits a structured "confirmation required"
+// object to stdout; in a non-interactive terminal it returns a validation error
+// directing the caller to --yes. This keeps agent invocations from silently
+// mutating state without an explicit --yes.
+func resolveConfirmation(yes, jsonOut bool, taskID, action, command string) (needPrompt bool, err error) {
+	if yes {
+		return false, nil
+	}
+
+	if jsonOut {
+		result := map[string]any{
+			"error":   "confirmation required",
+			"task":    taskID,
+			"message": "pass --yes to " + action + " non-interactively (e.g. '" + command + "')",
+		}
+		if encErr := shared.EncodeJSON(os.Stdout, result); encErr != nil {
+			return false, errors.Wrap(encErr, "encoding JSON output")
+		}
+		return false, errors.Validation("confirmation required for " + action).
+			WithField("task", taskID).
+			WithHint("pass --yes for non-interactive use")
+	}
+
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return false, errors.Validation("confirmation required for " + action).
+			WithField("task", taskID).
+			WithHint("pass --yes for non-interactive use")
+	}
+
+	return true, nil
+}
 
 // confirmCompletion asks the user to confirm task completion.
 // Returns true if the user confirms.

--- a/internal/commands/task/mutations_test.go
+++ b/internal/commands/task/mutations_test.go
@@ -1,0 +1,384 @@
+package task
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/progress"
+	"github.com/Obedience-Corp/fest/internal/scope"
+	"github.com/spf13/cobra"
+)
+
+// setupActiveFestival builds an active-status festival with one implementation
+// task and returns the festival dir plus the task's festival-relative path.
+func setupActiveFestival(t *testing.T) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	festYAML := "version: \"1.0\"\nname: task-mut-test\nid: TMT-001\nmetadata:\n  id: TMT-001\n  status_history:\n    - status: active\n      timestamp: 2026-02-10T00:00:00Z\n"
+	if err := os.WriteFile(filepath.Join(dir, "fest.yaml"), []byte(festYAML), 0o644); err != nil {
+		t.Fatalf("write fest.yaml: %v", err)
+	}
+
+	seqDir := filepath.Join(dir, "001_PHASE", "01_seq")
+	if err := os.MkdirAll(seqDir, 0o755); err != nil {
+		t.Fatalf("mkdir sequence: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".fest"), 0o755); err != nil {
+		t.Fatalf("mkdir .fest: %v", err)
+	}
+
+	phaseGoal := "---\nfest_type: phase_goal\nfest_id: 001_PHASE\nfest_phase_type: implementation\n---\n# Phase Goal\n"
+	if err := os.WriteFile(filepath.Join(dir, "001_PHASE", "PHASE_GOAL.md"), []byte(phaseGoal), 0o644); err != nil {
+		t.Fatalf("write phase goal: %v", err)
+	}
+	seqGoal := "---\nfest_type: sequence_goal\nfest_id: 01_seq\n---\n# Sequence Goal\n"
+	if err := os.WriteFile(filepath.Join(seqDir, "SEQUENCE_GOAL.md"), []byte(seqGoal), 0o644); err != nil {
+		t.Fatalf("write sequence goal: %v", err)
+	}
+	taskBody := "---\nfest_type: task\nfest_id: 01_task\n---\n# Task body\n"
+	if err := os.WriteFile(filepath.Join(seqDir, "01_task.md"), []byte(taskBody), 0o644); err != nil {
+		t.Fatalf("write task: %v", err)
+	}
+
+	return dir, filepath.Join("001_PHASE", "01_seq", "01_task.md")
+}
+
+// resetTaskFlags clears the package-level flag variables between subtests since
+// the RunE functions are invoked directly and bypass cobra flag parsing.
+func resetTaskFlags() {
+	completedJSON, completedYes = false, false
+	blockedJSON, blockedYes, blockedReason = false, false, ""
+	resetJSON, resetYes = false, false
+	updateJSON = false
+	unblockJSON = false
+}
+
+// captureIO redirects stdin to an EOF (non-TTY) pipe and captures stdout for the
+// duration of fn, returning whatever fn wrote to stdout. A pipe is never a TTY,
+// so the non-interactive refusal paths are exercised deterministically
+// regardless of how the test binary is launched.
+func captureIO(t *testing.T, fn func()) string {
+	t.Helper()
+	origIn, origOut := os.Stdin, os.Stdout
+
+	rIn, wIn, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stdin pipe: %v", err)
+	}
+	_ = wIn.Close() // immediate EOF; rIn is not a terminal
+
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+
+	os.Stdin, os.Stdout = rIn, wOut
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(rOut)
+		done <- string(b)
+	}()
+
+	fn()
+
+	_ = wOut.Close()
+	os.Stdin, os.Stdout = origIn, origOut
+	out := <-done
+	_ = rIn.Close()
+	return out
+}
+
+func taskCmd(t *testing.T, festDir string) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.SetContext(scope.WithFestival(context.Background(), festDir))
+	return cmd
+}
+
+func canonicalTaskID(t *testing.T, festDir, taskRel string) string {
+	t.Helper()
+	id, _, err := resolveExplicitTask(festDir, taskRel)
+	if err != nil {
+		t.Fatalf("resolve task id: %v", err)
+	}
+	return id
+}
+
+func taskStatus(t *testing.T, festDir, taskID string) (*progress.TaskProgress, bool) {
+	t.Helper()
+	mgr, err := progress.NewManager(context.Background(), festDir)
+	if err != nil {
+		t.Fatalf("load manager: %v", err)
+	}
+	return mgr.GetTaskProgress(taskID)
+}
+
+func TestResolveConfirmation(t *testing.T) {
+	tests := []struct {
+		name          string
+		yes           bool
+		jsonOut       bool
+		wantErr       bool
+		wantPrompt    bool
+		wantStdoutHas string
+	}{
+		{name: "json_without_yes_refuses", yes: false, jsonOut: true, wantErr: true, wantStdoutHas: "confirmation required"},
+		{name: "non_tty_without_yes_refuses", yes: false, jsonOut: false, wantErr: true},
+		{name: "yes_proceeds", yes: true, jsonOut: false, wantErr: false, wantPrompt: false},
+		{name: "yes_with_json_proceeds", yes: true, jsonOut: true, wantErr: false, wantPrompt: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPrompt bool
+			var gotErr error
+			out := captureIO(t, func() {
+				gotPrompt, gotErr = resolveConfirmation(tt.yes, tt.jsonOut, "001_PHASE/01_seq/01_task.md",
+					"complete this task", "fest task completed --yes")
+			})
+			if (gotErr != nil) != tt.wantErr {
+				t.Fatalf("resolveConfirmation() err = %v, wantErr %v", gotErr, tt.wantErr)
+			}
+			if gotPrompt != tt.wantPrompt {
+				t.Errorf("resolveConfirmation() prompt = %v, want %v", gotPrompt, tt.wantPrompt)
+			}
+			if tt.wantStdoutHas != "" && !strings.Contains(out, tt.wantStdoutHas) {
+				t.Errorf("stdout = %q, want it to contain %q", out, tt.wantStdoutHas)
+			}
+		})
+	}
+}
+
+func TestRunCompleted_NonTTYRefusesWithoutYes(t *testing.T) {
+	resetTaskFlags()
+	festDir, taskRel := setupActiveFestival(t)
+	wantID := canonicalTaskID(t, festDir, taskRel)
+
+	var err error
+	_ = captureIO(t, func() { err = runCompleted(taskCmd(t, festDir), []string{taskRel}) })
+	if err == nil {
+		t.Fatal("expected refusal error without --yes in non-TTY, got nil")
+	}
+
+	if task, ok := taskStatus(t, festDir, wantID); ok && task.Status == progress.StatusCompleted {
+		t.Fatal("task must NOT be completed when confirmation was refused")
+	}
+}
+
+func TestRunCompleted_JSONRequiresYes(t *testing.T) {
+	resetTaskFlags()
+	completedJSON = true
+	festDir, taskRel := setupActiveFestival(t)
+	wantID := canonicalTaskID(t, festDir, taskRel)
+
+	var err error
+	out := captureIO(t, func() { err = runCompleted(taskCmd(t, festDir), []string{taskRel}) })
+	if err == nil {
+		t.Fatal("expected error for --json without --yes, got nil")
+	}
+	if !strings.Contains(out, "confirmation required") {
+		t.Errorf("stdout = %q, want confirmation-required JSON", out)
+	}
+	if task, ok := taskStatus(t, festDir, wantID); ok && task.Status == progress.StatusCompleted {
+		t.Fatal("task must NOT be completed when --yes is absent")
+	}
+}
+
+func TestRunCompleted_Yes(t *testing.T) {
+	resetTaskFlags()
+	completedYes = true
+	festDir, taskRel := setupActiveFestival(t)
+	wantID := canonicalTaskID(t, festDir, taskRel)
+
+	var err error
+	_ = captureIO(t, func() { err = runCompleted(taskCmd(t, festDir), []string{taskRel}) })
+	if err != nil {
+		t.Fatalf("runCompleted --yes: unexpected error: %v", err)
+	}
+
+	task, ok := taskStatus(t, festDir, wantID)
+	if !ok {
+		t.Fatal("task not found after completion")
+	}
+	if task.Status != progress.StatusCompleted {
+		t.Errorf("status = %q, want completed", task.Status)
+	}
+}
+
+func TestRunCompleted_JSONYes(t *testing.T) {
+	resetTaskFlags()
+	completedYes = true
+	completedJSON = true
+	festDir, taskRel := setupActiveFestival(t)
+
+	var err error
+	out := captureIO(t, func() { err = runCompleted(taskCmd(t, festDir), []string{taskRel}) })
+	if err != nil {
+		t.Fatalf("runCompleted --yes --json: unexpected error: %v", err)
+	}
+
+	var payload map[string]any
+	if decErr := json.Unmarshal([]byte(out), &payload); decErr != nil {
+		t.Fatalf("stdout is not valid JSON (%v): %q", decErr, out)
+	}
+	if payload["success"] != true {
+		t.Errorf("json success = %v, want true", payload["success"])
+	}
+	if payload["status"] != progress.StatusCompleted {
+		t.Errorf("json status = %v, want completed", payload["status"])
+	}
+}
+
+func TestRunBlocked_Yes(t *testing.T) {
+	resetTaskFlags()
+	blockedYes = true
+	blockedReason = "waiting on API spec"
+	festDir, taskRel := setupActiveFestival(t)
+	wantID := canonicalTaskID(t, festDir, taskRel)
+
+	var err error
+	_ = captureIO(t, func() { err = runBlocked(taskCmd(t, festDir), []string{taskRel}) })
+	if err != nil {
+		t.Fatalf("runBlocked --yes: unexpected error: %v", err)
+	}
+
+	task, ok := taskStatus(t, festDir, wantID)
+	if !ok {
+		t.Fatal("task not found after blocking")
+	}
+	if task.Status != progress.StatusBlocked {
+		t.Errorf("status = %q, want blocked", task.Status)
+	}
+	if task.BlockerMessage != "waiting on API spec" {
+		t.Errorf("blocker = %q, want the supplied reason", task.BlockerMessage)
+	}
+}
+
+func TestRunReset_Yes(t *testing.T) {
+	resetTaskFlags()
+	completedYes = true
+	festDir, taskRel := setupActiveFestival(t)
+	wantID := canonicalTaskID(t, festDir, taskRel)
+
+	// Complete, then reset back to pending.
+	_ = captureIO(t, func() { _ = runCompleted(taskCmd(t, festDir), []string{taskRel}) })
+
+	resetTaskFlags()
+	resetYes = true
+	var err error
+	_ = captureIO(t, func() { err = runReset(taskCmd(t, festDir), []string{taskRel}) })
+	if err != nil {
+		t.Fatalf("runReset --yes: unexpected error: %v", err)
+	}
+
+	task, ok := taskStatus(t, festDir, wantID)
+	if !ok {
+		t.Fatal("task not found after reset")
+	}
+	if task.Status != progress.StatusPending {
+		t.Errorf("status = %q, want pending", task.Status)
+	}
+	if task.Progress != 0 {
+		t.Errorf("progress = %d, want 0", task.Progress)
+	}
+}
+
+func TestRunUpdate(t *testing.T) {
+	resetTaskFlags()
+	festDir, taskRel := setupActiveFestival(t)
+	wantID := canonicalTaskID(t, festDir, taskRel)
+
+	var err error
+	_ = captureIO(t, func() { err = runUpdate(taskCmd(t, festDir), []string{taskRel, "50%"}) })
+	if err != nil {
+		t.Fatalf("runUpdate: unexpected error: %v", err)
+	}
+
+	task, ok := taskStatus(t, festDir, wantID)
+	if !ok {
+		t.Fatal("task not found after update")
+	}
+	if task.Progress != 50 {
+		t.Errorf("progress = %d, want 50", task.Progress)
+	}
+	if task.Status != progress.StatusInProgress {
+		t.Errorf("status = %q, want in_progress", task.Status)
+	}
+}
+
+func TestRunUnblock(t *testing.T) {
+	resetTaskFlags()
+	blockedYes = true
+	blockedReason = "need a decision"
+	festDir, taskRel := setupActiveFestival(t)
+	wantID := canonicalTaskID(t, festDir, taskRel)
+
+	_ = captureIO(t, func() { _ = runBlocked(taskCmd(t, festDir), []string{taskRel}) })
+
+	resetTaskFlags()
+	var err error
+	_ = captureIO(t, func() { err = runUnblock(taskCmd(t, festDir), []string{taskRel}) })
+	if err != nil {
+		t.Fatalf("runUnblock: unexpected error: %v", err)
+	}
+
+	task, ok := taskStatus(t, festDir, wantID)
+	if !ok {
+		t.Fatal("task not found after unblock")
+	}
+	if task.BlockerMessage != "" {
+		t.Errorf("blocker = %q, want empty after unblock", task.BlockerMessage)
+	}
+	if task.Status != progress.StatusInProgress {
+		t.Errorf("status = %q, want in_progress after unblock", task.Status)
+	}
+}
+
+func TestParsePercent(t *testing.T) {
+	valid := []struct {
+		in   string
+		want int
+	}{
+		{"0", 0}, {"0%", 0}, {"50", 50}, {"50%", 50}, {"100", 100}, {"100%", 100}, {" 75% ", 75},
+	}
+	for _, tt := range valid {
+		got, err := parsePercent(tt.in)
+		if err != nil {
+			t.Errorf("parsePercent(%q) unexpected error: %v", tt.in, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("parsePercent(%q) = %d, want %d", tt.in, got, tt.want)
+		}
+	}
+
+	invalid := []string{"-1", "101", "abc", "", "50.5"}
+	for _, in := range invalid {
+		if _, err := parsePercent(in); err == nil {
+			t.Errorf("parsePercent(%q) expected error, got nil", in)
+		}
+	}
+}
+
+func TestStatusForPercent(t *testing.T) {
+	tests := []struct {
+		pct  int
+		want string
+	}{
+		{0, progress.StatusPending},
+		{1, progress.StatusInProgress},
+		{99, progress.StatusInProgress},
+		{100, progress.StatusCompleted},
+	}
+	for _, tt := range tests {
+		if got := statusForPercent(tt.pct); got != tt.want {
+			t.Errorf("statusForPercent(%d) = %q, want %q", tt.pct, got, tt.want)
+		}
+	}
+}

--- a/internal/commands/task/mutations_test.go
+++ b/internal/commands/task/mutations_test.go
@@ -312,6 +312,29 @@ func TestRunUpdate(t *testing.T) {
 	}
 }
 
+func TestRunUpdate_100RequiresGatedCompletion(t *testing.T) {
+	resetTaskFlags()
+	festDir, taskRel := setupActiveFestival(t)
+	wantID := canonicalTaskID(t, festDir, taskRel)
+
+	var err error
+	_ = captureIO(t, func() { err = runUpdate(taskCmd(t, festDir), []string{taskRel, "100"}) })
+	if err == nil {
+		t.Fatal("runUpdate at 100% unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "fest task completed") {
+		t.Fatalf("error = %v, want gated completion guidance", err)
+	}
+
+	task, ok := taskStatus(t, festDir, wantID)
+	if ok && task.Status == progress.StatusCompleted {
+		t.Fatal("task must not be completed through fest task update 100")
+	}
+	if ok && task.Progress == 100 {
+		t.Fatal("task progress must not reach 100 through fest task update")
+	}
+}
+
 func TestRunUnblock(t *testing.T) {
 	resetTaskFlags()
 	blockedYes = true

--- a/internal/commands/task/reset.go
+++ b/internal/commands/task/reset.go
@@ -13,20 +13,29 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var resetJSON bool
+var (
+	resetJSON bool
+	resetYes  bool
+)
 
 func newResetCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "reset [task]",
-		Short: "Reset a task to pending (requires confirmation)",
-		Args:  cobra.MaximumNArgs(1),
+		Short: "Reset a task to pending",
+		Long: `Reset a task to pending, clearing all progress, time, and blocker data.
+
+By default a confirmation prompt is shown; pass --yes to skip it for
+non-interactive or agent use. --json emits a structured result and requires
+--yes.`,
+		Args: cobra.MaximumNArgs(1),
 		Annotations: map[string]string{
 			"scope": string(scope.Festival),
 		},
 		RunE: runReset,
 	}
 
-	cmd.Flags().BoolVar(&resetJSON, "json", false, "output as JSON (blocks: interactive confirmation required)")
+	cmd.Flags().BoolVar(&resetJSON, "json", false, "output as JSON (requires --yes)")
+	cmd.Flags().BoolVarP(&resetYes, "yes", "y", false, "skip the interactive confirmation prompt")
 
 	return cmd
 }
@@ -56,17 +65,11 @@ func runReset(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Require interactive mode
-	if resetJSON {
-		result := map[string]any{
-			"error":   "interactive confirmation required",
-			"task":    taskID,
-			"message": "Use 'fest task reset' without --json to reset a task interactively",
-		}
-		if encErr := shared.EncodeJSON(os.Stdout, result); encErr != nil {
-			return errors.Wrap(encErr, "encoding JSON output")
-		}
-		return errors.Validation("interactive confirmation required for task reset")
+	// Refuse before doing any work when confirmation cannot be obtained.
+	needPrompt, err := resolveConfirmation(resetYes, resetJSON, taskID,
+		"reset this task", "fest task reset --yes")
+	if err != nil {
+		return err
 	}
 
 	mgr, err := progress.NewManagerWithGate(ctx, festivalPath,
@@ -75,30 +78,39 @@ func runReset(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "loading progress")
 	}
 
-	// Show current status before reset
-	task, _ := mgr.GetTaskProgress(taskID)
-	if task != nil {
-		fmt.Printf("%s %s (%s)\n", ui.Label("Task"), ui.Value(taskID, ui.TaskColor),
-			ui.GetStateStyle(task.Status).Render(task.Status))
-		if task.Progress > 0 {
-			fmt.Printf("%s %s\n", ui.Label("Progress"), ui.Value(fmt.Sprintf("%d%%", task.Progress)))
+	if !resetJSON {
+		task, _ := mgr.GetTaskProgress(taskID)
+		if task != nil {
+			fmt.Printf("%s %s (%s)\n", ui.Label("Task"), ui.Value(taskID, ui.TaskColor),
+				ui.GetStateStyle(task.Status).Render(task.Status))
+			if task.Progress > 0 {
+				fmt.Printf("%s %s\n", ui.Label("Progress"), ui.Value(fmt.Sprintf("%d%%", task.Progress)))
+			}
+			if task.TimeSpentMinutes > 0 {
+				fmt.Printf("%s %s\n", ui.Label("Time"), ui.Value(ui.FormatDuration(task.TimeSpentMinutes)))
+			}
+		} else {
+			fmt.Printf("%s %s (%s)\n", ui.Label("Task"), ui.Value(taskID, ui.TaskColor),
+				ui.GetStateStyle(progress.StatusPending).Render(progress.StatusPending))
 		}
-		if task.TimeSpentMinutes > 0 {
-			fmt.Printf("%s %s\n", ui.Label("Time"), ui.Value(ui.FormatDuration(task.TimeSpentMinutes)))
-		}
-	} else {
-		fmt.Printf("%s %s (%s)\n", ui.Label("Task"), ui.Value(taskID, ui.TaskColor),
-			ui.GetStateStyle(progress.StatusPending).Render(progress.StatusPending))
 	}
 
-	// Interactive confirmation
-	if !confirmReset(taskID) {
+	if needPrompt && !confirmReset(taskID) {
 		fmt.Println(ui.Info("Cancelled."))
 		return nil
 	}
 
 	if err := mgr.ResetTask(ctx, taskID); err != nil {
 		return err
+	}
+
+	if resetJSON {
+		result := map[string]any{
+			"success": true,
+			"task":    taskID,
+			"status":  progress.StatusPending,
+		}
+		return shared.EncodeJSON(os.Stdout, result)
 	}
 
 	fmt.Println()

--- a/internal/commands/task/task.go
+++ b/internal/commands/task/task.go
@@ -16,9 +16,11 @@ func NewTaskCommand() *cobra.Command {
 		},
 		Long: `Commands for managing individual task status within a festival.
 
-These commands provide a simpler interface for viewing, editing, marking
-tasks complete, blocked, or resetting them. Each mutation requires
-interactive confirmation to ensure agents verify their work before proceeding.
+This is the single home for task state mutations. Consequential changes
+(completed, blocked, reset) prompt for confirmation to ensure agents verify
+their work; pass --yes to skip the prompt for non-interactive or agent use, and
+--json to emit a structured result (--json requires --yes). Progress signals
+(update, unblock) are frictionless and never prompt.
 
 Task Resolution:
   When [task] is omitted, the command auto-detects the current task:
@@ -35,8 +37,12 @@ Examples:
   fest task show 01_design.md             # Show specific task
   fest task edit                          # Open current task in editor
   fest task completed                     # Mark current task complete (Y/n)
+  fest task completed --yes               # Mark complete, no prompt (agents)
+  fest task completed --yes --json        # Mark complete, structured output
   fest task blocked --reason "need API"   # Mark task blocked (Y/n)
-  fest task reset                         # Reset task to pending (Y/n)`,
+  fest task reset                         # Reset task to pending (Y/n)
+  fest task update 50%                    # Set progress to 50%
+  fest task unblock                       # Clear a blocker, resume work`,
 	}
 
 	cmd.AddCommand(
@@ -45,6 +51,8 @@ Examples:
 		newCompletedCmd(),
 		newBlockedCmd(),
 		newResetCmd(),
+		newUpdateCmd(),
+		newUnblockCmd(),
 	)
 
 	return cmd

--- a/internal/commands/task/unblock.go
+++ b/internal/commands/task/unblock.go
@@ -1,0 +1,90 @@
+package task
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Obedience-Corp/fest/internal/commands/shared"
+	"github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/lifecycle"
+	"github.com/Obedience-Corp/fest/internal/progress"
+	"github.com/Obedience-Corp/fest/internal/scope"
+	"github.com/Obedience-Corp/fest/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+var unblockJSON bool
+
+func newUnblockCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "unblock [task]",
+		Short: "Clear a task's blocker and resume work",
+		Long: `Clear a task's blocker, returning it to in_progress.
+
+This is a frictionless forward-motion signal and does not prompt for
+confirmation. When [task] is omitted the current task is auto-detected.`,
+		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{
+			"scope": string(scope.Festival),
+		},
+		RunE: runUnblock,
+	}
+
+	cmd.Flags().BoolVar(&unblockJSON, "json", false, "output as JSON")
+
+	return cmd
+}
+
+func runUnblock(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	festivalPath, ok := scope.FestivalFrom(ctx)
+	if !ok {
+		return errors.Validation("no festival context")
+	}
+
+	var arg string
+	if len(args) > 0 {
+		arg = args[0]
+	}
+
+	taskID, _, err := resolveTask(ctx, festivalPath, arg)
+	if err != nil {
+		return err
+	}
+
+	if err := lifecycle.EnforcePreActive(ctx, festivalPath, lifecycle.EnforceOptions{
+		TaskID: taskID,
+		Reason: "fest task unblock",
+	}); err != nil {
+		return err
+	}
+
+	mgr, err := progress.NewManagerWithGate(ctx, festivalPath,
+		lifecycle.NewGateWithReason(festivalPath, "fest task unblock"))
+	if err != nil {
+		return errors.Wrap(err, "loading progress")
+	}
+
+	if err := mgr.ClearBlocker(ctx, taskID); err != nil {
+		return err
+	}
+
+	if unblockJSON {
+		result := map[string]any{
+			"success": true,
+			"task":    taskID,
+			"cleared": true,
+		}
+		return shared.EncodeJSON(os.Stdout, result)
+	}
+
+	status := progress.StatusInProgress
+	if task, ok := mgr.GetTaskProgress(taskID); ok && task != nil {
+		status = task.Status
+	}
+	fmt.Printf("%s %s (%s)\n", ui.Label("Task"), ui.Value(taskID, ui.TaskColor),
+		ui.GetStateStyle(status).Render(status))
+	fmt.Println(ui.Success("Blocker cleared: " + taskID))
+	return nil
+}

--- a/internal/commands/task/update.go
+++ b/internal/commands/task/update.go
@@ -24,7 +24,9 @@ func newUpdateCmd() *cobra.Command {
 		Long: `Update a task's progress percentage (0-100).
 
 This is a frictionless forward-motion signal and does not prompt for
-confirmation. When [task] is omitted the current task is auto-detected.`,
+confirmation. Progress must stay below 100%; use 'fest task completed' at
+100% so quality gates are evaluated. When [task] is omitted the current task
+is auto-detected.`,
 		Args: cobra.RangeArgs(1, 2),
 		Annotations: map[string]string{
 			"scope": string(scope.Festival),
@@ -57,6 +59,10 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	pct, err := parsePercent(pctArg)
 	if err != nil {
 		return err
+	}
+	if pct == 100 {
+		return errors.Validation("100% progress must be finalized with 'fest task completed'").
+			WithHint("run 'fest task completed --yes' to evaluate quality gates and complete the task")
 	}
 
 	taskID, _, err := resolveTask(ctx, festivalPath, taskArg)

--- a/internal/commands/task/update.go
+++ b/internal/commands/task/update.go
@@ -1,0 +1,129 @@
+package task
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/Obedience-Corp/fest/internal/commands/shared"
+	"github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/lifecycle"
+	"github.com/Obedience-Corp/fest/internal/progress"
+	"github.com/Obedience-Corp/fest/internal/scope"
+	"github.com/Obedience-Corp/fest/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+var updateJSON bool
+
+func newUpdateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update [task] <percent>",
+		Short: "Update a task's progress percentage",
+		Long: `Update a task's progress percentage (0-100).
+
+This is a frictionless forward-motion signal and does not prompt for
+confirmation. When [task] is omitted the current task is auto-detected.`,
+		Args: cobra.RangeArgs(1, 2),
+		Annotations: map[string]string{
+			"scope": string(scope.Festival),
+		},
+		RunE: runUpdate,
+	}
+
+	cmd.Flags().BoolVar(&updateJSON, "json", false, "output as JSON")
+
+	return cmd
+}
+
+func runUpdate(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	festivalPath, ok := scope.FestivalFrom(ctx)
+	if !ok {
+		return errors.Validation("no festival context")
+	}
+
+	var taskArg, pctArg string
+	switch len(args) {
+	case 1:
+		pctArg = args[0]
+	default:
+		taskArg = args[0]
+		pctArg = args[1]
+	}
+
+	pct, err := parsePercent(pctArg)
+	if err != nil {
+		return err
+	}
+
+	taskID, _, err := resolveTask(ctx, festivalPath, taskArg)
+	if err != nil {
+		return err
+	}
+
+	if err := lifecycle.EnforcePreActive(ctx, festivalPath, lifecycle.EnforceOptions{
+		TaskID: taskID,
+		Reason: "fest task update",
+	}); err != nil {
+		return err
+	}
+
+	mgr, err := progress.NewManagerWithGate(ctx, festivalPath,
+		lifecycle.NewGateWithReason(festivalPath, "fest task update"))
+	if err != nil {
+		return errors.Wrap(err, "loading progress")
+	}
+
+	if err := mgr.UpdateProgress(ctx, taskID, pct); err != nil {
+		return err
+	}
+
+	status := statusForPercent(pct)
+	if task, ok := mgr.GetTaskProgress(taskID); ok && task != nil {
+		status = task.Status
+	}
+
+	if updateJSON {
+		result := map[string]any{
+			"success":  true,
+			"task":     taskID,
+			"progress": pct,
+			"status":   status,
+		}
+		return shared.EncodeJSON(os.Stdout, result)
+	}
+
+	fmt.Printf("%s %s (%s)\n", ui.Label("Task"), ui.Value(taskID, ui.TaskColor),
+		ui.GetStateStyle(status).Render(status))
+	fmt.Printf("%s %s\n", ui.Label("Progress"), ui.Value(fmt.Sprintf("%d%%", pct)))
+	return nil
+}
+
+// parsePercent parses a percentage string like "50" or "50%" into an int in the
+// range 0-100.
+func parsePercent(s string) (int, error) {
+	s = strings.TrimSuffix(strings.TrimSpace(s), "%")
+	pct, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, errors.Validation("invalid percentage").WithField("value", s)
+	}
+	if pct < 0 || pct > 100 {
+		return 0, errors.Validation("percentage must be 0-100").WithField("value", pct)
+	}
+	return pct, nil
+}
+
+// statusForPercent maps a progress percentage to a task status.
+func statusForPercent(pct int) string {
+	switch {
+	case pct >= 100:
+		return progress.StatusCompleted
+	case pct > 0:
+		return progress.StatusInProgress
+	default:
+		return progress.StatusPending
+	}
+}


### PR DESCRIPTION
## Problem

There were two ways to mark a task complete, with different guardrails:

- `fest task completed`: interactive confirmation required; hard-blocked in `--json`/non-interactive mode. The human path.
- `fest progress --task X --complete`: no confirmation; evaluated quality gates and blocked on failure, otherwise frictionless. The programmatic path.

The same split existed for other task-state changes (`--update`, `--blocker`, `--clear`) living on `fest progress` alongside the read-only display. Per Lance's recorded direction (intent `consolidate-task-completion-under-fest-20260709-154346`): `fest progress` should stay for display only, task-state mutations should live only under `fest task`, and there should be one way to mark a task complete.

## Fix

Consolidate task-state mutations under `fest task`, keep `fest progress` as the display surface, and give `fest progress` mutations a deprecation shim for one release.

`fest task` (the single home for mutations):
- `completed` / `blocked` / `reset` gain `--yes` (`-y`) to skip the confirmation prompt, plus an agent-safe `--json` path. `--json` requires `--yes`; a non-interactive terminal without `--yes` now refuses with a clear error instead of silently cancelling. Quality-gate evaluation is preserved in `completed` and still blocks completion on failure (gate failures emit JSON when `--json`).
- New `fest task update [task] <percent>` and `fest task unblock [task]` are frictionless progress signals (no confirmation), giving `--update` and `--clear` a home.

`fest progress` (display only):
- Unchanged: overview, `--json`, `--watch`, `--in-progress`.
- Deprecated: `--complete`, `--update`, `--blocker`, `--clear`. They still perform the action for one release but print a deprecation notice to stderr naming the `fest task` replacement. `--json` output on stdout stays clean (warning is stderr-only), so agents parsing JSON are unaffected.

## Command-surface decisions (with reasoning)

- **`--yes` skips confirmation; `--json` requires `--yes`.** The confirmation is the "verify your work" guardrail. Rather than let `--json` bypass mutations entirely (the old hard-block), an explicit `--yes` carries that intent for agents while still refusing to mutate silently when neither a TTY nor `--yes` is present. JSON success shapes match the old `progress --complete --json` output, so existing parsers are consistent.
- **`update` and `unblock` are frictionless (no confirmation).** Confirmation is reserved for consequential/terminal changes (marking done, pausing work with a blocker, destroying progress with reset). Setting a progress percentage and clearing a blocker to resume are benign forward-motion signals, and they were frictionless under `fest progress`. Keeping them frictionless preserves capability with zero new friction.
- **`--in-progress` stays on `fest progress` and is NOT deprecated.** The intent's explicit deprecation list is `--complete/--update/--blocker/--clear` only, and it lists `--in-progress` among what `fest progress` keeps. Marking in-progress is the benign "I'm working on this" signal set during the execution loop, not a terminal mutation. Flagging this as a decision for Lance: if he wants `--in-progress` moved under `fest task` too, that is a small follow-up.

## Rollout ordering (cross-repo)

The obey daemon executor shells out to the installed `fest` binary at runtime. The companion PR (`Obedience-Corp/obey`, branch `chore/executor-fest-task-completed`) switches that call site from `fest progress --task X --complete` to `fest task completed <path> --yes`.

**This fest PR merges and releases first.** Until a `fest` release ships with `fest task completed --yes`, the deprecation shim keeps the old `fest progress --complete` invocation working, so nothing breaks in either merge order. obey is not publicly released, so there is no external compatibility burden there.

## Verification evidence

Gates (run in the worktree):
- `just build`: BUILD SUCCESSFUL
- `just test unit`: 97 packages, 2576/2576 tests passed
- `just lint all`: 0 issues

New table-driven unit tests (error cases first) cover: the confirmation resolver (json-without-yes refuse, non-TTY refuse, yes proceeds), `completed` non-TTY refuse / `--json`-requires-`--yes` / `--yes` / `--yes --json`, `blocked --yes`, `reset --yes`, `update`, `unblock`, and the deprecation shim (each deprecated flag names its replacement; `--in-progress` and read-only paths stay silent).

Real-binary smoke check (built binary, mute stdin via `/dev/null`, fixture campaign):
- `fest task completed <path>` (non-TTY, no `--yes`) -> `Error: confirmation required ... pass --yes`, exit 1, task stays `pending`.
- `fest task completed <path> --yes` -> completes, exit 0, status `completed`.
- `fest task completed <path> --yes --json` -> clean JSON `{"success":true,"status":"completed",...}` on stdout, exit 0.
- `fest task completed <path> --json` (no `--yes`) -> confirmation-required JSON, exit 1, task not completed.
- `fest progress --task <path> --complete` -> still completes AND prints the deprecation notice to stderr; with `--json`, stdout JSON stays clean.

## Reference

Intent: `consolidate-task-completion-under-fest-20260709-154346`
