### PR TITLE
feat(workflow): surface judge followups so blocked agents can fix and continue

### DIFF
--- a/embedded/templates/agent/workflow/step.tmpl
+++ b/embedded/templates/agent/workflow/step.tmpl
@@ -56,7 +56,10 @@ EXAMPLE OUTPUT:
 Progress: Step {{.StepNumber}}/{{.TotalSteps}} | Phase: {{.PhaseName}} | Type: {{.PhaseType}}
 {{if eq .Status "blocked"}}
 This step is BLOCKED: {{.Feedback}}
-
+{{if .Followups}}
+Fixes the judge requires (address every item, then re-submit):
+{{range .Followups}}  - {{.}}
+{{end}}{{end}}
 Address the feedback and try again.
 {{if .JudgeRetryAvailable}}
 When the revised evidence is ready, re-run the approval judge:

--- a/internal/commands/shared/workflow_render.go
+++ b/internal/commands/shared/workflow_render.go
@@ -24,6 +24,7 @@ type WorkflowStepView struct {
 	HasCheckpoint bool
 	Goal          string
 	Feedback      string
+	Followups     []string
 	Judge         *wf.JudgeState
 }
 
@@ -98,6 +99,16 @@ func RenderWorkflowStepLine(step WorkflowStepView, compact bool) string {
 			fmt.Fprintf(&sb, "     %s: %s\n", ui.Error("Feedback"), feedback)
 		case wf.StepStatusSkipped, wf.StepStatusCompleted:
 			fmt.Fprintf(&sb, "     %s: %s\n", ui.Warning("Note"), feedback)
+		}
+	}
+
+	if !compact && len(step.Followups) > 0 &&
+		(step.Status == wf.StepStatusBlocked || step.Status == wf.StepStatusFailedRemediation) {
+		fmt.Fprintf(&sb, "     %s:\n", ui.Error("Fixes required"))
+		for i, f := range step.Followups {
+			if f = strings.TrimSpace(f); f != "" {
+				fmt.Fprintf(&sb, "       %d. %s\n", i+1, f)
+			}
 		}
 	}
 
@@ -176,10 +187,12 @@ func LoadWorkflowStepsForPhase(ctx context.Context, festivalPath, phasePath stri
 		stepState := state.GetStepState(step.Number)
 		status := wf.StepStatusPending
 		feedback := ""
+		var followups []string
 		var judge *wf.JudgeState
 		if stepState != nil {
 			status = stepState.Status
 			feedback = wf.DisplayFeedback(stepState.Feedback)
+			followups = stepState.Followups
 			judge = stepState.Judge
 		}
 
@@ -191,6 +204,7 @@ func LoadWorkflowStepsForPhase(ctx context.Context, festivalPath, phasePath stri
 			HasCheckpoint: step.HasCheckpoint(),
 			Goal:          step.Goal,
 			Feedback:      feedback,
+			Followups:     followups,
 			Judge:         judge,
 		}
 	}
@@ -273,10 +287,12 @@ func LoadGateStepsForPhase(ctx context.Context, festivalPath, phasePath string) 
 		stepState := state.GetStepState(step.Number)
 		status := wf.StepStatusPending
 		feedback := ""
+		var followups []string
 		var judge *wf.JudgeState
 		if stepState != nil {
 			status = stepState.Status
 			feedback = wf.DisplayFeedback(stepState.Feedback)
+			followups = stepState.Followups
 			judge = stepState.Judge
 		}
 
@@ -288,6 +304,7 @@ func LoadGateStepsForPhase(ctx context.Context, festivalPath, phasePath string) 
 			HasCheckpoint: step.HasCheckpoint(),
 			Goal:          step.Goal,
 			Feedback:      feedback,
+			Followups:     followups,
 			Judge:         judge,
 		}
 	}

--- a/internal/commands/workflow/approval_guidance.go
+++ b/internal/commands/workflow/approval_guidance.go
@@ -56,3 +56,31 @@ func printApprovalRecoveryFor(ctx context.Context, nav *wf.Navigator, step wf.Wo
 		fmt.Println(line)
 	}
 }
