### PR TITLE
fix: restore fgo completion colors

### DIFF
--- a/docs/demos/fgo-completion-colors.tape
+++ b/docs/demos/fgo-completion-colors.tape
@@ -1,0 +1,37 @@
+# fgo zsh completion colors — explicit completion output through a pipe.
+#
+# Record with a disposable fixture containing the branch binary:
+# FEST_VHS_ROOT=/path/to/fest-status-colors-fixture vhs docs/demos/fgo-completion-colors.tape
+
+Output out/fgo-completion-colors.gif
+
+Set Shell "zsh"
+Set FontFamily "JetBrainsMono Nerd Font"
+Set FontSize 14
+Set Width 1040
+Set Height 700
+Set Padding 22
+Set Margin 0
+Set BorderRadius 0
+Set Framerate 30
+Set TypingSpeed 80ms
+Set Theme {"name":"Obedience Corp","background":"#0D0D11","foreground":"#F8F8F2","selection":"#3A2418","cursor":"#F2721C","black":"#0D0D11","red":"#FF5F57","green":"#50FA7B","yellow":"#FEBC2E","blue":"#4DA3FF","magenta":"#B388FF","cyan":"#66D9EF","white":"#F8F8F2","brightBlack":"#A1A1AA","brightRed":"#FF5F57","brightGreen":"#50FA7B","brightYellow":"#FEBC2E","brightBlue":"#60A5FA","brightMagenta":"#D8B4FE","brightCyan":"#67E8F9","brightWhite":"#FFFFFF"}
+
+# Hidden fixture setup: load the real zsh shell integration and branch binary.
+Hide
+Type "unset NO_COLOR CI" Enter
+Type "export PATH=$FEST_VHS_ROOT/bin:$PATH" Enter
+Type "export FEST_CONFIG_DIR=$FEST_VHS_ROOT/config" Enter
+Type "export TERM=xterm-256color COLORTERM=truecolor COLORFGBG=15\;0" Enter
+Type "export PS1=$'\033[38;5;208m❯\033[0m '" Enter
+Type "mkdir -p $FEST_VHS_ROOT/workspace/.campaign" Enter
+Type "cd $FEST_VHS_ROOT/workspace" Enter
+Type "autoload -Uz compinit && compinit" Enter
+Type "fest shell-init zsh > $FEST_VHS_ROOT/fgo-init.zsh" Enter
+Type "source $FEST_VHS_ROOT/fgo-init.zsh" Enter
+Type "clear" Enter
+Show
+
+# fgo's completion list shows the lifecycle status colors directly in zsh.
+Type "fgo " Sleep 700ms Tab
+Sleep 3000ms

--- a/internal/commands/navigation/completions.go
+++ b/internal/commands/navigation/completions.go
@@ -39,8 +39,8 @@ func NewGoCompletionsCommand() *cobra.Command {
 	return cmd
 }
 
