### PR TITLE
test(integration): move fixtures to nested hooks.definitions schema

### DIFF
--- a/tests/integration/approval_readiness_test.go
+++ b/tests/integration/approval_readiness_test.go
@@ -27,8 +27,9 @@ mkdir -p "` + phasePath + `/output_specs" /outside
 cat > /festivals/.festival/config.yaml <<'EOF'
 version: "1.0"
 hooks:
-  approval_judge:
-    command: /bin/false
+  definitions:
+    approval_judge:
+      command: /bin/false
 EOF
 cat > "` + festivalPath + `/fest.yaml" <<'EOF'
 version: "1.0"

--- a/tests/integration/async_judge_test.go
+++ b/tests/integration/async_judge_test.go
@@ -279,8 +279,9 @@ EOF
 cat > /festivals/.festival/config.yaml <<EOF
 version: "1.0"
 hooks:
-  approval_judge:
-    command: %[2]s
+  definitions:
+    approval_judge:
+      command: %[2]s
 EOF
 
 cat > "%[1]s/fest.yaml" <<'EOF'

--- a/tests/integration/system_update_test.go
+++ b/tests/integration/system_update_test.go
@@ -160,8 +160,9 @@ func writeOperatorConfig(t *testing.T, tc *TestContainer, configPath, command st
 	_, err := tc.runCommand([]string{"sh", "-c", fmt.Sprintf(`cat > %s <<'EOF'
 version: "1.0"
 hooks:
-  approval_judge:
-    command: %s
+  definitions:
+    approval_judge:
+      command: %s
 EOF`, configPath, command)})
 	require.NoError(t, err, "failed to write operator config")
 }
@@ -276,8 +277,9 @@ func TestSystemUpdate_PreservesUserConfigAcrossUpdates(t *testing.T) {
 	_, err = tc.runCommand([]string{"sh", "-c", fmt.Sprintf(`cat > %s/.festival/config.yaml <<'EOF'
 version: "1.0"
 hooks:
-  approval_judge:
-    command: /bin/STALE-SOURCE
+  definitions:
+    approval_judge:
+      command: /bin/STALE-SOURCE
 EOF`, sourceDir)})
 	require.NoError(t, err, "failed to plant stale source config")
 


### PR DESCRIPTION
## Why

PR #297 (e900887) removed the flat `hooks.approval_judge` config key and its alias shim, but updated only the unit tests. Four integration fixtures still wrote the flat schema, so on main the operator judge hook silently stopped resolving inside the container harness and 7 tests fail:

- `TestApprovalReadinessRejectsEvidenceSymlinkOutsidePhase`
- all six `TestAsyncJudge_*` tests

The two `system_update_test.go` fixtures kept passing because those tests treat config.yaml as opaque bytes (survival assertions, schema never parsed), but they were writing a dead schema and are updated for consistency.

## Fix

Fixture heredocs now write the current nested form:

    hooks:
      definitions:
        approval_judge:
          command: ...

No production code changes.

## Verification

`just test integration` on this branch: 71/71 passed, 194s. Same suite on main fails 7/71.

## Note

The containerized integration suite is not part of the pre-merge gate, which is how #297 landed green while breaking it. Worth considering a gate or a pre-release checklist item that runs `just test integration` for changes touching `internal/hooks`.