### PR TITLE
chore: standardize VHS evidence recipes

### DIFF
--- a/.justfiles/vhs.just
+++ b/.justfiles/vhs.just
@@ -4,6 +4,8 @@
 # Build and validate its evidence with: just vhs bundle <evidence-dir> <binary> <tape> <fixture-id> <states...>
 # Create a secret-Gist handoff with: just vhs gist out/demo.gif
 
+set positional-arguments
+
 [private]
 default:
     @just --list --justfile {{source_file()}}
@@ -30,12 +32,16 @@ record tape:
 bundle evidence_dir binary tape fixture_id +states:
     #!/usr/bin/env bash
     set -euo pipefail
-    campaign_root="${CAMP_ROOT:-$(camp root 2>/dev/null || true)}"
-    [[ -n "$campaign_root" ]] || {
-        echo "vhs: campaign root not found; set CAMP_ROOT or VHS_PRIVATE_GIST_ROOT" >&2
-        exit 1
-    }
-    skill_root="${VHS_PRIVATE_GIST_ROOT:-$campaign_root/.campaign/skills/vhs-private-gist}"
+    if [[ -n "${VHS_PRIVATE_GIST_ROOT:-}" ]]; then
+        skill_root="$VHS_PRIVATE_GIST_ROOT"
+    else
+        campaign_root="${CAMP_ROOT:-$(camp root 2>/dev/null || true)}"
+        [[ -n "$campaign_root" ]] || {
+            echo "vhs: campaign root not found; set CAMP_ROOT or VHS_PRIVATE_GIST_ROOT" >&2
+            exit 1
+        }
+        skill_root="$campaign_root/.campaign/skills/vhs-private-gist"
+    fi
     validator="$skill_root/scripts/validate-evidence.py"
     optimizer="$skill_root/scripts/optimize-gif.sh"
     metadata="$skill_root/scripts/collect-artifact-metadata.py"
@@ -109,8 +115,12 @@ bundle evidence_dir binary tape fixture_id +states:
 gist gif *args:
     #!/usr/bin/env bash
     set -euo pipefail
-    campaign_root="${CAMP_ROOT:-$(camp root 2>/dev/null || true)}"
-    [[ -n "$campaign_root" ]] || { echo "vhs: campaign root not found" >&2; exit 1; }
-    helper="${VHS_PRIVATE_GIST_ROOT:-$campaign_root/.campaign/skills/vhs-private-gist}/scripts/publish-secret-gist.sh"
+    if [[ -n "${VHS_PRIVATE_GIST_ROOT:-}" ]]; then
+        helper="$VHS_PRIVATE_GIST_ROOT/scripts/publish-secret-gist.sh"
+    else
+        campaign_root="${CAMP_ROOT:-$(camp root 2>/dev/null || true)}"
+        [[ -n "$campaign_root" ]] || { echo "vhs: campaign root not found" >&2; exit 1; }
+        helper="$campaign_root/.campaign/skills/vhs-private-gist/scripts/publish-secret-gist.sh"
+    fi
     [[ -x "$helper" ]] || { echo "vhs: missing shared Gist helper: $helper" >&2; exit 1; }
-    exec "$helper" "{{gif}}" {{args}}
+    exec "$helper" "{{gif}}" "${@:2}"

--- a/.justfiles/vhs.just
+++ b/.justfiles/vhs.just
@@ -1,9 +1,8 @@
 # VHS recording helpers for Fest demos and integration fixtures.
 #
 # Record a tape with: just vhs record path/to/demo.tape
-# Create a PR-ready Gist with: just vhs gist out/demo.gif
-
-termcast := env_var_or_default("TERMCAST_BIN", "termcast")
+# Build and validate its evidence with: just vhs bundle <evidence-dir> <binary> <tape> <fixture-id> <states...>
+# Create a secret-Gist handoff with: just vhs gist out/demo.gif
 
 [private]
 default:
@@ -13,7 +12,7 @@ default:
 doctor:
     #!/usr/bin/env bash
     set -euo pipefail
