### PR TITLE
docs: lifecycle hooks schema and operator guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ templates you can inspect and change:
   for your own workflow shapes.
 - **Quality gates** - defaults included; replace or modify them campaign-wide
   or per festival.
-- **Approval judges** - delegate workflow checkpoints to any command via the
-  `hooks.approval_judge` hook in `.festival/config.yaml` (an AI judge, a CI
-  call, or your own script).
+- **Lifecycle hooks** - declare named commands at machine / festivals / festival
+  layers, bind them to steps, and inspect with `fest hooks list`. The approval
+  judge is one hook (`approval_judge`); see [docs/concepts/hooks.md](docs/concepts/hooks.md).
 - **Template syncing** - `fest system sync` pulls templates from a
   configurable repository (`repository.url`, `branch`, and `path` in
   [configuration](docs/configuration.md)), so a team can maintain and

--- a/docs/cli-reference/fest-reference.md
+++ b/docs/cli-reference/fest-reference.md
@@ -2087,6 +2087,65 @@ fest go unmap <name> [flags]
 ```
 ---
 
+## fest hooks
+
+Inspect resolved lifecycle hooks
+
+### Synopsis
+
+Inspect the hooks resolved from the machine, festivals, and festival layers.
+
+Available Commands:
+  list   Show the effective resolved hook set with source layers and shadow diffs
+
+### Options
+
+```
+  -h, --help   help for hooks
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## fest hooks list
+
+Show the effective resolved hook set
+
+```
+fest hooks list [flags]
+```
+
+### Examples
+
+```
+  fest hooks list
+  fest hooks list --json
+```
+
+### Options
+
+```
+  -h, --help   help for list
+      --json   Output in JSON format
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
 ## fest id
 
 Show the festival ID for the current context
@@ -5654,6 +5713,7 @@ QUICK REFERENCE:
   fest understand checklist      Validation checklist before starting
   fest understand rules          Naming conventions for automation
   fest understand workflow       Just-in-time reading + workflow/gates
+  fest understand hooks          Lifecycle hooks schema, bindings, human gates
 ```
 
 The understand command helps you grasp WHEN and WHY to use specific
@@ -5844,6 +5904,38 @@ fest understand gates [flags]
 ```
   -h, --help   help for gates
       --json   output as JSON
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## fest understand hooks
+
+Lifecycle hooks schema, bindings, and human gates
+
+### Synopsis
+
+Learn how fest resolves hooks across machine, festivals, and festival
+layers; how step bindings fire; legacy approval_judge alias behavior; and
+non-bypassable human gates (approval: human-required).
+
+See also docs/concepts/hooks.md and docs/concepts/hook-evidence-contract.md.
+
+```
+fest understand hooks [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for hooks
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/fest.md
+++ b/docs/cli-reference/fest.md
@@ -54,6 +54,7 @@ Run 'fest understand' to learn the methodology before executing tasks.
 * [fest feedback](fest_feedback.md)	 - Manage structured feedback collection
 * [fest gates](fest_gates.md)	 - Manage quality gates - validation steps at sequence end
 * [fest go](fest_go.md)	 - Navigate to festivals/ - use 'fgo' after shell-init setup
+* [fest hooks](fest_hooks.md)	 - Inspect resolved lifecycle hooks
 * [fest id](fest_id.md)	 - Show the festival ID for the current context
 * [fest index](fest_index.md)	 - Manage festival indices
 * [fest init](fest_init.md)	 - Initialize a new festival directory structure

--- a/docs/cli-reference/fest_hooks.md
+++ b/docs/cli-reference/fest_hooks.md
@@ -1,0 +1,30 @@
+## fest hooks
+
+Inspect resolved lifecycle hooks
+
+### Synopsis
+
+Inspect the hooks resolved from the machine, festivals, and festival layers.
+
+Available Commands:
+  list   Show the effective resolved hook set with source layers and shadow diffs
+
+### Options
+
+```
+  -h, --help   help for hooks
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest](fest.md)	 - Festival Methodology CLI - goal-oriented project management for AI agents
+* [fest hooks list](fest_hooks_list.md)	 - Show the effective resolved hook set

--- a/docs/cli-reference/fest_hooks_list.md
+++ b/docs/cli-reference/fest_hooks_list.md
@@ -1,0 +1,34 @@
+## fest hooks list
+
+Show the effective resolved hook set
+
+```
+fest hooks list [flags]
+```
+
+### Examples
+
+```
+  fest hooks list
+  fest hooks list --json
+```
+
+### Options
+
+```
+  -h, --help   help for list
+      --json   Output in JSON format
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest hooks](fest_hooks.md)	 - Inspect resolved lifecycle hooks

--- a/docs/cli-reference/fest_understand.md
+++ b/docs/cli-reference/fest_understand.md
@@ -19,6 +19,7 @@ QUICK REFERENCE:
   fest understand checklist      Validation checklist before starting
   fest understand rules          Naming conventions for automation
   fest understand workflow       Just-in-time reading + workflow/gates
