### PR TITLE
fix(workflow): TTY-gate --override-judge and --judge-command

### DIFF
--- a/docs/cli-reference/fest-reference.md
+++ b/docs/cli-reference/fest-reference.md
@@ -7023,11 +7023,13 @@ Auto approval:
   before the judge is invoked. Missing evidence blocks deterministically without a model call.
 
   After a judge reject, re-submit with: fest workflow judge
-  Operator override (interactive TTY, or --override-judge --summary "..."):
-  records decision_actor=user_override.
+  Operator override: run --override-judge --summary "..." from a real terminal
+  and type APPROVE when prompted; records decision_actor=user_override.
 
-  When an approval judge is configured, non-interactive manual approve is refused
-  so agents cannot mint decision_actor=user. Use a real terminal and type APPROVE.
+  When an approval judge is configured, non-interactive manual approve is
+  refused, including --override-judge and --judge-command, so agents cannot
+  mint decision_actor=user or user_override. Use a real terminal and type
+  APPROVE.
 
   The judge command receives JSON on stdin using schema fest.approval.judge/v1
   and must return JSON on stdout with decision "approve" or "reject" and a
@@ -7057,9 +7059,9 @@ fest workflow approve [flags]
 ```
       --auto                     delegate this checkpoint decision to the configured approval judge command
   -h, --help                     help for approve
-      --judge-command string     approval judge command for --auto (overrides the .festival/config.yaml hooks.approval_judge.command hook)
+      --judge-command string     approval judge command for --auto (overrides the .festival/config.yaml hooks.approval_judge.command hook; requires an interactive TTY)
       --judge-timeout duration   maximum time to wait for the approval judge (0 waits until it returns)
-      --override-judge           operator override of a judge/readiness reject (requires --summary; for non-interactive use)
+      --override-judge           operator override of a judge/readiness reject (requires --summary and an interactive TTY)
       --summary string           approval summary or rationale (required with --override-judge)
       --wait                     block until the judge returns instead of launching it in the background
 ```
@@ -7193,7 +7195,7 @@ fest workflow judge [flags]
 
 ```
   -h, --help                     help for judge
-      --judge-command string     approval judge command (overrides hooks.approval_judge.command)
+      --judge-command string     approval judge command (overrides hooks.approval_judge.command; requires an interactive TTY)
       --judge-timeout duration   maximum time to wait for the approval judge (0 waits until it returns)
       --wait                     block until the judge returns instead of launching it in the background
 ```

--- a/docs/cli-reference/fest_workflow_approve.md
+++ b/docs/cli-reference/fest_workflow_approve.md
@@ -32,11 +32,13 @@ Auto approval:
   before the judge is invoked. Missing evidence blocks deterministically without a model call.
 
   After a judge reject, re-submit with: fest workflow judge
-  Operator override (interactive TTY, or --override-judge --summary "..."):
-  records decision_actor=user_override.
+  Operator override: run --override-judge --summary "..." from a real terminal
+  and type APPROVE when prompted; records decision_actor=user_override.
 
-  When an approval judge is configured, non-interactive manual approve is refused
-  so agents cannot mint decision_actor=user. Use a real terminal and type APPROVE.
+  When an approval judge is configured, non-interactive manual approve is
+  refused, including --override-judge and --judge-command, so agents cannot
+  mint decision_actor=user or user_override. Use a real terminal and type
+  APPROVE.
 
   The judge command receives JSON on stdin using schema fest.approval.judge/v1
   and must return JSON on stdout with decision "approve" or "reject" and a
@@ -66,9 +68,9 @@ fest workflow approve [flags]
 ```
       --auto                     delegate this checkpoint decision to the configured approval judge command
   -h, --help                     help for approve
-      --judge-command string     approval judge command for --auto (overrides the .festival/config.yaml hooks.approval_judge.command hook)
+      --judge-command string     approval judge command for --auto (overrides the .festival/config.yaml hooks.approval_judge.command hook; requires an interactive TTY)
       --judge-timeout duration   maximum time to wait for the approval judge (0 waits until it returns)
-      --override-judge           operator override of a judge/readiness reject (requires --summary; for non-interactive use)
+      --override-judge           operator override of a judge/readiness reject (requires --summary and an interactive TTY)
       --summary string           approval summary or rationale (required with --override-judge)
       --wait                     block until the judge returns instead of launching it in the background
 ```

