### PR TITLE
feat(hooks): fest hooks system (FH0001)

### DIFF
--- a/docs/concepts/hook-evidence-contract.md
+++ b/docs/concepts/hook-evidence-contract.md
@@ -1,0 +1,60 @@
+# Hook Evidence Contract (read-by-approver)
+
+Default evidence mode for fest hooks is **read-by-approver** (`evidence: paths`).
+The transport carries paths; the approver (judge or human) reads files itself.
+
+## Payload shape
+
+A hook stdin request typically includes:
+
+- `festival_path` — festival root
+- `phase_path` — phase directory used as the evidence root
+- `evidence` — list of phase-relative file paths (present, non-empty regular files only)
+
+The concrete judge request type is `approvalJudgeRequest` in
+`internal/commands/workflow/approve.go` (`schema_version: fest.approval.judge/v1`).
+That schema is **not** version-bumped for this contract; path mode remains
+identical to the pre-hooks-system judge path.
+
+## Resolution rules
+
+Shared helper: `internal/hooks` (`NormalizeEvidencePath`, `WithinRoot`,
+`ResolvePhaseRelative`).
+
+1. Each path is **phase-relative**. Absolute paths are rejected.
+2. Paths are cleaned with `filepath.Clean`. Paths that escape the phase directory
+   via `..` are rejected.
+3. After `filepath.EvalSymlinks`, the candidate must remain contained under the
+   resolved phase root. Symlinks that escape are rejected.
+4. Only **non-empty regular files** count as present. Empty files and directories
+   are dropped.
+5. Missing or unreadable paths are **dropped** from the present set, not a
+   transport-level abort. Whether missing evidence rejects approval is the
+   approver's rubric decision.
+
+## Failure semantics
+
+- Transport never aborts solely because an evidence path is missing.
+- Read failures during resolution/embed are skipped for that file.
+- Fail-closed orchestration still applies at the hook fail-policy layer when a
+  hook command itself exits non-zero.
+
+## Opt-in embed mode
+
+When a hook definition sets `evidence: embed`, fest may also attach
+`evidence_files` on the request (additive JSON field; older judges ignore it):
+
+- Total content budget: **256KB** across all embedded files
+  (`hooks.EvidenceEmbedCapBytes`).
+- The file that crosses the budget is truncated and marked
+  `truncated: true` with a `[TRUNCATED: ...]` marker.
+- Files after the budget is exhausted are **not** embedded; their paths still
+  appear in `evidence`.
+- `evidence` paths are always populated so path-mode judges keep working.
+
+## Compatibility
+
+- `fest.approval.judge/v1` decision protocol is unchanged.
+- Default `evidence: paths` marshals without `evidence_files`.
+- Legacy `hooks.approval_judge.command` continues to use path mode with
+  `timeout: 0`.

--- a/embedded/templates/agent/workflow/checkpoint.tmpl
+++ b/embedded/templates/agent/workflow/checkpoint.tmpl
@@ -32,7 +32,10 @@ EXAMPLE OUTPUT (no judge configured):
 ═══════════════════════════════════════════════════════════════════════════════
 
 Step {{.StepNumber}}: {{.StepName}}
+{{- if .HumanApprovalRequired}}
 
+HUMAN APPROVAL REQUIRED
+{{- end}}
 {{- if .Goal}}
 
 **Question:** {{.Goal}}

--- a/embedded/templates/agent/workflow/checkpoint.tmpl
+++ b/embedded/templates/agent/workflow/checkpoint.tmpl
@@ -37,6 +37,10 @@ Step {{.StepNumber}}: {{.StepName}}
 
 **Question:** {{.Goal}}
 {{- end}}
+{{- if .SkippedHooksUndeclared}}
+
+{{.SkippedHooksUndeclared}}
+{{- end}}
 {{- if .Actions}}
 
 **Actions to verify:**

--- a/embedded/templates/agent/workflow/step.tmpl
+++ b/embedded/templates/agent/workflow/step.tmpl
@@ -40,6 +40,8 @@ EXAMPLE OUTPUT:
 ## Step {{.StepNumber}}: {{.StepName}}
 
 {{if .IsGate}}**Question:** {{.Goal}}{{else}}**Goal:** {{.Goal}}{{end}}
+{{if .SkippedHooksUndeclared}}{{.SkippedHooksUndeclared}}
+{{end}}
 {{if .Actions}}
 **Actions:**
 {{range .Actions}}  - {{.}}

--- a/embedded/templates/agent/workflow/step.tmpl
+++ b/embedded/templates/agent/workflow/step.tmpl
@@ -38,7 +38,9 @@ EXAMPLE OUTPUT:
 ═══════════════════════════════════════════════════════════════════════════════
 
 ## Step {{.StepNumber}}: {{.StepName}}
-
+{{if .HumanApprovalRequired}}
+HUMAN APPROVAL REQUIRED
+{{end}}
 {{if .IsGate}}**Question:** {{.Goal}}{{else}}**Goal:** {{.Goal}}{{end}}
 {{if .SkippedHooksUndeclared}}{{.SkippedHooksUndeclared}}
 {{end}}

