### PR TITLE
docs: explain how to find fest binary path after shell-init

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,32 @@ This gives you:
 - `fls` - Quick listing (`fest list`)
 - Tab completion for all fest commands
 
+### Finding the installed binary
+
+Shell integration defines `fest` as a **shell function** (so `fest go` / `fgo`
+can `cd` in your current shell). That means plain `which fest` usually prints
+the function body, not a filesystem path.
+
+Use these instead:
+
+```bash
+# zsh — path of the external binary (skips shell functions)
+whence -p fest
+# or: which -p fest
+
+# bash
+type -P fest
+
+# show the function plus every binary on PATH
+type -a fest
+
+# resolve symlinks to the real file
+realpath "$(whence -p fest)"   # zsh
+realpath "$(type -P fest)"     # bash
+```
+
+To run the binary without the wrapper (scripts, debugging): `command fest version`.
+
 ## Agent Workflow
 
 The typical workflow for AI agents:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,6 +2,31 @@
 
 Common issues and fixes for Fest CLI output and styling.
 
+## Finding the installed binary
+
+After shell integration (`eval "$(fest shell-init zsh)"` or the Festival helper
+file), `fest` is a **shell function**, not just a PATH entry. Plain
+`which fest` usually prints that function body instead of a filesystem path.
+
+```bash
+# zsh — external binary only (skips shell functions)
+whence -p fest
+# or: which -p fest
+
+# bash
+type -P fest
+
+# function + every binary on PATH
+type -a fest
+
+# resolve symlinks to the real install location
+realpath "$(whence -p fest)"   # zsh
+realpath "$(type -P fest)"     # bash
+```
+
+Run the binary without the wrapper with `command fest ...` (for example
+`command fest version`).
+
 ## Styled Output and Color
 
 ### Output has no color in a TTY


### PR DESCRIPTION
## Summary
- Document that shell-init defines `fest` as a shell function, so plain `which fest` prints the function body instead of a path.
- Show the correct discovery commands: `whence -p` / `which -p` (zsh), `type -P` (bash), `type -a`, and `realpath`.
- Add the same guidance to troubleshooting docs.

## Test plan
- [ ] Read the new README and troubleshooting sections for clarity
- [ ] After `eval "$(fest shell-init zsh)"`, confirm `whence -p fest` returns a binary path while `which fest` shows the function