+  fest understand hooks          Lifecycle hooks schema, bindings, human gates
 ```
 
 The understand command helps you grasp WHEN and WHY to use specific
@@ -54,6 +55,7 @@ fest understand [flags]
 * [fest understand context](fest_understand_context.md)	 - CONTEXT.md - session memory for AI agents (CREATE FIRST)
 * [fest understand extensions](fest_understand_extensions.md)	 - Show loaded extensions
 * [fest understand gates](fest_understand_gates.md)	 - Show quality gate configuration
+* [fest understand hooks](fest_understand_hooks.md)	 - Lifecycle hooks schema, bindings, and human gates
 * [fest understand lifecycle](fest_understand_lifecycle.md)	 - Festival lifecycle: planning -> ready -> active -> dungeon
 * [fest understand loop](fest_understand_loop.md)	 - The fest next loop: festivals and standalone WORKFLOW.md as work loops
 * [fest understand methodology](fest_understand_methodology.md)	 - Core principles - START HERE for new agents

--- a/docs/cli-reference/fest_understand_hooks.md
+++ b/docs/cli-reference/fest_understand_hooks.md
@@ -1,0 +1,34 @@
+## fest understand hooks
+
+Lifecycle hooks schema, bindings, and human gates
+
+### Synopsis
+
+Learn how fest resolves hooks across machine, festivals, and festival
+layers; how step bindings fire; legacy approval_judge alias behavior; and
+non-bypassable human gates (approval: human-required).
+
+See also docs/concepts/hooks.md and docs/concepts/hook-evidence-contract.md.
+
+```
+fest understand hooks [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for hooks
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest understand](fest_understand.md)	 - Learn methodology FIRST - run before executing festival tasks

--- a/docs/concepts/hook-evidence-contract.md
+++ b/docs/concepts/hook-evidence-contract.md
@@ -1,5 +1,7 @@
 # Hook Evidence Contract (read-by-approver)
 
+> Parent guide: [hooks.md](./hooks.md) (layers, schema, bindings, human gates).
+
 Default evidence mode for fest hooks is **read-by-approver** (`evidence: paths`).
 The transport carries paths; the approver (judge or human) reads files itself.
 

--- a/docs/concepts/hooks.md
+++ b/docs/concepts/hooks.md
@@ -135,14 +135,20 @@ Bindings only reference names. They never set `command`, `fail`, or `timeout`.
 | `phase_complete` | phase completion |
 | `gate_approve` | GATES.md blocking approval checkpoint |
 
-Timings: **pre** (before the verb applies) and **post** (after success).
+Timings: **pre** (before the verb applies) and **post** (after the transition
+has already been applied).
 
 Orchestration:
 
 - Sequential, binding-list order (no parallel v1).
-- `fail: closed` (default): non-zero exit / timeout / spawn error short-circuits
-  remaining hooks and **blocks the verb**.
-- `fail: open`: failure is recorded; remaining hooks still run.
+- **`fail: closed` pre-hooks:** a non-zero exit / timeout / spawn error
+  short-circuits remaining pre-hooks and **blocks the verb** (completion or
+  approval is not applied).
+- **`fail: closed` post-hooks:** run **after** the verb is already applied.
+  Failure short-circuits remaining post-hooks and surfaces an audited warning;
+  it does **not** roll back task completion, sequence/phase completion, or gate
+  approval.
+- `fail: open`: failure is recorded; remaining hooks at that timing still run.
 - Undeclared bound names: **skip + warn** (not an error). Scaffolded templates
   may bind `approval_judge` while config is still empty.
 