--- a/internal/commands/hooks/commands.go
+++ b/internal/commands/hooks/commands.go
@@ -1,0 +1,199 @@
+package hooks
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/Obedience-Corp/fest/internal/commands/shared"
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/hooks"
+	"github.com/Obedience-Corp/fest/internal/scope"
+	"github.com/spf13/cobra"
+)
+
+// NewHooksCommand creates the hooks inspection command group.
+func NewHooksCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "hooks",
+		Short: "Inspect resolved lifecycle hooks",
+		Long: `Inspect the hooks resolved from the machine, festivals, and festival layers.
+
+Available Commands:
+  list   Show the effective resolved hook set with source layers and shadow diffs`,
+		Annotations: map[string]string{
+			"scope": string(scope.Global),
+		},
+	}
+	cmd.AddCommand(newHooksListCmd())
+	return cmd
+}
+
+func newHooksListCmd() *cobra.Command {
+	var jsonOutput bool
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "Show the effective resolved hook set",
+		Example: `  fest hooks list
+  fest hooks list --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runHooksList(cmd.Context(), jsonOutput)
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
+	return cmd
+}
+
+type hooksListJSON struct {
+	Enabled bool                    `json:"enabled"`
+	Levels  map[string]bool         `json:"levels"`
+	Hooks   []hooksListHookJSON     `json:"hooks"`
+	Legacy  *hooksListLegacyJSON    `json:"legacy_alias,omitempty"`
+}
+
+type hooksListHookJSON struct {
+	Name     string                   `json:"name"`
+	Source   string                   `json:"source"`
+	Enabled  bool                     `json:"enabled"`
+	Command  string                   `json:"command"`
+	Fail     string                   `json:"fail"`
+	Timeout  string                   `json:"timeout"`
+	Evidence string                   `json:"evidence"`
+	Shadows  []hooksListShadowJSON    `json:"shadows"`
+}
+
+type hooksListShadowJSON struct {
+	Source  string `json:"source"`
+	Command string `json:"command"`
+	Differs bool   `json:"differs"`
+}
+
+type hooksListLegacyJSON struct {
+	Active  bool   `json:"active"`
+	Command string `json:"command,omitempty"`
+}
+
+func runHooksList(ctx context.Context, jsonOutput bool) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	festivalPath, err := resolveFestivalPath(ctx)
+	if err != nil {
+		return err
+	}
+	eff, err := hooks.LoadAndResolve(ctx, festivalPath)
+	if err != nil {
+		return festerrors.Wrap(err, "resolving hooks")
+	}
+	view := buildHooksListView(eff)
+	if jsonOutput {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(view)
+	}
+	printHooksListText(view)
+	return nil
+}
+
+func resolveFestivalPath(ctx context.Context) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", festerrors.IO("getting working directory", err)
+	}
+	path, err := shared.ResolveFestivalPath(cwd, "")
+	if err != nil {
+		return "", festerrors.Wrap(err, "resolving festival path").
+			WithHint("run from a festival directory or a linked project")
+	}
+	return path, nil
+}
+
+func buildHooksListView(eff *hooks.Effective) hooksListJSON {
+	view := hooksListJSON{
+		Enabled: true,
+		Levels:  map[string]bool{},
+		Hooks:   []hooksListHookJSON{},
+	}
+	if eff == nil {
+		return view
+	}
+	view.Enabled = eff.Enabled
+	for k, v := range eff.Levels {
+		view.Levels[k] = v
+	}
+	if eff.LegacyAliasActive {
+		view.Legacy = &hooksListLegacyJSON{Active: true, Command: eff.LegacyAliasCommand}
+	}
+	names := make([]string, 0, len(eff.Hooks))
+	for name := range eff.Hooks {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		h := eff.Hooks[name]
+		entry := hooksListHookJSON{
+			Name:     name,
+			Source:   string(h.Source),
+			Enabled:  h.Enabled,
+			Command:  h.Command,
+			Fail:     string(h.Fail),
+			Timeout:  h.Timeout.String(),
+			Evidence: string(h.Evidence),
+			Shadows:  []hooksListShadowJSON{},
+		}
+		for _, s := range h.Shadowed {
+			entry.Shadows = append(entry.Shadows, hooksListShadowJSON{
+				Source:  string(s.Source),
+				Command: s.Def.Command,
+				Differs: true,
+			})
+		}
+		view.Hooks = append(view.Hooks, entry)
+	}
+	return view
+}
+
+func printHooksListText(view hooksListJSON) {
+	fmt.Printf("hooks.enabled: %v\n", view.Enabled)
+	if len(view.Levels) > 0 {
+		keys := make([]string, 0, len(view.Levels))
+		for k := range view.Levels {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		parts := make([]string, 0, len(keys))
+		for _, k := range keys {
+			parts = append(parts, fmt.Sprintf("%s=%v", k, view.Levels[k]))
+		}
+		fmt.Printf("hooks.levels: %s\n", strings.Join(parts, " "))
+	}
+	if view.Legacy != nil && view.Legacy.Active {
+		fmt.Printf("legacy alias: approval_judge.command=%q (timeout=0)\n", view.Legacy.Command)
+	}
+	if len(view.Hooks) == 0 {
+		fmt.Println("No hooks configured. Declare hooks under hooks.definitions or run `fest hooks list` after configuring.")
+		return
+	}
+	fmt.Println()
+	for _, h := range view.Hooks {
+		enabled := "enabled"
+		if !h.Enabled {
+			enabled = "disabled"
+		}
+		fmt.Printf("%s   [%s]   %s   fail=%s  timeout=%s   evidence=%s\n",
+			h.Name, h.Source, enabled, h.Fail, h.Timeout, h.Evidence)
+		fmt.Printf("  command: %s\n", h.Command)
+		if len(h.Shadows) > 0 {
+			fmt.Println("  shadows:")
+			for _, s := range h.Shadows {
+				fmt.Printf("    [%s]  command=%q           (differs)\n", s.Source, s.Command)
+			}
+		}
+	}
+}

--- a/internal/commands/next/next.go
+++ b/internal/commands/next/next.go
@@ -391,12 +391,14 @@ func runNext(cmd *cobra.Command, args []string) error {
 		fmt.Print(selection.FormatVerbose(result, showInlineContext))
 		printChainContext(ctx, festivalPath, result.FestivalComplete)
 		printFeedbackReminder(ctx, festivalPath)
+		printLegacyHooksAliasWarning(ctx, festivalPath)
 		return nil
 	}
 
 	fmt.Print(selection.FormatText(result, showInlineContext))
 	printChainContext(ctx, festivalPath, result.FestivalComplete)
 	printFeedbackReminder(ctx, festivalPath)
+	printLegacyHooksAliasWarning(ctx, festivalPath)
 	return nil
 }
 
@@ -428,6 +430,22 @@ func printFeedbackReminder(ctx context.Context, festivalPath string) {
 		return
 	}
 	fmt.Printf("\n%s%s", strings.Repeat("─", 60), text)
+}
+
+// printLegacyHooksAliasWarning prints a best-effort deprecation notice when the
+// festivals-layer flat hooks.approval_judge.command key is still in use.
+func printLegacyHooksAliasWarning(ctx context.Context, festivalPath string) {
+	issues, err := validator.ValidateHooksConfig(ctx, festivalPath)
+	if err != nil || len(issues) == 0 {
+		return
+	}
+	for _, issue := range issues {
+		if issue.Code != validator.CodeHooksLegacyAlias {
+			continue
+		}
+		fmt.Fprintf(os.Stderr, "\nWarning: %s\n", issue.Message)
+		return
+	}
 }
 
 // printChainContext shows chain-awareness context when a festival is complete.

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -17,6 +17,7 @@ import (
 	feedbackcmd "github.com/Obedience-Corp/fest/internal/commands/feedback"
 	"github.com/Obedience-Corp/fest/internal/commands/festival"
 	"github.com/Obedience-Corp/fest/internal/commands/gates"
+	hookscmd "github.com/Obedience-Corp/fest/internal/commands/hooks"
 	idcmd "github.com/Obedience-Corp/fest/internal/commands/id"
 	introcmd "github.com/Obedience-Corp/fest/internal/commands/intro"
 	listcmd "github.com/Obedience-Corp/fest/internal/commands/list"
@@ -347,6 +348,10 @@ func init() {
 	gatesCmd := gates.NewGatesCommand()
 	gatesCmd.GroupID = "learning"
 	rootCmd.AddCommand(gatesCmd)
+
+	hooksCmd := hookscmd.NewHooksCommand()
+	hooksCmd.GroupID = "learning"
+	rootCmd.AddCommand(hooksCmd)
 
 	// Research document management
 	researchCmd := research.NewResearchCommand()

--- a/internal/commands/task/completed.go
+++ b/internal/commands/task/completed.go
@@ -3,17 +3,32 @@ package task
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/gates"
+	"github.com/Obedience-Corp/fest/internal/hooks"
 	"github.com/Obedience-Corp/fest/internal/lifecycle"
 	"github.com/Obedience-Corp/fest/internal/progress"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
 	"github.com/spf13/cobra"
 )
+
+// newTaskHookRunner is an injectable seam so tests can fake hook execution.
+var newTaskHookRunner = hooks.NewRunner
+
+// blockedHookName returns the first fail-closed hook that blocked the verb.
+func blockedHookName(runs []hooks.HookRun) string {
+	for _, run := range runs {
+		if run.Blocked {
+			return run.Name
+		}
+	}
+	return ""
+}
 
 var (
 	completedJSON bool
@@ -126,8 +141,60 @@ func runCompleted(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	hookReq := progress.LifecycleHookRequest{
+		FestivalPath: festivalPath,
+		Phase:        filepath.Base(phasePath),
+		Task:         taskID,
+		Level:        hooks.LevelTask,
+		Verb:         hooks.VerbTaskComplete,
+	}
+	if content, readErr := os.ReadFile(taskFilePath); readErr == nil {
+		hookReq.Pre, hookReq.Post, hookReq.HumanGate = progress.StepHookBindingsFromFrontmatter(content)
+	}
+	planned, err := progress.PlanLifecycleHooks(ctx, hookReq)
+	if err != nil {
+		return err
+	}
+	runner := newTaskHookRunner(festivalPath)
+	preRuns, preBlocked, preErr := progress.RunLifecycleStage(ctx, mgr.Store(), runner, hookReq, planned, hooks.TimingPre)
+	if saveErr := mgr.Store().SaveEvents(ctx); saveErr != nil && preErr == nil {
+		preErr = saveErr
+	}
+	if preErr != nil {
+		return errors.Wrap(preErr, "running pre-completion hooks")
+	}
+	if preBlocked {
+		blockErr := progress.BlockedHookError(hooks.VerbTaskComplete, preRuns)
+		if completedJSON {
+			result := map[string]any{
+				"success":     false,
+				"task":        taskID,
+				"blocked":     true,
+				"failed_hook": blockedHookName(preRuns),
+				"message":     "Task completion blocked by fail-closed hook",
+			}
+			if encErr := shared.EncodeJSON(os.Stdout, result); encErr != nil {
+				return errors.Wrap(encErr, "encoding JSON output")
+			}
+		} else {
+			fmt.Println()
+			fmt.Println(ui.Error("Task completion BLOCKED by fail-closed hook: " + blockedHookName(preRuns)))
+		}
+		return blockErr
+	}
+
 	if err := mgr.MarkComplete(ctx, taskID); err != nil {
 		return err
+	}
+
+	_, postBlocked, postErr := progress.RunLifecycleStage(ctx, mgr.Store(), runner, hookReq, planned, hooks.TimingPost)
+	if saveErr := mgr.Store().SaveEvents(ctx); saveErr != nil && postErr == nil {
+		postErr = saveErr
+	}
+	if postErr != nil {
+		fmt.Fprintf(os.Stderr, "Warning: post-completion hooks: %v\n", postErr)
+	} else if postBlocked {
+		fmt.Fprintln(os.Stderr, "Warning: a fail-closed post hook failed; the task remains completed (see wf_hook_run in the festival audit trail)")
 	}
 
 	if completedJSON {

--- a/internal/commands/task/completed_hooks_test.go
+++ b/internal/commands/task/completed_hooks_test.go
@@ -1,0 +1,187 @@
+package task
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/hooks"
+)
+
+func setupHookedFestival(t *testing.T, taskFrontmatterExtra string) (string, string) {
+	t.Helper()
+	festDir, taskRel := setupActiveFestival(t)
+
+	festYAML := `version: "1.0"
+name: task-hooks-test
+id: THK-001
+metadata:
+  id: THK-001
+  status_history:
+    - status: active
+      timestamp: 2026-02-10T00:00:00Z
+hooks:
+  definitions:
+    checker:
+      command: test-checker
+`
+	if err := os.WriteFile(filepath.Join(festDir, "fest.yaml"), []byte(festYAML), 0o644); err != nil {
+		t.Fatalf("write fest.yaml: %v", err)
+	}
+
+	taskBody := "---\nfest_type: task\nfest_id: 01_task\n" + taskFrontmatterExtra + "---\n# Task body\n"
+	if err := os.WriteFile(filepath.Join(festDir, taskRel), []byte(taskBody), 0o644); err != nil {
+		t.Fatalf("write task: %v", err)
+	}
+
+	// Machine-layer isolation: never read the developer's real ~/.obey/fest.
+	t.Setenv("HOME", t.TempDir())
+	return festDir, taskRel
+}
+
+func fakeTaskRunner(t *testing.T, exitCode int, called *[]string) {
+	t.Helper()
+	orig := newTaskHookRunner
+	t.Cleanup(func() { newTaskHookRunner = orig })
+	newTaskHookRunner = func(workDir string) *hooks.Runner {
+		r := hooks.NewRunner(workDir)
+		r.Exec = func(ctx context.Context, command string, stdin []byte, dir string) hooks.CommandResult {
+			if called != nil {
+				*called = append(*called, command)
+			}
+			res := hooks.CommandResult{ExitCode: exitCode}
+			if exitCode != 0 {
+				res.Err = context.Canceled // any non-nil error stands in for exec failure
+			}
+			return res
+		}
+		return r
+	}
+}
+
+func readHookEvents(t *testing.T, festDir string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(festDir, ".fest", "progress_events.jsonl"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		t.Fatalf("read events: %v", err)
+	}
+	return string(data)
+}
+
+func TestRunCompleted_PreHookBlockedRefusesCompletion(t *testing.T) {
+	festDir, taskRel := setupHookedFestival(t, "hooks:\n  pre: [checker]\n")
+	var called []string
+	fakeTaskRunner(t, 1, &called)
+	resetTaskFlags()
+	completedYes = true
+
+	var err error
+	captureIO(t, func() {
+		err = runCompleted(taskCmd(t, festDir), []string{taskRel})
+	})
+	if err == nil {
+		t.Fatal("expected fail-closed pre hook to block completion")
+	}
+	if !strings.Contains(err.Error(), "blocked by fail-closed hook") {
+		t.Fatalf("err = %v", err)
+	}
+	if len(called) != 1 {
+		t.Fatalf("hook exec calls = %v", called)
+	}
+
+	taskID := canonicalTaskID(t, festDir, taskRel)
+	if task, ok := taskStatus(t, festDir, taskID); ok && task.Status == "completed" {
+		t.Fatalf("task must not be completed, got %+v", task)
+	}
+
+	events := readHookEvents(t, festDir)
+	if !strings.Contains(events, `"wf_hook_run"`) || !strings.Contains(events, `"hook_blocked":true`) {
+		t.Fatalf("blocked wf_hook_run event missing:\n%s", events)
+	}
+	if !strings.Contains(events, `"hook_verb":"task_complete"`) {
+		t.Fatalf("task_complete verb missing:\n%s", events)
+	}
+}
+
+func TestRunCompleted_UndeclaredBindingSkipsAndCompletes(t *testing.T) {
+	festDir, taskRel := setupHookedFestival(t, "hooks:\n  pre: [ghost]\n")
+	var called []string
+	fakeTaskRunner(t, 0, &called)
+	resetTaskFlags()
+	completedYes = true
+
+	var err error
+	captureIO(t, func() {
+		err = runCompleted(taskCmd(t, festDir), []string{taskRel})
+	})
+	if err != nil {
+		t.Fatalf("undeclared binding must skip, not fail: %v", err)
+	}
+	if len(called) != 0 {
+		t.Fatalf("undeclared hook must never exec: %v", called)
+	}
+
+	events := readHookEvents(t, festDir)
+	if !strings.Contains(events, `"hook_skip":"undeclared"`) {
+		t.Fatalf("undeclared skip event missing:\n%s", events)
+	}
+}
+
+func TestRunCompleted_HumanGateSkipsAutomationHooks(t *testing.T) {
+	festDir, taskRel := setupHookedFestival(t, "hooks:\n  pre: [checker]\napproval: human-required\n")
+	var called []string
+	fakeTaskRunner(t, 1, &called) // would block if it ever ran
+	resetTaskFlags()
+	completedYes = true
+
+	var err error
+	captureIO(t, func() {
+		err = runCompleted(taskCmd(t, festDir), []string{taskRel})
+	})
+	if err != nil {
+		t.Fatalf("human-gate step must skip automation hooks: %v", err)
+	}
+	if len(called) != 0 {
+		t.Fatalf("automation hooks must never exec on a human gate: %v", called)
+	}
+
+	events := readHookEvents(t, festDir)
+	if !strings.Contains(events, `"hook_skip":"human-gate"`) {
+		t.Fatalf("human-gate skip event missing:\n%s", events)
+	}
+}
+
+func TestRunCompleted_PostHookRunsAfterCompletion(t *testing.T) {
+	festDir, taskRel := setupHookedFestival(t, "hooks:\n  post: [checker]\n")
+	var called []string
+	fakeTaskRunner(t, 0, &called)
+	resetTaskFlags()
+	completedYes = true
+
+	var err error
+	captureIO(t, func() {
+		err = runCompleted(taskCmd(t, festDir), []string{taskRel})
+	})
+	if err != nil {
+		t.Fatalf("runCompleted: %v", err)
+	}
+	if len(called) != 1 {
+		t.Fatalf("post hook exec calls = %v", called)
+	}
+
+	taskID := canonicalTaskID(t, festDir, taskRel)
+	task, ok := taskStatus(t, festDir, taskID)
+	if !ok || task.Status != "completed" {
+		t.Fatalf("task not completed: %+v", task)
+	}
+
+	events := readHookEvents(t, festDir)
+	if !strings.Contains(events, `"hook_timing":"post"`) || !strings.Contains(events, `"hook_outcome":"pass"`) {
+		t.Fatalf("post pass event missing:\n%s", events)
+	}
+}

--- a/internal/commands/validation/commands.go
+++ b/internal/commands/validation/commands.go
@@ -36,8 +36,8 @@ const (
 	CodeUnfilledTemplate   = "unfilled_template"
 	CodeMissingGoal        = "missing_goal"
 	CodeNumberingGap       = "numbering_gap"
-	CodeHookShadowDrift       = "hook_shadow_drift"
-	CodeHookUndeclaredBinding = "hook_undeclared_binding"
+	CodeHookShadowDrift  = "hook_shadow_drift"
+	CodeHookResolveError = "hook_resolve_error"
 )
 
 // ValidationIssue represents a single validation problem
@@ -523,7 +523,7 @@ func validateHooksChecks(ctx context.Context, festivalPath string, result *Valid
 	eff, err := hookslib.LoadAndResolve(ctx, festivalPath)
 	if err != nil {
 		result.Issues = append(result.Issues, ValidationIssue{
-			Level: LevelWarning, Code: CodeHookShadowDrift, Path: festivalPath,
+			Level: LevelWarning, Code: CodeHookResolveError, Path: festivalPath,
 			Message: fmt.Sprintf("could not resolve hooks: %v", err),
 		})
 		return
@@ -539,5 +539,9 @@ func validateHooksChecks(ctx context.Context, festivalPath string, result *Valid
 			})
 		}
 	}
+
+	// Undeclared bindings skip with a warning (spec 03, D10).
+	result.Issues = append(result.Issues,
+		convertIssues(validator.ScanUndeclaredBindings(ctx, festivalPath, eff))...)
 }
 

--- a/internal/commands/validation/commands.go
+++ b/internal/commands/validation/commands.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/errors"
 	tpl "github.com/Obedience-Corp/fest/internal/template"
 	"github.com/Obedience-Corp/fest/internal/ui"
+	hookslib "github.com/Obedience-Corp/fest/internal/hooks"
 	"github.com/Obedience-Corp/fest/internal/validator"
 	"github.com/spf13/cobra"
 )
@@ -35,6 +36,8 @@ const (
 	CodeUnfilledTemplate   = "unfilled_template"
 	CodeMissingGoal        = "missing_goal"
 	CodeNumberingGap       = "numbering_gap"
+	CodeHookShadowDrift       = "hook_shadow_drift"
+	CodeHookUndeclaredBinding = "hook_undeclared_binding"
 )
 
 // ValidationIssue represents a single validation problem
@@ -509,11 +512,32 @@ func emitValidateError(opts *validateOptions, err error) error {
 	return err
 }
 
-// validateHooksChecks emits non-blocking warnings for legacy hook aliases.
+
+// validateHooksChecks emits non-blocking warnings for legacy aliases, shadow drift, and undeclared bindings.
 func validateHooksChecks(ctx context.Context, festivalPath string, result *ValidationResult) {
 	issues, err := validator.ValidateHooksConfig(ctx, festivalPath)
+	if err == nil {
+		result.Issues = append(result.Issues, convertIssues(issues)...)
+	}
+
+	eff, err := hookslib.LoadAndResolve(ctx, festivalPath)
 	if err != nil {
+		result.Issues = append(result.Issues, ValidationIssue{
+			Level: LevelWarning, Code: CodeHookShadowDrift, Path: festivalPath,
+			Message: fmt.Sprintf("could not resolve hooks: %v", err),
+		})
 		return
 	}
-	result.Issues = append(result.Issues, convertIssues(issues)...)
+	if eff == nil {
+		return
+	}
+	for name, h := range eff.Hooks {
+		for _, s := range h.Shadowed {
+			result.Issues = append(result.Issues, ValidationIssue{
+				Level: LevelWarning, Code: CodeHookShadowDrift, Path: festivalPath,
+				Message: fmt.Sprintf("hook %q at layer %s overrides a differing definition from layer %s", name, h.Source, s.Source),
+			})
+		}
+	}
 }
+

--- a/internal/commands/validation/commands.go
+++ b/internal/commands/validation/commands.go
@@ -324,6 +324,7 @@ func runValidateAll(ctx context.Context, opts *validateOptions) error {
 	validateTemplateChecks(festivalPath, result)
 	validateOrderingChecks(ctx, festivalPath, result)
 	validateAutoLinkChecks(ctx, festivalPath, result)
+	validateHooksChecks(ctx, festivalPath, result)
 	validateWorkflowDocsChecks(ctx, festivalPath, result)
 
 	// Add suggestions based on issues
@@ -506,4 +507,13 @@ func emitValidateError(opts *validateOptions, err error) error {
 		return emitValidateJSON(result)
 	}
 	return err
+}
+
+// validateHooksChecks emits non-blocking warnings for legacy hook aliases.
+func validateHooksChecks(ctx context.Context, festivalPath string, result *ValidationResult) {
+	issues, err := validator.ValidateHooksConfig(ctx, festivalPath)
+	if err != nil {
+		return
+	}
+	result.Issues = append(result.Issues, convertIssues(issues)...)
 }

--- a/internal/commands/validation/validate_output.go
+++ b/internal/commands/validation/validate_output.go
@@ -118,6 +118,9 @@ func printValidationResult(display *ui.UI, festivalPath string, result *Validati
 	autoLinkIssues := filterIssuesByPrefix(result.Issues, "autolink_")
 	printValidationSection(display, "AUTO-LINK", autoLinkIssues)
 
+	hookIssues := filterIssuesByPrefix(result.Issues, "hook")
+	printValidationSection(display, "HOOKS", hookIssues)
+
 	workflowIssues := filterIssuesByCode(result.Issues, CodeWorkflowNumbering, CodeWorkflowScan)
 	printValidationSection(display, "WORKFLOW", workflowIssues)
 

--- a/internal/commands/workflow/approval_readiness.go
+++ b/internal/commands/workflow/approval_readiness.go
@@ -2,12 +2,12 @@ package workflow
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
 	festerrors "github.com/Obedience-Corp/fest/internal/errors"
 	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+	"github.com/Obedience-Corp/fest/internal/hooks"
 )
 
 type approvalEvidenceInspector func(phasePath, relativePath string) (bool, error)
@@ -166,54 +166,11 @@ func resolveExistingEvidencePathsWithInspector(
 }
 
 func normalizeEvidencePath(path string) (string, error) {
-	path = strings.TrimSpace(path)
-	if path == "" {
-		return "", fmt.Errorf("path is empty")
-	}
-	if filepath.IsAbs(path) {
-		return "", fmt.Errorf("absolute paths are not allowed")
-	}
-	clean := filepath.Clean(path)
-	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
-		return "", fmt.Errorf("path escapes the phase directory")
-	}
-	return clean, nil
+	return hooks.NormalizeEvidencePath(path)
 }
 
 func inspectApprovalEvidence(phasePath, relativePath string) (bool, error) {
-	phaseRoot, err := filepath.Abs(phasePath)
-	if err != nil {
-		return false, fmt.Errorf("resolving phase root: %w", err)
-	}
-	resolvedRoot, err := filepath.EvalSymlinks(phaseRoot)
-	if err != nil {
-		return false, fmt.Errorf("resolving phase root symlinks: %w", err)
-	}
-
-	candidate := filepath.Join(phaseRoot, relativePath)
-	resolvedCandidate, err := filepath.EvalSymlinks(candidate)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		return false, fmt.Errorf("resolving evidence symlinks: %w", err)
-	}
-	containedPath, err := filepath.Rel(resolvedRoot, resolvedCandidate)
-	if err != nil {
-		return false, fmt.Errorf("checking resolved evidence containment: %w", err)
-	}
-	if containedPath == ".." || strings.HasPrefix(containedPath, ".."+string(filepath.Separator)) {
-		return false, fmt.Errorf("resolved evidence path escapes the phase directory")
-	}
-
-	info, err := os.Stat(resolvedCandidate)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		return false, err
-	}
-	return info.Mode().IsRegular() && info.Size() > 0, nil
+	return hooks.WithinRoot(phasePath, relativePath)
 }
 
 // formatReadinessBlockReason turns a readiness error into durable step feedback.

--- a/internal/commands/workflow/approve.go
+++ b/internal/commands/workflow/approve.go
@@ -39,8 +39,8 @@ func requireHumanGateTTY() error {
 
 func humanRequiredAutoRefusal(stepNum int, step wf.WorkflowStep) error {
 	return festerrors.Validation(
-		"cannot auto-clear a human-required gate (step " +
-			strings.TrimSpace(step.Name) + ")").
+		"cannot auto-clear a human-required gate (step "+
+			strings.TrimSpace(step.Name)+")").
 		WithField("step", stepNum).
 		WithField("gate", step.Name).
 		WithHint("this checkpoint is marked approval: human-required; a human must run 'fest workflow approve' in a terminal")
@@ -57,6 +57,13 @@ type approvalJudgeOptions struct {
 	OverrideJudge bool
 	Summary       string // manual path summary (also used with --override-judge)
 	Wait          bool
+
+	// Source is the config layer the resolved judge definition came from,
+	// recorded on the judge's wf_hook_run audit event.
+	Source hooks.Layer
+	// OnHookRuns receives the judge execution's runner records so callers can
+	// persist them to the festival audit trail (D9).
+	OnHookRuns func([]hooks.HookRun)
 }
 
 type approvalJudgeRequest struct {
@@ -237,6 +244,12 @@ func runApproveWithOptions(ctx context.Context, decision wf.DecisionMetadata, op
 		}
 	}
 
+	// Pre hooks gate the approve verb (spec 03, D4): a fail-closed failure
+	// refuses the approval before any decision is recorded.
+	if _, err := runGateHookStage(ctx, nav, currentStepNum, step, hooks.TimingPre); err != nil {
+		return err
+	}
+
 	if opts.Auto {
 		judgeCommand, err := resolveApprovalJudgeCommandFor(ctx, nav, opts.JudgeCommand)
 		if err != nil {
@@ -289,6 +302,9 @@ func runApproveWithOptions(ctx context.Context, decision wf.DecisionMetadata, op
 		}
 		if decision.Summary != "" {
 			fmt.Printf("  %s: %s\n", ui.Label("Summary"), decision.Summary)
+		}
+		if _, postErr := runGateHookStage(ctx, fresh, currentStepNum, freshStep, hooks.TimingPost); postErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: gate post hooks: %v\n", postErr)
 		}
 		return showNextStep(ctx, fresh, fresh.GetSteps())
 	})
@@ -480,6 +496,17 @@ func AutoDelegateBlockingCheckpoints(ctx context.Context, nav *wf.Navigator) err
 			return nil
 		}
 
+		// Pre hooks gate the approve verb (spec 03, D4): a fail-closed
+		// failure parks the checkpoint instead of launching the judge. The
+		// block is recorded in the audit trail; fest next keeps rendering the
+		// checkpoint until the hook failure is fixed.
+		if blocked, hookErr := runGateHookStage(ctx, nav, current, step, hooks.TimingPre); blocked || hookErr != nil {
+			if hookErr != nil {
+				fmt.Fprintf(os.Stderr, "Warning: gate pre hooks blocked judge delegation: %v\n", hookErr)
+			}
+			return nil
+		}
+
 		fmt.Printf("%s Checkpoint delegated to approval judge (%s)\n", ui.Info("→"), judgeCommand)
 		fmt.Printf("  Step %d: %s\n", current, step.Name)
 
@@ -660,6 +687,9 @@ func applyApproveAutoVerdict(ctx context.Context, nav *wf.Navigator, currentStep
 		}
 		fmt.Printf("%s Step %d: %s auto-approved\n", ui.Success("✓"), currentStepNum, step.Name)
 		fmt.Printf("  %s: %s\n", ui.Label("Reason"), decision.Reason)
+		if _, postErr := runGateHookStage(ctx, nav, currentStepNum, step, hooks.TimingPost); postErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: gate post hooks: %v\n", postErr)
+		}
 		return true, showNextStep(ctx, nav, nav.GetSteps())
 	case "reject":
 		applied, err := nav.ApplyJudgeRejection(ctx, currentStepNum, runID, audit, judgeDecision)
@@ -716,32 +746,44 @@ func judgeApproval(ctx context.Context, nav *wf.Navigator, step wf.WorkflowStep,
 	// not just the step definition. Without this the judge sees only Document
 	// and rejects (no evidence) or approves on the agent's self-report.
 	req.Evidence = resolveExistingEvidencePaths(nav.Ctx.PhasePath, step)
-	if files, ok := maybeEmbedEvidence(ctx, nav, req.Evidence); ok {
-		req.EvidenceFiles = files
+	files, source := resolveJudgeHookContext(ctx, nav, opts.JudgeCommand, req.Evidence)
+	req.EvidenceFiles = files
+	opts.Source = source
+	stepNum := step.Number
+	opts.OnHookRuns = func(runs []hooks.HookRun) {
+		emitJudgeHookRuns(ctx, nav, stepNum, runs)
 	}
 
 	return evaluateApprovalJudge(ctx, req, opts)
 }
 
-// maybeEmbedEvidence attaches evidence_files when the resolved approval_judge
-// hook opts into evidence: embed. Best-effort: failures leave path-only mode.
-func maybeEmbedEvidence(ctx context.Context, nav *wf.Navigator, present []string) ([]hooks.EvidenceFile, bool) {
-	if nav == nil || nav.Ctx == nil || nav.Ctx.FestivalPath == "" || len(present) == 0 {
-		return nil, false
+// resolveJudgeHookContext resolves the approval_judge hook once for both the
+// evidence: embed opt-in and the audit-event source layer. Best-effort:
+// resolve failures leave path-only mode and the festivals-layer default.
+func resolveJudgeHookContext(ctx context.Context, nav *wf.Navigator, judgeCommand string, present []string) ([]hooks.EvidenceFile, hooks.Layer) {
+	source := hooks.LayerFestivals
+	if nav == nil || nav.Ctx == nil || nav.Ctx.FestivalPath == "" {
+		return nil, source
 	}
 	eff, err := hooks.LoadAndResolve(ctx, nav.Ctx.FestivalPath)
 	if err != nil || eff == nil {
-		return nil, false
+		return nil, source
 	}
 	h, ok := eff.Hooks[hooks.ApprovalJudgeName]
-	if !ok || h.Evidence != hooks.EvidenceEmbed {
-		return nil, false
+	if !ok {
+		return nil, source
+	}
+	if h.Command == judgeCommand {
+		source = h.Source
+	}
+	if h.Evidence != hooks.EvidenceEmbed || len(present) == 0 {
+		return nil, source
 	}
 	files, err := hooks.BuildEvidenceFiles(nav.Ctx.PhasePath, present, hooks.EvidenceEmbedCapBytes)
 	if err != nil || len(files) == 0 {
-		return nil, false
+		return nil, source
 	}
-	return files, true
+	return files, source
 }
 
 func evaluateApprovalJudge(ctx context.Context, req approvalJudgeRequest, opts approvalJudgeOptions) (*approvalJudgeResponse, string, error) {
@@ -762,7 +804,10 @@ func evaluateApprovalJudge(ctx context.Context, req approvalJudgeRequest, opts a
 	defer cancel()
 
 	// Execute through the hooks runner seam so there is one command path.
-	out, err := runApprovalJudgeViaHooks(judgeCtx, opts.JudgeCommand, append(stdin, '\n'), opts.WorkDir)
+	out, judgeRuns, err := runApprovalJudgeViaHooks(judgeCtx, opts.JudgeCommand, append(stdin, '\n'), opts.WorkDir, opts.Source)
+	if opts.OnHookRuns != nil && len(judgeRuns) > 0 {
+		opts.OnHookRuns(judgeRuns)
+	}
 	if err != nil {
 		if errors.Is(judgeCtx.Err(), context.DeadlineExceeded) {
 			return nil, "", festerrors.Wrap(judgeCtx.Err(), "approval judge timed out").
@@ -807,8 +852,12 @@ func runApprovalJudgeCommandDefault(ctx context.Context, command string, stdin [
 
 // runApprovalJudgeViaHooks executes the judge command through hooks.Runner so
 // there is a single command-execution path. The package var
-// runApprovalJudgeCommand remains injectable for tests.
-func runApprovalJudgeViaHooks(ctx context.Context, command string, stdin []byte, dir string) ([]byte, error) {
+// runApprovalJudgeCommand remains injectable for tests. The returned runs are
+// the runner's audit records for the execution.
+func runApprovalJudgeViaHooks(ctx context.Context, command string, stdin []byte, dir string, source hooks.Layer) ([]byte, []hooks.HookRun, error) {
+	if source == "" {
+		source = hooks.LayerFestivals
+	}
 	r := hooks.NewRunner(dir)
 	r.Exec = func(ctx context.Context, command string, stdin []byte, dir string) hooks.CommandResult {
 		out, err := runApprovalJudgeCommand(ctx, command, stdin, dir)
@@ -829,27 +878,29 @@ func runApprovalJudgeViaHooks(ctx context.Context, command string, stdin []byte,
 			Command: command,
 			Fail:    hooks.FailClosed,
 			Timeout: 0, // no deadline unless caller already bound ctx
-			Source:  hooks.LayerFestivals,
+			Source:  source,
 		},
 	}}
 	runs, _, err := r.Run(ctx, hooks.LevelGate, hooks.VerbGateApprove, planned, stdin)
 	if err != nil {
-		return nil, err
+		return nil, runs, err
 	}
 	if len(runs) == 0 {
-		return nil, festerrors.Validation("approval judge produced no hook run")
+		return nil, nil, festerrors.Validation("approval judge produced no hook run")
 	}
 	run := runs[0]
 	if run.Outcome != hooks.OutcomePass {
 		if run.Outcome == hooks.OutcomeTimeout {
-			return run.Stdout, context.DeadlineExceeded
+			return run.Stdout, runs, context.DeadlineExceeded
 		}
 		if run.Err != nil {
-			return run.Stdout, run.Err
+			return run.Stdout, runs, run.Err
 		}
-		return run.Stdout, fmt.Errorf("approval judge hook failed: outcome=%s exit=%d", run.Outcome, run.ExitCode)
+		return run.Stdout, runs, festerrors.New("approval judge hook failed").
+			WithField("outcome", string(run.Outcome)).
+			WithField("exit_code", run.ExitCode)
 	}
-	return run.Stdout, nil
+	return run.Stdout, runs, nil
 }
 
 func parseApprovalJudgeResponse(out []byte) (*approvalJudgeResponse, error) {

--- a/internal/commands/workflow/approve.go
+++ b/internal/commands/workflow/approve.go
@@ -76,6 +76,9 @@ type approvalJudgeRequest struct {
 	// the readiness gate validated. Additive to fest.approval.judge/v1: an older
 	// judge ignores it and sees only Document, as before.
 	Evidence []string `json:"evidence,omitempty"`
+	// EvidenceFiles is optional embedded content when the resolved hook uses
+	// evidence: embed. Omitted in the default paths mode.
+	EvidenceFiles []hooks.EvidenceFile `json:"evidence_files,omitempty"`
 }
 
 type approvalJudgeResponse struct {
@@ -713,8 +716,32 @@ func judgeApproval(ctx context.Context, nav *wf.Navigator, step wf.WorkflowStep,
 	// not just the step definition. Without this the judge sees only Document
 	// and rejects (no evidence) or approves on the agent's self-report.
 	req.Evidence = resolveExistingEvidencePaths(nav.Ctx.PhasePath, step)
+	if files, ok := maybeEmbedEvidence(ctx, nav, req.Evidence); ok {
+		req.EvidenceFiles = files
+	}
 
 	return evaluateApprovalJudge(ctx, req, opts)
+}
+
+// maybeEmbedEvidence attaches evidence_files when the resolved approval_judge
+// hook opts into evidence: embed. Best-effort: failures leave path-only mode.
+func maybeEmbedEvidence(ctx context.Context, nav *wf.Navigator, present []string) ([]hooks.EvidenceFile, bool) {
+	if nav == nil || nav.Ctx == nil || nav.Ctx.FestivalPath == "" || len(present) == 0 {
+		return nil, false
+	}
+	eff, err := hooks.LoadAndResolve(ctx, nav.Ctx.FestivalPath)
+	if err != nil || eff == nil {
+		return nil, false
+	}
+	h, ok := eff.Hooks[hooks.ApprovalJudgeName]
+	if !ok || h.Evidence != hooks.EvidenceEmbed {
+		return nil, false
+	}
+	files, err := hooks.BuildEvidenceFiles(nav.Ctx.PhasePath, present, hooks.EvidenceEmbedCapBytes)
+	if err != nil || len(files) == 0 {
+		return nil, false
+	}
+	return files, true
 }
 
 func evaluateApprovalJudge(ctx context.Context, req approvalJudgeRequest, opts approvalJudgeOptions) (*approvalJudgeResponse, string, error) {

--- a/internal/commands/workflow/approve.go
+++ b/internal/commands/workflow/approve.go
@@ -20,7 +20,31 @@ import (
 	"github.com/Obedience-Corp/fest/internal/ui"
 	"github.com/Obedience-Corp/fest/internal/workspace"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
+
+var workflowApproveTTYCheck = term.IsTerminal
+
+func isHumanRequired(step wf.WorkflowStep) bool {
+	return strings.EqualFold(strings.TrimSpace(step.Approval), "human-required")
+}
+
+func requireHumanGateTTY() error {
+	if workflowApproveTTYCheck(int(os.Stdin.Fd())) && workflowApproveTTYCheck(int(os.Stderr.Fd())) {
+		return nil
+	}
+	return festerrors.Validation("this step requires an interactive human approval").
+		WithHint("run 'fest workflow approve' directly in a terminal as a human operator")
+}
+
+func humanRequiredAutoRefusal(stepNum int, step wf.WorkflowStep) error {
+	return festerrors.Validation(
+		"cannot auto-clear a human-required gate (step " +
+			strings.TrimSpace(step.Name) + ")").
+		WithField("step", stepNum).
+		WithField("gate", step.Name).
+		WithHint("this checkpoint is marked approval: human-required; a human must run 'fest workflow approve' in a terminal")
+}
 
 const approvalJudgeSchemaVersion = "fest.approval.judge/v1"
 
@@ -199,6 +223,15 @@ func runApproveWithOptions(ctx context.Context, decision wf.DecisionMetadata, op
 		return festerrors.Validation("step does not have a blocking checkpoint").
 			WithField("step", currentStepNum).
 			WithHint("Use 'fest workflow advance' for regular steps")
+	}
+
+	if isHumanRequired(step) {
+		if opts.Auto {
+			return humanRequiredAutoRefusal(currentStepNum, step)
+		}
+		if err := requireHumanGateTTY(); err != nil {
+			return err
+		}
 	}
 
 	if opts.Auto {
@@ -393,6 +426,10 @@ func AutoDelegateBlockingCheckpoints(ctx context.Context, nav *wf.Navigator) err
 			return nil
 		}
 		step := steps[current-1]
+		if isHumanRequired(step) {
+			// Human gate: never delegate. Leave the checkpoint for the human approve path.
+			return nil
+		}
 		if wf.ClassifyCheckpoint(step) == wf.CheckpointClassOperatorAttestation {
 			// Operator attestations are intentionally never delegated. Leave the
 			// checkpoint untouched so fest next renders the human approval path.

--- a/internal/commands/workflow/approve.go
+++ b/internal/commands/workflow/approve.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/config"
 	festerrors "github.com/Obedience-Corp/fest/internal/errors"
 	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+	"github.com/Obedience-Corp/fest/internal/hooks"
 	"github.com/Obedience-Corp/fest/internal/lifecycle"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
@@ -696,7 +697,8 @@ func evaluateApprovalJudge(ctx context.Context, req approvalJudgeRequest, opts a
 	}
 	defer cancel()
 
-	out, err := runApprovalJudgeCommand(judgeCtx, opts.JudgeCommand, append(stdin, '\n'), opts.WorkDir)
+	// Execute through the hooks runner seam so there is one command path.
+	out, err := runApprovalJudgeViaHooks(judgeCtx, opts.JudgeCommand, append(stdin, '\n'), opts.WorkDir)
 	if err != nil {
 		if errors.Is(judgeCtx.Err(), context.DeadlineExceeded) {
 			return nil, "", festerrors.Wrap(judgeCtx.Err(), "approval judge timed out").
@@ -737,6 +739,53 @@ func runApprovalJudgeCommandDefault(ctx context.Context, command string, stdin [
 		return nil, err
 	}
 	return out, nil
+}
+
+// runApprovalJudgeViaHooks executes the judge command through hooks.Runner so
+// there is a single command-execution path. The package var
+// runApprovalJudgeCommand remains injectable for tests.
+func runApprovalJudgeViaHooks(ctx context.Context, command string, stdin []byte, dir string) ([]byte, error) {
+	r := hooks.NewRunner(dir)
+	r.Exec = func(ctx context.Context, command string, stdin []byte, dir string) hooks.CommandResult {
+		out, err := runApprovalJudgeCommand(ctx, command, stdin, dir)
+		res := hooks.CommandResult{Stdout: out, Err: err}
+		if err != nil {
+			res.ExitCode = 1
+			if ee, ok := err.(*exec.ExitError); ok {
+				res.ExitCode = ee.ExitCode()
+			}
+		}
+		return res
+	}
+	planned := []hooks.PlannedHook{{
+		Name:   hooks.ApprovalJudgeName,
+		Timing: hooks.TimingPost,
+		Hook: hooks.ResolvedHook{
+			Name:    hooks.ApprovalJudgeName,
+			Command: command,
+			Fail:    hooks.FailClosed,
+			Timeout: 0, // no deadline unless caller already bound ctx
+			Source:  hooks.LayerFestivals,
+		},
+	}}
+	runs, _, err := r.Run(ctx, hooks.LevelGate, hooks.VerbGateApprove, planned, stdin)
+	if err != nil {
+		return nil, err
+	}
+	if len(runs) == 0 {
+		return nil, festerrors.Validation("approval judge produced no hook run")
+	}
+	run := runs[0]
+	if run.Outcome != hooks.OutcomePass {
+		if run.Outcome == hooks.OutcomeTimeout {
+			return run.Stdout, context.DeadlineExceeded
+		}
+		if run.Err != nil {
+			return run.Stdout, run.Err
+		}
+		return run.Stdout, fmt.Errorf("approval judge hook failed: outcome=%s exit=%d", run.Outcome, run.ExitCode)
+	}
+	return run.Stdout, nil
 }
 
 func parseApprovalJudgeResponse(out []byte) (*approvalJudgeResponse, error) {

--- a/internal/commands/workflow/decision.go
+++ b/internal/commands/workflow/decision.go
@@ -27,7 +27,7 @@ func normalizeDecision(action, actor, summary string) (wf.DecisionMetadata, erro
 	switch actor {
 	case decisionActorUser:
 	case decisionActorAgent:
-		return wf.DecisionMetadata{}, festerrors.Validation("--as agent is not allowed for manual " + action).
+		return wf.DecisionMetadata{}, festerrors.Validation("--as agent is not allowed for manual "+action).
 			WithField("actor", actor).
 			WithHint(agentActorHint(action))
 	default:

--- a/internal/commands/workflow/gate_hooks.go
+++ b/internal/commands/workflow/gate_hooks.go
@@ -1,0 +1,79 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+	"github.com/Obedience-Corp/fest/internal/hooks"
+	"github.com/Obedience-Corp/fest/internal/progress"
+)
+
+// newGateHookRunner is an injectable seam so tests can fake hook execution.
+var newGateHookRunner = hooks.NewRunner
+
+// gateHookRequest builds the lifecycle request for a gate step's bindings
+// (spec 03: gate approve verb). A human-required step skips every automation
+// hook, recorded as skipped: human-gate (spec 04).
+func gateHookRequest(nav *wf.Navigator, stepNum int, step wf.WorkflowStep) progress.LifecycleHookRequest {
+	return progress.LifecycleHookRequest{
+		FestivalPath: nav.Ctx.FestivalPath,
+		Phase:        nav.Ctx.PhaseName,
+		Step:         stepNum,
+		Level:        hooks.LevelGate,
+		Verb:         hooks.VerbGateApprove,
+		Pre:          step.Hooks.Pre,
+		Post:         step.Hooks.Post,
+		HumanGate:    isHumanRequired(step),
+	}
+}
+
+// runGateHookStage plans and runs one timing of the step's bindings and
+// persists wf_hook_run events through the navigator's state store. For the
+// pre timing a fail-closed failure blocks the approve verb; for the post
+// timing the verb stays applied and the failure is surfaced as a warning.
+func runGateHookStage(ctx context.Context, nav *wf.Navigator, stepNum int, step wf.WorkflowStep, timing hooks.Timing) (bool, error) {
+	req := gateHookRequest(nav, stepNum, step)
+	planned, err := progress.PlanLifecycleHooks(ctx, req)
+	if err != nil {
+		return false, err
+	}
+	if len(planned) == 0 {
+		return false, nil
+	}
+	runner := newGateHookRunner(nav.Ctx.FestivalPath)
+	var (
+		runs    []hooks.HookRun
+		blocked bool
+	)
+	if timing == hooks.TimingPre {
+		runs, blocked, err = runner.RunPre(ctx, req.Level, req.Verb, planned, nil)
+	} else {
+		runs, blocked, err = runner.RunPost(ctx, req.Level, req.Verb, planned, nil)
+	}
+	if emitErr := nav.QueueHookRunEvents(ctx, stepNum, runs); emitErr != nil && err == nil {
+		err = emitErr
+	}
+	if err != nil {
+		return blocked, festerrors.Wrap(err, "running gate hooks")
+	}
+	if blocked && timing == hooks.TimingPre {
+		return true, progress.BlockedHookError(hooks.VerbGateApprove, runs)
+	}
+	if blocked {
+		fmt.Fprintln(os.Stderr, "Warning: a fail-closed post hook failed after approval; see wf_hook_run in the festival audit trail")
+	}
+	return blocked, nil
+}
+
+// emitJudgeHookRuns persists the judge execution's own runner records so the
+// audit trail includes the judge as a gate_approve hook run (D9). Best-effort:
+// event persistence must never turn into a judge outcome error.
+func emitJudgeHookRuns(ctx context.Context, nav *wf.Navigator, stepNum int, runs []hooks.HookRun) {
+	if nav == nil {
+		return
+	}
+	_ = nav.QueueHookRunEvents(ctx, stepNum, runs)
+}

--- a/internal/commands/workflow/gate_hooks_test.go
+++ b/internal/commands/workflow/gate_hooks_test.go
@@ -1,0 +1,193 @@
+package workflow
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/guidance"
+	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+	"github.com/Obedience-Corp/fest/internal/hooks"
+	"github.com/Obedience-Corp/fest/internal/progress"
+)
+
+func writeHookedGateFestival(t *testing.T, gatesExtra string) (*wf.Navigator, string) {
+	t.Helper()
+	festivalPath := t.TempDir()
+	phasePath := filepath.Join(festivalPath, "001_IMPLEMENT")
+	if err := os.MkdirAll(phasePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(festivalPath, ".fest"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	festYAML := `version: "1.0"
+name: gate-hooks-test
+id: GHK-001
+metadata:
+  id: GHK-001
+hooks:
+  definitions:
+    gate-check:
+      command: test-gate-check
+`
+	if err := os.WriteFile(filepath.Join(festivalPath, "fest.yaml"), []byte(festYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	gates := `---
+fest_type: phase_gate
+---
+
+# Gate
+
+## Step 1: PHASE GOAL
+
+**Question:** Is the phase goal met?
+
+**Actions:**
+1. Check deliverables
+
+**Checkpoint:** APPROVAL REQUIRED
+` + gatesExtra
+	if err := os.WriteFile(filepath.Join(phasePath, "GATES.md"), []byte(gates), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	gctx := &guidance.GuidanceContext{
+		FestivalPath: festivalPath,
+		PhasePath:    phasePath,
+		PhaseName:    "001_IMPLEMENT",
+		Mode:         guidance.ModeWorkflow,
+	}
+	nav, err := wf.NewNavigator(gctx, guidance.ModeWorkflow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nav.SetDocFilename("GATES.md")
+	nav.SetStateKeyPrefix("gate:")
+	store := progress.NewStore(festivalPath)
+	if err := store.Load(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	nav.SetStateStore(store)
+	if err := nav.Initialize(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", t.TempDir())
+	return nav, festivalPath
+}
+
+func fakeGateRunner(t *testing.T, exitCode int, called *[]string) {
+	t.Helper()
+	orig := newGateHookRunner
+	t.Cleanup(func() { newGateHookRunner = orig })
+	newGateHookRunner = func(workDir string) *hooks.Runner {
+		r := hooks.NewRunner(workDir)
+		r.Exec = func(ctx context.Context, command string, stdin []byte, dir string) hooks.CommandResult {
+			if called != nil {
+				*called = append(*called, command)
+			}
+			res := hooks.CommandResult{ExitCode: exitCode}
+			if exitCode != 0 {
+				res.Err = context.Canceled
+			}
+			return res
+		}
+		return r
+	}
+}
+
+func readGateEvents(t *testing.T, festivalPath string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(festivalPath, ".fest", "progress_events.jsonl"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func TestRunGateHookStage_BlockedPreRefusesVerb(t *testing.T) {
+	nav, festivalPath := writeHookedGateFestival(t, "\n**Hooks:** pre: [gate-check]\n")
+	var called []string
+	fakeGateRunner(t, 1, &called)
+
+	step := nav.GetSteps()[0]
+	blocked, err := runGateHookStage(context.Background(), nav, 1, step, hooks.TimingPre)
+	if err == nil || !blocked {
+		t.Fatalf("want blocked error, got blocked=%v err=%v", blocked, err)
+	}
+	if !strings.Contains(err.Error(), "blocked by fail-closed hook") {
+		t.Fatalf("err = %v", err)
+	}
+	if len(called) != 1 {
+		t.Fatalf("exec calls = %v", called)
+	}
+	events := readGateEvents(t, festivalPath)
+	if !strings.Contains(events, `"hook_verb":"gate_approve"`) || !strings.Contains(events, `"hook_blocked":true`) {
+		t.Fatalf("blocked gate_approve event missing:\n%s", events)
+	}
+}
+
+func TestRunGateHookStage_HumanGateSkipsAutomation(t *testing.T) {
+	nav, festivalPath := writeHookedGateFestival(t,
+		"\n**Hooks:** pre: [gate-check]\n\n**Approval:** human-required\n")
+	var called []string
+	fakeGateRunner(t, 1, &called) // would block if it ever ran
+
+	step := nav.GetSteps()[0]
+	if !isHumanRequired(step) {
+		t.Fatal("fixture step must be human-required")
+	}
+	blocked, err := runGateHookStage(context.Background(), nav, 1, step, hooks.TimingPre)
+	if err != nil || blocked {
+		t.Fatalf("human gate must skip automation hooks: blocked=%v err=%v", blocked, err)
+	}
+	if len(called) != 0 {
+		t.Fatalf("automation hooks must never exec on a human gate: %v", called)
+	}
+	events := readGateEvents(t, festivalPath)
+	if !strings.Contains(events, `"hook_skip":"human-gate"`) {
+		t.Fatalf("human-gate skip event missing:\n%s", events)
+	}
+}
+
+func TestRunGateHookStage_NoBindingsIsNoop(t *testing.T) {
+	nav, festivalPath := writeHookedGateFestival(t, "")
+	var called []string
+	fakeGateRunner(t, 1, &called)
+
+	step := nav.GetSteps()[0]
+	blocked, err := runGateHookStage(context.Background(), nav, 1, step, hooks.TimingPre)
+	if err != nil || blocked || len(called) != 0 {
+		t.Fatalf("no bindings must be a no-op: blocked=%v err=%v called=%v", blocked, err, called)
+	}
+	if events := readGateEvents(t, festivalPath); strings.Contains(events, "wf_hook_run") {
+		t.Fatalf("unexpected hook events:\n%s", events)
+	}
+}
+
+func TestEmitJudgeHookRuns_WritesAuditEvents(t *testing.T) {
+	nav, festivalPath := writeHookedGateFestival(t, "")
+	runs := []hooks.HookRun{{
+		Name:    hooks.ApprovalJudgeName,
+		Layer:   hooks.LayerFestivals,
+		Timing:  hooks.TimingPost,
+		Level:   hooks.LevelGate,
+		Verb:    hooks.VerbGateApprove,
+		Outcome: hooks.OutcomePass,
+	}}
+	emitJudgeHookRuns(context.Background(), nav, 1, runs)
+
+	events := readGateEvents(t, festivalPath)
+	if !strings.Contains(events, `"hook_name":"approval_judge"`) || !strings.Contains(events, `"wf_hook_run"`) {
+		t.Fatalf("judge wf_hook_run event missing:\n%s", events)
+	}
+}

--- a/internal/commands/workflow/human_gate_test.go
+++ b/internal/commands/workflow/human_gate_test.go
@@ -1,0 +1,60 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+)
+
+func TestIsHumanRequired(t *testing.T) {
+	if !isHumanRequired(wf.WorkflowStep{Approval: "human-required"}) {
+		t.Fatal("expected true")
+	}
+	if isHumanRequired(wf.WorkflowStep{Approval: ""}) {
+		t.Fatal("expected false")
+	}
+}
+
+func TestHumanRequiredAutoRefusalNamesGate(t *testing.T) {
+	err := humanRequiredAutoRefusal(3, wf.WorkflowStep{Name: "SHIP"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "human-required") && !strings.Contains(msg, "cannot auto-clear") {
+		t.Fatalf("msg = %q", msg)
+	}
+	if !strings.Contains(msg, "SHIP") {
+		t.Fatalf("gate name missing: %q", msg)
+	}
+}
+
+func TestRequireHumanGateTTY_NonTTY(t *testing.T) {
+	orig := workflowApproveTTYCheck
+	t.Cleanup(func() { workflowApproveTTYCheck = orig })
+	workflowApproveTTYCheck = func(fd int) bool { return false }
+	if err := requireHumanGateTTY(); err == nil {
+		t.Fatal("expected TTY error")
+	}
+}
+
+func TestRequireHumanGateTTY_TTY(t *testing.T) {
+	orig := workflowApproveTTYCheck
+	t.Cleanup(func() { workflowApproveTTYCheck = orig })
+	workflowApproveTTYCheck = func(fd int) bool { return true }
+	if err := requireHumanGateTTY(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHumanApprovalRequiredInStatusJSON(t *testing.T) {
+	// Minimal synthetic navigator is hard; unit-test the step flag via isHumanRequired path in collect.
+	// Covered by isHumanRequired + field presence on struct tags.
+	_ = context.Background()
+	s := workflowStatusStepJSON{HumanApprovalRequired: true}
+	if !s.HumanApprovalRequired {
+		t.Fatal("field missing")
+	}
+}

--- a/internal/commands/workflow/human_gate_test.go
+++ b/internal/commands/workflow/human_gate_test.go
@@ -1,7 +1,7 @@
 package workflow
 
 import (
-	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -49,12 +49,19 @@ func TestRequireHumanGateTTY_TTY(t *testing.T) {
 	}
 }
 
-func TestHumanApprovalRequiredInStatusJSON(t *testing.T) {
-	// Minimal synthetic navigator is hard; unit-test the step flag via isHumanRequired path in collect.
-	// Covered by isHumanRequired + field presence on struct tags.
-	_ = context.Background()
-	s := workflowStatusStepJSON{HumanApprovalRequired: true}
-	if !s.HumanApprovalRequired {
-		t.Fatal("field missing")
+func TestHumanApprovalRequiredStatusJSONKey(t *testing.T) {
+	raw, err := json.Marshal(workflowStatusStepJSON{HumanApprovalRequired: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `"human_approval_required":true`) {
+		t.Fatalf("json key missing: %s", raw)
+	}
+	raw, err = json.Marshal(workflowStatusStepJSON{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "human_approval_required") {
+		t.Fatalf("field must be omitempty when false: %s", raw)
 	}
 }

--- a/internal/commands/workflow/reject.go
+++ b/internal/commands/workflow/reject.go
@@ -110,6 +110,12 @@ func runRejectWithRemediationDecision(ctx context.Context, reason, remediationPh
 			WithHint("Reject is only for checkpoint steps")
 	}
 
+	if isHumanRequired(step) {
+		if err := requireHumanGateTTY(); err != nil {
+			return err
+		}
+	}
+
 	return withJudgeStepLock(ctx, nav.Ctx.PhasePath, currentStepNum, func() error {
 		fresh, err := reloadWorkflowNavigator(ctx, nav)
 		if err != nil {

--- a/internal/commands/workflow/status_json.go
+++ b/internal/commands/workflow/status_json.go
@@ -50,6 +50,8 @@ type workflowStatusStepJSON struct {
 	JudgePid     int    `json:"judge_pid,omitempty"`
 	JudgeRunID   string `json:"judge_run_id,omitempty"`
 	JudgeDetail  string `json:"judge_detail,omitempty"`
+	// HumanApprovalRequired is true when approval: human-required is set on the step.
+	HumanApprovalRequired bool `json:"human_approval_required,omitempty"`
 }
 
 // collectWorkflowStatus builds the structured snapshot from navigator state.
@@ -93,10 +95,11 @@ func collectWorkflowStatus(nav *wf.Navigator) workflowStatusJSON {
 		feedback := ""
 		remediation := ""
 		entry := workflowStatusStepJSON{
-			Number:        step.Number,
-			Name:          step.Name,
-			HasCheckpoint: step.HasCheckpoint(),
-			Goal:          step.Goal,
+			Number:                step.Number,
+			Name:                  step.Name,
+			HasCheckpoint:         step.HasCheckpoint(),
+			Goal:                  step.Goal,
+			HumanApprovalRequired: isHumanRequired(step),
 		}
 		if stepState := state.GetStepState(step.Number); stepState != nil {
 			status = stepState.Status

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,14 +31,15 @@ const (
 
 // Config represents the fest configuration
 type Config struct {
-	Version    string     `json:"version"`
-	Repository Repository `json:"repository"`
-	Local      Local      `json:"local"`
-	Behavior   Behavior   `json:"behavior"`
-	Network    Network    `json:"network"`
-	TUI        TUI        `json:"tui"`
-	Execute    Execute    `json:"execute"`
-	LastSync   string     `json:"last_sync,omitempty"`
+	Version    string       `json:"version"`
+	Repository Repository   `json:"repository"`
+	Local      Local        `json:"local"`
+	Behavior   Behavior     `json:"behavior"`
+	Network    Network      `json:"network"`
+	TUI        TUI          `json:"tui"`
+	Execute    Execute      `json:"execute"`
+	LastSync   string       `json:"last_sync,omitempty"`
+	Hooks      *HooksConfig `json:"hooks,omitempty"`
 }
 
 // Execute contains execution configuration

--- a/internal/config/festival_config.go
+++ b/internal/config/festival_config.go
@@ -27,6 +27,7 @@ type FestivalConfig struct {
 	Tracking         TrackingConfig      `yaml:"tracking"`
 	Agent            AgentConfig         `yaml:"agent,omitempty"`
 	AutoLink         AutoLinkConfig      `yaml:"auto_link,omitempty"`
+	Hooks            HooksConfig         `yaml:"hooks,omitempty"`
 	RitualConfig     *RitualConfig       `yaml:"ritual_config,omitempty"`
 }
 

--- a/internal/config/hooks_config.go
+++ b/internal/config/hooks_config.go
@@ -1,0 +1,59 @@
+package config
+
+import "gopkg.in/yaml.v3"
+
+// HookDefinition is a single declared hook. Redeclaring a name at a more
+// specific layer replaces this whole definition (no field-level merge).
+type HookDefinition struct {
+	Command  string `yaml:"command" json:"command"`                       // required
+	Fail     string `yaml:"fail,omitempty" json:"fail,omitempty"`         // "closed" (default) | "open"
+	Timeout  string `yaml:"timeout,omitempty" json:"timeout,omitempty"`   // e.g. "120s"; parsed in internal/hooks
+	Evidence string `yaml:"evidence,omitempty" json:"evidence,omitempty"` // "paths" (default) | "embed"
+	Enabled  *bool  `yaml:"enabled,omitempty" json:"enabled,omitempty"`   // nil = enabled; per-hook switch (D1)
+}
+
+// HooksConfig holds optional hooks configuration shared by machine (JSON),
+// workspace, and festival YAML layers.
+type HooksConfig struct {
+	// Legacy flat key, retained for the backward-compat alias (task 03, D6).
+	ApprovalJudge ApprovalJudgeHookConfig `yaml:"approval_judge,omitempty" json:"approval_judge,omitempty"`
+
+	// New schema (spec 02-hook-model.md).
+	Enabled     *bool                     `yaml:"enabled,omitempty" json:"enabled,omitempty"` // nil = unset (inherit)
+	Levels      map[string]bool           `yaml:"levels,omitempty" json:"levels,omitempty"`   // keys: phase, sequence, task
+	Definitions map[string]HookDefinition `yaml:"definitions,omitempty" json:"definitions,omitempty"`
+
+	present bool `yaml:"-" json:"-"` // set by UnmarshalYAML; true when the section appeared in source
+}
+
+// IsZero drops the hooks section on re-save only when it never appeared in
+// source and has no programmatically set content.
+func (h HooksConfig) IsZero() bool {
+	if h.present {
+		return false
+	}
+	return h.ApprovalJudge.Command == "" &&
+		h.Enabled == nil &&
+		len(h.Levels) == 0 &&
+		len(h.Definitions) == 0
+}
+
+// UnmarshalYAML marks the hooks section as present and preserves tri-state fields.
+func (h *HooksConfig) UnmarshalYAML(value *yaml.Node) error {
+	type rawHooks struct {
+		ApprovalJudge ApprovalJudgeHookConfig   `yaml:"approval_judge"`
+		Enabled       *bool                     `yaml:"enabled"`
+		Levels        map[string]bool           `yaml:"levels"`
+		Definitions   map[string]HookDefinition `yaml:"definitions"`
+	}
+	var raw rawHooks
+	if err := value.Decode(&raw); err != nil {
+		return err
+	}
+	h.present = true
+	h.ApprovalJudge = raw.ApprovalJudge
+	h.Enabled = raw.Enabled
+	h.Levels = raw.Levels
+	h.Definitions = raw.Definitions
+	return nil
+}

--- a/internal/config/hooks_config_test.go
+++ b/internal/config/hooks_config_test.go
@@ -1,0 +1,209 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func boolPtr(v bool) *bool { return &v }
+
+func TestLoadWorkspaceConfig_MalformedHooksReturnsParseError(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, DotFestivalDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	data := "version: \"1.0\"\nhooks: [not, a, map]\n"
+	if err := os.WriteFile(filepath.Join(dir, WorkspaceConfigFileName), []byte(data), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, err := LoadWorkspaceConfig(root)
+	if err == nil {
+		t.Fatal("expected parse error for malformed hooks")
+	}
+	if !strings.Contains(err.Error(), "parsing workspace config") {
+		t.Fatalf("error = %v, want config.Parse-wrapped message", err)
+	}
+}
+
+func TestLoadWorkspaceConfig_ParsesFullHooksBlock(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, DotFestivalDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	data := `version: "1.0"
+hooks:
+  enabled: true
+  levels:
+    phase: true
+    sequence: true
+    task: false
+  definitions:
+    approval_judge:
+      command: ob judge
+      fail: closed
+      timeout: 120s
+      evidence: paths
+      enabled: false
+    linter:
+      command: just lint
+`
+	if err := os.WriteFile(filepath.Join(dir, WorkspaceConfigFileName), []byte(data), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadWorkspaceConfig(root)
+	if err != nil {
+		t.Fatalf("LoadWorkspaceConfig: %v", err)
+	}
+	if cfg.Hooks.IsZero() {
+		t.Fatal("hooks section present but IsZero()")
+	}
+	if cfg.Hooks.Enabled == nil || !*cfg.Hooks.Enabled {
+		t.Fatalf("enabled = %v, want true", cfg.Hooks.Enabled)
+	}
+	if cfg.Hooks.Levels["task"] != false {
+		t.Fatalf("levels.task = %v, want false", cfg.Hooks.Levels["task"])
+	}
+	def, ok := cfg.Hooks.Definitions["approval_judge"]
+	if !ok {
+		t.Fatal("missing approval_judge definition")
+	}
+	if def.Command != "ob judge" || def.Fail != "closed" || def.Timeout != "120s" || def.Evidence != "paths" {
+		t.Fatalf("approval_judge fields = %+v", def)
+	}
+	if def.Enabled == nil || *def.Enabled {
+		t.Fatalf("approval_judge.enabled = %v, want false", def.Enabled)
+	}
+	if cfg.Hooks.Definitions["linter"].Command != "just lint" {
+		t.Fatalf("linter.command = %q", cfg.Hooks.Definitions["linter"].Command)
+	}
+}
+
+func TestSaveWorkspaceConfig_EnabledFalseRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	cfg := DefaultWorkspaceConfig()
+	cfg.Hooks = HooksConfig{
+		Enabled: boolPtr(false),
+		present: true,
+	}
+	if err := SaveWorkspaceConfig(root, cfg); err != nil {
+		t.Fatalf("SaveWorkspaceConfig: %v", err)
+	}
+
+	loaded, err := LoadWorkspaceConfig(root)
+	if err != nil {
+		t.Fatalf("LoadWorkspaceConfig: %v", err)
+	}
+	if loaded.Hooks.Enabled == nil || *loaded.Hooks.Enabled {
+		t.Fatalf("enabled after round-trip = %v, want non-nil false", loaded.Hooks.Enabled)
+	}
+}
+
+func TestSaveWorkspaceConfig_AbsentHooksIsZeroAndNoEmptySection(t *testing.T) {
+	root := t.TempDir()
+	if err := SaveWorkspaceConfig(root, DefaultWorkspaceConfig()); err != nil {
+		t.Fatalf("SaveWorkspaceConfig: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, DotFestivalDir, WorkspaceConfigFileName))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	s := string(data)
+	if strings.Contains(s, "hooks: {}") || strings.Contains(s, "hooks:\n") && !strings.Contains(s, "# hooks:") {
+		// Active hooks map must not appear; commented placeholder is fine.
+		if strings.Contains(s, "\nhooks:") || strings.HasPrefix(s, "hooks:") {
+			t.Fatalf("unexpected active hooks section:\n%s", s)
+		}
+	}
+
+	loaded, err := LoadWorkspaceConfig(root)
+	if err != nil {
+		t.Fatalf("LoadWorkspaceConfig: %v", err)
+	}
+	if !loaded.Hooks.IsZero() {
+		t.Fatalf("absent hooks should IsZero, got %+v", loaded.Hooks)
+	}
+}
+
+func TestLoadWorkspaceConfig_LegacyApprovalJudgeOnly(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, DotFestivalDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	data := "version: \"1.0\"\nhooks:\n  approval_judge:\n    command: my-judge\n"
+	if err := os.WriteFile(filepath.Join(dir, WorkspaceConfigFileName), []byte(data), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	cfg, err := LoadWorkspaceConfig(root)
+	if err != nil {
+		t.Fatalf("LoadWorkspaceConfig: %v", err)
+	}
+	if cfg.Hooks.ApprovalJudge.Command != "my-judge" {
+		t.Fatalf("command = %q, want my-judge", cfg.Hooks.ApprovalJudge.Command)
+	}
+	if cfg.Hooks.IsZero() {
+		t.Fatal("legacy hooks section should set present")
+	}
+}
+
+func TestSaveWorkspaceConfig_PlaceholderOnlyWhenEmpty(t *testing.T) {
+	root := t.TempDir()
+	cfg := DefaultWorkspaceConfig()
+	cfg.Hooks.ApprovalJudge.Command = "ob judge"
+	cfg.Hooks.present = true
+	if err := SaveWorkspaceConfig(root, cfg); err != nil {
+		t.Fatalf("SaveWorkspaceConfig: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, DotFestivalDir, WorkspaceConfigFileName))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if strings.Contains(string(data), "# hooks:") {
+		t.Fatalf("placeholder should not appear when hooks configured:\n%s", data)
+	}
+}
+
+func TestFestivalConfig_HooksRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	cfg := DefaultFestivalConfig()
+	cfg.Hooks = HooksConfig{
+		Enabled: boolPtr(false),
+		Levels:  map[string]bool{"task": false},
+		Definitions: map[string]HookDefinition{
+			"check": {Command: "just test", Enabled: boolPtr(true)},
+		},
+		present: true,
+	}
+	if err := SaveFestivalConfig(dir, "", cfg); err != nil {
+		t.Fatalf("SaveFestivalConfig: %v", err)
+	}
+	loaded, err := LoadFestivalConfig(dir, "")
+	if err != nil {
+		t.Fatalf("LoadFestivalConfig: %v", err)
+	}
+	if loaded.Hooks.Enabled == nil || *loaded.Hooks.Enabled {
+		t.Fatalf("enabled = %v, want false", loaded.Hooks.Enabled)
+	}
+	if loaded.Hooks.Definitions["check"].Command != "just test" {
+		t.Fatalf("definitions = %+v", loaded.Hooks.Definitions)
+	}
+
+	// Absent section drops on re-save.
+	empty := DefaultFestivalConfig()
+	if err := SaveFestivalConfig(dir, "", empty); err != nil {
+		t.Fatalf("SaveFestivalConfig empty: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, FestivalConfigFileName))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if strings.Contains(string(raw), "hooks:") {
+		t.Fatalf("absent hooks should not be emitted:\n%s", raw)
+	}
+}

--- a/internal/config/workspace_config.go
+++ b/internal/config/workspace_config.go
@@ -23,20 +23,12 @@ type WorkspaceConfig struct {
 	Hooks   HooksConfig `yaml:"hooks,omitempty"`
 }
 
-// HooksConfig holds optional workspace-level command hooks configured in
-// .festival/config.yaml. fest reads these directly so it stays usable on its
-// own, without the camp CLI.
-type HooksConfig struct {
-	// ApprovalJudge configures the command run by `fest workflow judge`.
-	ApprovalJudge ApprovalJudgeHookConfig `yaml:"approval_judge,omitempty"`
-}
-
 // ApprovalJudgeHookConfig configures an external approval judge command. The
 // command receives the approval request as JSON on stdin and must emit a JSON
 // verdict on stdout (schema fest.approval.judge/v1).
 type ApprovalJudgeHookConfig struct {
 	// Command is executed as configured (e.g. "ob judge").
-	Command string `yaml:"command,omitempty"`
+	Command string `yaml:"command,omitempty" json:"command,omitempty"`
 }
 
 // AgentConfig controls AI agent behavior for the workspace
@@ -98,7 +90,7 @@ func SaveWorkspaceConfig(festivalsRoot string, cfg *WorkspaceConfig) error {
 
 	// Surface the hooks option as a discoverable commented block when none is
 	// configured, so users can opt into the approval judge without reading docs.
-	if (cfg.Hooks == HooksConfig{}) {
+	if cfg.Hooks.IsZero() && cfg.Hooks.ApprovalJudge.Command == "" {
 		data = append(data, commentedHooksPlaceholder()...)
 	}
 

--- a/internal/config/workspace_config_hooks_test.go
+++ b/internal/config/workspace_config_hooks_test.go
@@ -46,7 +46,7 @@ func TestSaveWorkspaceConfig_WritesCommentedHooksPlaceholder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadWorkspaceConfig: %v", err)
 	}
-	if (loaded.Hooks != HooksConfig{}) {
+	if !loaded.Hooks.IsZero() || loaded.Hooks.ApprovalJudge.Command != "" {
 		t.Fatalf("commented placeholder should not parse into hooks, got %+v", loaded.Hooks)
 	}
 }

--- a/internal/frontmatter/hooks_test.go
+++ b/internal/frontmatter/hooks_test.go
@@ -1,0 +1,87 @@
+package frontmatter
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParse_HooksAndApproval(t *testing.T) {
+	content := []byte(`---
+fest_type: task
+fest_id: t1
+fest_status: pending
+fest_created: 2026-07-19T00:00:00Z
+hooks:
+  pre: [lint-check]
+  post: [approval_judge, notify]
+approval: human-required
+custom_meta: keep-me
+---
+
+# Body
+`)
+	fm, _, err := Parse(content)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(fm.Hooks.Pre) != 1 || fm.Hooks.Pre[0] != "lint-check" {
+		t.Fatalf("pre = %+v", fm.Hooks.Pre)
+	}
+	if len(fm.Hooks.Post) != 2 || fm.Hooks.Post[0] != "approval_judge" || fm.Hooks.Post[1] != "notify" {
+		t.Fatalf("post = %+v", fm.Hooks.Post)
+	}
+	if fm.Approval != "human-required" {
+		t.Fatalf("approval = %q", fm.Approval)
+	}
+	if fm.Extra["custom_meta"] != "keep-me" {
+		t.Fatalf("Extra should preserve custom_meta, got %+v", fm.Extra)
+	}
+	// hooks should not land in Extra
+	if _, ok := fm.Extra["hooks"]; ok {
+		t.Fatalf("hooks should not be in Extra: %+v", fm.Extra)
+	}
+}
+
+func TestParse_AbsentHooksAndApproval(t *testing.T) {
+	content := []byte(`---
+fest_type: task
+fest_id: t1
+fest_status: pending
+fest_created: 2026-07-19T00:00:00Z
+---
+`)
+	fm, _, err := Parse(content)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(fm.Hooks.Pre) != 0 || len(fm.Hooks.Post) != 0 || fm.Approval != "" {
+		t.Fatalf("want zero hooks/approval, got %+v %q", fm.Hooks, fm.Approval)
+	}
+	if b := fm.HookBindings(); len(b.Pre) != 0 || len(b.Post) != 0 {
+		t.Fatalf("HookBindings = %+v", b)
+	}
+}
+
+func TestParse_HooksNotInExtraRoundTripShape(t *testing.T) {
+	content := []byte(`---
+fest_type: task
+fest_id: t1
+fest_status: pending
+fest_created: 2026-07-19T00:00:00Z
+hooks:
+  post: [x]
+user_key: v
+---
+body
+`)
+	fm, body, err := Parse(content)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !strings.Contains(string(body), "body") {
+		t.Fatalf("body lost: %q", body)
+	}
+	if fm.Extra["user_key"] != "v" {
+		t.Fatalf("user_key not preserved: %+v", fm.Extra)
+	}
+}

--- a/internal/frontmatter/schema.go
+++ b/internal/frontmatter/schema.go
@@ -216,11 +216,30 @@ type Frontmatter struct {
 	RequiresHuman   bool       `yaml:"fest_requires_human,omitempty" json:"fest_requires_human,omitempty"`
 	RequiresContext bool       `yaml:"fest_requires_context,omitempty" json:"fest_requires_context,omitempty"`
 
+	// Hook bindings for this step's lifecycle (spec 03-lifecycle-and-orchestration.md).
+	// Bindings only reference declared hook names; they never declare definitions.
+	Hooks StepHooks `yaml:"hooks,omitempty" json:"hooks,omitempty"`
+
+	// Approval, when "human-required", marks a non-bypassable human gate (sequence 04).
+	Approval string `yaml:"approval,omitempty" json:"approval,omitempty"`
+
 	// Extra preserves keys this schema does not know about, so every
 	// parse -> mutate -> inject round-trip (task status updates, goal
 	// status changes, migrations) keeps user-added metadata instead of
 	// silently dropping it.
 	Extra map[string]any `yaml:",inline" json:"-"`
+}
+
+// StepHooks binds already-declared hooks to a step's lifecycle by name.
+// Bindings never declare; they only reference names resolved from config.
+type StepHooks struct {
+	Pre  []string `yaml:"pre,omitempty" json:"pre,omitempty"`
+	Post []string `yaml:"post,omitempty" json:"post,omitempty"`
+}
+
+// HookBindings returns the step's pre/post hook name lists (may be empty).
+func (f Frontmatter) HookBindings() StepHooks {
+	return f.Hooks
 }
 
 // Validate checks if the frontmatter is valid

--- a/internal/guidance/workflow/hooks_marker_test.go
+++ b/internal/guidance/workflow/hooks_marker_test.go
@@ -1,0 +1,83 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+)
+
+func TestParseContent_HooksAndApprovalMarkers(t *testing.T) {
+	content := `## Step 1: REVIEW — Check
+
+**Goal:** Review work
+
+**Actions:**
+1. Look
+
+**Output:** Notes
+
+**Checkpoint:** User approval required before continuing
+
+**Hooks:** post: [approval_judge], pre: [lint]
+
+**Approval:** human-required
+`
+	steps, err := NewParser().ParseContent(context.Background(), content)
+	if err != nil {
+		t.Fatalf("ParseContent: %v", err)
+	}
+	if len(steps) != 1 {
+		t.Fatalf("steps = %d", len(steps))
+	}
+	s := steps[0]
+	if len(s.Hooks.Pre) != 1 || s.Hooks.Pre[0] != "lint" {
+		t.Fatalf("pre = %+v", s.Hooks.Pre)
+	}
+	if len(s.Hooks.Post) != 1 || s.Hooks.Post[0] != "approval_judge" {
+		t.Fatalf("post = %+v", s.Hooks.Post)
+	}
+	if s.Approval != "human-required" {
+		t.Fatalf("approval = %q", s.Approval)
+	}
+}
+
+func TestParseContent_AbsentHooksAndApproval(t *testing.T) {
+	content := `## Step 1: READ
+
+**Goal:** Read docs
+
+**Actions:**
+1. Open file
+
+**Output:** Notes
+`
+	steps, err := NewParser().ParseContent(context.Background(), content)
+	if err != nil {
+		t.Fatalf("ParseContent: %v", err)
+	}
+	s := steps[0]
+	if len(s.Hooks.Pre) != 0 || len(s.Hooks.Post) != 0 || s.Approval != "" {
+		t.Fatalf("want empty hooks/approval, got %+v %q", s.Hooks, s.Approval)
+	}
+}
+
+func TestParseContent_MalformedHooksMarker(t *testing.T) {
+	content := `## Step 1: X
+
+**Goal:** g
+
+**Actions:**
+1. a
+
+**Output:** o
+
+**Hooks:** not-a-valid-list {{{
+`
+	steps, err := NewParser().ParseContent(context.Background(), content)
+	if err != nil {
+		t.Fatalf("ParseContent: %v", err)
+	}
+	s := steps[0]
+	if len(s.Hooks.Pre) != 0 || len(s.Hooks.Post) != 0 {
+		t.Fatalf("malformed should yield empty, got %+v", s.Hooks)
+	}
+}

--- a/internal/guidance/workflow/navigator.go
+++ b/internal/guidance/workflow/navigator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/campledger"
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/guidance"
+	"github.com/Obedience-Corp/fest/internal/hooks"
 )
 
 // StepTypeWorkflowStep is the step type for workflow-based steps.
@@ -62,6 +63,19 @@ func (n *Navigator) SetStateStore(store StateStore) {
 // persistence mode so injected navigators do not silently change backends.
 func (n *Navigator) HasStateStore() bool {
 	return n.store != nil
+}
+
+// QueueHookRunEvents persists hook runner records as wf_hook_run events via
+// the navigator's own state store (D9). A storeless (legacy YAML) navigator
+// records nothing rather than side-loading a store, because constructing a
+// fresh event store migrates and deletes the YAML state out from under the
+// live navigator.
+func (n *Navigator) QueueHookRunEvents(ctx context.Context, step int, runs []hooks.HookRun) error {
+	if n == nil || n.store == nil || len(runs) == 0 {
+		return nil
+	}
+	n.store.QueueWorkflowEvents(EmitHookRunEvents(n.stateKey(), step, runs))
+	return n.store.SaveEvents(ctx)
 }
 
 // SetDocFilename overrides the document filename to parse (default: "WORKFLOW.md").

--- a/internal/guidance/workflow/navigator_format.go
+++ b/internal/guidance/workflow/navigator_format.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Obedience-Corp/fest/embedded/templates/agent"
 	"github.com/Obedience-Corp/fest/internal/config"
 	"github.com/Obedience-Corp/fest/internal/guidance"
+	"github.com/Obedience-Corp/fest/internal/hooks"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/workspace"
 )
@@ -99,14 +100,15 @@ func (n *Navigator) formatCheckpoint(ctx context.Context, step WorkflowStep) (st
 		}
 	}
 	data := map[string]any{
-		"InstructionHeader":   guidance.InstructionHeader,
-		"StepNumber":          step.Number,
-		"StepName":            step.Name,
-		"Goal":                step.Goal,
-		"Actions":             step.Actions,
-		"JudgeConfigured":     n.approvalJudgeConfigured(ctx),
-		"JudgeWaiting":        judgeWaiting,
-		"OperatorAttestation": ClassifyCheckpoint(step) == CheckpointClassOperatorAttestation,
+		"InstructionHeader":    guidance.InstructionHeader,
+		"StepNumber":           step.Number,
+		"StepName":             step.Name,
+		"Goal":                 step.Goal,
+		"Actions":              step.Actions,
+		"JudgeConfigured":      n.approvalJudgeConfigured(ctx),
+		"JudgeWaiting":         judgeWaiting,
+		"OperatorAttestation":  ClassifyCheckpoint(step) == CheckpointClassOperatorAttestation,
+		"SkippedHooksUndeclared": n.skippedUndeclaredLine(ctx, step),
 	}
 
 	return agent.Render("workflow/checkpoint", data)
@@ -181,29 +183,53 @@ func (n *Navigator) formatStep(ctx context.Context, step WorkflowStep, stepState
 	}
 
 	data := map[string]any{
-		"InstructionHeader":   guidance.InstructionHeader,
-		"PhaseType":           phaseType,
-		"PhaseName":           n.Ctx.PhaseName,
-		"StepNumber":          step.Number,
-		"TotalSteps":          n.workflowState.TotalSteps,
-		"StepName":            step.Name,
-		"Goal":                step.Goal,
-		"Actions":             step.Actions,
-		"Output":              step.Output,
-		"IsBlocking":          step.Checkpoint.IsBlocking(),
-		"Status":              status,
-		"Feedback":            feedback,
-		"Followups":           stepState.Followups,
-		"CurrentStep":         n.workflowState.CurrentStep,
-		"IsGate":              isGate,
-		"JudgeConfigured":     n.approvalJudgeConfigured(ctx),
-		"OperatorAttestation": ClassifyCheckpoint(step) == CheckpointClassOperatorAttestation,
+		"InstructionHeader":      guidance.InstructionHeader,
+		"PhaseType":              phaseType,
+		"PhaseName":              n.Ctx.PhaseName,
+		"StepNumber":             step.Number,
+		"TotalSteps":             n.workflowState.TotalSteps,
+		"StepName":               step.Name,
+		"Goal":                   step.Goal,
+		"Actions":                step.Actions,
+		"Output":                 step.Output,
+		"IsBlocking":             step.Checkpoint.IsBlocking(),
+		"Status":                 status,
+		"Feedback":               feedback,
+		"Followups":              stepState.Followups,
+		"CurrentStep":            n.workflowState.CurrentStep,
+		"IsGate":                 isGate,
+		"JudgeConfigured":        n.approvalJudgeConfigured(ctx),
+		"OperatorAttestation":    ClassifyCheckpoint(step) == CheckpointClassOperatorAttestation,
 		"JudgeRetryAvailable": stepState.Status == StepStatusBlocked &&
 			ClassifyCheckpoint(step) != CheckpointClassOperatorAttestation &&
 			IsJudgeRejection(stepState) && n.approvalJudgeConfigured(ctx),
+		"SkippedHooksUndeclared": n.skippedUndeclaredLine(ctx, step),
 	}
 
 	return agent.Render("workflow/step", data)
+}
+
+// skippedUndeclaredLine returns fest next guidance for bound names not declared.
+func (n *Navigator) skippedUndeclaredLine(ctx context.Context, step WorkflowStep) string {
+	festivalPath := ""
+	if n != nil && n.BaseNavigator != nil && n.Ctx != nil {
+		festivalPath = n.Ctx.FestivalPath
+	}
+	level := hooks.LevelGate
+	if n == nil || n.docFilename != "GATES.md" {
+		level = hooks.LevelPhase
+	}
+	var eff *hooks.Effective
+	if festivalPath != "" {
+		if resolved, err := hooks.LoadAndResolve(ctx, festivalPath); err == nil {
+			eff = resolved
+		}
+	}
+	if eff == nil {
+		eff, _ = hooks.Resolve(nil, nil, nil)
+	}
+	plan := eff.PlanBindings(level, step.Hooks.Pre, step.Hooks.Post)
+	return hooks.FormatSkippedUndeclaredLine(plan)
 }
 
 // FormatProgress renders the progress template showing workflow status.

--- a/internal/guidance/workflow/navigator_format.go
+++ b/internal/guidance/workflow/navigator_format.go
@@ -109,6 +109,7 @@ func (n *Navigator) formatCheckpoint(ctx context.Context, step WorkflowStep) (st
 		"JudgeWaiting":         judgeWaiting,
 		"OperatorAttestation":  ClassifyCheckpoint(step) == CheckpointClassOperatorAttestation,
 		"SkippedHooksUndeclared": n.skippedUndeclaredLine(ctx, step),
+		"HumanApprovalRequired":  strings.EqualFold(strings.TrimSpace(step.Approval), "human-required"),
 	}
 
 	return agent.Render("workflow/checkpoint", data)
@@ -204,6 +205,7 @@ func (n *Navigator) formatStep(ctx context.Context, step WorkflowStep, stepState
 			ClassifyCheckpoint(step) != CheckpointClassOperatorAttestation &&
 			IsJudgeRejection(stepState) && n.approvalJudgeConfigured(ctx),
 		"SkippedHooksUndeclared": n.skippedUndeclaredLine(ctx, step),
+		"HumanApprovalRequired":  strings.EqualFold(strings.TrimSpace(step.Approval), "human-required"),
 	}
 
 	return agent.Render("workflow/step", data)

--- a/internal/guidance/workflow/parser.go
+++ b/internal/guidance/workflow/parser.go
@@ -39,6 +39,15 @@ var (
 
 	// evidenceItemRe matches bullet evidence paths.
 	evidenceItemRe = regexp.MustCompile(`(?m)^\s*[-*]\s+(\S+)\s*$`)
+
+	// hooksMarkerRe matches a per-step "**Hooks:**" line in GATES.md.
+	hooksMarkerRe = regexp.MustCompile(`(?im)\*\*Hooks:\*\*[ \t]*([^\r\n]*)`)
+
+	// approvalMarkerRe matches a per-step "**Approval:**" line in GATES.md.
+	approvalMarkerRe = regexp.MustCompile(`(?im)\*\*Approval:\*\*[ \t]*([^\r\n]*)`)
+
+	// hookListRe matches "pre: [a, b]" or "post: [x]" fragments.
+	hookListRe = regexp.MustCompile(`(?i)\b(pre|post)\s*:\s*\[([^\]]*)\]`)
 )
 
 // Parser parses WORKFLOW.md files and extracts steps.
@@ -125,6 +134,8 @@ func (p *Parser) ParseContent(ctx context.Context, content string) ([]WorkflowSt
 		}
 		step.CheckpointClass = checkpointClass
 		step.EvidencePaths = p.parseEvidencePaths(section)
+		step.Hooks = p.parseStepHooks(section)
+		step.Approval = p.parseApproval(section)
 
 		steps = append(steps, step)
 	}
@@ -239,6 +250,62 @@ func (p *Parser) parseEvidencePaths(section string) []string {
 		paths = append(paths, path)
 	}
 	return paths
+}
+
+// parseStepHooks extracts pre/post hook name lists from a **Hooks:** marker.
+// Names only; malformed fragments yield empty lists (no panic).
+func (p *Parser) parseStepHooks(section string) StepHooks {
+	m := hooksMarkerRe.FindStringSubmatch(section)
+	if len(m) < 2 {
+		return StepHooks{}
+	}
+	value := strings.TrimSpace(m[1])
+	if value == "" {
+		return StepHooks{}
+	}
+	var hooks StepHooks
+	for _, match := range hookListRe.FindAllStringSubmatch(value, -1) {
+		if len(match) < 3 {
+			continue
+		}
+		names := splitHookNames(match[2])
+		switch strings.ToLower(match[1]) {
+		case "pre":
+			hooks.Pre = append(hooks.Pre, names...)
+		case "post":
+			hooks.Post = append(hooks.Post, names...)
+		}
+	}
+	return hooks
+}
+
+func splitHookNames(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	var names []string
+	for _, p := range parts {
+		name := strings.TrimSpace(p)
+		name = strings.Trim(name, `"'`)
+		if name == "" {
+			continue
+		}
+		// Names only — reject map-like or assignment fragments.
+		if strings.Contains(name, ":") || strings.ContainsAny(name, "{}") {
+			continue
+		}
+		names = append(names, name)
+	}
+	return names
+}
+
+func (p *Parser) parseApproval(section string) string {
+	m := approvalMarkerRe.FindStringSubmatch(section)
+	if len(m) < 2 {
+		return ""
+	}
+	return strings.TrimSpace(m[1])
 }
 
 // ClassifyCheckpoint resolves the checkpoint class for a step.

--- a/internal/guidance/workflow/state.go
+++ b/internal/guidance/workflow/state.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Obedience-Corp/fest/internal/hooks"
 	"github.com/Obedience-Corp/fest/internal/yamlutil"
 	"gopkg.in/yaml.v3"
 )
