### PR TITLE
fix(workflow): stop silently dropping evidence bullets the parser cannot read

### DIFF
--- a/internal/commands/workflow/approval_readiness.go
+++ b/internal/commands/workflow/approval_readiness.go
@@ -46,6 +46,24 @@ func checkApprovalReadinessWithInspector(
 		return err
 	}
 
+	// An Evidence block the parser could not fully read is refused before the
+	// judge starts. The judge can only see what Evidence lists, so an unfilled
+	// scaffold placeholder ("- (attach the task outputs for this step)") or a
+	// path with a space used to be dropped in silence, leaving a list that
+	// looked deliberate. The judge would then reject for missing deliverables
+	// that were never handed to it, which costs a full round-trip and reads as
+	// the judge being wrong rather than the gate being unfilled.
+	if len(step.EvidenceUnparsed) > 0 {
+		return festerrors.Validation("approval readiness failed: evidence list has entries that are not paths: "+
+			strings.Join(step.EvidenceUnparsed, " | ")).
+			WithField("step", step.Number).
+			WithField("step_name", step.Name).
+			WithField("unreadable", strings.Join(step.EvidenceUnparsed, " | ")).
+			WithHint("each **Evidence:** bullet must be a single phase-relative path with no spaces; " +
+				"replace the listed lines in GATES.md with the real deliverables, then re-submit " +
+				"with 'fest workflow judge'")
+	}
+
 	// Presentation-like steps require a non-empty presentation (or listed evidence).
 	if !wf.IsPresentationStep(step) && len(step.EvidencePaths) == 0 {
 		return nil

--- a/internal/commands/workflow/approval_readiness_unfilled_test.go
+++ b/internal/commands/workflow/approval_readiness_unfilled_test.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -47,5 +48,85 @@ func TestReadinessAllowsAFilledEvidenceList(t *testing.T) {
 		return true, nil
 	}); err != nil {
 		t.Errorf("a filled list must pass readiness: %v", err)
+	}
+}
+
+// The unit tests above build a WorkflowStep by hand, so the parser and the
+// readiness gate are only ever exercised apart. This runs a scaffold-shaped
+// GATES.md section through the real parse and then into readiness, so the field
+// wiring between them cannot regress independently of either.
+func TestScaffoldGateDoesNotReachTheJudge(t *testing.T) {
+	const content = `## Step 1: PHASE GOAL — Verify Goal Achievement
+
+**Question:** Did the phase achieve its stated objective?
+
+**Evidence:**
+- PHASE_GOAL.md
+- (attach each sequence's SEQUENCE_GOAL.md and task outputs relevant to this gate step)
+
+**Checkpoint class:** artifact_review
+
+**Checkpoint:** APPROVAL REQUIRED — Confirm goal is met
+`
+
+	steps, err := (&wf.Parser{}).ParseContent(context.Background(), content)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(steps) != 1 {
+		t.Fatalf("parsed %d steps, want 1", len(steps))
+	}
+	step := steps[0]
+
+	// The placeholder must survive parsing rather than vanishing, which is what
+	// let the gate look deliberate.
+	if len(step.EvidenceUnparsed) != 1 {
+		t.Fatalf("unparsed = %v, want the placeholder line", step.EvidenceUnparsed)
+	}
+	if len(step.EvidencePaths) != 1 || step.EvidencePaths[0] != "PHASE_GOAL.md" {
+		t.Fatalf("paths = %v, want just PHASE_GOAL.md", step.EvidencePaths)
+	}
+
+	err = checkApprovalReadinessWithInspector(t.TempDir(), step, func(string, string) (bool, error) {
+		return true, nil
+	})
+	if err == nil {
+		t.Fatal("a scaffold gate must not reach the judge")
+	}
+	if !strings.Contains(err.Error(), "attach each sequence") {
+		t.Errorf("error must quote the unfilled line: %s", err)
+	}
+}
+
+// An evidence list of only unparsed bullets is the worst case: no paths at all,
+// so nothing looks deliberate and the judge would see an empty list.
+func TestGateWithOnlyUnparsedEvidenceIsRefused(t *testing.T) {
+	const content = `## Step 1: PHASE GOAL — Verify
+
+**Evidence:**
+- (attach the outputs for this gate step)
+
+**Checkpoint class:** artifact_review
+
+**Checkpoint:** APPROVAL REQUIRED
+`
+
+	steps, err := (&wf.Parser{}).ParseContent(context.Background(), content)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(steps) != 1 {
+		t.Fatalf("parsed %d steps, want 1", len(steps))
+	}
+	if len(steps[0].EvidencePaths) != 0 {
+		t.Errorf("paths = %v, want none", steps[0].EvidencePaths)
+	}
+	if len(steps[0].EvidenceUnparsed) != 1 {
+		t.Fatalf("unparsed = %v, want the placeholder", steps[0].EvidenceUnparsed)
+	}
+
+	if err := checkApprovalReadinessWithInspector(t.TempDir(), steps[0],
+		func(string, string) (bool, error) { return true, nil }); err == nil {
+		t.Fatal("a gate with no real evidence must not reach the judge")
 	}
 }