--- a/docs/concepts/hooks.md
+++ b/docs/concepts/hooks.md
@@ -1,0 +1,232 @@
+# Lifecycle Hooks
+
+fest hooks are **named commands** bound to festival lifecycle events (task
+complete, sequence complete, phase complete, gate approve). They are the
+generalization of the older single `hooks.approval_judge.command` workspace
+setting.
+
+Related:
+
+- Evidence transport details: [hook-evidence-contract.md](./hook-evidence-contract.md)
+- Inspect resolution: `fest hooks list` / `fest hooks list --json`
+- Learn in-terminal: `fest understand hooks`
+
+## Two primitives
+
+| Primitive | What it is | Controlled by |
+| --- | --- | --- |
+| **Automation hooks** | Commands on lifecycle events (judge, linters, tests, notifications) | `hooks.*` config + step bindings |
+| **Human gates** | Person-required checkpoints | `approval: human-required` on the step |
+
+Human gates are **not** hooks. No `hooks.enabled` / level / per-hook switch can
+disable them.
+
+## Declaration layers
+
+Hook **definitions** live only at three layers. Each layer overrides the
+previous **by hook name** (whole definition replace; no field-level merge). A
+layer that declares nothing inherits everything above it.
+
+| Layer | Location | Format | Scope |
+| --- | --- | --- | --- |
+| 1. Machine | `~/.obey/fest/config.json` | JSON | every campaign on this machine |
+| 2. Festivals | `festivals/.festival/config.yaml` | YAML | every festival in the campaign |
+| 3. Festival | `fest.yaml` | YAML | this festival only |
+
+**Default at every layer is empty:** a fresh machine, campaign, or festival
+runs no hooks until you declare some.
+
+### Schema
+
+```yaml
+hooks:
+  enabled: true            # layer-wide switch; most specific layer wins
+  levels:                  # per-level switches; default all true
+    phase: true
+    sequence: true
+    task: true
+  definitions:
+    approval_judge:
+      command: ob judge    # required; cwd = festival root
+      fail: closed         # closed (default) | open
+      timeout: 120s        # default 120s for newly declared hooks; 0 = no deadline
+      evidence: paths      # paths (default) | embed
+      enabled: true        # per-hook switch
+```
+
+Field notes:
+
+- `command` is the only required definition field.
+- `definitions` is a map keyed by hook name (unit of layer override and binding).
+- `hooks.enabled` and `hooks.levels` resolve most-specific-wins across layers,
+  independently of `definitions`.
+- Commands are split on whitespace (same model as today's judge exec): no shell
+  operators or quoting in the command string.
+
+JSON machine-layer example:
+
+```json
+{
+  "hooks": {
+    "enabled": true,
+    "definitions": {
+      "lint": {
+        "command": "just lint",
+        "fail": "open",
+        "timeout": "60s"
+      }
+    }
+  }
+}
+```
+
+### Resolution (operator view)
+
+```
+effective definitions = merge least → most specific by name (replace whole def)
+enabled  = most_specific_set(hooks.enabled, default true)
+levels   = most_specific_set(hooks.levels.*, default true)
+runnable(name, level) =
+    enabled && levels[level] && definition.enabled
+```
+
+Inspect with:
+
+```bash
+fest hooks list
+fest hooks list --json
+```
+
+Differing upper-layer definitions appear under `shadows` so a local override
+cannot silently hide an updated default without visibility.
+
+## Step bindings
+
+Definitions alone do nothing. Steps **bind** names to pre/post timing:
+
+### Frontmatter (phase / sequence / task documents)
+
+```yaml
+---
+fest_type: task
+# ...
+hooks:
+  pre: [lint]
+  post: [approval_judge, notify]
+---
+```
+
+### GATES.md body markers
+
+```markdown
+## Step 2: REVIEW
+
+**Hooks:** post: [approval_judge], pre: [lint]
+```
+
+Bindings only reference names. They never set `command`, `fail`, or `timeout`.
+
+### Lifecycle verbs (v1)
+
+| Verb | When |
+| --- | --- |
+| `task_complete` | `fest task completed` |
+| `sequence_complete` | sequence completion |
+| `phase_complete` | phase completion |
+| `gate_approve` | GATES.md blocking approval checkpoint |
+
+Timings: **pre** (before the verb applies) and **post** (after success).
+
+Orchestration:
+
+- Sequential, binding-list order (no parallel v1).
+- `fail: closed` (default): non-zero exit / timeout / spawn error short-circuits
+  remaining hooks and **blocks the verb**.
+- `fail: open`: failure is recorded; remaining hooks still run.
+- Undeclared bound names: **skip + warn** (not an error). Scaffolded templates
+  may bind `approval_judge` while config is still empty.
+
+## Legacy approval_judge alias
+
+Production campaigns often have:
+
+```yaml
+# festivals/.festival/config.yaml
+hooks:
+  approval_judge:
+    command: ob judge
+```
+
+That flat key is still honored as an implicit festivals-layer
+`definitions.approval_judge` with:
+
+- `fail: closed`
+- `evidence: paths`
+- **`timeout: 0`** (preserves today's no-deadline judge behavior)
+
+An explicit `definitions.approval_judge` wins over the flat key.
+`fest validate` emits a non-blocking deprecation warning; migrate when ready:
+
+```yaml
+hooks:
+  definitions:
+    approval_judge:
+      command: ob judge
+      timeout: 0
+```
+
+## Human gates
+
+```yaml
+# frontmatter on the step document, or:
+# **Approval:** human-required   (GATES.md marker)
+approval: human-required
+```
+
+When the loop reaches a human-required step:
+
+1. Automation hooks for that step are skipped (`skipped: human-gate` in audit).
+2. `fest next` shows a `HUMAN APPROVAL REQUIRED` banner and **parks** the loop.
+3. Clear only with interactive-TTY `fest workflow approve` / `reject`.
+4. `fest workflow approve --auto` and `fest workflow judge` **refuse** with an
+   error that names the gate.
+
+`fest workflow status --json` includes `human_approval_required: true` on
+affected steps.
+
+## Evidence
+
+Default is read-by-approver (`evidence: paths`): the request carries paths; the
+approver reads files. Opt-in `evidence: embed` may attach capped file contents.
+See [hook-evidence-contract.md](./hook-evidence-contract.md).
+
+The approval judge protocol remains `fest.approval.judge/v1` (JSON stdin/stdout).
+
+## Audit trail
+
+Hook runs append `wf_hook_run` events to the festival-local ledger:
+
+```text
+<festival>/.fest/progress_events.jsonl
+```
+
+These are **events**, not campaign-ledger decisions. Judge approve/reject still
+records decisions only through the existing judge/approve paths.
+
+## Validate
+
+`fest validate` may emit **non-blocking** warnings for:
+
+- legacy flat `approval_judge` alias
+- differing layer shadows
+- bindings that name undeclared hooks
+
+Warnings never fail the validate exit path by themselves (only errors do).
+
+## Quick operator checklist
+
+1. Declare definitions at the layer you want (machine / festivals / festival).
+2. Bind names on the steps that should run them.
+3. `fest hooks list` — confirm source layer, enabled state, shadows.
+4. Exercise the lifecycle verb (`fest task completed`, gate approve, …).
+5. On human-required steps, use a real TTY for approve — never `--auto`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,6 +102,61 @@ Controls local file paths for caching and backups.
 | `backup_dir` | string | `".fest-backup"` | Directory for file backups (relative to workspace) |
 | `checksum_file` | string | `".fest-checksums.json"` | File for tracking template checksums |
 
+## Lifecycle Hooks
+
+Hooks are named commands bound to festival lifecycle events (task/sequence/phase
+complete, gate approve). Definitions can be declared at three layers; the most
+specific layer wins **by hook name** (whole definition replace).
+
+| Layer | File | Format |
+| --- | --- | --- |
+| Machine | `~/.obey/fest/config.json` (or `$FEST_CONFIG_DIR/config.json`) | JSON |
+| Festivals | `festivals/.festival/config.yaml` | YAML |
+| Festival | `fest.yaml` | YAML |
+
+Default at every layer is **empty** (no hooks run until declared).
+
+### Definition schema
+
+```yaml
+hooks:
+  enabled: true
+  levels:
+    phase: true
+    sequence: true
+    task: true
+  definitions:
+    approval_judge:
+      command: ob judge   # required
+      fail: closed        # closed (default) | open
+      timeout: 120s       # default 120s; use 0 for no deadline
+      evidence: paths     # paths (default) | embed
+      enabled: true
+```
+
+Machine-layer JSON uses the same fields under a top-level `"hooks"` object.
+
+### Legacy approval_judge key
+
+```yaml
+hooks:
+  approval_judge:
+    command: ob judge
+```
+
+Still honored at the festivals layer as an implicit `definitions.approval_judge`
+with `timeout: 0`. Prefer explicit `definitions`. `fest validate` warns.
+
+### Inspect
+
+```bash
+fest hooks list
+fest hooks list --json
+```
+
+Full guide: [docs/concepts/hooks.md](concepts/hooks.md). Evidence transport:
+[docs/concepts/hook-evidence-contract.md](concepts/hook-evidence-contract.md).
+
 ## Environment Variables
 
 fest respects the following environment variables:
@@ -146,6 +201,16 @@ fest respects the following environment variables:
     "expand_inputs": true,
     "max_input_height": 10,
     "theme": "adaptive"
+  },
+  "hooks": {
+    "enabled": true,
+    "definitions": {
+      "lint": {
+        "command": "just lint",
+        "fail": "open",
+        "timeout": "60s"
+      }
+    }
   },
   "last_sync": "2025-01-22T10:30:00Z"
 }