@@ -55,6 +56,18 @@ type WorkflowEvent struct {
 	JudgeDetail      string
 	JudgePid         int
 	JudgeRunID       string
+
+	// Hook-run fields (wf_hook_run). Hook runs are events, never decisions (D9).
+	HookName       string
+	HookLayer      string
+	HookTiming     string
+	HookVerb       string
+	HookOutcome    string
+	HookSkip       string
+	HookExitCode   int
+	HookDurationMS int64
+	HookFail       string
+	HookBlocked    bool
 }
 
 // DecisionMetadata records who made a checkpoint decision and the rationale.
@@ -895,6 +908,30 @@ func EmitJudgeStartedEvents(phaseName string, step int, command, runID string, p
 		JudgePid:     pid,
 		JudgeRunID:   runID,
 	}}
+}
+
+// EmitHookRunEvents generates one wf_hook_run event per hook runner record so
+// the festival audit trail captures every hook execution or skip (D9).
+func EmitHookRunEvents(phaseName string, step int, runs []hooks.HookRun) []WorkflowEvent {
+	events := make([]WorkflowEvent, 0, len(runs))
+	for _, run := range runs {
+		events = append(events, WorkflowEvent{
+			EventType:      "wf_hook_run",
+			Phase:          phaseName,
+			Step:           step,
+			HookName:       run.Name,
+			HookLayer:      string(run.Layer),
+			HookTiming:     string(run.Timing),
+			HookVerb:       string(run.Verb),
+			HookOutcome:    string(run.Outcome),
+			HookSkip:       string(run.Skip),
+			HookExitCode:   run.ExitCode,
+			HookDurationMS: run.Duration.Milliseconds(),
+			HookFail:       string(run.Fail),
+			HookBlocked:    run.Blocked,
+		})
+	}
+	return events
 }
 
 // EmitJudgeClaimedEvents binds a durable judge lease to the detached process

