### PR TITLE
deps: bump obey-shared to v0.4.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.6
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/Obedience-Corp/camp v0.3.0-rc.2
-	github.com/Obedience-Corp/obey-shared v0.4.4
+	github.com/Obedience-Corp/obey-shared v0.4.5
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/Obedience-Corp/camp v0.3.0-rc.2 h1:a0GCh/E69AlvDmsE14zcXmcB31rGtq3Zf7
 github.com/Obedience-Corp/camp v0.3.0-rc.2/go.mod h1:0K3f98p4IDeC1IFZoX0g7k3aGr1LAy5rF2SYA6iwMxc=
 github.com/Obedience-Corp/obey-shared v0.4.4 h1:BLsOvnvZ0ViHLFVOQ5i1zC3+sa+XLMXhsX67ueMTGpY=
 github.com/Obedience-Corp/obey-shared v0.4.4/go.mod h1:X7xXZJ/S8Ek7s6dsihrnpFLnBykOkv2dQnHv+sRHx/Q=
+github.com/Obedience-Corp/obey-shared v0.4.5 h1:xc79WYccpToLTKOjLqcdRDyGp2Mu9U0WUAwfDaIHX5M=
+github.com/Obedience-Corp/obey-shared v0.4.5/go.mod h1:VZ9rp2YklgdlipSr7aUlOHbmNjrRjif4qHybkLdn6ic=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/chroma/v2 v2.23.1 h1:nv2AVZdTyClGbVQkIzlDm/rnhk1E9bU9nXwmZ/Vk/iY=


### PR DESCRIPTION
## What changed\n\n- Bump github.com/Obedience-Corp/obey-shared from v0.4.4 to v0.4.5.\n- Update the corresponding go.sum entries.\n\n## Why\n\nConsume the released shared brand theme and flame-logo primitives from the clean remote-main consumer branch.\n\n## Validation\n\n- go mod verify\n- just test unit-raw\n- just build dashboard\n- just lint vet\n- just test integration — 69/69 tests passed