--- a/embedded/docs/understand/embed.go
+++ b/embedded/docs/understand/embed.go
@@ -3,7 +3,7 @@ package understand
 
 import "embed"
 
-//go:embed overview.txt rules.txt templates.txt structure.txt methodology.txt workflow.txt tasks.txt context.txt nodeids.txt loop.txt lifecycle.txt roles.txt planning.txt chains.txt rituals.txt
+//go:embed overview.txt rules.txt templates.txt structure.txt methodology.txt workflow.txt tasks.txt context.txt nodeids.txt loop.txt lifecycle.txt roles.txt planning.txt chains.txt rituals.txt hooks.txt
 //go:embed scaffolds/*.txt
 var Content embed.FS
 

--- a/embedded/docs/understand/hooks.txt
+++ b/embedded/docs/understand/hooks.txt
@@ -48,8 +48,11 @@ GATES.md step markers:
   **Hooks:** post: [approval_judge]
 
 v1 verbs: task_complete, sequence_complete, phase_complete, gate_approve.
-pre runs before the verb; post runs after success.
-fail:closed short-circuits and blocks the verb; fail:open continues.
+pre runs before the verb; post runs after the transition is already applied.
+fail:closed pre-hooks block the verb (completion/approval not applied).
+fail:closed post-hooks short-circuit remaining post-hooks and warn; they do
+not roll back an already-applied completion or approval.
+fail:open records failure and continues remaining hooks at that timing.
 Undeclared bound names skip with a warning (not a hard error).
 
 Legacy alias