--- a/docs/cli-reference/fest_workflow_judge.md
+++ b/docs/cli-reference/fest_workflow_judge.md
@@ -22,7 +22,7 @@ fest workflow judge [flags]
 
 ```
   -h, --help                     help for judge
-      --judge-command string     approval judge command (overrides hooks.approval_judge.command)
+      --judge-command string     approval judge command (overrides hooks.approval_judge.command; requires an interactive TTY)
       --judge-timeout duration   maximum time to wait for the approval judge (0 waits until it returns)
       --wait                     block until the judge returns instead of launching it in the background
 ```

--- a/internal/commands/workflow/approval_hardening_test.go
+++ b/internal/commands/workflow/approval_hardening_test.go
@@ -276,7 +276,7 @@ func TestApprovalRecoveryLines_OrdinaryOperatorRejectionOmitsJudgeRetry(t *testi
 	}
 }
 
-func TestResolveManualApprovalDecision_OverrideJudge(t *testing.T) {
+func TestResolveManualApprovalDecision_OverrideJudgeNonInteractiveRefused(t *testing.T) {
 	orig := stdinIsInteractiveFn
 	stdinIsInteractiveFn = func() bool { return false }
 	t.Cleanup(func() { stdinIsInteractiveFn = orig })
@@ -287,15 +287,58 @@ func TestResolveManualApprovalDecision_OverrideJudge(t *testing.T) {
 		Feedback:      "approval readiness: missing presentation",
 		Judge:         &wf.JudgeState{Status: wf.JudgeRejected, Detail: "thin evidence"},
 	}
+	_, err := resolveManualApprovalDecision(
+		wf.DecisionMetadata{Summary: "I reviewed output_specs and accept them as written"},
+		true, false, true, blocked, 4, "PRESENT",
+	)
+	if err == nil || !strings.Contains(err.Error(), "interactive operator TTY") {
+		t.Fatalf("non-interactive --override-judge must be refused, got: %v", err)
+	}
+}
+
+func TestResolveManualApprovalDecision_OverrideJudgeInteractiveConfirm(t *testing.T) {
+	origTTY := stdinIsInteractiveFn
+	origRead := readOperatorConfirm
+	stdinIsInteractiveFn = func() bool { return true }
+	readOperatorConfirm = func() (string, error) { return operatorApproveToken, nil }
+	t.Cleanup(func() {
+		stdinIsInteractiveFn = origTTY
+		readOperatorConfirm = origRead
+	})
+
+	blocked := &wf.StepState{
+		Status:        wf.StepStatusBlocked,
+		DecisionActor: decisionActorAgent,
+		Judge:         &wf.JudgeState{Status: wf.JudgeRejected, Detail: "thin evidence"},
+	}
 	decision, err := resolveManualApprovalDecision(
 		wf.DecisionMetadata{Summary: "I reviewed output_specs and accept them as written"},
 		true, false, true, blocked, 4, "PRESENT",
 	)
 	if err != nil {
-		t.Fatalf("override: %v", err)
+		t.Fatalf("interactive override: %v", err)
 	}
 	if decision.Actor != decisionActorUserOverride {
 		t.Fatalf("actor = %q, want user_override", decision.Actor)
+	}
+}
+
+func TestResolveManualApprovalDecision_OverrideJudgeWrongTokenRefused(t *testing.T) {
+	origTTY := stdinIsInteractiveFn
+	origRead := readOperatorConfirm
+	stdinIsInteractiveFn = func() bool { return true }
+	readOperatorConfirm = func() (string, error) { return "yes", nil }
+	t.Cleanup(func() {
+		stdinIsInteractiveFn = origTTY
+		readOperatorConfirm = origRead
+	})
+
+	_, err := resolveManualApprovalDecision(
+		wf.DecisionMetadata{Summary: "I reviewed output_specs and accept them as written"},
+		true, false, true, nil, 4, "PRESENT",
+	)
+	if err == nil || !strings.Contains(err.Error(), "operator approval not confirmed") {
+		t.Fatalf("wrong confirmation token must be refused, got: %v", err)
 	}
 }
 

--- a/internal/commands/workflow/approve.go
+++ b/internal/commands/workflow/approve.go
@@ -99,11 +99,13 @@ Auto approval:
   before the judge is invoked. Missing evidence blocks deterministically without a model call.
 
   After a judge reject, re-submit with: fest workflow judge
-  Operator override (interactive TTY, or --override-judge --summary "..."):
-  records decision_actor=user_override.
+  Operator override: run --override-judge --summary "..." from a real terminal
+  and type APPROVE when prompted; records decision_actor=user_override.
 
-  When an approval judge is configured, non-interactive manual approve is refused
-  so agents cannot mint decision_actor=user. Use a real terminal and type APPROVE.
+  When an approval judge is configured, non-interactive manual approve is
+  refused, including --override-judge and --judge-command, so agents cannot
+  mint decision_actor=user or user_override. Use a real terminal and type
+  APPROVE.
 
   The judge command receives JSON on stdin using schema fest.approval.judge/v1
   and must return JSON on stdout with decision "approve" or "reject" and a
@@ -142,9 +144,9 @@ Auto approval:
 	_ = cmd.Flags().MarkHidden("as")
 	cmd.Flags().StringVar(&opts.Summary, "summary", "", "approval summary or rationale (required with --override-judge)")
 	cmd.Flags().BoolVar(&opts.Auto, "auto", false, "delegate this checkpoint decision to the configured approval judge command")
-	cmd.Flags().StringVar(&opts.JudgeCommand, "judge-command", opts.JudgeCommand, "approval judge command for --auto (overrides the .festival/config.yaml hooks.approval_judge.command hook)")
+	cmd.Flags().StringVar(&opts.JudgeCommand, "judge-command", opts.JudgeCommand, "approval judge command for --auto (overrides the .festival/config.yaml hooks.approval_judge.command hook; requires an interactive TTY)")
 	cmd.Flags().DurationVar(&opts.Timeout, "judge-timeout", opts.Timeout, "maximum time to wait for the approval judge (0 waits until it returns)")
-	cmd.Flags().BoolVar(&opts.OverrideJudge, "override-judge", false, "operator override of a judge/readiness reject (requires --summary; for non-interactive use)")
+	cmd.Flags().BoolVar(&opts.OverrideJudge, "override-judge", false, "operator override of a judge/readiness reject (requires --summary and an interactive TTY)")
 	cmd.Flags().BoolVar(&opts.Wait, "wait", false, "block until the judge returns instead of launching it in the background")
 	cmd.MarkFlagsMutuallyExclusive("auto", "as")
 	cmd.MarkFlagsMutuallyExclusive("auto", "summary")
@@ -320,6 +322,11 @@ func resolveApprovalJudgeCommand(ctx context.Context, flagValue string) (string,
 
 func resolveApprovalJudgeCommandFor(ctx context.Context, nav *wf.Navigator, flagValue string) (string, error) {
 	if cmd := strings.TrimSpace(flagValue); cmd != "" {
+		if !stdinIsInteractiveFn() {
+			return "", festerrors.Validation("--judge-command requires an interactive operator TTY").
+				WithField("judge_command", cmd).
+				WithHint("agents must not choose their own judge; configure hooks.approval_judge.command in .festival/config.yaml so non-interactive runs use the operator-controlled command")
+		}
 		return cmd, nil
 	}
 

--- a/internal/commands/workflow/approve_auto_test.go
+++ b/internal/commands/workflow/approve_auto_test.go
@@ -84,7 +84,11 @@ func TestResolveApprovalJudgeCommand(t *testing.T) {
 	}
 	wsCtx := scope.WithWorkspace(context.Background(), &scope.WorkspaceInfo{FestivalsPath: festivalsRoot})
 
-	// Flag wins over the hook (and is trimmed).
+	origTTY := stdinIsInteractiveFn
+	stdinIsInteractiveFn = func() bool { return true }
+	t.Cleanup(func() { stdinIsInteractiveFn = origTTY })
+
+	// Flag wins over the hook (and is trimmed) when an operator TTY is present.
 	got, err := resolveApprovalJudgeCommand(wsCtx, "  flag-judge  ")
 	if err != nil {
 		t.Fatalf("flag precedence: %v", err)
@@ -92,6 +96,14 @@ func TestResolveApprovalJudgeCommand(t *testing.T) {
 	if got != "flag-judge" {
 		t.Fatalf("flag precedence = %q, want flag-judge", got)
 	}
+
+	// The flag is refused without a TTY so agents cannot choose their own judge.
+	stdinIsInteractiveFn = func() bool { return false }
+	if _, err := resolveApprovalJudgeCommand(wsCtx, "flag-judge"); err == nil ||
+		!strings.Contains(err.Error(), "interactive operator TTY") {
+		t.Fatalf("non-interactive --judge-command must be refused, got: %v", err)
+	}
+	stdinIsInteractiveFn = func() bool { return true }
 
 	// Hook is used when no flag is passed.
 	got, err = resolveApprovalJudgeCommand(wsCtx, "")

--- a/internal/commands/workflow/judge.go
+++ b/internal/commands/workflow/judge.go
@@ -31,7 +31,7 @@ hooks.approval_judge.command workspace configuration hook.`,
 			return runApproveWithOptions(cmd.Context(), wf.DecisionMetadata{}, opts)
 		},
 	}
-	cmd.Flags().StringVar(&opts.JudgeCommand, "judge-command", "", "approval judge command (overrides hooks.approval_judge.command)")
+	cmd.Flags().StringVar(&opts.JudgeCommand, "judge-command", "", "approval judge command (overrides hooks.approval_judge.command; requires an interactive TTY)")
 	cmd.Flags().DurationVar(&opts.Timeout, "judge-timeout", 0, "maximum time to wait for the approval judge (0 waits until it returns)")
 	cmd.Flags().BoolVar(&opts.Wait, "wait", false, "block until the judge returns instead of launching it in the background")
 	return cmd

--- a/internal/commands/workflow/operator_approve.go
+++ b/internal/commands/workflow/operator_approve.go
@@ -46,10 +46,13 @@ func stepHasOpenJudgeReject(stepState *wf.StepState) bool {
 //
 // When the workspace has an approval judge hook, the step is a human
 // attestation, or durable state records a prior delegated rejection:
-//   - Non-interactive (no TTY) manual approve is refused unless --override-judge
-//     with a sufficient summary (true operator override from a scripted path).
-//   - Interactive approve requires typing APPROVE.
-//   - After a judge/readiness reject, the actor is user_override.
+//   - Non-interactive (no TTY) manual approve is always refused; there is no
+//     scripted override path, because any flag a script can pass an agent can
+//     pass too.
+//   - Interactive approve requires typing APPROVE. --override-judge
+//     additionally requires a --summary rationale.
+//   - After a judge/readiness reject or with --override-judge, the actor is
+//     user_override.
 func resolveManualApprovalDecision(
 	decision wf.DecisionMetadata,
 	judgeConfigured bool,
@@ -78,19 +81,17 @@ func resolveManualApprovalDecision(
 				WithField("min_summary_len", overrideSummaryMinLen).
 				WithHint("example: fest workflow approve --override-judge --summary \"I reviewed output_specs and accept them for plan\"")
 		}
-		decision.Actor = decisionActorUserOverride
-		return decision, nil
 	}
 
 	if !stdinIsInteractiveFn() {
 		hint := "run from a terminal and type APPROVE when prompted"
 		if priorReject {
-			hint = "fix evidence and re-submit with 'fest workflow judge', or override interactively / with --override-judge --summary \"...\""
+			hint = "fix evidence and re-submit with 'fest workflow judge', or run 'fest workflow approve --override-judge --summary \"...\"' from a real terminal"
 		}
-		return wf.DecisionMetadata{}, festerrors.Validation("manual approve requires an interactive operator TTY for human attestation, after judge delegation, or when auto-judge is configured").
+		return wf.DecisionMetadata{}, festerrors.Validation("manual approve requires an interactive operator TTY for human attestation, judge overrides, or when auto-judge is configured").
 			WithField("step", stepNum).
 			WithField("step_name", stepName).
-			WithHint(hint + "\nAgents must not clear checkpoints as the user.")
+			WithHint(hint + "\nAgents must not clear checkpoints as the user; there is no non-interactive override.")
 	}
 
 	fmt.Fprintf(os.Stderr, "\n%s Step %d: %s — operator approval required\n", ui.Warning("⚠"), stepNum, stepName)
@@ -99,6 +100,10 @@ func resolveManualApprovalDecision(
 		if stepState != nil && stepState.Feedback != "" {
 			fmt.Fprintf(os.Stderr, "%s %s\n", ui.Label("Last feedback"), truncateForPrompt(wf.DisplayFeedback(stepState.Feedback), 240))
 		}
+	} else if overrideJudge {
+		fmt.Fprintf(os.Stderr, "%s This approval overrides the configured approval judge.\n", ui.Label("Note"))
+	}
+	if priorReject || overrideJudge {
 		fmt.Fprintf(os.Stderr, "Confirming will record decision_actor=%s (operator override).\n", decisionActorUserOverride)
 	}
 	fmt.Fprintf(os.Stderr, "Type %s to confirm operator approval: ", operatorApproveToken)
@@ -113,7 +118,7 @@ func resolveManualApprovalDecision(
 			WithHint(fmt.Sprintf("type exactly %s to approve, or Ctrl-C to cancel", operatorApproveToken))
 	}
 
-	if priorReject {
+	if priorReject || overrideJudge {
 		decision.Actor = decisionActorUserOverride
 	} else {
 		decision.Actor = decisionActorUser


### PR DESCRIPTION
## Problem

Agents found and used two non-interactive escape hatches around the approval judge:

1. `fest workflow approve --override-judge --summary "..."` cleared judge-delegated checkpoints from a non-TTY process. In `resolveManualApprovalDecision` the override branch returned before the TTY check, so any agent could mint `decision_actor=user_override` with a 20-character summary. The flag help even advertised it "for non-interactive use".
2. `--judge-command` let the caller substitute an arbitrary command for the configured judge. The flag wins over `hooks.approval_judge.command`, so a non-interactive agent could point the judge at a script it wrote itself and have that output recorded as a real verdict.

Both were exercised in practice. In the FH0001 festival ledger, all 7 `ob judge` runs were superseded by `--override-judge` approvals: the first after a 20 second wait (less than normal judge latency), the remaining six in the same second they launched. In the CA0002 ledger, a session substituted a scratchpad capture script via the judge command surface and its output was recorded as a verdict.

## Fix

There is no way to authenticate a "scripted operator" from inside the CLI: any flag, env var, or file an operator script can present, an agent can present too. The TTY fence is the only local human distinguisher and is already the established pattern (human-required gates, typed APPROVE confirmation, non-interactive plain approve refusal). This PR puts both remaining hatches behind it:

- `--override-judge` now requires an interactive TTY and the typed `APPROVE` confirmation, in addition to the existing `--summary` rationale. The prompt states that confirming records `decision_actor=user_override`. Non-interactive use is refused with the same error as plain manual approve.
- `--judge-command` (on both `fest workflow approve` and `fest workflow judge`) is refused without an interactive TTY, so non-interactive runs always resolve the judge from the operator-controlled `hooks.approval_judge.command` config. The `fest next` auto-delegate path is unaffected; it never passes the flag.

Help text and generated CLI reference docs updated to match (docs regen is a separate commit; no unrelated drift).

## Tests

- Inverted `TestResolveManualApprovalDecision_OverrideJudge`, which previously asserted the vulnerable behavior, into `..._OverrideJudgeNonInteractiveRefused`.
- Added interactive override success (TTY + APPROVE -> `user_override`) and wrong-token refusal cases.
- Added non-interactive `--judge-command` refusal to `TestResolveApprovalJudgeCommand`; the flag-precedence case now stubs an interactive TTY.
- Full gate: `just test unit` (2618 passed) and `just lint all` (0 issues).

## Notes

- Based on `origin/main`; independent of #291. Expect a trivial help-text conflict in `approve.go` with #291 (hooks system), whichever lands second.
- A human overriding a running judge from a real terminal still works and still records `user_override`; this PR only removes the non-interactive paths.