--- a/internal/commands/workflow/approval_readiness_unfilled_test.go
+++ b/internal/commands/workflow/approval_readiness_unfilled_test.go
@@ -1,0 +1,51 @@
+package workflow
+
+import (
+	"strings"
+	"testing"
+
+	wf "github.com/Obedience-Corp/fest/internal/guidance/workflow"
+)
+
+// TestReadinessRefusesUnfilledEvidence pins that an unfilled gate never reaches
+// the judge. Before this, the scaffold placeholder was dropped by the parser, the
+// remaining entry looked like a deliberate list, and the judge was launched with
+// a goal template and no deliverables. It rejected, correctly, for missing
+// evidence it was never given, which costs a full round-trip on the FIRST run of
+// every phase and reads as the judge being wrong.
+func TestReadinessRefusesUnfilledEvidence(t *testing.T) {
+	step := wf.WorkflowStep{
+		Number:           1,
+		Name:             "PHASE GOAL",
+		CheckpointClass:  wf.CheckpointClassArtifactReview,
+		EvidencePaths:    []string{"PHASE_GOAL.md"},
+		EvidenceUnparsed: []string{"(attach each sequence's SEQUENCE_GOAL.md and task outputs relevant to this gate step)"},
+	}
+
+	err := checkApprovalReadinessWithInspector(t.TempDir(), step, func(string, string) (bool, error) {
+		return true, nil
+	})
+	if err == nil {
+		t.Fatal("an unfilled evidence list must not reach the judge")
+	}
+	msg := err.Error()
+	for _, want := range []string{"not paths", "attach each sequence", "GATES.md"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error must name the problem and the file to fix; missing %q in: %s", want, msg)
+		}
+	}
+}
+
+func TestReadinessAllowsAFilledEvidenceList(t *testing.T) {
+	step := wf.WorkflowStep{
+		Number:          1,
+		Name:            "PHASE GOAL",
+		CheckpointClass: wf.CheckpointClassArtifactReview,
+		EvidencePaths:   []string{"PHASE_GOAL.md", "01_seq/outputs/spec.md"},
+	}
+	if err := checkApprovalReadinessWithInspector(t.TempDir(), step, func(string, string) (bool, error) {
+		return true, nil
+	}); err != nil {
+		t.Errorf("a filled list must pass readiness: %v", err)
+	}
+}

--- a/internal/guidance/workflow/parser.go
+++ b/internal/guidance/workflow/parser.go
@@ -37,8 +37,14 @@ var (
 	// evidenceRe matches an explicit evidence list for approval judging.
 	evidenceRe = regexp.MustCompile(`(?s)\*\*Evidence:\*\*\s*(.+?)(?:\n\n|\n\*\*|---|\n##|$)`)
 
-	// evidenceItemRe matches bullet evidence paths.
+	// evidenceItemRe matches bullet evidence paths: a single token on its own
+	// line. Anything else under **Evidence:** is captured by evidenceBulletRe
+	// instead and reported, rather than vanishing.
 	evidenceItemRe = regexp.MustCompile(`(?m)^\s*[-*]\s+(\S+)\s*$`)
+
+	// evidenceBulletRe matches EVERY bullet under **Evidence:**, so the parser
+	// can tell a path it understood from a line it could not.
+	evidenceBulletRe = regexp.MustCompile(`(?m)^\s*[-*]\s+(.+?)\s*$`)
 
 	// hooksMarkerRe matches a per-step "**Hooks:**" line in GATES.md.
 	hooksMarkerRe = regexp.MustCompile(`(?im)\*\*Hooks:\*\*[ \t]*([^\r\n]*)`)
@@ -134,6 +140,7 @@ func (p *Parser) ParseContent(ctx context.Context, content string) ([]WorkflowSt
 		}
 		step.CheckpointClass = checkpointClass
 		step.EvidencePaths = p.parseEvidencePaths(section)
+		step.EvidenceUnparsed = p.parseUnparsedEvidence(section)
 		step.Hooks = p.parseStepHooks(section)
 		step.Approval = p.parseApproval(section)
 
@@ -250,6 +257,34 @@ func (p *Parser) parseEvidencePaths(section string) []string {
 		paths = append(paths, path)
 	}
 	return paths
+}
+
+// parseUnparsedEvidence returns the bullets under **Evidence:** that are not
+// single-token paths.
+//
+// These used to disappear. evidenceItemRe requires one non-whitespace token, so
+// a scaffold placeholder like "- (attach the task outputs for this step)" or a
+// path containing a space matched nothing and was dropped in silence. The
+// remaining real entries then looked like a complete, deliberate evidence list,
+// and the approval judge was handed a partial set nobody was told was partial.
+// Reporting them is what lets readiness refuse with something actionable.
+func (p *Parser) parseUnparsedEvidence(section string) []string {
+	m := evidenceRe.FindStringSubmatch(section)
+	if len(m) < 2 {
+		return nil
+	}
+	var unparsed []string
+	for _, item := range evidenceBulletRe.FindAllStringSubmatch(m[1], -1) {
+		if len(item) < 2 {
+			continue
+		}
+		text := strings.TrimSpace(item[1])
+		if text == "" || !strings.ContainsAny(text, " \t") {
+			continue
+		}
+		unparsed = append(unparsed, text)
+	}
+	return unparsed
 }
 
 // parseStepHooks extracts pre/post hook name lists from a **Hooks:** marker.