-// ANSI codes for shortcut lines; status colors come from ui.StatusColorSequence
-// (the single theme-aware palette source).
+// ANSI codes for shortcut lines; status colors come from the UI's explicit
+// completion palette so they survive the shell's completion pipe.
 const (
 	ansiReset = "\033[0m"
 	ansiDim   = "\033[2m"
@@ -48,11 +48,11 @@ const (
 
 // statusANSI returns the ANSI color escape for a status directory name.
 func statusANSI(status string) string {
-	return ui.StatusColorSequence(status)
+	return ui.CompletionStatusColorSequence(status)
 }
 
 func runGoCompletions(descriptions, color bool, statusFilter string) error {
-	shortcutColor := ui.ColorSequence(ui.Current().Gate)
+	shortcutColor := ui.CompletionAccentSequence()
 	// Locate festivals directory (needed for both filtered and unfiltered modes)
 	cwd, err := os.Getwd()
 	if err != nil {

--- a/internal/commands/shared/completion_color.go
+++ b/internal/commands/shared/completion_color.go
@@ -12,7 +12,7 @@ const ansiReset = "\x1b[0m"
 // colorCompletionDisplay renders the zsh compadd -d display cell for a completion:
 // the value followed by its status, colorized from the active theme palette.
 func colorCompletionDisplay(value, status string) string {
-	return value + " " + ui.StatusColorSequence(status) + status + ansiReset
+	return value + " " + ui.CompletionStatusColorSequence(status) + status + ansiReset
 }
 
 // OrderedSelectorNames returns completion names from picker candidates while

--- a/internal/ui/color.go
+++ b/internal/ui/color.go
@@ -24,10 +24,14 @@ func SetNoColor(noColor bool) {
 // sequence for explicitly colorized shell completion output. The source color
 // remains a shared hex token; termenv performs the terminal-safe conversion.
 func ColorSequence(color lipgloss.TerminalColor) string {
-	if !CurrentBrandPalette().ColorEnabled || noColorOverride {
+	if noColorOverride {
 		return ""
 	}
 
+	return colorSequence(color)
+}
+
+func colorSequence(color lipgloss.TerminalColor) string {
 	value, ok := color.(lipgloss.Color)
 	if !ok || value == "" {
 		return ""

--- a/internal/ui/palette.go
+++ b/internal/ui/palette.go
@@ -20,6 +20,7 @@ import (
 var (
 	currentPalette      Palette
 	currentBrandPalette = defaultSharedDarkPalette()
+	configuredMode      = sharedbrand.ModeDark
 	paletteOnce         sync.Once
 	paletteInit         bool
 )
@@ -66,11 +67,13 @@ func InitPalette(ctx context.Context) {
 	paletteOnce.Do(func() {
 		cfg, err := config.Load(ctx, "")
 		if err != nil {
-			setPalette(ResolveBrandPalette(sharedbrand.ModeDark))
+			configuredMode = sharedbrand.ModeDark
+			setPalette(ResolveBrandPalette(configuredMode))
 			return
 		}
 
-		setPalette(ResolveBrandPalette(sharedbrand.ParseMode(cfg.TUI.Theme)))
+		configuredMode = sharedbrand.ParseMode(cfg.TUI.Theme)
+		setPalette(ResolveBrandPalette(configuredMode))
 	})
 }
 
@@ -145,6 +148,24 @@ func CurrentBrandPalette() sharedbrand.Palette {
 		return defaultSharedDarkPalette()
 	}
 	return currentBrandPalette
+}
+
+// completionPalette resolves the configured theme for explicit shell
+// completion display colors. Completion commands write into a shell pipe, so
+// the normal output policy resolves their palette to plain; the shell itself
+// still supports ANSI display cells and requested these colors explicitly.
+func completionPalette() Palette {
+	if noColorOverride || configuredMode == sharedbrand.ModePlain {
+		return Palette{}
+	}
+
+	shared := sharedbrand.Resolve(configuredMode, sharedbrand.Capabilities{
+		IsTTY:           true,
+		ColorDepth:      sharedbrand.ColorANSI256,
+		DarkBackground:  lipgloss.HasDarkBackground(),
+		BackgroundKnown: true,
+	})
+	return paletteFromShared(shared)
 }
 
 func outputIsTTY() bool {
@@ -291,6 +312,7 @@ func ResetPalette() {
 	paletteInit = false
 	currentPalette = Palette{}
 	currentBrandPalette = defaultSharedDarkPalette()
+	configuredMode = sharedbrand.ModeDark
 	defaultDarkPaletteInstance = nil
 	syncLegacyColors(defaultDarkPalette())
 }

--- a/internal/ui/status_sequence_test.go
+++ b/internal/ui/status_sequence_test.go
@@ -1,6 +1,10 @@
 package ui
 
-import "testing"
+import (
+	"testing"
+
+	sharedbrand "github.com/Obedience-Corp/obey-shared/brand"
+)
 
 func TestStatusColorSequence(t *testing.T) {
 	ResetPalette()
@@ -20,5 +24,24 @@ func TestStatusColorSequence(t *testing.T) {
 		if got := StatusColorSequence(status); got != want {
 			t.Errorf("StatusColorSequence(%q) = %q, want %q", status, got, want)
 		}
+	}
+}
+
+func TestCompletionStatusColorSequenceSurvivesPipedOutput(t *testing.T) {
+	ResetPalette()
+	t.Cleanup(ResetPalette)
+
+	// A shell completion command writes through a pipe, which resolves ordinary
+	// command output to plain even though zsh can render the display cells.
+	setPalette(sharedbrand.Resolve(sharedbrand.ModePlain, sharedbrand.Capabilities{}))
+
+	if got := StatusColorSequence("planning"); got != "" {
+		t.Fatalf("ordinary piped status sequence = %q, want no color", got)
+	}
+	if got := CompletionStatusColorSequence("planning"); got != "\x1b[38;5;75m" {
+		t.Fatalf("completion planning sequence = %q, want blue ANSI sequence", got)
+	}
+	if got := CompletionAccentSequence(); got != "\x1b[38;5;214m" {
+		t.Fatalf("completion accent sequence = %q, want amber ANSI sequence", got)
 	}
 }

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -137,12 +137,54 @@ func StatusColorSequence(status string) string {
 	if !CurrentBrandPalette().ColorEnabled {
 		return ""
 	}
-	color := GetStatusColor(status)
-	if sequence := ColorSequence(color); sequence != "" {
-		return sequence
+	return statusColorSequence(*Current(), status)
+}
+
+// CompletionStatusColorSequence returns the ANSI-256 foreground escape for
+// an explicitly colorized shell completion. Unlike ordinary command output,
+// completion display cells are intentionally written through a pipe, so they
+// use the configured theme even when the normal palette is plain.
+func CompletionStatusColorSequence(status string) string {
+	p := completionPalette()
+	if p.Active == nil {
+		return ""
 	}
-	if color == lipgloss.Color("") {
-		return "\x1b[2m"
+	return statusColorSequence(p, status)
+}
+
+// CompletionAccentSequence returns the configured accent for non-status
+// completion entries such as shortcuts.
+func CompletionAccentSequence() string {
+	return colorSequence(completionPalette().Gate)
+}
+
+func statusColor(p Palette, status string) lipgloss.TerminalColor {
+	switch strings.ToLower(status) {
+	case "active":
+		return p.Active
+	case "ready":
+		return p.Ready
+	case "planning":
+		return p.Planning
+	case "ritual":
+		return p.Ritual
+	case "completed", "dungeon/completed":
+		return p.Completed
+	case "archived", "dungeon/archived":
+		return p.Archived
+	case "someday", "dungeon/someday":
+		return p.Someday
+	case "dungeon":
+		return p.Dungeon
+	default:
+		return lipgloss.Color("")
+	}
+}
+
+func statusColorSequence(p Palette, status string) string {
+	color := statusColor(p, status)
+	if sequence := colorSequence(color); sequence != "" {
+		return sequence
 	}
 	return "\x1b[2m"
 }


### PR DESCRIPTION
## Summary

- restore colors for explicit `fgo` zsh completion display cells when completion output is piped
- preserve the configured dark, light, or high-contrast theme for completion display cells without re-enabling colors in ordinary piped output
- add regression coverage for piped completion output
- add a VHS recording of the real `fgo <TAB>` menu

## Root cause

`fgo` requests `fest go completions --color`, but the completion command writes through a shell pipe. The theme resolver correctly selected a plain palette for normal non-interactive output, and the completion renderer then inherited that plain palette, removing the ANSI display colors.

The fix keeps ordinary piped output plain while resolving the configured theme explicitly for completion display cells.

## Validation

- `GOCACHE=/tmp/fest-status-list-colors-gocache just test unit` — 98 packages, 2,615 tests
- `GOCACHE=/tmp/fest-status-list-colors-gocache just lint vet`
- `GOCACHE=/tmp/fest-status-list-colors-gocache just build quick`
- verified a real piped `fest go completions --color` invocation emits ANSI status sequences
- recorded and visually inspected the real `fgo <TAB>` menu with VHS

The VHS source is committed at `docs/demos/fgo-completion-colors.tape`; the recorded GIF will be attached in the PR conversation.