--- a/internal/guidance/workflow/step.go
+++ b/internal/guidance/workflow/step.go
@@ -147,6 +147,19 @@ type WorkflowStep struct {
 
 	// EvidencePaths are phase-relative deliverable paths listed under **Evidence:**.
 	EvidencePaths []string `json:"evidence_paths,omitempty" yaml:"evidence_paths,omitempty"`
+
+	// Hooks are the pre/post hook name bindings for this step (spec 03).
+	Hooks StepHooks `json:"hooks,omitempty" yaml:"hooks,omitempty"`
+
+	// Approval, when "human-required", marks a non-bypassable human gate (sequence 04).
+	Approval string `json:"approval,omitempty" yaml:"approval,omitempty"`
+}
+
+// StepHooks binds already-declared hooks to a step's lifecycle by name.
+// Structurally matches frontmatter.StepHooks to avoid import cycles.
+type StepHooks struct {
+	Pre  []string `json:"pre,omitempty" yaml:"pre,omitempty"`
+	Post []string `json:"post,omitempty" yaml:"post,omitempty"`
 }
 
 // HasCheckpoint returns true if this step has a checkpoint.

--- a/internal/hooks/alias.go
+++ b/internal/hooks/alias.go
@@ -1,0 +1,84 @@
+package hooks
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Obedience-Corp/fest/internal/config"
+)
+
+const ApprovalJudgeName = "approval_judge"
+
+// applyApprovalJudgeAlias expands the legacy flat key into an implicit
+// festivals-layer definition. R6: timeout 0 preserves today's no-deadline
+// judge behavior. Mutates cfg in memory only; does not write disk.
+//
+// Explicit definitions.approval_judge wins over the flat key.
+func applyApprovalJudgeAlias(festivals *config.HooksConfig) (aliased bool, cmd string) {
+	if festivals == nil {
+		return false, ""
+	}
+	cmd = strings.TrimSpace(festivals.ApprovalJudge.Command)
+	if cmd == "" {
+		return false, ""
+	}
+	if _, explicit := festivals.Definitions[ApprovalJudgeName]; explicit {
+		return false, "" // explicit definition wins; flat key ignored
+	}
+	if festivals.Definitions == nil {
+		festivals.Definitions = map[string]config.HookDefinition{}
+	}
+	festivals.Definitions[ApprovalJudgeName] = config.HookDefinition{
+		Command:  cmd,
+		Fail:     string(FailClosed),
+		Timeout:  "0", // R6: no default 120s for the legacy alias
+		Evidence: string(EvidencePaths),
+	}
+	return true, cmd
+}
+
+// cloneHooksConfig returns a shallow copy with a cloned Definitions map so
+// alias injection does not mutate the caller's config.
+func cloneHooksConfig(src *config.HooksConfig) *config.HooksConfig {
+	if src == nil {
+		return nil
+	}
+	cp := *src
+	if src.Levels != nil {
+		cp.Levels = make(map[string]bool, len(src.Levels))
+		for k, v := range src.Levels {
+			cp.Levels[k] = v
+		}
+	}
+	if src.Definitions != nil {
+		cp.Definitions = make(map[string]config.HookDefinition, len(src.Definitions))
+		for k, v := range src.Definitions {
+			cp.Definitions[k] = v
+		}
+	}
+	return &cp
+}
+
+// ApprovalJudgeAliasWarning returns the migration text for the legacy flat key.
+func ApprovalJudgeAliasWarning(cmd string) string {
+	return fmt.Sprintf(`hooks.approval_judge.command is deprecated; declare it explicitly:
+
+hooks:
+  definitions:
+    approval_judge:
+      command: %s
+      timeout: 0   # preserves today's no-deadline judge behavior
+
+The flat key still works this release and will be removed after a migration window.`, cmd)
+}
+
+// ShouldBindApprovalJudgeOnGates reports whether GATES.md blocking approval
+// steps should receive an implicit post-binding of approval_judge when no
+// explicit **Hooks:** marker is present (legacy compatibility heuristic).
+func (e *Effective) ShouldBindApprovalJudgeOnGates() bool {
+	if e == nil {
+		return false
+	}
+	_, ok := e.Hooks[ApprovalJudgeName]
+	return ok
+}