--- a/embedded/docs/understand/hooks.txt
+++ b/embedded/docs/understand/hooks.txt
@@ -1,0 +1,91 @@
+Lifecycle Hooks
+===============
+
+Hooks are named commands bound to festival lifecycle events. They generalize
+the older single workspace setting hooks.approval_judge.command.
+
+Read the full guide: docs/concepts/hooks.md
+Evidence transport: docs/concepts/hook-evidence-contract.md
+
+Declaration layers (least → most specific)
+-----------------------------------------
+
+  1. Machine     ~/.obey/fest/config.json          (JSON)
+  2. Festivals   festivals/.festival/config.yaml   (YAML)
+  3. Festival    fest.yaml                         (YAML)
+
+Default at every layer is empty. A more specific layer redeclares a name by
+replacing the whole definition (no field-level merge).
+
+Schema sketch
+-------------
+
+  hooks:
+    enabled: true
+    levels:
+      phase: true
+      sequence: true
+      task: true
+    definitions:
+      approval_judge:
+        command: ob judge    # required
+        fail: closed         # closed | open
+        timeout: 120s        # 0 = no deadline
+        evidence: paths      # paths | embed
+        enabled: true
+
+Bindings (names only)
+---------------------
+
+Frontmatter on PHASE_GOAL / SEQUENCE_GOAL / task docs:
+
+  hooks:
+    pre: [lint]
+    post: [approval_judge]
+
+GATES.md step markers:
+
+  **Hooks:** post: [approval_judge]
+
+v1 verbs: task_complete, sequence_complete, phase_complete, gate_approve.
+pre runs before the verb; post runs after success.
+fail:closed short-circuits and blocks the verb; fail:open continues.
+Undeclared bound names skip with a warning (not a hard error).
+
+Legacy alias
+------------
+
+  hooks:
+    approval_judge:
+      command: ob judge
+
+Still works at the festivals layer as an implicit definitions.approval_judge
+with timeout: 0. Prefer explicit definitions; fest validate warns.
+
+Human gates (not hooks)
+-----------------------
+
+  approval: human-required
+
+or GATES.md:
+
+  **Approval:** human-required
+
+Automation hooks for that step are skipped. fest next parks with a
+HUMAN APPROVAL REQUIRED banner. Clear only with interactive-TTY
+fest workflow approve / reject. --auto and fest workflow judge refuse.
+
+Inspect and validate
+--------------------
+
+  fest hooks list
+  fest hooks list --json
+  fest validate              # non-blocking warnings for alias / drift / undeclared
+
+Common commands
+---------------
+
+  fest hooks list
+  fest understand hooks
+  fest workflow judge        # re-run approval_judge after feedback
+  fest workflow approve      # human path (TTY on human-required gates)

--- a/embedded/docs/understand/overview.txt
+++ b/embedded/docs/understand/overview.txt
@@ -158,6 +158,7 @@ More Information
   fest understand rules          # MANDATORY structure requirements
   fest understand templates      # Variables that save tokens
   fest understand loop           # The fest next loop + standalone workflows
+  fest understand hooks          # Lifecycle hooks schema and human gates
   fest understand planning       # Turning a goal into a structured plan
   fest understand roles          # Human vs agent responsibilities
   fest understand lifecycle      # planning -> ready -> active -> dungeon

--- a/embedded/docs/understand/workflow.txt
+++ b/embedded/docs/understand/workflow.txt
@@ -61,11 +61,22 @@ Common commands:
 Approval Auto Mode
 ------------------
 
-Configuring `hooks.approval_judge.command` in `.festival/config.yaml` is the
-operator opt-in that delegates blocking checkpoints (WORKFLOW.md and GATES.md)
-away from human pings.
+Blocking checkpoints can be delegated to an automation hook named
+`approval_judge`. Preferred declaration (festivals layer):
 
-When that hook is set:
+  hooks:
+    definitions:
+      approval_judge:
+        command: ob judge
+        timeout: 0   # no deadline; matches historical judge behavior
+
+Legacy flat key (still works, deprecation-warned by fest validate):
+
+  hooks:
+    approval_judge:
+      command: ob judge
+
+When that definition is present and the step is not human-required:
 
   • `fest next` auto-invokes the judge on each consecutive blocking checkpoint
     and continues after approve (or stops after reject / fail-closed errors).
@@ -73,7 +84,7 @@ When that hook is set:
     feedback is addressed; `fest workflow approve --auto` remains a compatible
     alias.
 
-There is no default judge command: without the hook (or `--judge-command`),
+There is no default judge command: without a definition (or `--judge-command`),
 approval stays manual and fails closed for `--auto`.
 
 The judge command receives JSON on stdin using schema
@@ -83,6 +94,12 @@ non-zero exits, malformed JSON, unknown decisions, and empty reasons fail
 closed: fest does not approve the checkpoint and leaves the workflow state
 unchanged except for valid reject decisions, which block the step with the
 judge reason as concise feedback.
+
+Full hooks model (layers, bindings, fail policies, human gates):
+
+  fest understand hooks
+  docs/concepts/hooks.md
+  fest hooks list
 
 Auto-Routing Rules
 ------------------

--- a/internal/commands/understand/commands.go
+++ b/internal/commands/understand/commands.go
@@ -28,6 +28,7 @@ QUICK REFERENCE:
   fest understand checklist      Validation checklist before starting
   fest understand rules          Naming conventions for automation
   fest understand workflow       Just-in-time reading + workflow/gates
+  fest understand hooks          Lifecycle hooks schema, bindings, human gates
 
 The understand command helps you grasp WHEN and WHY to use specific
 approaches. For command syntax, use --help on any command.