-    for tool in vhs ttyd ffmpeg; do
+    for tool in vhs ttyd ffmpeg ffprobe python3 gh git curl fest; do
         command -v "$tool" >/dev/null 2>&1 || {
             echo "vhs: missing required tool: $tool" >&2
             exit 1
@@ -25,7 +24,74 @@ doctor:
 record tape:
     vhs "{{tape}}"
 
-# Create a GitHub Gist and print the PR-ready Markdown embed.
-# Additional arguments are passed to termcast gist (for example, --public).
+# Optimize, scan, and validate one complete evidence bundle. PTY metadata,
+# pyte snapshots, dependencies.txt, and pty-transcript.txt must already exist
+# in evidence_dir; raw GIFs stay in that evidence directory and are not uploaded.
+bundle evidence_dir binary tape fixture_id +states:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    campaign_root="${CAMP_ROOT:-$(camp root 2>/dev/null || true)}"
+    [[ -n "$campaign_root" ]] || {
+        echo "vhs: campaign root not found; set CAMP_ROOT or VHS_PRIVATE_GIST_ROOT" >&2
+        exit 1
+    }
+    skill_root="${VHS_PRIVATE_GIST_ROOT:-$campaign_root/.campaign/skills/vhs-private-gist}"
+    validator="$skill_root/scripts/validate-evidence.py"
+    optimizer="$skill_root/scripts/optimize-gif.sh"
+    metadata="$skill_root/scripts/collect-artifact-metadata.py"
+    privacy="$skill_root/scripts/scan-privacy.py"
+    for required in "$validator" "$optimizer" "$metadata" "$privacy"; do
+        [[ -f "$required" ]] || { echo "vhs: missing shared helper: $required" >&2; exit 1; }
+    done
+
+    evidence_dir="{{evidence_dir}}"
+    binary="{{binary}}"
+    tape="{{tape}}"
+    fixture_id="{{fixture_id}}"
+    mkdir -p "$evidence_dir"
+    "$optimizer" "$evidence_dir/raw.gif" "$evidence_dir/optimized.gif"
+    python3 "$metadata" \
+        --raw "$evidence_dir/raw.gif" \
+        --optimized "$evidence_dir/optimized.gif" \
+        --output "$evidence_dir/artifact-metadata.json"
+    python3 "$privacy" \
+        --repo-root "$PWD" \
+        --output "$evidence_dir/privacy-scan.txt" \
+        --path "$tape" \
+        --path "$evidence_dir/pty-transcript.txt" \
+        --path "$evidence_dir/pty-metadata.json" \
+        --path "$evidence_dir/screen-snapshots.json" \
+        --path "$evidence_dir/artifact-metadata.json"
+
+    expected=()
+    for state in {{states}}; do
+        expected+=(--expect-state "$state")
+    done
+    recorded_at=()
+    if [[ -n "${VHS_RECORDED_AT:-}" ]]; then
+        recorded_at=(--recorded-at "$VHS_RECORDED_AT")
+    fi
+    python3 "$validator" \
+        --evidence-dir "$evidence_dir" \
+        --repository fest \
+        --journey "${VHS_JOURNEY:-$(basename "$tape" .tape)}" \
+        --source-revision "$(git rev-parse HEAD)" \
+        --fixture-id "$fixture_id" \
+        --binary "$binary" \
+        --tape "$tape" \
+        --dependencies "$evidence_dir/dependencies.txt" \
+        "${expected[@]}" \
+        "${recorded_at[@]}" \
+        --validation-command "just vhs bundle $evidence_dir $binary $tape $fixture_id" \
+        --repo-root "$PWD"
+
+# Create a secret/unlisted GitHub Gist and print the PR-ready Markdown embed.
+# The shared helper rejects --public; publication never defaults to public.
 gist gif *args:
-    {{termcast}} gist "{{gif}}" {{args}}
+    #!/usr/bin/env bash
+    set -euo pipefail
+    campaign_root="${CAMP_ROOT:-$(camp root 2>/dev/null || true)}"
+    [[ -n "$campaign_root" ]] || { echo "vhs: campaign root not found" >&2; exit 1; }
+    helper="${VHS_PRIVATE_GIST_ROOT:-$campaign_root/.campaign/skills/vhs-private-gist}/scripts/publish-secret-gist.sh"
+    [[ -x "$helper" ]] || { echo "vhs: missing shared Gist helper: $helper" >&2; exit 1; }
+    exec "$helper" "{{gif}}" {{args}}

--- a/.justfiles/vhs.just
+++ b/.justfiles/vhs.just
@@ -56,8 +56,10 @@ bundle evidence_dir binary tape fixture_id +states:
         --output "$evidence_dir/artifact-metadata.json"
     python3 "$privacy" \
         --repo-root "$PWD" \
-        --output "$evidence_dir/privacy-scan.txt" \
+        --output "$evidence_dir/privacy-scan-pre.txt" \
         --path "$tape" \
+        --path "$evidence_dir/raw.gif" \
+        --path "$evidence_dir/optimized.gif" \
         --path "$evidence_dir/pty-transcript.txt" \
         --path "$evidence_dir/pty-metadata.json" \
         --path "$evidence_dir/screen-snapshots.json" \
@@ -71,19 +73,36 @@ bundle evidence_dir binary tape fixture_id +states:
     if [[ -n "${VHS_RECORDED_AT:-}" ]]; then
         recorded_at=(--recorded-at "$VHS_RECORDED_AT")
     fi
-    python3 "$validator" \
-        --evidence-dir "$evidence_dir" \
-        --repository fest \
-        --journey "${VHS_JOURNEY:-$(basename "$tape" .tape)}" \
-        --source-revision "$(git rev-parse HEAD)" \
-        --fixture-id "$fixture_id" \
-        --binary "$binary" \
-        --tape "$tape" \
-        --dependencies "$evidence_dir/dependencies.txt" \
-        "${expected[@]}" \
-        "${recorded_at[@]}" \
-        --validation-command "just vhs bundle $evidence_dir $binary $tape $fixture_id" \
-        --repo-root "$PWD"
+    validate_bundle() {
+        local privacy_scan=$1
+        python3 "$validator" \
+            --evidence-dir "$evidence_dir" \
+            --repository fest \
+            --journey "${VHS_JOURNEY:-$(basename "$tape" .tape)}" \
+            --source-revision "$(git rev-parse HEAD)" \
+            --fixture-id "$fixture_id" \
+            --binary "$binary" \
+            --tape "$tape" \
+            --dependencies "$evidence_dir/dependencies.txt" \
+            --privacy-scan "$privacy_scan" \
+            "${expected[@]}" \
+            "${recorded_at[@]}" \
+            --validation-command "just vhs bundle $evidence_dir $binary $tape $fixture_id" \
+            --repo-root "$PWD"
+    }
+    validate_bundle "$evidence_dir/privacy-scan-pre.txt"
+    python3 "$privacy" \
+        --repo-root "$PWD" \
+        --output "$evidence_dir/privacy-scan.txt" \
+        --path "$tape" \
+        --path "$evidence_dir/raw.gif" \
+        --path "$evidence_dir/optimized.gif" \
+        --path "$evidence_dir/pty-transcript.txt" \
+        --path "$evidence_dir/pty-metadata.json" \
+        --path "$evidence_dir/screen-snapshots.json" \
+        --path "$evidence_dir/artifact-metadata.json" \
+        --path "$evidence_dir/manifest.json"
+    validate_bundle "$evidence_dir/privacy-scan.txt"
 
 # Create a secret/unlisted GitHub Gist and print the PR-ready Markdown embed.
 # The shared helper rejects --public; publication never defaults to public.


### PR DESCRIPTION
## Summary

- wire Fest VHS bundle to the campaign shared optimizer, metadata collector, privacy scanner, and fail-closed validator
- replace the direct termcast/public-capable path with the secret-Gist helper
- keep raw evidence local and make campaign-root discovery explicit

## Verification

- just list for the VHS module
- VHS doctor passed
- dry-run bundle recipe parsed successfully
- shared validator self-test passed from CF0004

Based on current remote main at d753f782.