+
+// judgeFollowupLines renders a judge's itemized fixes as numbered, indented
+// lines under a header. Empty followups (a judge that gave only a reason)
+// produce no output so callers can print unconditionally.
+func judgeFollowupLines(followups []string) []string {
+	cleaned := make([]string, 0, len(followups))
+	for _, f := range followups {
+		if f = strings.TrimSpace(f); f != "" {
+			cleaned = append(cleaned, f)
+		}
+	}
+	if len(cleaned) == 0 {
+		return nil
+	}
+	lines := []string{"  " + ui.Label("Fixes the judge requires") + ":"}
+	for i, f := range cleaned {
+		lines = append(lines, fmt.Sprintf("    %d. %s", i+1, f))
+	}
+	return lines
+}
+
+// printJudgeFollowups writes the judge's itemized fixes to stdout. No-op when
+// the judge returned no followups.
+func printJudgeFollowups(followups []string) {
+	for _, line := range judgeFollowupLines(followups) {
+		fmt.Println(line)
+	}
+}

--- a/internal/commands/workflow/approve.go
+++ b/internal/commands/workflow/approve.go
@@ -606,7 +606,7 @@ func reopenJudgeRejectionIfRequested(ctx context.Context, nav *wf.Navigator, ste
 }
 
 func applyApproveAutoVerdict(ctx context.Context, nav *wf.Navigator, currentStepNum int, step wf.WorkflowStep, runID string, decision *approvalJudgeResponse, audit string) (bool, error) {
-	judgeDecision := wf.DecisionMetadata{Actor: decisionActorAgent, Summary: decision.Reason}
+	judgeDecision := wf.DecisionMetadata{Actor: decisionActorAgent, Summary: decision.Reason, Followups: decision.Followups}
 
 	switch decision.Decision {
 	case "approve":
@@ -629,7 +629,9 @@ func applyApproveAutoVerdict(ctx context.Context, nav *wf.Navigator, currentStep
 			return false, nil
 		}
 		fmt.Printf("%s Step %d: %s auto-rejected\n", ui.Warning("⚠"), currentStepNum, step.Name)
-		fmt.Printf("  %s: %s\n\n", ui.Label("Reason"), decision.Reason)
+		fmt.Printf("  %s: %s\n", ui.Label("Reason"), decision.Reason)
+		printJudgeFollowups(decision.Followups)
+		fmt.Println()
 		fmt.Println("The step is now blocked. Address the feedback and revise the work.")
 		printApprovalRecoveryFor(ctx, nav, step)
 		return true, nil

--- a/internal/commands/workflow/judge_exec.go
+++ b/internal/commands/workflow/judge_exec.go
@@ -414,7 +414,7 @@ func runJudgeExec(ctx context.Context, payloadPath string) error {
 		if decision.Decision == "reject" {
 			verdict = continuation.VerdictRejected
 		}
-		fireJudgeContinuation(ctx, nav, payload, verdict, decision.Reason)
+		fireJudgeContinuation(ctx, nav, payload, verdict, decision.Reason, decision.Followups...)
 	}
 	return nil
 }
@@ -488,7 +488,7 @@ func recordJudgeFailureIfOwned(ctx context.Context, nav *wf.Navigator, payload j
 // It is a no-op when no session identity was captured at launch. A submission
 // failure is isolated: the judge outcome is already authoritative, so the error
 // only degrades to the manual next-step instruction and never propagates.
-func fireJudgeContinuation(ctx context.Context, nav *wf.Navigator, payload judgeExecPayload, verdict continuation.Verdict, feedback string) {
+func fireJudgeContinuation(ctx context.Context, nav *wf.Navigator, payload judgeExecPayload, verdict continuation.Verdict, feedback string, followups ...string) {
 	if payload.TargetSessionID == "" {
 		return
 	}
@@ -504,6 +504,7 @@ func fireJudgeContinuation(ctx context.Context, nav *wf.Navigator, payload judge
 		StepName:      payload.StepName,
 		Verdict:       verdict,
 		Feedback:      feedback,
+		Followups:     followups,
 	}
 	if err := judgeContinuationNotifier.Notify(ctx, continuation.BuildNotification(result)); err != nil {
 		fmt.Printf("%s judge result recorded; continuation notice to the originating session was not delivered: %v\n",

--- a/internal/commands/workflow/status.go
+++ b/internal/commands/workflow/status.go
@@ -76,10 +76,12 @@ func runStatus(ctx context.Context, jsonOutput bool) error {
 		stepState := state.GetStepState(step.Number)
 		status := wf.StepStatusPending
 		feedback := ""
+		var followups []string
 		var judge *wf.JudgeState
 		if stepState != nil {
 			status = stepState.Status
 			feedback = wf.DisplayFeedback(stepState.Feedback)
+			followups = stepState.Followups
 			judge = stepState.Judge
 			if stepState.Status == wf.StepStatusFailedRemediation {
 				failedRemediation[i] = stepState
@@ -94,6 +96,7 @@ func runStatus(ctx context.Context, jsonOutput bool) error {
 			HasCheckpoint: step.HasCheckpoint(),
 			Goal:          step.Goal,
 			Feedback:      feedback,
+			Followups:     followups,
 			Judge:         judge,
 		}
 	}

--- a/internal/continuation/continuation.go
+++ b/internal/continuation/continuation.go
@@ -46,6 +46,9 @@ const (
 	// maxFeedbackLen bounds rendered feedback so a malformed or oversized
 	// judge reason cannot produce an unbounded agent message.
 	maxFeedbackLen = 500
+	// maxFollowups bounds the number of judge fix items rendered into a
+	// continuation message so a malformed verdict cannot make it unbounded.
+	maxFollowups = 12
 )
 
 // Verdict is the terminal judge outcome carried at the transport layer.
@@ -138,6 +141,9 @@ type JudgeResult struct {
 	StepName      string
 	Verdict       Verdict
 	Feedback      string
+	// Followups carries the judge's itemized fixes for a rejection so the
+	// resumed session receives the concrete revise list, not just the reason.
+	Followups []string
 }
 
 // DeliveryID derives the deterministic, retry-stable delivery id for a run.
@@ -165,8 +171,8 @@ func RenderMessage(r JudgeResult) string {
 	case VerdictApproved:
 		return fmt.Sprintf("Approval judge approved %s.\nContinue with: %s", loc, next)
 	case VerdictRejected:
-		return fmt.Sprintf("Approval judge rejected %s.\nFeedback: %s\nAddress the feedback, then run: %s",
-			loc, sanitizeFeedback(r.Feedback), next)
+		return fmt.Sprintf("Approval judge rejected %s.\nFeedback: %s%s\nAddress the feedback, then run: %s",
+			loc, sanitizeFeedback(r.Feedback), renderFollowups(r.Followups), next)
 	case VerdictFailed:
 		return fmt.Sprintf("Approval judge failed for %s.\nFeedback: %s\nInspect the judge configuration or evidence, then run: %s",
 			loc, sanitizeFeedback(r.Feedback), next)
@@ -195,6 +201,36 @@ func BuildNotification(r JudgeResult) SessionNotification {
 			"verdict":     string(r.Verdict),
 		},
 	}
+}
+
+// renderFollowups formats the judge's itemized fixes as an indented list
+// appended after the feedback line. It returns "" when there are no usable
+// followups so the rejection message is unchanged for a reason-only verdict.
+// Each item is sanitized and bounded, and the count is capped, so a malformed
+// verdict cannot produce an unbounded message.
+func renderFollowups(followups []string) string {
+	if len(followups) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("\nFixes required:")
+	n := 0
+	for _, f := range followups {
+		item := sanitizeFeedback(f)
+		if item == "(no detail provided)" {
+			continue
+		}
+		b.WriteString("\n- ")
+		b.WriteString(item)
+		n++
+		if n >= maxFollowups {
+			break
+		}
+	}
+	if n == 0 {
+		return ""
+	}
+	return b.String()
 }
 
 // sanitizeFeedback collapses whitespace, strips control characters, and bounds

--- a/internal/continuation/continuation_test.go
+++ b/internal/continuation/continuation_test.go
@@ -128,6 +128,48 @@ func TestRenderMessageRejection(t *testing.T) {
 	if !strings.HasSuffix(msg, "run: fest workflow judge") {
 		t.Fatalf("rejection message must end with the rejudge command: %q", msg)
 	}
+	if strings.Contains(msg, "Fixes required:") {
+		t.Fatalf("rejection with no followups must not render a fixes list: %q", msg)
+	}
+}
+
+func TestRenderMessageRejectionFollowups(t *testing.T) {
+	r := approvalResult()
+	r.Verdict = VerdictRejected
+	r.Feedback = "missing acceptance proof"
+	r.Followups = []string{"Attach the test console output.", "Include the ledger transition as captured output."}
+	msg := RenderMessage(r)
+	if !strings.Contains(msg, "Feedback: missing acceptance proof") {
+		t.Fatalf("rejection message missing feedback: %q", msg)
+	}
+	if !strings.Contains(msg, "Fixes required:") {
+		t.Fatalf("rejection message missing fixes list: %q", msg)
+	}
+	for _, f := range r.Followups {
+		if !strings.Contains(msg, "- "+f) {
+			t.Fatalf("rejection message missing followup %q: %q", f, msg)
+		}
+	}
+	// The itemized fixes precede the closing rejudge instruction.
+	if !strings.HasSuffix(msg, "Address the feedback, then run: fest workflow judge") {
+		t.Fatalf("rejection message must end with the rejudge instruction: %q", msg)
+	}
+}
+
+func TestRenderFollowupsBoundsAndSanitizes(t *testing.T) {
+	// Count is capped so a malformed verdict cannot make the message unbounded.
+	many := make([]string, maxFollowups+5)
+	for i := range many {
+		many[i] = "fix item"
+	}
+	got := renderFollowups(many)
+	if n := strings.Count(got, "\n- "); n != maxFollowups {
+		t.Fatalf("rendered %d items, want cap of %d", n, maxFollowups)
+	}
+	// Blank/whitespace-only items are dropped rather than rendered empty.
+	if renderFollowups([]string{"   ", ""}) != "" {
+		t.Fatalf("blank followups must render nothing")
+	}
 }
 
 func TestRenderMessageFailure(t *testing.T) {

--- a/internal/guidance/workflow/decision_test.go
+++ b/internal/guidance/workflow/decision_test.go
@@ -53,6 +53,42 @@ func TestWorkflowStateRejectWithDecision(t *testing.T) {
 	}
 }
 
+func TestWorkflowStateRejectStoresAndEmitsFollowups(t *testing.T) {
+	state := NewWorkflowState(1)
+	state.StartCurrentStep()
+
+	followups := []string{"attach console output", "capture the ledger transition"}
+	state.RejectWithDecision("thin evidence", DecisionMetadata{
+		Actor:     "agent",
+		Summary:   "thin evidence",
+		Followups: followups,
+	})
+
+	step := state.GetStepState(1)
+	if len(step.Followups) != len(followups) {
+		t.Fatalf("stored followups = %v, want %v", step.Followups, followups)
+	}
+
+	// The block event that persists to the log must carry the same fix list so
+	// the followups survive an event-sourced reload, not only the in-memory state.
+	events := EmitStepBlockWithDecisionEvents("gate:001_IMPLEMENT", 1, "thin evidence", DecisionMetadata{
+		Actor:     "agent",
+		Summary:   "thin evidence",
+		Followups: followups,
+	})
+	if len(events) != 1 || len(events[0].Followups) != len(followups) {
+		t.Fatalf("emitted event followups = %+v, want %v", events, followups)
+	}
+
+	// A judge re-run (reopen) clears the fix list along with the rejection.
+	if !state.ReopenJudgeRejection(1) {
+		t.Fatal("ReopenJudgeRejection = false, want reopened")
+	}
+	if step := state.GetStepState(1); len(step.Followups) != 0 {
+		t.Fatalf("followups after reopen = %v, want empty", step.Followups)
+	}
+}
+
 func TestWorkflowStateRecheckClearsDecision(t *testing.T) {
 	state := NewWorkflowState(1)
 	state.StartCurrentStep()

--- a/internal/guidance/workflow/navigator_format.go
+++ b/internal/guidance/workflow/navigator_format.go
@@ -193,6 +193,7 @@ func (n *Navigator) formatStep(ctx context.Context, step WorkflowStep, stepState
 		"IsBlocking":          step.Checkpoint.IsBlocking(),
 		"Status":              status,
 		"Feedback":            feedback,
+		"Followups":           stepState.Followups,
 		"CurrentStep":         n.workflowState.CurrentStep,
 		"IsGate":              isGate,
 		"JudgeConfigured":     n.approvalJudgeConfigured(ctx),

--- a/internal/guidance/workflow/state.go
+++ b/internal/guidance/workflow/state.go
@@ -49,6 +49,7 @@ type WorkflowEvent struct {
 	RemediationPhase string
 	DecisionActor    string
 	DecisionSummary  string
+	Followups        []string
 	JudgeStatus      string
 	JudgeCommand     string
 	JudgeDetail      string
@@ -60,6 +61,9 @@ type WorkflowEvent struct {
 type DecisionMetadata struct {
 	Actor   string
 	Summary string
+	// Followups carries the judge's concrete, itemized fixes for a rejection
+	// so a blocked agent knows exactly what to revise before re-submitting.
+	Followups []string
 }
 
 // Judge lifecycle status values recorded on StepState.Judge.
@@ -203,6 +207,10 @@ type StepState struct {
 
 	// Feedback stores rejection reasons or notes.
 	Feedback string `yaml:"feedback,omitempty" json:"feedback,omitempty"`
+
+	// Followups stores the judge's itemized fixes for a blocked step so a
+	// blocked agent has a concrete revise list, not just the one-line reason.
+	Followups []string `yaml:"followups,omitempty" json:"followups,omitempty"`
 
 	// RemediationPhase is the linked phase name for a step in
 	// StepStatusFailedRemediation. Empty for any other status.
@@ -587,6 +595,7 @@ func (s *WorkflowState) RejectWithDecision(feedback string, decision DecisionMet
 	s.cancelCurrentJudge("superseded by manual rejection")
 	state.Status = StepStatusBlocked
 	state.Feedback = feedback
+	state.Followups = decision.Followups
 	state.RemediationPhase = ""
 	if decision.Actor != "agent" && state.Judge != nil && state.Judge.Status != JudgeCanceled {
 		// Replace any prior terminal judge outcome so a later judge command
@@ -610,6 +619,7 @@ func (s *WorkflowState) RejectWithRemediationDecision(feedback, remediationPhase
 	s.cancelCurrentJudge("superseded by manual remediation decision")
 	state.Status = StepStatusFailedRemediation
 	state.Feedback = feedback
+	state.Followups = decision.Followups
 	state.RemediationPhase = remediationPhase
 	if decision.Actor != "agent" && state.Judge != nil && state.Judge.Status != JudgeCanceled {
 		state.Judge = nil
@@ -650,6 +660,7 @@ func (s *WorkflowState) ClearFailedRemediation() {
 	}
 	state.Status = StepStatusInProgress
 	state.RemediationPhase = ""
+	state.Followups = nil
 	state.DecisionActor = ""
 	state.DecisionSummary = ""
 	state.DecisionAt = nil
@@ -666,6 +677,7 @@ func (s *WorkflowState) ReopenJudgeRejection(step int) bool {
 	state := s.GetOrCreateStepState(step)
 	state.Status = StepStatusInProgress
 	state.Feedback = ""
+	state.Followups = nil
 	state.RemediationPhase = ""
 	state.DecisionActor = ""
 	state.DecisionSummary = ""
@@ -683,6 +695,7 @@ func (s *WorkflowState) Reset() {
 		state.StartedAt = nil
 		state.CompletedAt = nil
 		state.Feedback = ""
+		state.Followups = nil
 		state.DecisionActor = ""
 		state.DecisionSummary = ""
 		state.DecisionAt = nil
@@ -807,6 +820,7 @@ func EmitStepBlockWithDecisionEvents(phaseName string, step int, feedback string
 		Phase:           phaseName,
 		Step:            step,
 		Feedback:        feedback,
+		Followups:       decision.Followups,
 		DecisionActor:   decision.Actor,
 		DecisionSummary: decision.Summary,
 	}}
@@ -825,6 +839,7 @@ func EmitStepFailRemediationWithDecisionEvents(phaseName string, step int, feedb
 		Phase:            phaseName,
 		Step:             step,
 		Feedback:         feedback,
+		Followups:        decision.Followups,
 		RemediationPhase: remediationPhase,
 		DecisionActor:    decision.Actor,
 		DecisionSummary:  decision.Summary,

--- a/internal/progress/events.go
+++ b/internal/progress/events.go
@@ -79,18 +79,19 @@ type ProgressEvent struct {
 	Reason  string `json:"reason,omitempty"`  // blocked event
 
 	// Workflow event-specific fields (omitempty)
-	Phase            string `json:"phase,omitempty"`
-	Step             int    `json:"step,omitempty"`
-	TotalSteps       int    `json:"total_steps,omitempty"`
-	Feedback         string `json:"feedback,omitempty"`
-	RemediationPhase string `json:"remediation_phase,omitempty"`
-	DecisionActor    string `json:"decision_actor,omitempty"`
-	DecisionSummary  string `json:"decision_summary,omitempty"`
-	JudgeStatus      string `json:"judge_status,omitempty"`
-	JudgeCommand     string `json:"judge_command,omitempty"`
-	JudgeDetail      string `json:"judge_detail,omitempty"`
-	JudgePid         int    `json:"judge_pid,omitempty"`
-	JudgeRunID       string `json:"judge_run_id,omitempty"`
+	Phase            string   `json:"phase,omitempty"`
+	Step             int      `json:"step,omitempty"`
+	TotalSteps       int      `json:"total_steps,omitempty"`
+	Feedback         string   `json:"feedback,omitempty"`
+	Followups        []string `json:"followups,omitempty"`
+	RemediationPhase string   `json:"remediation_phase,omitempty"`
+	DecisionActor    string   `json:"decision_actor,omitempty"`
+	DecisionSummary  string   `json:"decision_summary,omitempty"`
+	JudgeStatus      string   `json:"judge_status,omitempty"`
+	JudgeCommand     string   `json:"judge_command,omitempty"`
+	JudgeDetail      string   `json:"judge_detail,omitempty"`
+	JudgePid         int      `json:"judge_pid,omitempty"`
+	JudgeRunID       string   `json:"judge_run_id,omitempty"`
 }
 
 // loadFromEvents reads the JSONL file and materializes current state.
@@ -377,6 +378,7 @@ func materializeWorkflowState(events []ProgressEvent) *wf.FestivalWorkflowState 
 		case EventWorkflowStepStart:
 			ss := phaseState.GetOrCreateStepState(e.Step)
 			ss.Status = wf.StepStatusInProgress
+			ss.Followups = nil
 			ts := e.Timestamp
 			ss.StartedAt = &ts
 
@@ -386,6 +388,7 @@ func materializeWorkflowState(events []ProgressEvent) *wf.FestivalWorkflowState 
 			ts := e.Timestamp
 			ss.CompletedAt = &ts
 			ss.Feedback = e.Feedback
+			ss.Followups = nil
 			recordDecision(ss, e)
 
 		case EventWorkflowStepSkip:
@@ -394,17 +397,20 @@ func materializeWorkflowState(events []ProgressEvent) *wf.FestivalWorkflowState 
 			ts := e.Timestamp
 			ss.CompletedAt = &ts
 			ss.Feedback = e.Feedback
+			ss.Followups = nil
 
 		case EventWorkflowStepBlock:
 			ss := phaseState.GetOrCreateStepState(e.Step)
 			ss.Status = wf.StepStatusBlocked
 			ss.Feedback = e.Feedback
+			ss.Followups = e.Followups
 			recordDecision(ss, e)
 
 		case EventWorkflowStepFailRemediation:
 			ss := phaseState.GetOrCreateStepState(e.Step)
 			ss.Status = wf.StepStatusFailedRemediation
 			ss.Feedback = e.Feedback
+			ss.Followups = e.Followups
 			ss.RemediationPhase = e.RemediationPhase
 			recordDecision(ss, e)
 
@@ -413,6 +419,7 @@ func materializeWorkflowState(events []ProgressEvent) *wf.FestivalWorkflowState 
 			if ss.Status == wf.StepStatusFailedRemediation {
 				ss.Status = wf.StepStatusInProgress
 				ss.RemediationPhase = ""
+				ss.Followups = nil
 				ss.DecisionActor = ""
 				ss.DecisionSummary = ""
 				ss.DecisionAt = nil
@@ -424,6 +431,7 @@ func materializeWorkflowState(events []ProgressEvent) *wf.FestivalWorkflowState 
 			if wf.IsJudgeRejection(ss) {
 				ss.Status = wf.StepStatusInProgress
 				ss.Feedback = ""
+				ss.Followups = nil
 				ss.RemediationPhase = ""
 				ss.DecisionActor = ""
 				ss.DecisionSummary = ""

--- a/internal/progress/store.go
+++ b/internal/progress/store.go
@@ -623,6 +623,7 @@ func (s *Store) QueueWorkflowEvents(events []wf.WorkflowEvent) {
 			Step:             we.Step,
 			TotalSteps:       we.TotalSteps,
 			Feedback:         we.Feedback,
+			Followups:        we.Followups,
 			RemediationPhase: we.RemediationPhase,
 			DecisionActor:    we.DecisionActor,
 			DecisionSummary:  we.DecisionSummary,

--- a/internal/progress/workflow_events_test.go
+++ b/internal/progress/workflow_events_test.go
@@ -119,6 +119,45 @@ func TestMaterializeWorkflowState_ClearsJudgeAfterOperatorDecision(t *testing.T)
 	}
 }
 
+func TestMaterializeWorkflowState_JudgeRejectionFollowupsRoundTrip(t *testing.T) {
+	now := time.Now().UTC()
+	followups := []string{
+		"Attach the actual test-run console output.",
+		"Include the ledger transition as captured output, not an assertion.",
+	}
+	events := []ProgressEvent{
+		{Timestamp: now, Event: EventWorkflowInit, Phase: "gate:001_IMPLEMENT", TotalSteps: 1},
+		{Timestamp: now.Add(time.Second), Event: EventWorkflowStepStart, Phase: "gate:001_IMPLEMENT", Step: 1},
+		{Timestamp: now.Add(2 * time.Second), Event: EventWorkflowJudgeStarted, Phase: "gate:001_IMPLEMENT", Step: 1, JudgeCommand: "ob judge", JudgeRunID: "run-1"},
+		{Timestamp: now.Add(3 * time.Second), Event: EventWorkflowJudgeReturned, Phase: "gate:001_IMPLEMENT", Step: 1, JudgeStatus: wf.JudgeRejected, JudgeDetail: "thin evidence", JudgeRunID: "run-1"},
+		{Timestamp: now.Add(4 * time.Second), Event: EventWorkflowStepBlock, Phase: "gate:001_IMPLEMENT", Step: 1, Feedback: "thin evidence", Followups: followups, DecisionActor: "agent", DecisionSummary: "thin evidence"},
+	}
+
+	step := materializeWorkflowState(events).Phases["gate:001_IMPLEMENT"].GetStepState(1)
+	if step == nil {
+		t.Fatal("expected step state")
+	}
+	if step.Status != wf.StepStatusBlocked {
+		t.Fatalf("status = %v, want blocked", step.Status)
+	}
+	if len(step.Followups) != len(followups) {
+		t.Fatalf("followups = %v, want %v", step.Followups, followups)
+	}
+	for i, f := range followups {
+		if step.Followups[i] != f {
+			t.Fatalf("followup[%d] = %q, want %q", i, step.Followups[i], f)
+		}
+	}
+
+	// A subsequent re-judge (JudgeRecheck) clears the stale fix list so the
+	// agent never re-reads fixes for evidence it has since revised.
+	events = append(events, ProgressEvent{Timestamp: now.Add(5 * time.Second), Event: EventWorkflowJudgeRecheck, Phase: "gate:001_IMPLEMENT", Step: 1})
+	step = materializeWorkflowState(events).Phases["gate:001_IMPLEMENT"].GetStepState(1)
+	if len(step.Followups) != 0 {
+		t.Fatalf("followups after recheck = %v, want empty", step.Followups)
+	}
+}
+
 func TestGenerateWorkflowEventsFromYAML_EmitsStepSkip(t *testing.T) {
 	now := time.Now().UTC()
 	phaseState := wf.NewWorkflowState(2)


### PR DESCRIPTION
## Problem

When an approval judge auto-rejects a blocking checkpoint, a driving agent was handed a dead-end: the one-line reason plus two human-oriented exits (`fest workflow approve` interactive override, or a blind `fest workflow judge` re-run). The judge's `followups`, the itemized fixes the judge template is explicitly told to produce on rejection, were parsed into `approvalJudgeResponse.Followups` and then **dropped at every layer**: never printed, never recorded on the step, never in the `wf_step_block` / `wf_judge_returned` events, never rendered by `fest workflow status` or `fest next`.

So an autonomous agent got the "why" but never the "what to fix", and stopped waiting for a human. This is why agents kept getting blocked at the judge.

Blocking is the desired behavior. The fix is not to weaken it; it is to make a legitimate block **actionable and loopable** so the agent can pick up the rejection, fix the specific issues the judge found, and re-submit.

## Fix

**Followups become first-class** through the whole path:
- `DecisionMetadata`, `StepState`, and the `WorkflowEvent` -> `ProgressEvent` JSONL round-trip carry `followups`, so they persist in the append-only log and survive replay.
- Printed on auto-reject; rendered by `fest workflow status` and in the `fest next` blocked-gate view, next to the existing "revise, then re-run `fest workflow judge`" loop instruction.
- Included (bounded + sanitized) in the obey session-continuation message, so a resumed obey-managed agent gets the same fix list.
- Cleared on any transition out of blocked (advance, skip, recheck, judge re-run, reset).

The fix-and-continue loop itself already existed (`fest next` says revise + re-run judge; `fest workflow judge` reopens and re-evaluates). The only missing piece was handing the agent the concrete fix list. Blocking is unchanged: substandard work still stops.

## Proven end to end

Driven against a real sandbox festival with a fake judge (not mocked). `fest next` at a blocked phase gate now shows:

```
This step is BLOCKED: The PHASE_GOAL_VERIFICATION.md asserts the suite passes but
attaches no console output; claims about a merged PR are self-report, not proof.

Fixes the judge requires (address every item, then re-submit):
  - Attach the actual test-run console output showing pass/fail counts.
  - Include the ledger transition (409->410) as captured output, not an assertion.
  - Do not cite a merged PR as evidence the judge cannot see.

Address the feedback and try again.

When the revised evidence is ready, re-run the approval judge:
  fest workflow judge
```

The followups persist in the durable event log (`"followups": [...]` in the `wf_step_block` JSONL event), and the full loop closes: reject with fix list -> agent revises -> `fest workflow judge` approves -> gate advances to the next step.

## Tests / gate

- New unit coverage: state round-trip (`RejectWithDecision` stores + emits followups, cleared on reopen), event replay (`wf_step_block` -> `StepState.Followups`, cleared on `wf_judge_recheck`), continuation rendering (rejection with/without followups, bounding + sanitizing).
- `just lint all`: 0 issues. `go vet ./...`: clean. Full module `go test ./...`: 99 packages pass.