@@ -52,6 +53,7 @@ ensuring you see the current methodology design and any customizations.`,
 	cmd.AddCommand(newUnderstandContextCmd()) // Session memory - CREATE FIRST
 	cmd.AddCommand(newUnderstandNodeIDsCmd()) // Node reference system for traceability
 	cmd.AddCommand(newUnderstandWorkflowCmd())
+	cmd.AddCommand(newUnderstandHooksCmd())     // Lifecycle hooks system
 	cmd.AddCommand(newUnderstandLoopCmd())      // The fest next execution loop (+ standalone workflows)
 	cmd.AddCommand(newUnderstandRolesCmd())     // Human vs agent responsibilities
 	cmd.AddCommand(newUnderstandPlanningCmd())  // Goal -> structured plan

--- a/internal/commands/understand/workflow.go
+++ b/internal/commands/understand/workflow.go
@@ -21,6 +21,21 @@ WORKFLOW.md phases and GATES.md phase gates.`,
 	}
 }
 
+func newUnderstandHooksCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "hooks",
+		Short: "Lifecycle hooks schema, bindings, and human gates",
+		Long: `Learn how fest resolves hooks across machine, festivals, and festival
+layers; how step bindings fire; legacy approval_judge alias behavior; and
+non-bypassable human gates (approval: human-required).
+
+See also docs/concepts/hooks.md and docs/concepts/hook-evidence-contract.md.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Print(understanddocs.Load("hooks.txt"))
+		},
+	}
+}
+
 func newUnderstandRulesCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "rules",

--- a/internal/commands/workflow/approve.go
+++ b/internal/commands/workflow/approve.go
@@ -315,21 +315,80 @@ func runApproveWithOptions(ctx context.Context, decision wf.DecisionMetadata, op
 type workspaceConfigLoader func(string) (*config.WorkspaceConfig, error)
 
 func approvalJudgeConfiguredFor(ctx context.Context, nav *wf.Navigator) (bool, error) {
-	festivalsRoot, err := approvalJudgeFestivalsRoot(ctx, nav)
+	cmd, err := lookupApprovalJudgeCommand(ctx, nav)
 	if err != nil {
 		return false, err
 	}
-	if festivalsRoot == "" {
-		return false, nil
+	return cmd != "", nil
+}
+
+// lookupApprovalJudgeCommand returns the effective approval_judge command from
+// the three-layer hooks resolver (definitions + legacy flat-key alias).
+func lookupApprovalJudgeCommand(ctx context.Context, nav *wf.Navigator) (string, error) {
+	festivalPath := ""
+	if nav != nil && nav.Ctx != nil {
+		festivalPath = strings.TrimSpace(nav.Ctx.FestivalPath)
 	}
-	cfg, err := config.LoadWorkspaceConfig(festivalsRoot)
+	festivalsRoot, err := approvalJudgeFestivalsRoot(ctx, nav)
 	if err != nil {
-		return false, festerrors.Wrap(err, "loading approval judge authority configuration")
+		return "", err
 	}
-	if cfg == nil {
-		return false, festerrors.Validation("approval judge authority configuration is empty")
+	return resolveApprovalJudgeCommandFromHooks(ctx, festivalPath, festivalsRoot)
+}
+
+// resolveApprovalJudgeCommandFromHooks uses hooks.Resolve so both
+// definitions.approval_judge and the legacy flat approval_judge.command key
+// configure auto-judge discovery (fest next / judge / approve --auto).
+func resolveApprovalJudgeCommandFromHooks(ctx context.Context, festivalPath, festivalsRoot string) (string, error) {
+	if festivalPath != "" {
+		eff, err := hooks.LoadAndResolve(ctx, festivalPath)
+		if err != nil {
+			return "", festerrors.Wrap(err, "resolving approval judge hooks")
+		}
+		if cmd := approvalJudgeCommandFromEffective(eff); cmd != "" {
+			return cmd, nil
+		}
 	}
-	return strings.TrimSpace(cfg.Hooks.ApprovalJudge.Command) != "", nil
+
+	if festivalsRoot == "" {
+		return "", nil
+	}
+
+	var machine *config.HooksConfig
+	if machineCfg, err := config.Load(ctx, ""); err != nil {
+		return "", festerrors.Wrap(err, "loading machine hooks for approval judge")
+	} else if machineCfg != nil {
+		machine = machineCfg.Hooks
+	}
+
+	wcfg, err := config.LoadWorkspaceConfig(festivalsRoot)
+	if err != nil {
+		return "", festerrors.Wrap(err, "loading approval judge authority configuration")
+	}
+	if wcfg == nil {
+		return "", festerrors.Validation("approval judge authority configuration is empty")
+	}
+	festivals := wcfg.Hooks
+	eff, err := hooks.Resolve(machine, &festivals, nil)
+	if err != nil {
+		return "", festerrors.Wrap(err, "resolving approval judge hooks")
+	}
+	if cmd := approvalJudgeCommandFromEffective(eff); cmd != "" {
+		return cmd, nil
+	}
+	// Defensive fallback if alias expansion did not apply for any reason.
+	return strings.TrimSpace(wcfg.Hooks.ApprovalJudge.Command), nil
+}
+
+func approvalJudgeCommandFromEffective(eff *hooks.Effective) string {
+	if eff == nil {
+		return ""
+	}
+	h, ok := eff.Hooks[hooks.ApprovalJudgeName]
+	if !ok || !h.Enabled {
+		return ""
+	}
+	return strings.TrimSpace(h.Command)
 }
 
 func approvalJudgeFestivalsRoot(ctx context.Context, nav *wf.Navigator) (string, error) {
@@ -361,14 +420,23 @@ func approvalJudgeConfiguredWithLoader(ctx context.Context, load workspaceConfig
 	if cfg == nil {
 		return false, festerrors.Validation("approval judge authority configuration is empty")
 	}
+	// Test loader path: resolve via hooks so definitions.approval_judge works too.
+	festivals := cfg.Hooks
+	eff, err := hooks.Resolve(nil, &festivals, nil)
+	if err != nil {
+		return false, err
+	}
+	if cmd := approvalJudgeCommandFromEffective(eff); cmd != "" {
+		return true, nil
+	}
 	return strings.TrimSpace(cfg.Hooks.ApprovalJudge.Command) != "", nil
 }
 
 // resolveApprovalJudgeCommand resolves the command used for --auto approval.
-// Precedence: the --judge-command flag, then the hooks.approval_judge.command
-// hook in .festival/config.yaml (via workspace context or navigator festival
-// path). It fails closed when neither is set so no checkpoint is delegated to
-// an unconfigured (or assumed) command.
+// Precedence: the --judge-command flag, then the resolved approval_judge hook
+// (definitions.approval_judge across layers, or the legacy flat
+// hooks.approval_judge.command alias). It fails closed when neither is set so
+// no checkpoint is delegated to an unconfigured (or assumed) command.
 func resolveApprovalJudgeCommand(ctx context.Context, flagValue string) (string, error) {
 	return resolveApprovalJudgeCommandFor(ctx, nil, flagValue)
 }
@@ -378,26 +446,17 @@ func resolveApprovalJudgeCommandFor(ctx context.Context, nav *wf.Navigator, flag
 		if !stdinIsInteractiveFn() {
 			return "", festerrors.Validation("--judge-command requires an interactive operator TTY").
 				WithField("judge_command", cmd).
-				WithHint("agents must not choose their own judge; configure hooks.approval_judge.command in .festival/config.yaml so non-interactive runs use the operator-controlled command")
+				WithHint("agents must not choose their own judge; configure hooks.definitions.approval_judge (or legacy hooks.approval_judge.command) so non-interactive runs use the operator-controlled command")
 		}
 		return cmd, nil
 	}
 
-	festivalsRoot, err := approvalJudgeFestivalsRoot(ctx, nav)
+	cmd, err := lookupApprovalJudgeCommand(ctx, nav)
 	if err != nil {
 		return "", err
 	}
-	if festivalsRoot != "" {
-		cfg, err := config.LoadWorkspaceConfig(festivalsRoot)
-		if err != nil {
-			return "", festerrors.Wrap(err, "loading approval judge hook")
-		}
-		if cfg == nil {
-			return "", festerrors.Validation("approval judge authority configuration is empty")
-		}
-		if cmd := strings.TrimSpace(cfg.Hooks.ApprovalJudge.Command); cmd != "" {
-			return cmd, nil
-		}
+	if cmd != "" {
+		return cmd, nil
 	}
 
 	return "", festerrors.Validation("approval judge command is not configured").
@@ -406,6 +465,14 @@ func resolveApprovalJudgeCommandFor(ctx context.Context, nav *wf.Navigator, flag
 Configure a command in .festival/config.yaml. It receives the approval request
 as JSON on stdin and must print a JSON verdict on stdout (schema
 fest.approval.judge/v1):
+
+hooks:
+  definitions:
+    approval_judge:
+      command: <your-approval-judge-tool>
+      timeout: 0
+
+Legacy flat form (still supported):
 
 hooks:
   approval_judge:

--- a/internal/commands/workflow/approve_auto_test.go
+++ b/internal/commands/workflow/approve_auto_test.go
@@ -126,6 +126,38 @@ func TestResolveApprovalJudgeCommand(t *testing.T) {
 	}
 }
 
+func TestResolveApprovalJudgeCommand_DefinitionsOnly(t *testing.T) {
+	// Regression: definitions.approval_judge alone must configure auto-judge
+	// discovery without the legacy flat hooks.approval_judge.command key.
+	festivalsRoot := t.TempDir()
+	cfg := config.DefaultWorkspaceConfig()
+	cfg.Hooks.Definitions = map[string]config.HookDefinition{
+		"approval_judge": {
+			Command: "defs-only-judge",
+			Timeout: "0",
+		},
+	}
+	if err := config.SaveWorkspaceConfig(festivalsRoot, cfg); err != nil {
+		t.Fatalf("SaveWorkspaceConfig: %v", err)
+	}
+	wsCtx := scope.WithWorkspace(context.Background(), &scope.WorkspaceInfo{FestivalsPath: festivalsRoot})
+
+	got, err := resolveApprovalJudgeCommand(wsCtx, "")
+	if err != nil {
+		t.Fatalf("definitions-only resolve: %v", err)
+	}
+	if got != "defs-only-judge" {
+		t.Fatalf("definitions-only = %q, want defs-only-judge", got)
+	}
+	ok, err := approvalJudgeConfiguredWithLoader(wsCtx, config.LoadWorkspaceConfig)
+	if err != nil {
+		t.Fatalf("configured: %v", err)
+	}
+	if !ok {
+		t.Fatal("definitions-only config must report judge configured")
+	}
+}
+
 func TestEvaluateApprovalJudge_ApproveDecision(t *testing.T) {
 	withApprovalJudgeRunner(t, judgeRunner(func(ctx context.Context, command string, stdin []byte) ([]byte, error) {
 		if command != "fake judge" {

--- a/internal/guidance/workflow/navigator_format.go
+++ b/internal/guidance/workflow/navigator_format.go
@@ -126,9 +126,24 @@ func (n *Navigator) approvalJudgeConfigured(ctx context.Context) bool {
 	return strings.TrimSpace(n.ApprovalJudgeCommand(ctx)) != ""
 }
 
-// ApprovalJudgeCommand returns hooks.approval_judge.command when configured.
-// Empty string means no judge is configured (manual approval path).
+// ApprovalJudgeCommand returns the resolved approval_judge hook command when
+// configured (definitions.approval_judge across layers, or the legacy flat
+// hooks.approval_judge.command alias). Empty means manual approval path.
 func (n *Navigator) ApprovalJudgeCommand(ctx context.Context) string {
+	festivalPath := ""
+	if n != nil && n.BaseNavigator != nil && n.Ctx != nil {
+		festivalPath = strings.TrimSpace(n.Ctx.FestivalPath)
+	}
+	if festivalPath != "" {
+		if eff, err := hooks.LoadAndResolve(ctx, festivalPath); err == nil && eff != nil {
+			if h, ok := eff.Hooks[hooks.ApprovalJudgeName]; ok && h.Enabled {
+				if cmd := strings.TrimSpace(h.Command); cmd != "" {
+					return cmd
+				}
+			}
+		}
+	}
+
 	festivalsRoot := n.festivalsRoot(ctx)
 	if festivalsRoot == "" {
 		return ""
@@ -136,6 +151,14 @@ func (n *Navigator) ApprovalJudgeCommand(ctx context.Context) string {
 	cfg, err := config.LoadWorkspaceConfig(festivalsRoot)
 	if err != nil || cfg == nil {
 		return ""
+	}
+	festivals := cfg.Hooks
+	if eff, err := hooks.Resolve(nil, &festivals, nil); err == nil && eff != nil {
+		if h, ok := eff.Hooks[hooks.ApprovalJudgeName]; ok && h.Enabled {
+			if cmd := strings.TrimSpace(h.Command); cmd != "" {
+				return cmd
+			}
+		}
 	}
 	return strings.TrimSpace(cfg.Hooks.ApprovalJudge.Command)
 }

--- a/internal/guidance/workflow/navigator_format_judge_test.go
+++ b/internal/guidance/workflow/navigator_format_judge_test.go
@@ -197,3 +197,39 @@ func TestApprovalJudgeConfigured_FromFestivalPathWithoutWorkspaceCtx(t *testing.
 		t.Fatalf("ApprovalJudgeCommand = %q, want %q", got, "ob judge")
 	}
 }
+
+func TestApprovalJudgeConfigured_DefinitionsOnly(t *testing.T) {
+	// Preferred schema: definitions.approval_judge without the flat key.
+	root := t.TempDir()
+	festivalsRoot := filepath.Join(root, "festivals")
+	festivalPath := filepath.Join(festivalsRoot, "active", "example-fest")
+	if err := os.MkdirAll(festivalPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dotFestival := filepath.Join(festivalsRoot, config.DotFestivalDir)
+	if err := os.MkdirAll(dotFestival, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfgYAML := `version: "1.0"
+hooks:
+  definitions:
+    approval_judge:
+      command: defs-only-judge
+      timeout: 0
+`
+	if err := os.WriteFile(filepath.Join(dotFestival, config.WorkspaceConfigFileName), []byte(cfgYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	gctx := &guidance.GuidanceContext{FestivalPath: festivalPath}
+	nav, err := NewNavigator(gctx, guidance.ModeWorkflow)
+	if err != nil {
+		t.Fatalf("NewNavigator: %v", err)
+	}
+	if !nav.approvalJudgeConfigured(context.Background()) {
+		t.Fatal("definitions-only approval_judge must configure the judge")
+	}
+	if got := nav.ApprovalJudgeCommand(context.Background()); got != "defs-only-judge" {
+		t.Fatalf("ApprovalJudgeCommand = %q, want defs-only-judge", got)
+	}
+}


### PR DESCRIPTION
## Summary

Documents the fest lifecycle hooks system shipped in #291 so operators and agents can learn the schema without reading code.

- Add `docs/concepts/hooks.md` (layers, schema, bindings, fail policies, legacy alias, human gates, audit/validate)
- Document hooks in `docs/configuration.md` with YAML/JSON samples
- Add `fest understand hooks` (`embedded/docs/understand/hooks.txt` + command wiring)
- Update `fest understand workflow` approval section to preferred `definitions` form
- Link from `hook-evidence-contract.md` and refresh README bullet
- Regenerate CLI reference (`fest hooks`, `fest hooks list`, `fest understand hooks`)

## Test plan

- [x] `just build quick`
- [x] `just docs` regenerated `docs/cli-reference/fest_hooks*.md`
- [x] `./bin/fest understand hooks` prints the new topic
- [x] `go test ./internal/commands/understand/`