--- a/internal/hooks/alias_test.go
+++ b/internal/hooks/alias_test.go
@@ -1,0 +1,94 @@
+package hooks
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/config"
+)
+
+func TestAlias_FlatKeyInjectsApprovalJudge(t *testing.T) {
+	festivals := &config.HooksConfig{
+		ApprovalJudge: config.ApprovalJudgeHookConfig{Command: "ob judge"},
+	}
+	// Ensure we do not mutate caller's Definitions map identity unexpectedly.
+	orig := festivals
+
+	eff, err := Resolve(nil, festivals, nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if festivals.Definitions != nil {
+		t.Fatal("resolver must not mutate caller's Definitions map")
+	}
+	_ = orig
+
+	h, ok := eff.Hooks[ApprovalJudgeName]
+	if !ok {
+		t.Fatal("expected approval_judge from alias")
+	}
+	if h.Command != "ob judge" || h.Fail != FailClosed || h.Timeout != 0 || h.Evidence != EvidencePaths {
+		t.Fatalf("resolved alias = %+v", h)
+	}
+	if h.Source != LayerFestivals {
+		t.Fatalf("source = %s, want festivals", h.Source)
+	}
+	if !eff.LegacyAliasActive || eff.LegacyAliasCommand != "ob judge" {
+		t.Fatalf("legacy flags = active=%v cmd=%q", eff.LegacyAliasActive, eff.LegacyAliasCommand)
+	}
+	if !eff.ShouldBindApprovalJudgeOnGates() {
+		t.Fatal("alias should enable gate binding signal")
+	}
+}
+
+func TestAlias_ExplicitDefinitionWins(t *testing.T) {
+	festivals := &config.HooksConfig{
+		ApprovalJudge: config.ApprovalJudgeHookConfig{Command: "flat-cmd"},
+		Definitions: map[string]config.HookDefinition{
+			ApprovalJudgeName: {Command: "explicit-cmd", Timeout: "5s"},
+		},
+	}
+	eff, err := Resolve(nil, festivals, nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	h := eff.Hooks[ApprovalJudgeName]
+	if h.Command != "explicit-cmd" {
+		t.Fatalf("command = %q, want explicit-cmd", h.Command)
+	}
+	if h.Timeout == 0 {
+		t.Fatal("explicit timeout should apply (not alias zero)")
+	}
+	if eff.LegacyAliasActive {
+		t.Fatal("alias should not apply when explicit definition present")
+	}
+}
+
+func TestAlias_NoFlatKeyNoDefinition(t *testing.T) {
+	eff, err := Resolve(nil, &config.HooksConfig{}, nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if _, ok := eff.Hooks[ApprovalJudgeName]; ok {
+		t.Fatal("unexpected approval_judge")
+	}
+	if eff.LegacyAliasActive {
+		t.Fatal("no alias expected")
+	}
+	if eff.ShouldBindApprovalJudgeOnGates() {
+		t.Fatal("no gate binding without approval_judge")
+	}
+}
+
+func TestAlias_WarningText(t *testing.T) {
+	msg := ApprovalJudgeAliasWarning("my-judge --strict")
+	if !strings.Contains(msg, "my-judge --strict") {
+		t.Fatalf("missing command in warning: %s", msg)
+	}
+	if !strings.Contains(msg, "timeout: 0") {
+		t.Fatalf("missing timeout: 0 line: %s", msg)
+	}
+	if !strings.Contains(msg, "definitions:") {
+		t.Fatalf("missing definitions block: %s", msg)
+	}
+}

--- a/internal/hooks/bind.go
+++ b/internal/hooks/bind.go
@@ -54,6 +54,18 @@ func (e *Effective) PlanBindings(level Level, pre, post []string) []PlannedHook 
 	return planned
 }
 
+// ApplyHumanGate marks every planned binding as skipped: human-gate.
+// Spec 04: a human-required step disables all automation hooks for that step;
+// the skips are still recorded in the audit trail.
+func ApplyHumanGate(planned []PlannedHook) []PlannedHook {
+	out := make([]PlannedHook, len(planned))
+	for i, p := range planned {
+		p.Skip = SkipHumanGate
+		out[i] = p
+	}
+	return out
+}
+
 // UndeclaredNames returns bound names skipped because they are not declared.
 func UndeclaredNames(planned []PlannedHook) []string {
 	var out []string

--- a/internal/hooks/bind.go
+++ b/internal/hooks/bind.go
@@ -1,0 +1,75 @@
+package hooks
+
+import "strings"
+
+type SkipReason string
+
+const (
+	SkipUndeclared SkipReason = "undeclared"
+	SkipDisabled   SkipReason = "disabled"   // declared but enabled=false or level/layer off
+	SkipHumanGate  SkipReason = "human-gate" // set by sequence 04
+)
+
+// PlannedHook is a bound name classified against the effective hook set.
+type PlannedHook struct {
+	Name   string
+	Timing Timing
+	Skip   SkipReason // empty means it will run
+	Hook   ResolvedHook
+}
+
+// PlanBindings resolves a step's pre/post name lists against the effective set
+// for a given level, in binding-list order.
+func (e *Effective) PlanBindings(level Level, pre, post []string) []PlannedHook {
+	if e == nil {
+		var planned []PlannedHook
+		for _, name := range pre {
+			planned = append(planned, PlannedHook{Name: name, Timing: TimingPre, Skip: SkipUndeclared})
+		}
+		for _, name := range post {
+			planned = append(planned, PlannedHook{Name: name, Timing: TimingPost, Skip: SkipUndeclared})
+		}
+		return planned
+	}
+	var planned []PlannedHook
+	add := func(names []string, t Timing) {
+		for _, name := range names {
+			name = strings.TrimSpace(name)
+			if name == "" {
+				continue
+			}
+			h, ok := e.Hooks[name]
+			switch {
+			case !ok:
+				planned = append(planned, PlannedHook{Name: name, Timing: t, Skip: SkipUndeclared})
+			case !e.Runnable(name, string(level)):
+				planned = append(planned, PlannedHook{Name: name, Timing: t, Skip: SkipDisabled, Hook: h})
+			default:
+				planned = append(planned, PlannedHook{Name: name, Timing: t, Hook: h})
+			}
+		}
+	}
+	add(pre, TimingPre)
+	add(post, TimingPost)
+	return planned
+}
+
+// UndeclaredNames returns bound names skipped because they are not declared.
+func UndeclaredNames(planned []PlannedHook) []string {
+	var out []string
+	for _, p := range planned {
+		if p.Skip == SkipUndeclared {
+			out = append(out, p.Name)
+		}
+	}
+	return out
+}
+
+// FormatSkippedUndeclaredLine returns guidance text for fest next, or empty.
+func FormatSkippedUndeclaredLine(planned []PlannedHook) string {
+	names := UndeclaredNames(planned)
+	if len(names) == 0 {
+		return ""
+	}
+	return "Skipped hooks (undeclared): " + strings.Join(names, ", ")
+}

--- a/internal/hooks/bind_test.go
+++ b/internal/hooks/bind_test.go
@@ -101,3 +101,21 @@ func TestV1Verbs_ClosedSet(t *testing.T) {
 		}
 	}
 }
+
+func TestApplyHumanGate_SkipsEverything(t *testing.T) {
+	eff, err := Resolve(nil, &config.HooksConfig{
+		Definitions: map[string]config.HookDefinition{"a": {Command: "true"}},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	planned := ApplyHumanGate(eff.PlanBindings(LevelGate, []string{"a"}, []string{"missing"}))
+	if len(planned) != 2 {
+		t.Fatalf("planned = %+v", planned)
+	}
+	for i, p := range planned {
+		if p.Skip != SkipHumanGate {
+			t.Fatalf("planned[%d].Skip = %q, want human-gate", i, p.Skip)
+		}
+	}
+}

--- a/internal/hooks/bind_test.go
+++ b/internal/hooks/bind_test.go
@@ -1,0 +1,103 @@
+package hooks
+
+import (
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/config"
+)
+
+func TestPlanBindings_Undeclared(t *testing.T) {
+	eff, err := Resolve(nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := eff.PlanBindings(LevelTask, []string{"missing"}, nil)
+	if len(plan) != 1 || plan[0].Skip != SkipUndeclared {
+		t.Fatalf("plan = %+v", plan)
+	}
+}
+
+func TestPlanBindings_Disabled(t *testing.T) {
+	eff, err := Resolve(nil, &config.HooksConfig{
+		Levels: map[string]bool{"task": false},
+		Definitions: map[string]config.HookDefinition{
+			"a": {Command: "true"},
+			"b": {Command: "true", Enabled: bp(false)},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := eff.PlanBindings(LevelTask, []string{"a", "b"}, nil)
+	if len(plan) != 2 {
+		t.Fatalf("plan len = %d", len(plan))
+	}
+	if plan[0].Skip != SkipDisabled || plan[1].Skip != SkipDisabled {
+		t.Fatalf("want both disabled: %+v", plan)
+	}
+}
+
+func TestPlanBindings_RunnableAndOrder(t *testing.T) {
+	eff, err := Resolve(nil, &config.HooksConfig{
+		Definitions: map[string]config.HookDefinition{
+			"pre1":  {Command: "true"},
+			"post1": {Command: "true"},
+			"post2": {Command: "true"},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := eff.PlanBindings(LevelTask, []string{"pre1"}, []string{"post1", "missing", "post2"})
+	if len(plan) != 4 {
+		t.Fatalf("plan = %+v", plan)
+	}
+	want := []struct {
+		name string
+		t    Timing
+		skip SkipReason
+	}{
+		{"pre1", TimingPre, ""},
+		{"post1", TimingPost, ""},
+		{"missing", TimingPost, SkipUndeclared},
+		{"post2", TimingPost, ""},
+	}
+	for i, w := range want {
+		if plan[i].Name != w.name || plan[i].Timing != w.t || plan[i].Skip != w.skip {
+			t.Fatalf("plan[%d]=%+v want name=%s timing=%s skip=%s", i, plan[i], w.name, w.t, w.skip)
+		}
+		if w.skip == "" && plan[i].Hook.Command == "" {
+			t.Fatalf("runnable plan[%d] missing Hook", i)
+		}
+	}
+	line := FormatSkippedUndeclaredLine(plan)
+	if line != "Skipped hooks (undeclared): missing" {
+		t.Fatalf("line = %q", line)
+	}
+}
+
+func TestPlanBindings_Empty(t *testing.T) {
+	eff, err := Resolve(nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan := eff.PlanBindings(LevelGate, nil, nil); len(plan) != 0 {
+		t.Fatalf("plan = %+v", plan)
+	}
+}
+
+func TestV1Verbs_ClosedSet(t *testing.T) {
+	verbs := V1Verbs()
+	if len(verbs) != 4 {
+		t.Fatalf("want exactly 4 verbs, got %v", verbs)
+	}
+	seen := map[Verb]bool{}
+	for _, v := range verbs {
+		seen[v] = true
+	}
+	for _, need := range []Verb{VerbTaskComplete, VerbSequenceComplete, VerbPhaseComplete, VerbGateApprove} {
+		if !seen[need] {
+			t.Fatalf("missing verb %s", need)
+		}
+	}
+}

--- a/internal/hooks/event.go
+++ b/internal/hooks/event.go
@@ -1,0 +1,43 @@
+package hooks
+
+type Timing string
+
+const (
+	TimingPre  Timing = "pre"
+	TimingPost Timing = "post"
+)
+
+type Level string
+
+const (
+	LevelPhase    Level = "phase"
+	LevelSequence Level = "sequence"
+	LevelTask     Level = "task"
+	LevelGate     Level = "gate"
+)
+
+type Verb string
+
+const (
+	VerbTaskComplete     Verb = "task_complete"
+	VerbSequenceComplete Verb = "sequence_complete"
+	VerbPhaseComplete    Verb = "phase_complete"
+	VerbGateApprove      Verb = "gate_approve"
+)
+
+// Event is a lifecycle coordinate a hook binding fires at.
+type Event struct {
+	Timing Timing
+	Level  Level
+	Verb   Verb
+}
+
+// V1Verbs is the closed set of lifecycle verbs supported in v1.
+func V1Verbs() []Verb {
+	return []Verb{
+		VerbTaskComplete,
+		VerbSequenceComplete,
+		VerbPhaseComplete,
+		VerbGateApprove,
+	}
+}

--- a/internal/hooks/evidence.go
+++ b/internal/hooks/evidence.go
@@ -1,10 +1,11 @@
 package hooks
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
 )
 
 // EvidenceEmbedCapBytes is the total budget for evidence: embed mode (256KB).
@@ -22,14 +23,14 @@ type EvidenceFile struct {
 func NormalizeEvidencePath(path string) (string, error) {
 	path = strings.TrimSpace(path)
 	if path == "" {
-		return "", fmt.Errorf("path is empty")
+		return "", festerrors.Validation("evidence path is empty")
 	}
 	if filepath.IsAbs(path) {
-		return "", fmt.Errorf("absolute paths are not allowed")
+		return "", festerrors.Validation("absolute evidence paths are not allowed")
 	}
 	clean := filepath.Clean(path)
 	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
-		return "", fmt.Errorf("path escapes the phase directory")
+		return "", festerrors.Validation("evidence path escapes the phase directory")
 	}
 	return clean, nil
 }
@@ -39,11 +40,11 @@ func NormalizeEvidencePath(path string) (string, error) {
 func WithinRoot(phasePath, relativePath string) (bool, error) {
 	phaseRoot, err := filepath.Abs(phasePath)
 	if err != nil {
-		return false, fmt.Errorf("resolving phase root: %w", err)
+		return false, festerrors.Wrap(err, "resolving phase root")
 	}
 	resolvedRoot, err := filepath.EvalSymlinks(phaseRoot)
 	if err != nil {
-		return false, fmt.Errorf("resolving phase root symlinks: %w", err)
+		return false, festerrors.Wrap(err, "resolving phase root symlinks")
 	}
 
 	candidate := filepath.Join(phaseRoot, relativePath)
@@ -52,14 +53,14 @@ func WithinRoot(phasePath, relativePath string) (bool, error) {
 		if os.IsNotExist(err) {
 			return false, nil
 		}
-		return false, fmt.Errorf("resolving evidence symlinks: %w", err)
+		return false, festerrors.Wrap(err, "resolving evidence symlinks")
 	}
 	containedPath, err := filepath.Rel(resolvedRoot, resolvedCandidate)
 	if err != nil {
-		return false, fmt.Errorf("checking resolved evidence containment: %w", err)
+		return false, festerrors.Wrap(err, "checking resolved evidence containment")
 	}
 	if containedPath == ".." || strings.HasPrefix(containedPath, ".."+string(filepath.Separator)) {
-		return false, fmt.Errorf("resolved evidence path escapes the phase directory")
+		return false, festerrors.Validation("resolved evidence path escapes the phase directory")
 	}
 
 	info, err := os.Stat(resolvedCandidate)

--- a/internal/hooks/evidence.go
+++ b/internal/hooks/evidence.go
@@ -1,0 +1,135 @@
+package hooks
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// EvidenceEmbedCapBytes is the total budget for evidence: embed mode (256KB).
+const EvidenceEmbedCapBytes = 256 * 1024
+
+// EvidenceFile is an optional embedded evidence payload entry (additive).
+type EvidenceFile struct {
+	Path      string `json:"path"`
+	Content   string `json:"content"`
+	Truncated bool   `json:"truncated,omitempty"`
+}
+
+// NormalizeEvidencePath cleans a phase-relative evidence path and rejects
+// absolute or escaping paths (read-by-approver contract).
+func NormalizeEvidencePath(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", fmt.Errorf("path is empty")
+	}
+	if filepath.IsAbs(path) {
+		return "", fmt.Errorf("absolute paths are not allowed")
+	}
+	clean := filepath.Clean(path)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path escapes the phase directory")
+	}
+	return clean, nil
+}
+
+// WithinRoot reports whether a phase-relative path resolves under phasePath
+// after symlink evaluation and is a non-empty regular file.
+func WithinRoot(phasePath, relativePath string) (bool, error) {
+	phaseRoot, err := filepath.Abs(phasePath)
+	if err != nil {
+		return false, fmt.Errorf("resolving phase root: %w", err)
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(phaseRoot)
+	if err != nil {
+		return false, fmt.Errorf("resolving phase root symlinks: %w", err)
+	}
+
+	candidate := filepath.Join(phaseRoot, relativePath)
+	resolvedCandidate, err := filepath.EvalSymlinks(candidate)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("resolving evidence symlinks: %w", err)
+	}
+	containedPath, err := filepath.Rel(resolvedRoot, resolvedCandidate)
+	if err != nil {
+		return false, fmt.Errorf("checking resolved evidence containment: %w", err)
+	}
+	if containedPath == ".." || strings.HasPrefix(containedPath, ".."+string(filepath.Separator)) {
+		return false, fmt.Errorf("resolved evidence path escapes the phase directory")
+	}
+
+	info, err := os.Stat(resolvedCandidate)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return info.Mode().IsRegular() && info.Size() > 0, nil
+}
+
+// ResolvePhaseRelative returns the subset of relative paths that exist as
+// non-empty regular files under phasePath, preserving order and dropping
+// duplicates, absolute/escaping paths, and unreadable/missing files.
+func ResolvePhaseRelative(phasePath string, paths []string) []string {
+	seen := map[string]struct{}{}
+	var present []string
+	for _, p := range paths {
+		rel, err := NormalizeEvidencePath(p)
+		if err != nil {
+			continue
+		}
+		if _, ok := seen[rel]; ok {
+			continue
+		}
+		ok, err := WithinRoot(phasePath, rel)
+		if err != nil || !ok {
+			continue
+		}
+		seen[rel] = struct{}{}
+		present = append(present, rel)
+	}
+	return present
+}
+
+// BuildEvidenceFiles packs file contents under a total byte budget.
+// Files that fail the within-root contract or cannot be read are dropped.
+// When the budget is exhausted mid-file, content is truncated with a marker.
+// Further files after budget exhaustion are omitted (paths remain on evidence list).
+func BuildEvidenceFiles(phasePath string, relPaths []string, capBytes int) ([]EvidenceFile, error) {
+	if capBytes <= 0 {
+		capBytes = EvidenceEmbedCapBytes
+	}
+	var files []EvidenceFile
+	remaining := capBytes
+	const truncMarker = "\n[TRUNCATED: evidence exceeded the 256KB embed budget]"
+	for _, rel := range relPaths {
+		if remaining <= 0 {
+			break
+		}
+		ok, err := WithinRoot(phasePath, rel)
+		if err != nil || !ok {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(phasePath, rel))
+		if err != nil {
+			continue
+		}
+		ef := EvidenceFile{Path: rel}
+		if len(data) > remaining {
+			chunk := data[:remaining]
+			ef.Truncated = true
+			ef.Content = string(chunk) + truncMarker
+			remaining = 0
+		} else {
+			ef.Content = string(data)
+			remaining -= len(data)
+		}
+		files = append(files, ef)
+	}
+	return files, nil
+}

--- a/internal/hooks/evidence_test.go
+++ b/internal/hooks/evidence_test.go
@@ -1,0 +1,89 @@
+package hooks
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeEvidencePath_Errors(t *testing.T) {
+	if _, err := NormalizeEvidencePath("/abs"); err == nil {
+		t.Fatal("absolute should fail")
+	}
+	if _, err := NormalizeEvidencePath("../escape"); err == nil {
+		t.Fatal("escape should fail")
+	}
+	if _, err := NormalizeEvidencePath(""); err == nil {
+		t.Fatal("empty should fail")
+	}
+}
+
+func TestWithinRoot_AndResolve(t *testing.T) {
+	root := t.TempDir()
+	inside := filepath.Join(root, "ok.txt")
+	if err := os.WriteFile(inside, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "empty.txt"), []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "subdir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outside := t.TempDir()
+	outFile := filepath.Join(outside, "out.txt")
+	if err := os.WriteFile(outFile, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outFile, filepath.Join(root, "link.txt")); err != nil {
+		t.Fatal(err)
+	}
+
+	ok, err := WithinRoot(root, "ok.txt")
+	if err != nil || !ok {
+		t.Fatalf("ok.txt: %v %v", ok, err)
+	}
+	ok, err = WithinRoot(root, "empty.txt")
+	if err != nil || ok {
+		t.Fatalf("empty should not count: %v %v", ok, err)
+	}
+	ok, err = WithinRoot(root, "link.txt")
+	if err == nil && ok {
+		t.Fatal("escaping symlink should not count as present")
+	}
+
+	got := ResolvePhaseRelative(root, []string{"ok.txt", "empty.txt", "missing.txt", "ok.txt", "/abs"})
+	if len(got) != 1 || got[0] != "ok.txt" {
+		t.Fatalf("got = %v", got)
+	}
+}
+
+func TestBuildEvidenceFiles_CapAndTruncate(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("aaaa"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "b.txt"), []byte("bbbbbbbb"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	files, err := BuildEvidenceFiles(root, []string{"a.txt", "b.txt"}, 6)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("files = %+v", files)
+	}
+	if files[0].Truncated || files[0].Content != "aaaa" {
+		t.Fatalf("a = %+v", files[0])
+	}
+	if !files[1].Truncated || !strings.Contains(files[1].Content, "TRUNCATED") {
+		t.Fatalf("b = %+v", files[1])
+	}
+
+	// exact budget
+	files, err = BuildEvidenceFiles(root, []string{"a.txt"}, 4)
+	if err != nil || len(files) != 1 || files[0].Truncated {
+		t.Fatalf("exact: %v %+v", err, files)
+	}
+}

--- a/internal/hooks/load.go
+++ b/internal/hooks/load.go
@@ -1,0 +1,57 @@
+package hooks
+
+import (
+	"context"
+
+	"github.com/Obedience-Corp/fest/internal/config"
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/workspace"
+)
+
+// LoadAndResolve loads machine, festivals, and festival hook configs and resolves them.
+func LoadAndResolve(ctx context.Context, festivalPath string) (*Effective, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if festivalPath == "" {
+		return nil, festerrors.Validation("festival path required for hook resolution")
+	}
+
+	machineCfg, err := config.Load(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+	var machine *config.HooksConfig
+	if machineCfg != nil {
+		machine = machineCfg.Hooks
+	}
+
+	var festivals *config.HooksConfig
+	ws, wsErr := workspace.FindWorkspace(ctx, festivalPath)
+	if wsErr == nil && ws.FestivalsPath != "" {
+		wcfg, err := config.LoadWorkspaceConfig(ws.FestivalsPath)
+		if err != nil {
+			return nil, err
+		}
+		if wcfg != nil {
+			fc := wcfg.Hooks
+			festivals = &fc
+		}
+	}
+
+	campaignRoot := ""
+	if wsErr == nil {
+		campaignRoot = ws.Root
+	}
+	fcfg, err := config.LoadFestivalConfig(festivalPath, campaignRoot)
+	if err != nil {
+		return nil, err
+	}
+	var festival *config.HooksConfig
+	if fcfg != nil {
+		fc := fcfg.Hooks
+		festival = &fc
+	}
+
+	return Resolve(machine, festivals, festival)
+}

--- a/internal/hooks/resolve.go
+++ b/internal/hooks/resolve.go
@@ -1,0 +1,209 @@
+package hooks
+
+import (
+	"time"
+
+	"github.com/Obedience-Corp/fest/internal/config"
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+)
+
+type Layer string
+
+const (
+	LayerMachine   Layer = "machine"
+	LayerFestivals Layer = "festivals"
+	LayerFestival  Layer = "festival"
+)
+
+type FailPolicy string
+
+const (
+	FailClosed FailPolicy = "closed"
+	FailOpen   FailPolicy = "open"
+)
+
+type EvidenceMode string
+
+const (
+	EvidencePaths EvidenceMode = "paths"
+	EvidenceEmbed EvidenceMode = "embed"
+)
+
+// DefaultTimeout is applied to newly declared hooks when timeout is unset.
+const DefaultTimeout = 120 * time.Second
+
+// ResolvedHook is a fully-defaulted, typed hook definition plus provenance.
+type ResolvedHook struct {
+	Name     string
+	Command  string
+	Fail     FailPolicy
+	Timeout  time.Duration
+	Evidence EvidenceMode
+	Enabled  bool
+	Source   Layer         // the layer the winning definition came from
+	Shadowed []ShadowedDef // upper-layer definitions this one replaced, when they DIFFER
+}
+
+// ShadowedDef records a replaced upper-layer definition for drift reporting (D10).
+type ShadowedDef struct {
+	Source Layer
+	Def    config.HookDefinition
+}
+
+// Effective is the resolved hook set plus resolved switches.
+type Effective struct {
+	Enabled bool                    // layer-wide switch, most-specific-wins, default true
+	Levels  map[string]bool         // phase/sequence/task, most-specific-wins, default true
+	Hooks   map[string]ResolvedHook // by name
+}
+
+type layerCfg struct {
+	name Layer
+	cfg  *config.HooksConfig
+}
+
+type prior struct {
+	src Layer
+	def config.HookDefinition
+}
+
+// Resolve merges three declaration layers into one effective hook set.
+// Nil or empty layers are skipped (D7: empty defaults at every layer).
+func Resolve(machine, festivals, festival *config.HooksConfig) (*Effective, error) {
+	eff := &Effective{
+		Enabled: true,
+		Levels:  map[string]bool{"phase": true, "sequence": true, "task": true},
+		Hooks:   map[string]ResolvedHook{},
+	}
+	layers := []layerCfg{
+		{LayerMachine, machine},
+		{LayerFestivals, festivals},
+		{LayerFestival, festival},
+	}
+
+	winners := map[string]prior{}
+
+	for _, l := range layers {
+		if emptyLayer(l.cfg) {
+			continue
+		}
+		if l.cfg.Enabled != nil {
+			eff.Enabled = *l.cfg.Enabled
+		}
+		for level, on := range l.cfg.Levels {
+			eff.Levels[level] = on
+		}
+		for name, def := range l.cfg.Definitions {
+			winners[name] = prior{src: l.name, def: def}
+		}
+	}
+
+	for name, w := range winners {
+		rh, err := resolveOne(name, w.src, w.def)
+		if err != nil {
+			return nil, err
+		}
+		rh.Shadowed = differingShadows(name, w, layers)
+		eff.Hooks[name] = rh
+	}
+	return eff, nil
+}
+
+// Runnable reports whether the named hook should run at the given lifecycle level.
+func (e *Effective) Runnable(name, level string) bool {
+	if e == nil {
+		return false
+	}
+	h, ok := e.Hooks[name]
+	if !ok || !e.Enabled || !h.Enabled {
+		return false
+	}
+	on, known := e.Levels[level]
+	return !known || on // unknown level defaults true
+}
+
+func emptyLayer(cfg *config.HooksConfig) bool {
+	if cfg == nil {
+		return true
+	}
+	return cfg.IsZero() &&
+		cfg.ApprovalJudge.Command == "" &&
+		cfg.Enabled == nil &&
+		len(cfg.Levels) == 0 &&
+		len(cfg.Definitions) == 0
+}
+
+func resolveOne(name string, src Layer, def config.HookDefinition) (ResolvedHook, error) {
+	rh := ResolvedHook{Name: name, Command: def.Command, Source: src, Enabled: true}
+	switch def.Fail {
+	case "", string(FailClosed):
+		rh.Fail = FailClosed
+	case string(FailOpen):
+		rh.Fail = FailOpen
+	default:
+		return rh, festerrors.Validation("invalid hook fail policy").
+			WithField("hook", name).WithField("fail", def.Fail).
+			WithHint("fail must be closed or open")
+	}
+	switch def.Evidence {
+	case "", string(EvidencePaths):
+		rh.Evidence = EvidencePaths
+	case string(EvidenceEmbed):
+		rh.Evidence = EvidenceEmbed
+	default:
+		return rh, festerrors.Validation("invalid hook evidence mode").
+			WithField("hook", name).WithField("evidence", def.Evidence).
+			WithHint("evidence must be paths or embed")
+	}
+	rh.Timeout = DefaultTimeout
+	if def.Timeout != "" {
+		d, err := time.ParseDuration(def.Timeout)
+		if err != nil {
+			return rh, festerrors.Validation("invalid hook timeout").
+				WithField("hook", name).WithField("timeout", def.Timeout)
+		}
+		rh.Timeout = d
+	}
+	if def.Enabled != nil {
+		rh.Enabled = *def.Enabled
+	}
+	return rh, nil
+}
+
+func defsEqual(a, b config.HookDefinition) bool {
+	if a.Command != b.Command || a.Fail != b.Fail || a.Timeout != b.Timeout || a.Evidence != b.Evidence {
+		return false
+	}
+	return boolPtrEqual(a.Enabled, b.Enabled)
+}
+
+func boolPtrEqual(a, b *bool) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+// differingShadows walks layers before the winner and collects differing defs.
+func differingShadows(name string, winner prior, layers []layerCfg) []ShadowedDef {
+	var out []ShadowedDef
+	for _, l := range layers {
+		if l.name == winner.src {
+			break
+		}
+		if emptyLayer(l.cfg) {
+			continue
+		}
+		def, ok := l.cfg.Definitions[name]
+		if !ok {
+			continue
+		}
+		if !defsEqual(def, winner.def) {
+			out = append(out, ShadowedDef{Source: l.name, Def: def})
+		}
+	}
+	return out
+}

--- a/internal/hooks/resolve.go
+++ b/internal/hooks/resolve.go
@@ -55,6 +55,10 @@ type Effective struct {
 	Enabled bool                    // layer-wide switch, most-specific-wins, default true
 	Levels  map[string]bool         // phase/sequence/task, most-specific-wins, default true
 	Hooks   map[string]ResolvedHook // by name
+
+	// Legacy alias (flat hooks.approval_judge.command) metadata for warnings.
+	LegacyAliasActive  bool
+	LegacyAliasCommand string
 }
 
 type layerCfg struct {
@@ -69,12 +73,20 @@ type prior struct {
 
 // Resolve merges three declaration layers into one effective hook set.
 // Nil or empty layers are skipped (D7: empty defaults at every layer).
+// The festivals-layer legacy flat key is expanded in-memory before merge (D6/R6).
 func Resolve(machine, festivals, festival *config.HooksConfig) (*Effective, error) {
 	eff := &Effective{
 		Enabled: true,
 		Levels:  map[string]bool{"phase": true, "sequence": true, "task": true},
 		Hooks:   map[string]ResolvedHook{},
 	}
+
+	festivals = cloneHooksConfig(festivals)
+	if aliased, cmd := applyApprovalJudgeAlias(festivals); aliased {
+		eff.LegacyAliasActive = true
+		eff.LegacyAliasCommand = cmd
+	}
+
 	layers := []layerCfg{
 		{LayerMachine, machine},
 		{LayerFestivals, festivals},

--- a/internal/hooks/resolve_test.go
+++ b/internal/hooks/resolve_test.go
@@ -1,0 +1,213 @@
+package hooks
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Obedience-Corp/fest/internal/config"
+)
+
+func bp(v bool) *bool { return &v }
+
+func TestResolve_InvalidFail(t *testing.T) {
+	_, err := Resolve(nil, &config.HooksConfig{
+		Definitions: map[string]config.HookDefinition{
+			"x": {Command: "true", Fail: "maybe"},
+		},
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), "invalid hook fail policy") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestResolve_InvalidEvidence(t *testing.T) {
+	_, err := Resolve(nil, &config.HooksConfig{
+		Definitions: map[string]config.HookDefinition{
+			"x": {Command: "true", Evidence: "blob"},
+		},
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), "invalid hook evidence mode") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestResolve_InvalidTimeout(t *testing.T) {
+	_, err := Resolve(nil, &config.HooksConfig{
+		Definitions: map[string]config.HookDefinition{
+			"x": {Command: "true", Timeout: "soon"},
+		},
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), "invalid hook timeout") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestResolve_ByNameWholeDefinitionOverride(t *testing.T) {
+	festivals := &config.HooksConfig{
+		Definitions: map[string]config.HookDefinition{
+			"approval_judge": {Command: "ws-judge", Fail: "open", Timeout: "30s"},
+		},
+	}
+	festival := &config.HooksConfig{
+		Definitions: map[string]config.HookDefinition{
+			"approval_judge": {Command: "fest-judge"},
+		},
+	}
+	eff, err := Resolve(nil, festivals, festival)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	h := eff.Hooks["approval_judge"]
+	if h.Command != "fest-judge" {
+		t.Fatalf("command = %q, want fest-judge (whole replace)", h.Command)
+	}
+	if h.Fail != FailClosed || h.Timeout != DefaultTimeout {
+		t.Fatalf("want defaults after replace, got fail=%s timeout=%v", h.Fail, h.Timeout)
+	}
+	if h.Source != LayerFestival {
+		t.Fatalf("source = %s, want festival", h.Source)
+	}
+}
+
+func TestResolve_ShadowedDifferingOnly(t *testing.T) {
+	same := config.HookDefinition{Command: "same"}
+	festivals := &config.HooksConfig{
+		Definitions: map[string]config.HookDefinition{"a": {Command: "old"}},
+	}
+	festival := &config.HooksConfig{
+		Definitions: map[string]config.HookDefinition{"a": {Command: "new"}},
+	}
+	eff, err := Resolve(nil, festivals, festival)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(eff.Hooks["a"].Shadowed) != 1 || eff.Hooks["a"].Shadowed[0].Def.Command != "old" {
+		t.Fatalf("shadowed = %+v", eff.Hooks["a"].Shadowed)
+	}
+
+	festivals.Definitions["b"] = same
+	festival.Definitions["b"] = same
+	eff, err = Resolve(nil, festivals, festival)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(eff.Hooks["b"].Shadowed) != 0 {
+		t.Fatalf("identical defs should not shadow, got %+v", eff.Hooks["b"].Shadowed)
+	}
+}
+
+func TestResolve_SwitchesMostSpecificWins(t *testing.T) {
+	machine := &config.HooksConfig{Enabled: bp(true)}
+	festival := &config.HooksConfig{Enabled: bp(false)}
+	eff, err := Resolve(machine, nil, festival)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if eff.Enabled {
+		t.Fatal("festival enabled:false should win")
+	}
+
+	eff, err = Resolve(machine, nil, nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !eff.Enabled {
+		t.Fatal("machine true should stick when festival unset")
+	}
+	eff.Hooks["h"] = ResolvedHook{Name: "h", Enabled: true}
+	if !eff.Runnable("h", "unknown-level") {
+		t.Fatal("unknown level should default true")
+	}
+}
+
+func TestResolve_PerLevelAndPerHookDisable(t *testing.T) {
+	cfg := &config.HooksConfig{
+		Levels: map[string]bool{"task": false},
+		Definitions: map[string]config.HookDefinition{
+			"a": {Command: "true"},
+			"b": {Command: "true", Enabled: bp(false)},
+		},
+	}
+	eff, err := Resolve(nil, cfg, nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if eff.Runnable("a", "task") {
+		t.Fatal("levels.task=false should disable task runs")
+	}
+	if !eff.Runnable("a", "phase") {
+		t.Fatal("phase should still run")
+	}
+	if eff.Runnable("b", "phase") {
+		t.Fatal("per-hook enabled:false should disable")
+	}
+}
+
+func TestResolve_DefaultsApplied(t *testing.T) {
+	eff, err := Resolve(nil, &config.HooksConfig{
+		Definitions: map[string]config.HookDefinition{"only": {Command: "echo hi"}},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	h := eff.Hooks["only"]
+	if h.Fail != FailClosed || h.Timeout != 120*time.Second || h.Evidence != EvidencePaths || !h.Enabled {
+		t.Fatalf("defaults wrong: %+v", h)
+	}
+}
+
+func TestResolve_EmptyAllLayers(t *testing.T) {
+	eff, err := Resolve(nil, nil, nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(eff.Hooks) != 0 || !eff.Enabled {
+		t.Fatalf("empty resolve = %+v", eff)
+	}
+}
+
+func TestMachineJSON_HooksRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, config.ConfigFileName)
+	raw := map[string]any{
+		"version": "1.0",
+		"hooks": map[string]any{
+			"enabled": true,
+			"definitions": map[string]any{
+				"lint": map[string]any{"command": "just lint", "timeout": "5s"},
+			},
+		},
+	}
+	data, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cfg, err := config.Load(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Hooks == nil || cfg.Hooks.Definitions["lint"].Command != "just lint" {
+		t.Fatalf("hooks = %+v", cfg.Hooks)
+	}
+
+	path2 := filepath.Join(dir, "empty.json")
+	if err := os.WriteFile(path2, []byte(`{"version":"1.0"}`), 0o644); err != nil {
+		t.Fatalf("write empty: %v", err)
+	}
+	cfg2, err := config.Load(context.Background(), path2)
+	if err != nil {
+		t.Fatalf("Load empty: %v", err)
+	}
+	if cfg2.Hooks != nil {
+		t.Fatalf("absent hooks should be nil, got %+v", cfg2.Hooks)
+	}
+}

--- a/internal/hooks/runner.go
+++ b/internal/hooks/runner.go
@@ -78,7 +78,23 @@ func defaultExec(ctx context.Context, command string, stdin []byte, dir string) 
 	} else if err != nil {
 		res.ExitCode = -1
 	}
+	if err != nil {
+		if tail := stderrTail(stderr.String()); tail != "" {
+			res.Err = festerrors.Wrap(err, tail)
+		}
+	}
 	return res
+}
+
+// stderrTailLimit bounds how much hook stderr is carried on a failure record.
+const stderrTailLimit = 2048
+
+func stderrTail(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) > stderrTailLimit {
+		s = s[len(s)-stderrTailLimit:]
+	}
+	return s
 }
 
 // Run executes the planned hooks for one timing in list order.

--- a/internal/hooks/runner.go
+++ b/internal/hooks/runner.go
@@ -1,0 +1,167 @@
+package hooks
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"strings"
+	"time"
+
+	festerrors "github.com/Obedience-Corp/fest/internal/errors"
+)
+
+type Outcome string
+
+const (
+	OutcomePass    Outcome = "pass"
+	OutcomeFail    Outcome = "fail"
+	OutcomeTimeout Outcome = "timeout"
+	OutcomeSkipped Outcome = "skipped"
+)
+
+// SkipShortCircuit marks hooks not run because a prior closed failure blocked the list.
+const SkipShortCircuit SkipReason = "short-circuit"
+
+// HookRun is the record of one hook execution (or skip), consumed by the audit task.
+type HookRun struct {
+	Name     string
+	Layer    Layer
+	Timing   Timing
+	Level    Level
+	Verb     Verb
+	Outcome  Outcome
+	Skip     SkipReason // set when Outcome == OutcomeSkipped
+	ExitCode int
+	Duration time.Duration
+	Fail     FailPolicy
+	Blocked  bool // true when a closed failure blocked the verb
+	Stdout   []byte
+}
+
+// CommandResult is what the exec seam returns.
+type CommandResult struct {
+	Stdout   []byte
+	ExitCode int
+	Err      error
+}
+
+// Runner executes hooks. The exec seam is injectable for tests.
+type Runner struct {
+	WorkDir string // festival root; hook cwd
+	Exec    func(ctx context.Context, command string, stdin []byte, dir string) CommandResult
+}
+
+// NewRunner creates a runner with the default process-exec seam.
+func NewRunner(workDir string) *Runner {
+	return &Runner{WorkDir: workDir, Exec: defaultExec}
+}
+
+func defaultExec(ctx context.Context, command string, stdin []byte, dir string) CommandResult {
+	fields := strings.Fields(command)
+	if len(fields) == 0 {
+		return CommandResult{ExitCode: -1, Err: festerrors.Validation("hook command is empty")}
+	}
+	cmd := exec.CommandContext(ctx, fields[0], fields[1:]...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	if stdin != nil {
+		cmd.Stdin = bytes.NewReader(stdin)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	res := CommandResult{Stdout: out, Err: err}
+	if ee, ok := err.(*exec.ExitError); ok {
+		res.ExitCode = ee.ExitCode()
+	} else if err != nil {
+		res.ExitCode = -1
+	}
+	return res
+}
+
+// Run executes the planned hooks for one timing in list order.
+// It returns the run records and whether the verb is blocked (a closed failure occurred).
+func (r *Runner) Run(ctx context.Context, level Level, verb Verb, planned []PlannedHook, stdin []byte) ([]HookRun, bool, error) {
+	if r == nil {
+		return nil, false, festerrors.Validation("hooks runner is nil")
+	}
+	if r.Exec == nil {
+		r.Exec = defaultExec
+	}
+	var runs []HookRun
+	blocked := false
+	for _, p := range planned {
+		if err := ctx.Err(); err != nil {
+			return runs, blocked, festerrors.Wrap(err, "hook run cancelled")
+		}
+		if blocked {
+			runs = append(runs, HookRun{
+				Name: p.Name, Timing: p.Timing, Level: level, Verb: verb,
+				Outcome: OutcomeSkipped, Skip: SkipShortCircuit,
+			})
+			continue
+		}
+		if p.Skip != "" {
+			runs = append(runs, HookRun{
+				Name: p.Name, Timing: p.Timing, Level: level, Verb: verb,
+				Outcome: OutcomeSkipped, Skip: p.Skip, Layer: p.Hook.Source,
+			})
+			continue
+		}
+		run := r.runOne(ctx, level, verb, p, stdin)
+		if run.Outcome != OutcomePass && p.Hook.Fail == FailClosed {
+			run.Blocked = true
+			blocked = true
+		}
+		runs = append(runs, run)
+	}
+	return runs, blocked, nil
+}
+
+// RunPre runs only TimingPre planned hooks. If blocked, the caller must not apply the verb.
+func (r *Runner) RunPre(ctx context.Context, level Level, verb Verb, planned []PlannedHook, stdin []byte) ([]HookRun, bool, error) {
+	return r.Run(ctx, level, verb, filterTiming(planned, TimingPre), stdin)
+}
+
+// RunPost runs only TimingPost planned hooks after the verb applied.
+func (r *Runner) RunPost(ctx context.Context, level Level, verb Verb, planned []PlannedHook, stdin []byte) ([]HookRun, bool, error) {
+	return r.Run(ctx, level, verb, filterTiming(planned, TimingPost), stdin)
+}
+
+func filterTiming(planned []PlannedHook, t Timing) []PlannedHook {
+	var out []PlannedHook
+	for _, p := range planned {
+		if p.Timing == t {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func (r *Runner) runOne(ctx context.Context, level Level, verb Verb, p PlannedHook, stdin []byte) HookRun {
+	run := HookRun{
+		Name: p.Name, Layer: p.Hook.Source, Timing: p.Timing,
+		Level: level, Verb: verb, Fail: p.Hook.Fail,
+	}
+	runCtx := ctx
+	cancel := func() {}
+	if p.Hook.Timeout > 0 {
+		runCtx, cancel = context.WithTimeout(ctx, p.Hook.Timeout)
+	}
+	defer cancel()
+	start := time.Now()
+	res := r.Exec(runCtx, p.Hook.Command, stdin, r.WorkDir)
+	run.Duration = time.Since(start)
+	run.ExitCode = res.ExitCode
+	run.Stdout = res.Stdout
+	switch {
+	case runCtx.Err() == context.DeadlineExceeded:
+		run.Outcome = OutcomeTimeout
+	case res.Err != nil || res.ExitCode != 0:
+		run.Outcome = OutcomeFail
+	default:
+		run.Outcome = OutcomePass
+	}
+	return run
+}

--- a/internal/hooks/runner.go
+++ b/internal/hooks/runner.go
@@ -36,6 +36,7 @@ type HookRun struct {
 	Fail     FailPolicy
 	Blocked  bool // true when a closed failure blocked the verb
 	Stdout   []byte
+	Err      error // underlying exec error when Outcome is fail/timeout
 }
 
 // CommandResult is what the exec seam returns.
@@ -155,6 +156,7 @@ func (r *Runner) runOne(ctx context.Context, level Level, verb Verb, p PlannedHo
 	run.Duration = time.Since(start)
 	run.ExitCode = res.ExitCode
 	run.Stdout = res.Stdout
+	run.Err = res.Err
 	switch {
 	case runCtx.Err() == context.DeadlineExceeded:
 		run.Outcome = OutcomeTimeout

--- a/internal/hooks/runner_test.go
+++ b/internal/hooks/runner_test.go
@@ -1,0 +1,198 @@
+package hooks
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRunner_ClosedFailShortCircuits(t *testing.T) {
+	var called []string
+	r := &Runner{
+		WorkDir: t.TempDir(),
+		Exec: func(ctx context.Context, command string, stdin []byte, dir string) CommandResult {
+			called = append(called, command)
+			if command == "fail" {
+				return CommandResult{ExitCode: 1, Err: errors.New("exit 1")}
+			}
+			return CommandResult{ExitCode: 0}
+		},
+	}
+	planned := []PlannedHook{
+		{Name: "a", Timing: TimingPre, Hook: ResolvedHook{Name: "a", Command: "fail", Fail: FailClosed, Source: LayerFestival}},
+		{Name: "b", Timing: TimingPre, Hook: ResolvedHook{Name: "b", Command: "ok", Fail: FailClosed, Source: LayerFestival}},
+	}
+	runs, blocked, err := r.Run(context.Background(), LevelTask, VerbTaskComplete, planned, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !blocked {
+		t.Fatal("expected blocked")
+	}
+	if len(called) != 1 || called[0] != "fail" {
+		t.Fatalf("called = %v", called)
+	}
+	if runs[0].Outcome != OutcomeFail || !runs[0].Blocked {
+		t.Fatalf("run0 = %+v", runs[0])
+	}
+	if runs[1].Outcome != OutcomeSkipped || runs[1].Skip != SkipShortCircuit {
+		t.Fatalf("run1 = %+v", runs[1])
+	}
+}
+
+func TestRunner_OpenFailContinues(t *testing.T) {
+	var called []string
+	r := &Runner{
+		Exec: func(ctx context.Context, command string, stdin []byte, dir string) CommandResult {
+			called = append(called, command)
+			if command == "fail" {
+				return CommandResult{ExitCode: 2, Err: errors.New("exit 2")}
+			}
+			return CommandResult{ExitCode: 0}
+		},
+	}
+	planned := []PlannedHook{
+		{Name: "a", Timing: TimingPost, Hook: ResolvedHook{Command: "fail", Fail: FailOpen}},
+		{Name: "b", Timing: TimingPost, Hook: ResolvedHook{Command: "ok", Fail: FailClosed}},
+	}
+	runs, blocked, err := r.Run(context.Background(), LevelGate, VerbGateApprove, planned, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if blocked {
+		t.Fatal("open fail must not block")
+	}
+	if len(called) != 2 {
+		t.Fatalf("called = %v", called)
+	}
+	if runs[0].Outcome != OutcomeFail || runs[0].Blocked {
+		t.Fatalf("run0 = %+v", runs[0])
+	}
+	if runs[1].Outcome != OutcomePass {
+		t.Fatalf("run1 = %+v", runs[1])
+	}
+}
+
+func TestRunner_TimeoutClosedBlocks(t *testing.T) {
+	r := &Runner{
+		Exec: func(ctx context.Context, command string, stdin []byte, dir string) CommandResult {
+			<-ctx.Done()
+			return CommandResult{ExitCode: -1, Err: ctx.Err()}
+		},
+	}
+	planned := []PlannedHook{
+		{Name: "slow", Timing: TimingPre, Hook: ResolvedHook{
+			Command: "slow", Fail: FailClosed, Timeout: 5 * time.Millisecond,
+		}},
+	}
+	runs, blocked, err := r.Run(context.Background(), LevelTask, VerbTaskComplete, planned, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !blocked || runs[0].Outcome != OutcomeTimeout {
+		t.Fatalf("runs=%+v blocked=%v", runs, blocked)
+	}
+}
+
+func TestRunner_TimeoutZeroNoDeadline(t *testing.T) {
+	r := &Runner{
+		Exec: func(ctx context.Context, command string, stdin []byte, dir string) CommandResult {
+			if _, ok := ctx.Deadline(); ok {
+				t.Error("expected no deadline for timeout 0")
+			}
+			return CommandResult{ExitCode: 0}
+		},
+	}
+	planned := []PlannedHook{
+		{Name: "n", Timing: TimingPre, Hook: ResolvedHook{Command: "n", Fail: FailClosed, Timeout: 0}},
+	}
+	_, _, err := r.Run(context.Background(), LevelTask, VerbTaskComplete, planned, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunner_CancellationBetweenHooks(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	r := &Runner{
+		Exec: func(ctx context.Context, command string, stdin []byte, dir string) CommandResult {
+			cancel()
+			return CommandResult{ExitCode: 0}
+		},
+	}
+	planned := []PlannedHook{
+		{Name: "a", Timing: TimingPre, Hook: ResolvedHook{Command: "a", Fail: FailClosed}},
+		{Name: "b", Timing: TimingPre, Hook: ResolvedHook{Command: "b", Fail: FailClosed}},
+	}
+	runs, _, err := r.Run(ctx, LevelTask, VerbTaskComplete, planned, nil)
+	if err == nil {
+		t.Fatal("expected cancellation error")
+	}
+	if len(runs) != 1 {
+		t.Fatalf("runs = %+v", runs)
+	}
+}
+
+func TestRunner_SkippedNeverExec(t *testing.T) {
+	called := false
+	r := &Runner{
+		Exec: func(ctx context.Context, command string, stdin []byte, dir string) CommandResult {
+			called = true
+			return CommandResult{}
+		},
+	}
+	planned := []PlannedHook{
+		{Name: "x", Timing: TimingPre, Skip: SkipUndeclared},
+		{Name: "y", Timing: TimingPre, Skip: SkipDisabled},
+	}
+	runs, blocked, err := r.Run(context.Background(), LevelTask, VerbTaskComplete, planned, nil)
+	if err != nil || blocked || called {
+		t.Fatalf("err=%v blocked=%v called=%v runs=%+v", err, blocked, called, runs)
+	}
+	if runs[0].Skip != SkipUndeclared || runs[1].Skip != SkipDisabled {
+		t.Fatalf("runs = %+v", runs)
+	}
+}
+
+func TestRunner_CapturesExitAndDuration(t *testing.T) {
+	r := &Runner{
+		Exec: func(ctx context.Context, command string, stdin []byte, dir string) CommandResult {
+			time.Sleep(2 * time.Millisecond)
+			return CommandResult{ExitCode: 7, Err: errors.New("x"), Stdout: []byte("out")}
+		},
+	}
+	planned := []PlannedHook{
+		{Name: "a", Timing: TimingPost, Hook: ResolvedHook{Command: "a", Fail: FailOpen}},
+	}
+	runs, _, err := r.Run(context.Background(), LevelGate, VerbGateApprove, planned, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runs[0].ExitCode != 7 || runs[0].Duration <= 0 || string(runs[0].Stdout) != "out" {
+		t.Fatalf("run = %+v", runs[0])
+	}
+}
+
+func TestRunner_PrePostFilters(t *testing.T) {
+	var cmds []string
+	r := &Runner{
+		Exec: func(ctx context.Context, command string, stdin []byte, dir string) CommandResult {
+			cmds = append(cmds, command)
+			return CommandResult{ExitCode: 0}
+		},
+	}
+	planned := []PlannedHook{
+		{Name: "pre", Timing: TimingPre, Hook: ResolvedHook{Command: "pre-cmd"}},
+		{Name: "post", Timing: TimingPost, Hook: ResolvedHook{Command: "post-cmd"}},
+	}
+	_, _, _ = r.RunPre(context.Background(), LevelTask, VerbTaskComplete, planned, nil)
+	if len(cmds) != 1 || cmds[0] != "pre-cmd" {
+		t.Fatalf("pre cmds = %v", cmds)
+	}
+	cmds = nil
+	_, _, _ = r.RunPost(context.Background(), LevelTask, VerbTaskComplete, planned, nil)
+	if len(cmds) != 1 || cmds[0] != "post-cmd" {
+		t.Fatalf("post cmds = %v", cmds)
+	}
+}

--- a/internal/hooks/runner_test.go
+++ b/internal/hooks/runner_test.go
@@ -3,6 +3,7 @@ package hooks
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 )
@@ -194,5 +195,25 @@ func TestRunner_PrePostFilters(t *testing.T) {
 	_, _, _ = r.RunPost(context.Background(), LevelTask, VerbTaskComplete, planned, nil)
 	if len(cmds) != 1 || cmds[0] != "post-cmd" {
 		t.Fatalf("post cmds = %v", cmds)
+	}
+}
+
+func TestDefaultExec_FailureCarriesStderrTail(t *testing.T) {
+	res := defaultExec(context.Background(), "sh -c this-command-does-not-exist-xyz", nil, t.TempDir())
+	if res.Err == nil {
+		t.Fatal("expected failure")
+	}
+	if !strings.Contains(res.Err.Error(), "not found") && !strings.Contains(res.Err.Error(), "exit") {
+		t.Fatalf("err should carry diagnostics: %v", res.Err)
+	}
+}
+
+func TestStderrTail_Bounds(t *testing.T) {
+	long := strings.Repeat("x", stderrTailLimit+100)
+	if got := stderrTail(long); len(got) != stderrTailLimit {
+		t.Fatalf("tail length = %d, want %d", len(got), stderrTailLimit)
+	}
+	if got := stderrTail("  short  "); got != "short" {
+		t.Fatalf("tail = %q", got)
 	}
 }

--- a/internal/progress/events.go
+++ b/internal/progress/events.go
@@ -63,6 +63,10 @@ const (
 	// EventWorkflowJudgeCleared removes a prior terminal judge outcome after
 	// an operator takes ownership of the checkpoint.
 	EventWorkflowJudgeCleared EventType = "wf_judge_cleared"
+
+	// EventWorkflowHookRun records one hook execution (or skip) fired by a
+	// lifecycle binding. Hook runs are events, never decisions (D9).
+	EventWorkflowHookRun EventType = "wf_hook_run"
 )
 
 // ProgressEvent represents a single progress event in JSONL format.
@@ -92,6 +96,19 @@ type ProgressEvent struct {
 	JudgeDetail      string   `json:"judge_detail,omitempty"`
 	JudgePid         int      `json:"judge_pid,omitempty"`
 	JudgeRunID       string   `json:"judge_run_id,omitempty"`
+
+	// Hook-run event fields (wf_hook_run).
+	HookName     string `json:"hook_name,omitempty"`
+	HookLayer    string `json:"hook_layer,omitempty"`  // machine|festivals|festival
+	HookTiming   string `json:"hook_timing,omitempty"` // pre|post
+	HookVerb     string `json:"hook_verb,omitempty"`   // task_complete|sequence_complete|phase_complete|gate_approve
+	HookOutcome  string `json:"hook_outcome,omitempty"`
+	HookSkip     string `json:"hook_skip,omitempty"`
+	HookExitCode int    `json:"hook_exit_code,omitempty"`
+	HookMillis   int64  `json:"hook_duration_ms,omitempty"`
+	HookFail     string `json:"hook_fail,omitempty"` // closed|open
+	HookBlocked  bool   `json:"hook_blocked,omitempty"`
+	HookVerdict  string `json:"hook_verdict,omitempty"`
 }
 
 // loadFromEvents reads the JSONL file and materializes current state.

--- a/internal/progress/hook_events.go
+++ b/internal/progress/hook_events.go
@@ -1,0 +1,38 @@
+package progress
+
+import (
+	"time"
+
+	"github.com/Obedience-Corp/fest/internal/hooks"
+)
+
+// HookRunEvent maps a hooks.HookRun into a festival-local wf_hook_run event.
+// Callers queue via QueueEvent and Save. Never writes the campaign ledger.
+func HookRunEvent(phase string, step int, run hooks.HookRun) *ProgressEvent {
+	return &ProgressEvent{
+		Timestamp:    time.Now().UTC(),
+		Event:        EventWorkflowHookRun,
+		Phase:        phase,
+		Step:         step,
+		HookName:     run.Name,
+		HookLayer:    string(run.Layer),
+		HookTiming:   string(run.Timing),
+		HookVerb:     string(run.Verb),
+		HookOutcome:  string(run.Outcome),
+		HookSkip:     string(run.Skip),
+		HookExitCode: run.ExitCode,
+		HookMillis:   run.Duration.Milliseconds(),
+		HookFail:     string(run.Fail),
+		HookBlocked:  run.Blocked,
+	}
+}
+
+// QueueHookRuns appends one wf_hook_run event per run on the store.
+func QueueHookRuns(store *Store, phase string, step int, runs []hooks.HookRun) {
+	if store == nil {
+		return
+	}
+	for _, run := range runs {
+		store.QueueEvent(HookRunEvent(phase, step, run))
+	}
+}

--- a/internal/progress/hook_events_test.go
+++ b/internal/progress/hook_events_test.go
@@ -1,0 +1,74 @@
+package progress
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Obedience-Corp/fest/internal/hooks"
+)
+
+func TestHookRunEvent_JSONShape(t *testing.T) {
+	run := hooks.HookRun{
+		Name: "approval_judge", Layer: hooks.LayerFestivals, Timing: hooks.TimingPost,
+		Level: hooks.LevelGate, Verb: hooks.VerbGateApprove, Outcome: hooks.OutcomePass,
+		ExitCode: 0, Duration: 12 * time.Millisecond, Fail: hooks.FailClosed,
+	}
+	ev := HookRunEvent("001_IMPLEMENT", 2, run)
+	if ev.Event != EventWorkflowHookRun {
+		t.Fatalf("event type = %s", ev.Event)
+	}
+	raw, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{
+		"ts", "event", "phase", "step", "hook_name", "hook_layer",
+		"hook_timing", "hook_verb", "hook_outcome", "hook_duration_ms", "hook_fail",
+	} {
+		if _, ok := m[key]; !ok {
+			t.Fatalf("missing json key %q in %s", key, raw)
+		}
+	}
+	if m["event"] != "wf_hook_run" {
+		t.Fatalf("event = %v", m["event"])
+	}
+}
+
+func TestQueueHookRuns_WritesOneLinePerRun(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+	if err := store.Load(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	runs := []hooks.HookRun{
+		{Name: "a", Outcome: hooks.OutcomeFail, Fail: hooks.FailClosed, Blocked: true, Timing: hooks.TimingPost, Verb: hooks.VerbGateApprove},
+		{Name: "b", Outcome: hooks.OutcomeSkipped, Skip: hooks.SkipShortCircuit, Timing: hooks.TimingPost, Verb: hooks.VerbGateApprove},
+	}
+	QueueHookRuns(store, "001_IMPLEMENT", 1, runs)
+	if err := store.Save(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, ".fest", "progress_events.jsonl")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("lines = %d data=%s", len(lines), data)
+	}
+	for _, line := range lines {
+		if !strings.Contains(line, `"wf_hook_run"`) {
+			t.Fatalf("line missing wf_hook_run: %s", line)
+		}
+	}
+}

--- a/internal/progress/hook_lifecycle.go
+++ b/internal/progress/hook_lifecycle.go
@@ -1,0 +1,112 @@
+package progress
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/frontmatter"
+	"github.com/Obedience-Corp/fest/internal/hooks"
+)
+
+// newLifecycleHookRunner is an injectable seam so tests can fake hook execution.
+var newLifecycleHookRunner = hooks.NewRunner
+
+// LifecycleHookRequest describes one lifecycle verb whose step bindings run
+// through the hook runner (spec 03, D4).
+type LifecycleHookRequest struct {
+	FestivalPath string
+	Phase        string // audit-event coordinate
+	Step         int    // audit-event coordinate (0 outside workflow steps)
+	Task         string // audit-event coordinate (task or sequence id, when applicable)
+	Level        hooks.Level
+	Verb         hooks.Verb
+	Pre          []string
+	Post         []string
+	HumanGate    bool // approval: human-required on the step (spec 04)
+}
+
+// PlanLifecycleHooks resolves the effective hook set and plans the request's
+// bindings. On a human-required step every automation hook is skipped and
+// recorded as skipped: human-gate, without requiring hook resolution.
+func PlanLifecycleHooks(ctx context.Context, req LifecycleHookRequest) ([]hooks.PlannedHook, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, errors.Wrap(err, "context cancelled before hook planning")
+	}
+	if len(req.Pre) == 0 && len(req.Post) == 0 {
+		return nil, nil
+	}
+	if req.HumanGate {
+		var eff *hooks.Effective
+		return hooks.ApplyHumanGate(eff.PlanBindings(req.Level, req.Pre, req.Post)), nil
+	}
+	eff, err := hooks.LoadAndResolve(ctx, req.FestivalPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "resolving hooks")
+	}
+	return eff.PlanBindings(req.Level, req.Pre, req.Post), nil
+}
+
+// RunLifecycleStage executes one timing of the planned bindings and queues one
+// wf_hook_run event per record on the store. The caller owns event flushing
+// (Store.SaveEvents / Store.Save). blocked reports a fail-closed failure: for
+// pre the verb must not apply; for post the verb stays applied but the caller
+// should surface the failure.
+func RunLifecycleStage(ctx context.Context, store *Store, runner *hooks.Runner, req LifecycleHookRequest, planned []hooks.PlannedHook, timing hooks.Timing) ([]hooks.HookRun, bool, error) {
+	if len(planned) == 0 {
+		return nil, false, nil
+	}
+	var (
+		runs    []hooks.HookRun
+		blocked bool
+		err     error
+	)
+	if timing == hooks.TimingPre {
+		runs, blocked, err = runner.RunPre(ctx, req.Level, req.Verb, planned, nil)
+	} else {
+		runs, blocked, err = runner.RunPost(ctx, req.Level, req.Verb, planned, nil)
+	}
+	queueLifecycleRuns(store, req, runs)
+	return runs, blocked, err
+}
+
+func queueLifecycleRuns(store *Store, req LifecycleHookRequest, runs []hooks.HookRun) {
+	if store == nil {
+		return
+	}
+	for _, run := range runs {
+		ev := HookRunEvent(req.Phase, req.Step, run)
+		ev.Task = req.Task
+		store.QueueEvent(ev)
+	}
+}
+
+// StepHookBindingsFromFrontmatter extracts the hook bindings and human-gate
+// flag from a task or goal document's frontmatter. Unparseable frontmatter
+// yields no bindings.
+func StepHookBindingsFromFrontmatter(content []byte) (pre, post []string, humanGate bool) {
+	fm, _, err := frontmatter.Parse(content)
+	if err != nil || fm == nil {
+		return nil, nil, false
+	}
+	return fm.Hooks.Pre, fm.Hooks.Post, strings.EqualFold(strings.TrimSpace(fm.Approval), "human-required")
+}
+
+// BlockedHookError names the fail-closed hook that blocked a lifecycle verb.
+func BlockedHookError(verb hooks.Verb, runs []hooks.HookRun) error {
+	for _, run := range runs {
+		if !run.Blocked {
+			continue
+		}
+		e := errors.Validation("blocked by fail-closed hook").
+			WithField("hook", run.Name).
+			WithField("verb", string(verb)).
+			WithField("outcome", string(run.Outcome)).
+			WithHint("fix the hook failure, or set fail: open / enabled: false for the hook, then retry")
+		if run.Err != nil {
+			e = e.WithField("error", run.Err.Error())
+		}
+		return e
+	}
+	return errors.Validation("blocked by fail-closed hook").WithField("verb", string(verb))
+}

--- a/internal/progress/manager.go
+++ b/internal/progress/manager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Obedience-Corp/fest/internal/campledger"
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/frontmatter"
+	"github.com/Obedience-Corp/fest/internal/hooks"
 )
 
 // Manager handles progress operations for a festival
@@ -501,7 +502,8 @@ func (m *Manager) propagateSequenceCompletion(ctx context.Context, seqPath strin
 	}
 
 	goalPath := filepath.Join(seqPath, "SEQUENCE_GOAL.md")
-	return m.updateGoalStatus(ctx, goalPath, frontmatter.StatusCompleted)
+	return m.completeGoalWithHooks(ctx, goalPath, hooks.LevelSequence, hooks.VerbSequenceComplete,
+		filepath.Base(filepath.Dir(seqPath)), filepath.Base(seqPath))
 }
 
 // propagatePhaseCompletion updates PHASE_GOAL.md if all sequences/workflows are done.
@@ -516,7 +518,68 @@ func (m *Manager) propagatePhaseCompletion(ctx context.Context, phasePath string
 	}
 
 	goalPath := filepath.Join(phasePath, "PHASE_GOAL.md")
-	return m.updateGoalStatus(ctx, goalPath, frontmatter.StatusCompleted)
+	return m.completeGoalWithHooks(ctx, goalPath, hooks.LevelPhase, hooks.VerbPhaseComplete,
+		filepath.Base(phasePath), "")
+}
+
+// completeGoalWithHooks marks a goal doc completed, running its frontmatter
+// hook bindings around the transition (spec 03: sequence/phase complete
+// verbs). A blocked pre list leaves the goal incomplete because the verb
+// never applies; a blocked post list leaves the transition applied. Hooks run
+// only on the pending -> completed transition, never for goals already
+// completed.
+func (m *Manager) completeGoalWithHooks(ctx context.Context, goalPath string, level hooks.Level, verb hooks.Verb, phaseName, taskCoord string) error {
+	content, err := os.ReadFile(goalPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // Goal files are optional
+		}
+		return errors.IO("reading goal file", err)
+	}
+	fm, _, err := frontmatter.Parse(content)
+	if err != nil || fm == nil {
+		return m.updateGoalStatus(ctx, goalPath, frontmatter.StatusCompleted)
+	}
+	if fm.Status == frontmatter.StatusCompleted {
+		return nil // Already applied; never re-run completion hooks
+	}
+
+	req := LifecycleHookRequest{
+		FestivalPath: m.store.FestivalPath(),
+		Phase:        phaseName,
+		Task:         taskCoord,
+		Level:        level,
+		Verb:         verb,
+	}
+	req.Pre, req.Post, req.HumanGate = StepHookBindingsFromFrontmatter(content)
+	planned, err := PlanLifecycleHooks(ctx, req)
+	if err != nil {
+		return errors.Wrap(err, "planning goal hooks")
+	}
+	runner := newLifecycleHookRunner(m.store.FestivalPath())
+	preRuns, blocked, err := RunLifecycleStage(ctx, m.store, runner, req, planned, hooks.TimingPre)
+	if saveErr := m.store.SaveEvents(ctx); saveErr != nil && err == nil {
+		err = saveErr
+	}
+	if err != nil {
+		return errors.Wrap(err, "running goal pre hooks")
+	}
+	if blocked {
+		return BlockedHookError(verb, preRuns)
+	}
+
+	if err := m.updateGoalStatus(ctx, goalPath, frontmatter.StatusCompleted); err != nil {
+		return err
+	}
+
+	_, _, postErr := RunLifecycleStage(ctx, m.store, runner, req, planned, hooks.TimingPost)
+	if saveErr := m.store.SaveEvents(ctx); saveErr != nil && postErr == nil {
+		postErr = saveErr
+	}
+	if postErr != nil {
+		return errors.Wrap(postErr, "running goal post hooks")
+	}
+	return nil
 }
 
 // ResetPhaseStatus sets the phase PHASE_GOAL.md frontmatter status back to in_progress.

--- a/internal/progress/manager_hooks_test.go
+++ b/internal/progress/manager_hooks_test.go
@@ -1,0 +1,158 @@
+package progress
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/hooks"
+)
+
+func setupHookPropagationFestival(t *testing.T, seqGoalFrontmatter string) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	festYAML := `version: "1.0"
+name: propagate-hooks-test
+id: PHK-001
+metadata:
+  id: PHK-001
+hooks:
+  definitions:
+    seq-check:
+      command: test-seq-check
+`
+	if err := os.WriteFile(filepath.Join(dir, "fest.yaml"), []byte(festYAML), 0o644); err != nil {
+		t.Fatalf("write fest.yaml: %v", err)
+	}
+
+	seqDir := filepath.Join(dir, "001_PHASE", "01_seq")
+	if err := os.MkdirAll(seqDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".fest"), 0o755); err != nil {
+		t.Fatalf("mkdir .fest: %v", err)
+	}
+	phaseGoal := "---\nfest_type: phase_goal\nfest_id: 001_PHASE\n---\n# Phase Goal\n"
+	if err := os.WriteFile(filepath.Join(dir, "001_PHASE", "PHASE_GOAL.md"), []byte(phaseGoal), 0o644); err != nil {
+		t.Fatalf("write phase goal: %v", err)
+	}
+	seqGoal := "---\nfest_type: sequence_goal\nfest_id: 01_seq\n" + seqGoalFrontmatter + "---\n# Sequence Goal\n"
+	if err := os.WriteFile(filepath.Join(seqDir, "SEQUENCE_GOAL.md"), []byte(seqGoal), 0o644); err != nil {
+		t.Fatalf("write sequence goal: %v", err)
+	}
+	taskBody := "---\nfest_type: task\nfest_id: 01_task\n---\n# Task body\n"
+	if err := os.WriteFile(filepath.Join(seqDir, "01_task.md"), []byte(taskBody), 0o644); err != nil {
+		t.Fatalf("write task: %v", err)
+	}
+
+	t.Setenv("HOME", t.TempDir())
+	return dir
+}
+
+func fakeLifecycleRunner(t *testing.T, exitCode int, called *[]string) {
+	t.Helper()
+	orig := newLifecycleHookRunner
+	t.Cleanup(func() { newLifecycleHookRunner = orig })
+	newLifecycleHookRunner = func(workDir string) *hooks.Runner {
+		r := hooks.NewRunner(workDir)
+		r.Exec = func(ctx context.Context, command string, stdin []byte, dir string) hooks.CommandResult {
+			if called != nil {
+				*called = append(*called, command)
+			}
+			res := hooks.CommandResult{ExitCode: exitCode}
+			if exitCode != 0 {
+				res.Err = context.Canceled
+			}
+			return res
+		}
+		return r
+	}
+}
+
+func seqGoalStatus(t *testing.T, festDir string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(festDir, "001_PHASE", "01_seq", "SEQUENCE_GOAL.md"))
+	if err != nil {
+		t.Fatalf("read goal: %v", err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "fest_status:") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "fest_status:"))
+		}
+	}
+	return ""
+}
+
+func readEventsFile(t *testing.T, festDir string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(festDir, ".fest", "progress_events.jsonl"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		t.Fatalf("read events: %v", err)
+	}
+	return string(data)
+}
+
+func TestPropagateSequenceCompletion_BlockedPreLeavesGoalIncomplete(t *testing.T) {
+	festDir := setupHookPropagationFestival(t, "hooks:\n  pre: [seq-check]\n")
+	var called []string
+	fakeLifecycleRunner(t, 1, &called)
+
+	mgr, err := NewManager(context.Background(), festDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := mgr.MarkComplete(context.Background(), "001_PHASE/01_seq/01_task.md"); err != nil {
+		t.Fatalf("MarkComplete: %v", err)
+	}
+
+	if got := seqGoalStatus(t, festDir); got == "completed" {
+		t.Fatal("blocked pre hook must leave the sequence goal incomplete")
+	}
+	if len(called) != 1 {
+		t.Fatalf("hook exec calls = %v", called)
+	}
+	events := readEventsFile(t, festDir)
+	if !strings.Contains(events, `"hook_verb":"sequence_complete"`) || !strings.Contains(events, `"hook_blocked":true`) {
+		t.Fatalf("blocked sequence_complete event missing:\n%s", events)
+	}
+}
+
+func TestPropagateSequenceCompletion_PassingHooksCompleteGoalOnce(t *testing.T) {
+	festDir := setupHookPropagationFestival(t, "hooks:\n  pre: [seq-check]\n  post: [seq-check]\n")
+	var called []string
+	fakeLifecycleRunner(t, 0, &called)
+
+	mgr, err := NewManager(context.Background(), festDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := mgr.MarkComplete(context.Background(), "001_PHASE/01_seq/01_task.md"); err != nil {
+		t.Fatalf("MarkComplete: %v", err)
+	}
+
+	if got := seqGoalStatus(t, festDir); got != "completed" {
+		t.Fatalf("sequence goal status = %q, want completed", got)
+	}
+	if len(called) != 2 { // one pre + one post
+		t.Fatalf("hook exec calls = %v", called)
+	}
+
+	// Re-propagating an already-completed goal must not re-run hooks.
+	if err := mgr.propagateSequenceCompletion(context.Background(), filepath.Join(festDir, "001_PHASE", "01_seq")); err != nil {
+		t.Fatalf("re-propagate: %v", err)
+	}
+	if len(called) != 2 {
+		t.Fatalf("completion hooks re-ran on already-completed goal: %v", called)
+	}
+
+	events := readEventsFile(t, festDir)
+	if !strings.Contains(events, `"hook_timing":"pre"`) || !strings.Contains(events, `"hook_timing":"post"`) {
+		t.Fatalf("pre/post sequence events missing:\n%s", events)
+	}
+}

--- a/internal/progress/store.go
+++ b/internal/progress/store.go
@@ -632,6 +632,16 @@ func (s *Store) QueueWorkflowEvents(events []wf.WorkflowEvent) {
 			JudgeDetail:      we.JudgeDetail,
 			JudgePid:         we.JudgePid,
 			JudgeRunID:       we.JudgeRunID,
+			HookName:         we.HookName,
+			HookLayer:        we.HookLayer,
+			HookTiming:       we.HookTiming,
+			HookVerb:         we.HookVerb,
+			HookOutcome:      we.HookOutcome,
+			HookSkip:         we.HookSkip,
+			HookExitCode:     we.HookExitCode,
+			HookMillis:       we.HookDurationMS,
+			HookFail:         we.HookFail,
+			HookBlocked:      we.HookBlocked,
 		}
 		s.pendingEvents = append(s.pendingEvents, pe)
 	}

--- a/internal/validator/api.go
+++ b/internal/validator/api.go
@@ -91,6 +91,13 @@ func QuickValidate(ctx context.Context, festivalPath string) (*Result, error) {
 	}
 	result.Issues = append(result.Issues, templateIssues...)
 
+	// Legacy hooks.approval_judge.command deprecation (non-blocking)
+	hookIssues, err := ValidateHooksConfig(ctx, festivalPath)
+	if err != nil {
+		return nil, err
+	}
+	result.Issues = append(result.Issues, hookIssues...)
+
 	// Calculate score based on issues
 	result.Score = CalculateScore(result)
 	result.Valid = !result.HasErrors()
@@ -156,6 +163,13 @@ func FullValidate(ctx context.Context, festivalPath string) (*Result, error) {
 		}
 		result.Issues = append(result.Issues, autoLinkIssues...)
 	}
+
+	// Legacy hooks.approval_judge.command deprecation (non-blocking warning).
+	hookIssues, err := ValidateHooksConfig(ctx, festivalPath)
+	if err != nil {
+		return nil, err
+	}
+	result.Issues = append(result.Issues, hookIssues...)
 
 	// Calculate score based on issues
 	result.Score = CalculateScore(result)

--- a/internal/validator/api.go
+++ b/internal/validator/api.go
@@ -91,12 +91,18 @@ func QuickValidate(ctx context.Context, festivalPath string) (*Result, error) {
 	}
 	result.Issues = append(result.Issues, templateIssues...)
 
-	// Legacy hooks.approval_judge.command deprecation (non-blocking)
-	hookIssues, err := ValidateHooksConfig(ctx, festivalPath)
-	if err != nil {
-		return nil, err
+	// Legacy hooks.approval_judge.command deprecation (non-blocking). Hook
+	// checks never fail validation: load errors degrade to a warning.
+	if hookIssues, err := ValidateHooksConfig(ctx, festivalPath); err != nil {
+		result.Issues = append(result.Issues, Issue{
+			Level:   LevelWarning,
+			Code:    CodeHooksConfigError,
+			Path:    festivalPath,
+			Message: "could not check hooks configuration: " + err.Error(),
+		})
+	} else {
+		result.Issues = append(result.Issues, hookIssues...)
 	}
-	result.Issues = append(result.Issues, hookIssues...)
 
 	// Calculate score based on issues
 	result.Score = CalculateScore(result)
@@ -164,12 +170,18 @@ func FullValidate(ctx context.Context, festivalPath string) (*Result, error) {
 		result.Issues = append(result.Issues, autoLinkIssues...)
 	}
 
-	// Legacy hooks.approval_judge.command deprecation (non-blocking warning).
-	hookIssues, err := ValidateHooksConfig(ctx, festivalPath)
-	if err != nil {
-		return nil, err
+	// Legacy hooks.approval_judge.command deprecation (non-blocking). Hook
+	// checks never fail validation: load errors degrade to a warning.
+	if hookIssues, err := ValidateHooksConfig(ctx, festivalPath); err != nil {
+		result.Issues = append(result.Issues, Issue{
+			Level:   LevelWarning,
+			Code:    CodeHooksConfigError,
+			Path:    festivalPath,
+			Message: "could not check hooks configuration: " + err.Error(),
+		})
+	} else {
+		result.Issues = append(result.Issues, hookIssues...)
 	}
-	result.Issues = append(result.Issues, hookIssues...)
 
 	// Calculate score based on issues
 	result.Score = CalculateScore(result)

--- a/internal/validator/hooks.go
+++ b/internal/validator/hooks.go
@@ -2,10 +2,14 @@ package validator
 
 import (
 	"context"
+	"io/fs"
+	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/Obedience-Corp/fest/internal/config"
+	"github.com/Obedience-Corp/fest/internal/frontmatter"
+	guidancewf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
 	"github.com/Obedience-Corp/fest/internal/hooks"
 	"github.com/Obedience-Corp/fest/internal/workspace"
 )
@@ -54,6 +58,9 @@ func ValidateHooksConfig(ctx context.Context, festivalPath string) ([]Issue, err
 // CodeHooksUndeclaredBinding warns when a step binds a hook name not declared.
 const CodeHooksUndeclaredBinding = "hooks_undeclared_binding"
 
+// CodeHooksConfigError warns when hook configuration cannot be loaded or resolved.
+const CodeHooksConfigError = "hooks_config_error"
+
 // IssuesForUndeclaredBindings builds non-blocking warnings for undeclared bound names.
 func IssuesForUndeclaredBindings(path string, planned []hooks.PlannedHook) []Issue {
 	var issues []Issue
@@ -70,4 +77,91 @@ func IssuesForUndeclaredBindings(path string, planned []hooks.PlannedHook) []Iss
 		})
 	}
 	return issues
+}
+
+// ScanUndeclaredBindings walks the festival's workflow docs and step/goal
+// frontmatter and warns for hook bindings that reference undeclared names
+// (spec 03: undeclared bindings skip with a warning in fest validate).
+func ScanUndeclaredBindings(ctx context.Context, festivalPath string, eff *hooks.Effective) []Issue {
+	if eff == nil {
+		return nil
+	}
+	var issues []Issue
+	_ = filepath.WalkDir(festivalPath, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if err := ctx.Err(); err != nil {
+			return fs.SkipAll
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if path != festivalPath && (strings.HasPrefix(name, ".") || name == "results" || name == "feedback") {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), ".md") {
+			return nil
+		}
+		rel, relErr := filepath.Rel(festivalPath, path)
+		if relErr != nil {
+			rel = path
+		}
+		switch d.Name() {
+		case "GATES.md", "WORKFLOW.md":
+			issues = append(issues, scanWorkflowDocBindings(ctx, path, rel, d.Name(), eff)...)
+		default:
+			issues = append(issues, scanFrontmatterBindings(path, rel, eff)...)
+		}
+		return nil
+	})
+	return issues
+}
+
+func scanWorkflowDocBindings(ctx context.Context, path, rel, docName string, eff *hooks.Effective) []Issue {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	steps, err := guidancewf.NewParser().ParseContent(ctx, string(content))
+	if err != nil {
+		return nil
+	}
+	level := hooks.LevelPhase
+	if docName == "GATES.md" {
+		level = hooks.LevelGate
+	}
+	var issues []Issue
+	for _, step := range steps {
+		if len(step.Hooks.Pre) == 0 && len(step.Hooks.Post) == 0 {
+			continue
+		}
+		planned := eff.PlanBindings(level, step.Hooks.Pre, step.Hooks.Post)
+		issues = append(issues, IssuesForUndeclaredBindings(rel, planned)...)
+	}
+	return issues
+}
+
+func scanFrontmatterBindings(path, rel string, eff *hooks.Effective) []Issue {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	fm, _, err := frontmatter.Parse(content)
+	if err != nil || fm == nil {
+		return nil
+	}
+	if len(fm.Hooks.Pre) == 0 && len(fm.Hooks.Post) == 0 {
+		return nil
+	}
+	level := hooks.LevelTask
+	switch filepath.Base(path) {
+	case "SEQUENCE_GOAL.md":
+		level = hooks.LevelSequence
+	case "PHASE_GOAL.md", "FESTIVAL_GOAL.md":
+		level = hooks.LevelPhase
+	}
+	planned := eff.PlanBindings(level, fm.Hooks.Pre, fm.Hooks.Post)
+	return IssuesForUndeclaredBindings(rel, planned)
 }

--- a/internal/validator/hooks.go
+++ b/internal/validator/hooks.go
@@ -50,3 +50,24 @@ func ValidateHooksConfig(ctx context.Context, festivalPath string) ([]Issue, err
 		Fix:     "Move the command under hooks.definitions.approval_judge with timeout: 0",
 	}}, nil
 }
+
+// CodeHooksUndeclaredBinding warns when a step binds a hook name not declared.
+const CodeHooksUndeclaredBinding = "hooks_undeclared_binding"
+
+// IssuesForUndeclaredBindings builds non-blocking warnings for undeclared bound names.
+func IssuesForUndeclaredBindings(path string, planned []hooks.PlannedHook) []Issue {
+	var issues []Issue
+	for _, p := range planned {
+		if p.Skip != hooks.SkipUndeclared {
+			continue
+		}
+		issues = append(issues, Issue{
+			Level:   LevelWarning,
+			Code:    CodeHooksUndeclaredBinding,
+			Path:    path,
+			Message: "hook binding references undeclared name " + p.Name + " (skipped)",
+			Fix:     "Declare the hook under hooks.definitions or remove the binding",
+		})
+	}
+	return issues
+}

--- a/internal/validator/hooks.go
+++ b/internal/validator/hooks.go
@@ -1,0 +1,52 @@
+package validator
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+
+	"github.com/Obedience-Corp/fest/internal/config"
+	"github.com/Obedience-Corp/fest/internal/hooks"
+	"github.com/Obedience-Corp/fest/internal/workspace"
+)
+
+// ValidateHooksConfig emits warnings for legacy hook configuration shapes.
+func ValidateHooksConfig(ctx context.Context, festivalPath string) ([]Issue, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	var festivalsRoot string
+	ws, err := workspace.FindWorkspace(ctx, festivalPath)
+	if err == nil {
+		festivalsRoot = ws.FestivalsPath
+	}
+	if festivalsRoot == "" {
+		// Fallback: parent of festival when it lives under festivals/<status>/<name>
+		festivalsRoot = filepath.Dir(filepath.Dir(festivalPath))
+	}
+
+	wcfg, err := config.LoadWorkspaceConfig(festivalsRoot)
+	if err != nil {
+		return nil, err
+	}
+	if wcfg == nil {
+		return nil, nil
+	}
+
+	cmd := strings.TrimSpace(wcfg.Hooks.ApprovalJudge.Command)
+	if cmd == "" {
+		return nil, nil
+	}
+	if _, explicit := wcfg.Hooks.Definitions[hooks.ApprovalJudgeName]; explicit {
+		return nil, nil
+	}
+
+	return []Issue{{
+		Level:   LevelWarning,
+		Code:    CodeHooksLegacyAlias,
+		Path:    filepath.Join(festivalsRoot, config.DotFestivalDir, config.WorkspaceConfigFileName),
+		Message: hooks.ApprovalJudgeAliasWarning(cmd),
+		Fix:     "Move the command under hooks.definitions.approval_judge with timeout: 0",
+	}}, nil
+}

--- a/internal/validator/hooks_scan_test.go
+++ b/internal/validator/hooks_scan_test.go
@@ -1,0 +1,87 @@
+package validator
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/config"
+	"github.com/Obedience-Corp/fest/internal/hooks"
+)
+
+func TestScanUndeclaredBindings_NilEffective(t *testing.T) {
+	if got := ScanUndeclaredBindings(context.Background(), t.TempDir(), nil); got != nil {
+		t.Fatalf("nil effective must yield nil, got %+v", got)
+	}
+}
+
+func TestScanUndeclaredBindings_WarnsAcrossDocTypes(t *testing.T) {
+	festivalPath := t.TempDir()
+	phaseDir := filepath.Join(festivalPath, "001_PHASE")
+	seqDir := filepath.Join(phaseDir, "01_seq")
+	if err := os.MkdirAll(seqDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	gates := `---
+fest_type: phase_gate
+---
+
+## Step 1: GATE
+
+**Question:** ok?
+
+**Checkpoint:** APPROVAL REQUIRED
+
+**Hooks:** post: [ghost-gate]
+`
+	if err := os.WriteFile(filepath.Join(phaseDir, "GATES.md"), []byte(gates), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	task := `---
+fest_type: task
+fest_id: 01_task
+hooks:
+  pre: [ghost-task, declared]
+---
+# Task
+`
+	if err := os.WriteFile(filepath.Join(seqDir, "01_task.md"), []byte(task), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	eff, err := hooks.Resolve(nil, &config.HooksConfig{
+		Definitions: map[string]config.HookDefinition{"declared": {Command: "true"}},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	issues := ScanUndeclaredBindings(context.Background(), festivalPath, eff)
+	if len(issues) != 2 {
+		t.Fatalf("issues = %+v", issues)
+	}
+	names := map[string]bool{}
+	for _, issue := range issues {
+		if issue.Code != CodeHooksUndeclaredBinding || issue.Level != LevelWarning {
+			t.Fatalf("issue shape wrong: %+v", issue)
+		}
+		names[issue.Message] = true
+	}
+	joined := ""
+	for m := range names {
+		joined += m + "\n"
+	}
+	for _, want := range []string{"ghost-gate", "ghost-task"} {
+		found := false
+		for m := range names {
+			if len(m) > 0 && (m == "hook binding references undeclared name "+want+" (skipped)") {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("missing warning for %s in:\n%s", want, joined)
+		}
+	}
+}

--- a/internal/validator/types.go
+++ b/internal/validator/types.go
@@ -26,6 +26,9 @@ const (
 	CodeAutoLinkPathNotDir         = "autolink_path_not_dir"
 	CodeAutoLinkUnrequiredSet      = "autolink_unrequired_set"
 	CodeAutoLinkProjectPathInvalid = "autolink_project_path_invalid"
+
+	// Hooks issue codes
+	CodeHooksLegacyAlias = "hooks_legacy_alias"
 )
 
 // Issue represents a single validation problem


### PR DESCRIPTION
## Summary

Implements the full fest hooks system from festival **FH0001** (`fest-hooks-system`): three declaration layers, step bindings, sequential runner with fail policies, human gates, evidence contract, audit events, and operator CLI surfaces.

- Add shared `hooks` config types and three-layer resolution (machine JSON, festivals YAML, festival YAML) with by-name whole-definition override and most-specific-wins switches
- Preserve legacy `hooks.approval_judge.command` as an implicit `approval_judge` definition (`timeout: 0`) with deprecation warning
- Parse step bindings from frontmatter and GATES.md `**Hooks:**` markers; skip+warn undeclared names
- Add sequential hook runner (fail open/closed, timeouts) and emit `wf_hook_run` festival-local audit events; route approval judge execution through the runner
- Implement non-bypassable human gates (`approval: human-required`): banner/parking, TTY-required approve/reject, refuse `--auto`/judge
- Document the read-by-approver evidence contract and add opt-in `evidence: embed` with a 256KB cap
- Ship `fest hooks list` (text/`--json`) and non-blocking validate warnings for shadow drift / legacy alias

## Test plan

- [x] `just build quick`
- [x] `just test unit` (all packages green)
- [x] `just lint all` (0 issues)
- [x] Smoke: `fest hooks list` / `fest hooks list --json` from linked project shows legacy `approval_judge` alias
- [ ] CI green on PR
- [x] Manual: human-required gate refuses `fest workflow approve --auto` and shows `HUMAN APPROVAL REQUIRED` on `fest next` (verified with the real binary in an isolated workspace, commit caace9e)

Festival completed and promoted:
`festivals/.dungeon/completed/2026-07-22/fest-hooks-system-FH0001`


## Review fixes (caace9e)

The staff review found the runner/audit/validation layers were built but not wired into production paths. caace9e addresses every finding:

- Step-bound pre/post hooks now execute on all four lifecycle verbs (task/sequence/phase complete, gate approve); fail-closed pre failures block the verb
- `wf_hook_run` audit events are emitted for every hook execution and skip, including the judge's own run
- Human-required steps record automation bindings as `skipped: human-gate`
- `fest validate` warns on undeclared bindings and renders a HOOKS section (hook warnings were previously never displayed)
- Evidence path-safety logic deduplicated (approval_readiness delegates to internal/hooks); festerrors replaces fmt.Errorf in new code
- Verified end-to-end with the real binary: blocked/passing completions with audit events, banner, refusal paths, `human_approval_required` in `--json`
