### PR TITLE
fix: restore colors in the fgo enter picker

### DIFF
--- a/internal/commands/shared/festival_picker.go
+++ b/internal/commands/shared/festival_picker.go
@@ -83,7 +83,7 @@ func festivalPickerItemsFromCandidates(candidates []FestivalPickCandidate) []pic
 	for _, candidate := range candidates {
 		items = append(items, picker.Item{
 			Prefix:      festivalStatusLabel(candidate),
-			PrefixColor: ui.GetStatusColor(candidate.Status),
+			PrefixColor: ui.GetInteractiveStatusColor(candidate.Status),
 			Name:        festivalPickerItemName(candidate),
 			Value:       candidate.Path,
 		})

--- a/internal/tui/picker/picker.go
+++ b/internal/tui/picker/picker.go
@@ -60,7 +60,7 @@ type Model struct {
 // When rendering to stderr (e.g. fgo piping stdout), pass a renderer created
 // from os.Stderr so colors are detected against the actual TTY.
 func New(items []Item, scorer Scorer, renderer *lipgloss.Renderer) Model {
-	p := ui.Current()
+	p := ui.InteractivePalette()
 	ti := textinput.New()
 	ti.Placeholder = "Type to filter..."
 	ti.Focus()

--- a/internal/ui/palette.go
+++ b/internal/ui/palette.go
@@ -150,6 +150,26 @@ func CurrentBrandPalette() sharedbrand.Palette {
 	return currentBrandPalette
 }
 
+// InteractivePalette resolves the configured theme for a TUI rendered to a
+// terminal other than stdout. Shell navigation wrappers capture stdout so
+// they can use it as the selected path, while the picker itself renders to
+// stderr. In that case Current() is intentionally plain, but the TUI still
+// has a color-capable terminal to render into.
+func InteractivePalette() Palette {
+	if noColorOverride || configuredMode == sharedbrand.ModePlain {
+		return Palette{}
+	}
+
+	profile := termenv.EnvColorProfile()
+	shared := sharedbrand.Resolve(configuredMode, sharedbrand.Capabilities{
+		IsTTY:           true,
+		ColorDepth:      colorDepth(profile),
+		DarkBackground:  lipgloss.HasDarkBackground(),
+		BackgroundKnown: true,
+	})
+	return paletteFromShared(shared)
+}
+
 // completionPalette resolves the configured theme for explicit shell
 // completion display colors. Completion commands write into a shell pipe, so
 // the normal output policy resolves their palette to plain; the shell itself

--- a/internal/ui/palette_test.go
+++ b/internal/ui/palette_test.go
@@ -100,6 +100,31 @@ func TestFestivalStatusColorsDisableInPlainMode(t *testing.T) {
 	}
 }
 
+func TestInteractivePaletteKeepsColorsWhenOutputPaletteIsPlain(t *testing.T) {
+	ResetPalette()
+	t.Cleanup(func() {
+		SetNoColor(false)
+		ResetPalette()
+	})
+	t.Setenv("TERM", "xterm-256color")
+	t.Setenv("COLORTERM", "truecolor")
+	t.Setenv("CLICOLOR_FORCE", "1")
+	t.Setenv("NO_COLOR", "")
+
+	// Simulate a shell wrapper capturing stdout for a selected path. The
+	// interactive picker still renders to a color-capable stderr TTY.
+	configuredMode = sharedbrand.ModeDark
+	setPalette(sharedbrand.Resolve(sharedbrand.ModePlain, sharedbrand.Capabilities{}))
+
+	got := InteractivePalette()
+	if got.Planning == nil || got.Ready == nil {
+		t.Fatalf("interactive palette lost colors: planning=%v ready=%v", got.Planning, got.Ready)
+	}
+	if string(got.Planning.(lipgloss.Color)) != "#4DA3FF" {
+		t.Fatalf("interactive planning color = %q, want #4DA3FF", got.Planning)
+	}
+}
+
 func TestResolveBrandPaletteHonorsExplicitNoColor(t *testing.T) {
 	ResetPalette()
 	SetNoColor(true)

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -104,10 +104,7 @@ func GetStatusStyle(status string) lipgloss.Style {
 	}
 }
 
-// GetStatusColor returns the appropriate color for a given status string.
-// Now uses the palette for theme-aware colors.
-func GetStatusColor(status string) lipgloss.TerminalColor {
-	p := Current()
+func statusColor(p Palette, status string) lipgloss.TerminalColor {
 	switch strings.ToLower(status) {
 	case "active":
 		return p.Active
@@ -128,6 +125,18 @@ func GetStatusColor(status string) lipgloss.TerminalColor {
 	default:
 		return lipgloss.Color("")
 	}
+}
+
+// GetStatusColor returns the appropriate color for a given status string.
+// Now uses the palette for theme-aware colors.
+func GetStatusColor(status string) lipgloss.TerminalColor {
+	return statusColor(*Current(), status)
+}
+
+// GetInteractiveStatusColor returns a status color for a TUI rendered to a
+// terminal while the command's stdout may be captured by a shell wrapper.
+func GetInteractiveStatusColor(status string) lipgloss.TerminalColor {
+	return statusColor(InteractivePalette(), status)
 }
 
 // StatusColorSequence returns an ANSI-256 foreground escape for a festival
@@ -156,29 +165,6 @@ func CompletionStatusColorSequence(status string) string {
 // completion entries such as shortcuts.
 func CompletionAccentSequence() string {
 	return colorSequence(completionPalette().Gate)
-}
-
-func statusColor(p Palette, status string) lipgloss.TerminalColor {
-	switch strings.ToLower(status) {
-	case "active":
-		return p.Active
-	case "ready":
-		return p.Ready
-	case "planning":
-		return p.Planning
-	case "ritual":
-		return p.Ritual
-	case "completed", "dungeon/completed":
-		return p.Completed
-	case "archived", "dungeon/archived":
-		return p.Archived
-	case "someday", "dungeon/someday":
-		return p.Someday
-	case "dungeon":
-		return p.Dungeon
-	default:
-		return lipgloss.Color("")
-	}
 }
 
 func statusColorSequence(p Palette, status string) string {


### PR DESCRIPTION
## Summary

- restore configured palette colors in the interactive `fgo`/`fest go` picker
- keep stdout clean for shell command substitution while rendering the TUI to stderr
- preserve plain output for explicit `--no-color` and plain themes

## Root cause

The shell wrapper captures `fest go --print` stdout to obtain the selected path. Palette initialization used that piped stdout stream, so the shared palette resolved to plain even though the picker was rendering to the terminal-bound stderr stream.

## Validation

- `just test unit` — 2,616 tests passed
- `just build dashboard`
- `just lint vet`
- `just lint all`
- PTY reproduction confirmed ANSI color sequences from the picker and a clean selected path on stdout
