### PR TITLE
chore: add VHS recording recipes

### DIFF
--- a/.justfiles/vhs.just
+++ b/.justfiles/vhs.just
@@ -1,0 +1,31 @@
+# VHS recording helpers for Fest demos and integration fixtures.
+#
+# Record a tape with: just vhs record path/to/demo.tape
+# Create a PR-ready Gist with: just vhs gist out/demo.gif
+
+termcast := env_var_or_default("TERMCAST_BIN", "termcast")
+
+[private]
+default:
+    @just --list --justfile {{source_file()}}
+
+# Verify the binaries required by VHS are available.
+doctor:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for tool in vhs ttyd ffmpeg; do
+        command -v "$tool" >/dev/null 2>&1 || {
+            echo "vhs: missing required tool: $tool" >&2
+            exit 1
+        }
+    done
+    vhs --version
+
+# Record one VHS tape. The tape owns its output path and setup commands.
+record tape:
+    vhs "{{tape}}"
+
+# Create a GitHub Gist and print the PR-ready Markdown embed.
+# Additional arguments are passed to termcast gist (for example, --public).
+gist gif *args:
+    {{termcast}} gist "{{gif}}" {{args}}

--- a/Justfile
+++ b/Justfile
@@ -31,6 +31,8 @@ mod install '.justfiles/install.just'
 [doc('Linting (golangci-lint, gopls, vet)')]
 mod lint '.justfiles/lint.just'
 
+[doc('Record terminal workflows with VHS')]
+mod vhs '.justfiles/vhs.just'
 
 [private]
 default:


### PR DESCRIPTION
## Summary

- add a project-local `vhs` Justfile module
- expose `just vhs doctor` to check VHS, ttyd, and ffmpeg
- expose `just vhs record <tape>` for direct VHS recordings
- expose `just vhs gist <gif> [options]` through the existing Termcast Gist formatter

## Why

Project-owned VHS recipes keep recording workflows close to the Camp/Fest/Obey
code they demonstrate. VHS remains the recording engine; Termcast is used only
for the shared PR-ready Gist formatting step.

## Validation

- `git diff --check`
- `just --list`
- `just vhs`
- `just vhs doctor`
- `just --dry-run vhs record docs/demo.tape`
- `TERMCAST_BIN=printf just vhs gist out/demo.gif --markdown-only`