--- a/internal/guidance/workflow/parser.go
+++ b/internal/guidance/workflow/parser.go
@@ -37,13 +37,19 @@ var (
 	// evidenceRe matches an explicit evidence list for approval judging.
 	evidenceRe = regexp.MustCompile(`(?s)\*\*Evidence:\*\*\s*(.+?)(?:\n\n|\n\*\*|---|\n##|$)`)
 
-	// evidenceItemRe matches bullet evidence paths: a single token on its own
-	// line. Anything else under **Evidence:** is captured by evidenceBulletRe
-	// instead and reported, rather than vanishing.
+	// evidenceItemRe matches a bullet evidence path: a single token on its own
+	// line. It is the ONLY definition of "this bullet is a path"; a `-`/`*`
+	// bullet it does not match is reported as unparsed rather than dropped.
+	//
+	// Non-bullet lines, other list markers, and empty bullets under
+	// **Evidence:** still match neither regex and are still ignored. Closing
+	// that would mean classifying every line in the block, which is a wider
+	// change than the silent drop this fixes.
 	evidenceItemRe = regexp.MustCompile(`(?m)^\s*[-*]\s+(\S+)\s*$`)
 
-	// evidenceBulletRe matches EVERY bullet under **Evidence:**, so the parser
-	// can tell a path it understood from a line it could not.
+	// evidenceBulletRe matches EVERY bullet under **Evidence:**. Each one is
+	// then classified against evidenceItemRe, so "not a path" is defined by
+	// that regex rather than by a second heuristic that can drift from it.
 	evidenceBulletRe = regexp.MustCompile(`(?m)^\s*[-*]\s+(.+?)\s*$`)
 
 	// hooksMarkerRe matches a per-step "**Hooks:**" line in GATES.md.
@@ -139,8 +145,7 @@ func (p *Parser) ParseContent(ctx context.Context, content string) ([]WorkflowSt
 			return nil, fmt.Errorf("step %d checkpoint class: %w", num, err)
 		}
 		step.CheckpointClass = checkpointClass
-		step.EvidencePaths = p.parseEvidencePaths(section)
-		step.EvidenceUnparsed = p.parseUnparsedEvidence(section)
+		step.EvidencePaths, step.EvidenceUnparsed = p.parseEvidence(section)
 		step.Hooks = p.parseStepHooks(section)
 		step.Approval = p.parseApproval(section)
 
@@ -240,51 +245,35 @@ func (p *Parser) parseCheckpointClass(section string) (CheckpointClass, error) {
 	}
 }
 
-func (p *Parser) parseEvidencePaths(section string) []string {
-	m := evidenceRe.FindStringSubmatch(section)
-	if len(m) < 2 {
-		return nil
-	}
-	var paths []string
-	for _, item := range evidenceItemRe.FindAllStringSubmatch(m[1], -1) {
-		if len(item) < 2 {
-			continue
-		}
-		path := strings.TrimSpace(item[1])
-		if path == "" {
-			continue
-		}
-		paths = append(paths, path)
-	}
-	return paths
-}
-
-// parseUnparsedEvidence returns the bullets under **Evidence:** that are not
-// single-token paths.
+// parseEvidence classifies every bullet under **Evidence:** exactly once: a
+// bullet is either a path or it is reported.
 //
-// These used to disappear. evidenceItemRe requires one non-whitespace token, so
-// a scaffold placeholder like "- (attach the task outputs for this step)" or a
-// path containing a space matched nothing and was dropped in silence. The
-// remaining real entries then looked like a complete, deliberate evidence list,
-// and the approval judge was handed a partial set nobody was told was partial.
-// Reporting them is what lets readiness refuse with something actionable.
-func (p *Parser) parseUnparsedEvidence(section string) []string {
+// One scan on purpose. Splitting this into a path pass and a separate
+// "not a path" pass meant two definitions of what a path is, and the readiness
+// gate's invariant -- no bullet is silently discarded -- held only while the
+// two happened to agree.
+func (p *Parser) parseEvidence(section string) (paths, unparsed []string) {
 	m := evidenceRe.FindStringSubmatch(section)
 	if len(m) < 2 {
-		return nil
+		return nil, nil
 	}
-	var unparsed []string
-	for _, item := range evidenceBulletRe.FindAllStringSubmatch(m[1], -1) {
-		if len(item) < 2 {
+	for _, bullet := range evidenceBulletRe.FindAllStringSubmatch(m[1], -1) {
+		if len(bullet) < 2 {
 			continue
 		}
-		text := strings.TrimSpace(item[1])
-		if text == "" || !strings.ContainsAny(text, " \t") {
+		text := strings.TrimSpace(bullet[1])
+		if text == "" {
 			continue
+		}
+		if item := evidenceItemRe.FindStringSubmatch(bullet[0]); len(item) >= 2 {
+			if path := strings.TrimSpace(item[1]); path != "" {
+				paths = append(paths, path)
+				continue
+			}
 		}
 		unparsed = append(unparsed, text)
 	}
-	return unparsed
+	return paths, unparsed
 }
 
 // parseStepHooks extracts pre/post hook name lists from a **Hooks:** marker.

--- a/internal/guidance/workflow/parser_evidence_test.go
+++ b/internal/guidance/workflow/parser_evidence_test.go
@@ -57,8 +57,7 @@ func TestEvidenceBulletsAreNeverSilentlyDropped(t *testing.T) {
 	p := &Parser{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotPaths := p.parseEvidencePaths(tt.section)
-			gotUnparsed := p.parseUnparsedEvidence(tt.section)
+			gotPaths, gotUnparsed := p.parseEvidence(tt.section)
 
 			if strings.Join(gotPaths, ",") != strings.Join(tt.wantPaths, ",") {
 				t.Errorf("paths = %v, want %v", gotPaths, tt.wantPaths)

--- a/internal/guidance/workflow/parser_evidence_test.go
+++ b/internal/guidance/workflow/parser_evidence_test.go
@@ -1,0 +1,71 @@
+package workflow
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestEvidenceBulletsAreNeverSilentlyDropped pins the defect this fixes: an
+// Evidence bullet the parser cannot read as a path used to vanish, leaving a
+// partial list that looked complete.
+func TestEvidenceBulletsAreNeverSilentlyDropped(t *testing.T) {
+	tests := []struct {
+		name         string
+		section      string
+		wantPaths    []string
+		wantUnparsed []string
+	}{
+		{
+			name: "the scaffold placeholder is reported, not dropped",
+			section: `## Step 1: PHASE GOAL
+
+**Evidence:**
+- PHASE_GOAL.md
+- (attach each sequence's SEQUENCE_GOAL.md and task outputs relevant to this gate step)
+
+**Checkpoint:** APPROVAL REQUIRED
+`,
+			wantPaths:    []string{"PHASE_GOAL.md"},
+			wantUnparsed: []string{"(attach each sequence's SEQUENCE_GOAL.md and task outputs relevant to this gate step)"},
+		},
+		{
+			name: "a path containing a space is reported",
+			section: `## Step 1: GOAL
+
+**Evidence:**
+- outputs/my spec.md
+
+**Checkpoint:** APPROVAL REQUIRED
+`,
+			wantUnparsed: []string{"outputs/my spec.md"},
+		},
+		{
+			name: "a fully filled list reports nothing unparsed",
+			section: `## Step 1: GOAL
+
+**Evidence:**
+- PHASE_GOAL.md
+- 01_seq/outputs/spec.md
+- 01_seq/results/testing-results.md
+
+**Checkpoint:** APPROVAL REQUIRED
+`,
+			wantPaths: []string{"PHASE_GOAL.md", "01_seq/outputs/spec.md", "01_seq/results/testing-results.md"},
+		},
+	}
+
+	p := &Parser{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPaths := p.parseEvidencePaths(tt.section)
+			gotUnparsed := p.parseUnparsedEvidence(tt.section)
+
+			if strings.Join(gotPaths, ",") != strings.Join(tt.wantPaths, ",") {
+				t.Errorf("paths = %v, want %v", gotPaths, tt.wantPaths)
+			}
+			if strings.Join(gotUnparsed, ",") != strings.Join(tt.wantUnparsed, ",") {
+				t.Errorf("unparsed = %v, want %v", gotUnparsed, tt.wantUnparsed)
+			}
+		})
+	}
+}

--- a/internal/guidance/workflow/step.go
+++ b/internal/guidance/workflow/step.go
@@ -148,6 +148,13 @@ type WorkflowStep struct {
 	// EvidencePaths are phase-relative deliverable paths listed under **Evidence:**.
 	EvidencePaths []string `json:"evidence_paths,omitempty" yaml:"evidence_paths,omitempty"`
 
+	// EvidenceUnparsed are bullets under **Evidence:** that are not single-token
+	// paths: an unfilled scaffold instruction, a path containing a space, a
+	// typo. They are recorded rather than dropped so approval readiness can
+	// refuse with a message naming the line, instead of judging a partial
+	// evidence set nobody was told was partial.
+	EvidenceUnparsed []string `json:"evidence_unparsed,omitempty" yaml:"evidence_unparsed,omitempty"`
+
 	// Hooks are the pre/post hook name bindings for this step (spec 03).
 	Hooks StepHooks `json:"hooks,omitempty" yaml:"hooks,omitempty"`
 


### PR DESCRIPTION
An `**Evidence:**` bullet the parser cannot read as a path disappears without a word, and the judge gets launched against whatever is left.

## What happens today

`evidenceItemRe` is `^\s*[-*]\s+(\S+)\s*$` — one non-whitespace token on its own line. The gate scaffold ships this:

```markdown
**Evidence:**
- PHASE_GOAL.md
- (attach each sequence's SEQUENCE_GOAL.md and task outputs relevant to this gate step)
```

The second bullet has spaces, so it matches nothing and is dropped. What survives is `["PHASE_GOAL.md"]`, which looks exactly like a deliberate one-file evidence list. Readiness passes it. The judge is launched holding a **goal template whose boxes are all unchecked** and no deliverables.

It then rejects, correctly, for missing evidence it was never handed:

> *"The submission contains only planning documents (PHASE_GOAL.md and three SEQUENCE_GOAL.md files) with no actual deliverables; PHASE_GOAL.md shows all required outcomes unchecked."*

That is a wasted judge round-trip on the **first run of every phase**, and it reads as the judge being wrong when the gate was simply never filled in. I hit it three times running festival MN0001 end to end.

## The fix

Record the bullets the parser could not read, and refuse before the judge starts, with the offending line in the message:

```
approval readiness failed: evidence list has entries that are not paths:
(attach each sequence's SEQUENCE_GOAL.md and task outputs relevant to this gate step)
Hint: each **Evidence:** bullet must be a single phase-relative path with no spaces;
replace the listed lines in GATES.md with the real deliverables, then re-submit with
'fest workflow judge'
```

The rule is **general, not placeholder-specific**: it also catches a path containing a space and a typo'd bullet, which failed the same silent way.

Parser output on the real scaffold block, before any readiness check:

```
paths    = ["PHASE_GOAL.md"]
unparsed = ["(attach each sequence's SEQUENCE_GOAL.md and task outputs relevant to this gate step)"]
```

## Ordering

The new guard sits after `checkAutoJudgeAllowed`, so an operator-attestation checkpoint is still refused first regardless of its evidence list. A fully filled list is unaffected, which is pinned by a test.

## Tests

`just gate` green: 2686.

- `TestEvidenceBulletsAreNeverSilentlyDropped`: the scaffold placeholder is reported not dropped; a path with a space is reported; a filled list reports nothing unparsed.
- `TestReadinessRefusesUnfilledEvidence`: an unfilled gate never reaches the judge, and the error names both the offending line and `GATES.md`.
- `TestReadinessAllowsAFilledEvidenceList`: no regression for filled gates.

## Note on the other half

I also filed a separate observation in that festival's feedback about the judge-in-flight notice: `fest next` prints "Judge launched (pid N)" *above* the `EXECUTE THE FOLLOWING INSTRUCTIONS` banner, where an agent reading the tail of a long block never sees it, so it stops at a checkpoint whose verdict is already coming. Not fixed here; this PR is scoped to the evidence defect.
