### PR TITLE
feat(workflow): send working dirs and campaign root to the approval judge

### DIFF
--- a/docs/concepts/hook-evidence-contract.md
+++ b/docs/concepts/hook-evidence-contract.md
@@ -12,6 +12,8 @@ A hook stdin request typically includes:
 - `festival_path` — festival root
 - `phase_path` — phase directory used as the evidence root
 - `evidence` — list of phase-relative file paths (present, non-empty regular files only)
+- `campaign_root` — campaign directory containing the festival (optional)
+- `working_dirs` — where the phase's work actually landed (optional)
 
 The concrete judge request type is `approvalJudgeRequest` in
 `internal/commands/workflow/approve.go` (`schema_version: fest.approval.judge/v1`).
@@ -54,7 +56,42 @@ When a hook definition sets `evidence: embed`, fest may also attach
   appear in `evidence`.
 - `evidence` paths are always populated so path-mode judges keep working.
 
+## Working directories
+
+An implementation phase's deliverable is code in another repository. Without it
+the judge can only read the executor's own account of what it did, so fest also
+sends where the work landed (additive JSON fields; older judges ignore them):
+
+```json
+{
+  "campaign_root": "/campaigns/demo",
+  "working_dirs": [
+    { "sequence": "01_implement", "path": "projects/camp" }
+  ]
+}
+```
+
+- `path` is **campaign-relative**, taken from each sequence's `fest_working_dir`
+  and normalized by `pathutil.NormalizeWorkingDir`. Absolute, `~`-prefixed, and
+  `..`-escaping values are rejected.
+- Paths stay relative deliberately. A judge request is rendered into a prompt
+  that reaches a model provider and is recorded in ledgers and transcripts; an
+  absolute path per working dir would put the operator's home directory and
+  username into all of them. `campaign_root` is the single absolute path, and
+  the judge joins.
+- `campaign_root` comes from `workspace.DetectCampaign`, so it honors `CAMP_ROOT`
+  and matches the root the rest of fest resolves. Empty when detection fails,
+  which leaves the relative paths intact.
+- Containment is enforced on the path **string** only. A campaign-relative entry
+  that is a symlink out of the campaign still normalizes cleanly, so a judge that
+  opens these directories must re-validate before reading — unlike `evidence`,
+  which is `EvalSymlinks`-resolved and root-checked here.
+- Sequences that declare no working dir are skipped: the work is in the festival
+  itself, which the judge already sees through `phase_path`. A declaration that
+  was present but rejected is reported on stderr rather than dropped silently.
+
 ## Compatibility
 
 - `fest.approval.judge/v1` decision protocol is unchanged.
 - Default `evidence: paths` marshals without `evidence_files`.
+- `campaign_root` and `working_dirs` are omitted when empty.

--- a/internal/commands/workflow/approve.go
+++ b/internal/commands/workflow/approve.go
@@ -86,6 +86,19 @@ type approvalJudgeRequest struct {
 	// EvidenceFiles is optional embedded content when the resolved hook uses
 	// evidence: embed. Omitted in the default paths mode.
 	EvidenceFiles []hooks.EvidenceFile `json:"evidence_files,omitempty"`
+	// CampaignRoot is the campaign directory containing this festival, so a
+	// judge can resolve working dirs and read the repositories the phase
+	// actually changed. Empty when no campaign root is found.
+	CampaignRoot string `json:"campaign_root,omitempty"`
+	// WorkingDirs are the fest_working_dir declarations of the phase's
+	// sequences: where the work landed, as opposed to where the plan lives.
+	//
+	// Without these a judge evaluating an implementation phase can only read
+	// the executor's own account of what it did, because the deliverable is
+	// code in another repository that the request never mentioned. Additive to
+	// fest.approval.judge/v1: an older judge ignores the field and behaves
+	// exactly as before.
+	WorkingDirs []judgeWorkingDir `json:"working_dirs,omitempty"`
 }
 
 type approvalJudgeResponse struct {
@@ -800,6 +813,11 @@ func judgeApproval(ctx context.Context, nav *wf.Navigator, step wf.WorkflowStep,
 		Output:        step.Output,
 		Checkpoint:    step.Checkpoint.String(),
 	}
+	// Where the work landed, not just where the plan lives. Best-effort: a
+	// phase with no declared working dirs (design, docs) simply sends none, and
+	// the judge sees the festival through phase_path as before.
+	req.CampaignRoot = campaignRootFor(nav.Ctx.FestivalPath)
+	req.WorkingDirs = collectPhaseWorkingDirs(nav.Ctx.PhasePath, req.CampaignRoot)
 	if nav.IsGate() {
 		req.Document = "GATES.md"
 	}

--- a/internal/commands/workflow/approve.go
+++ b/internal/commands/workflow/approve.go
@@ -89,6 +89,11 @@ type approvalJudgeRequest struct {
 	// CampaignRoot is the campaign directory containing this festival, so a
 	// judge can resolve working dirs and read the repositories the phase
 	// actually changed. Empty when no campaign root is found.
+	//
+	// It is the one absolute path in the request, and it is here so the
+	// working dirs themselves can stay relative: an absolute path per working
+	// dir would put the operator's home directory and username into every
+	// judge prompt, provider log, ledger entry and transcript.
 	CampaignRoot string `json:"campaign_root,omitempty"`
 	// WorkingDirs are the fest_working_dir declarations of the phase's
 	// sequences: where the work landed, as opposed to where the plan lives.
@@ -816,8 +821,10 @@ func judgeApproval(ctx context.Context, nav *wf.Navigator, step wf.WorkflowStep,
 	// Where the work landed, not just where the plan lives. Best-effort: a
 	// phase with no declared working dirs (design, docs) simply sends none, and
 	// the judge sees the festival through phase_path as before.
-	req.CampaignRoot = campaignRootFor(nav.Ctx.FestivalPath)
-	req.WorkingDirs = collectPhaseWorkingDirs(nav.Ctx.PhasePath, req.CampaignRoot)
+	req.CampaignRoot = campaignRootFor(ctx, nav.Ctx.FestivalPath)
+	workingDirs, skipped := collectPhaseWorkingDirs(nav.Ctx.PhasePath)
+	req.WorkingDirs = workingDirs
+	reportWorkingDirSkips(os.Stderr, skipped, len(workingDirs))
 	if nav.IsGate() {
 		req.Document = "GATES.md"
 	}

--- a/internal/commands/workflow/judge_workdirs.go
+++ b/internal/commands/workflow/judge_workdirs.go
@@ -1,0 +1,107 @@
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/Obedience-Corp/fest/internal/frontmatter"
+	"github.com/Obedience-Corp/fest/internal/pathutil"
+)
+
+// judgeWorkingDir is one place a phase's work actually landed.
+//
+// It exists because a judge that cannot see the working directory is being
+// asked whether an implementation satisfied its goal while structurally unable
+// to look at the implementation. Implementation phases produce code in
+// projects/*, and the festival directory holds only the plan and whatever the
+// executor wrote about the work. Without this the judge can only evaluate the
+// executor's own account of what it did.
+type judgeWorkingDir struct {
+	// Sequence is the sequence directory that declared this working dir, so a
+	// judge can tell which deliverable belongs where when a phase spans repos.
+	Sequence string `json:"sequence"`
+	// Path is relative to the campaign root, exactly as fest_working_dir
+	// declares it (for example "projects/camp").
+	Path string `json:"path"`
+	// AbsolutePath is resolved for the judge's convenience; it is the campaign
+	// root joined with Path, and is empty when the campaign root is unknown.
+	AbsolutePath string `json:"absolute_path,omitempty"`
+}
+
+// collectPhaseWorkingDirs reads fest_working_dir from every sequence in the
+// phase. Sequences that declare none are skipped rather than defaulted: a
+// missing working dir means the work is in the festival itself (a design or
+// docs phase), which the judge already sees through phase_path.
+//
+// Best-effort by design. An unreadable sequence or a malformed value is skipped
+// rather than failing the checkpoint, because a judge with partial working-dir
+// context is strictly better than a gate that will not run.
+func collectPhaseWorkingDirs(phasePath, campaignRoot string) []judgeWorkingDir {
+	entries, err := os.ReadDir(phasePath)
+	if err != nil {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	var dirs []judgeWorkingDir
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		goalPath := filepath.Join(phasePath, entry.Name(), "SEQUENCE_GOAL.md")
+		raw, err := os.ReadFile(goalPath)
+		if err != nil {
+			continue
+		}
+		fm, _, err := frontmatter.Parse(raw)
+		if err != nil || fm == nil {
+			continue
+		}
+		rel, err := pathutil.NormalizeWorkingDir(fm.WorkingDir)
+		if err != nil || rel == "" {
+			continue
+		}
+		key := entry.Name() + "\x00" + rel
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		wd := judgeWorkingDir{Sequence: entry.Name(), Path: rel}
+		if campaignRoot != "" {
+			wd.AbsolutePath = filepath.Join(campaignRoot, rel)
+		}
+		dirs = append(dirs, wd)
+	}
+
+	sort.Slice(dirs, func(i, j int) bool {
+		if dirs[i].Sequence != dirs[j].Sequence {
+			return dirs[i].Sequence < dirs[j].Sequence
+		}
+		return dirs[i].Path < dirs[j].Path
+	})
+	return dirs
+}
+
+// campaignRootFor walks up from the festival path looking for the campaign
+// marker, so working dirs can be handed to the judge as absolute paths it can
+// actually open. Empty when no campaign root is found, which leaves the
+// relative paths intact and costs the judge only the join.
+func campaignRootFor(festivalPath string) string {
+	dir := festivalPath
+	for {
+		if dir == "" || dir == string(filepath.Separator) {
+			return ""
+		}
+		if info, err := os.Stat(filepath.Join(dir, ".campaign")); err == nil && info.IsDir() {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}

--- a/internal/commands/workflow/judge_workdirs.go
+++ b/internal/commands/workflow/judge_workdirs.go
@@ -1,6 +1,9 @@
 package workflow
 
 import (
+	"context"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -8,6 +11,7 @@ import (
 
 	"github.com/Obedience-Corp/fest/internal/frontmatter"
 	"github.com/Obedience-Corp/fest/internal/pathutil"
+	"github.com/Obedience-Corp/fest/internal/workspace"
 )
 
 // judgeWorkingDir is one place a phase's work actually landed.
@@ -24,10 +28,26 @@ type judgeWorkingDir struct {
 	Sequence string `json:"sequence"`
 	// Path is relative to the campaign root, exactly as fest_working_dir
 	// declares it (for example "projects/camp").
+	//
+	// Deliberately relative. An absolute path carries the operator's home
+	// directory and username, and this value is rendered into a judge prompt
+	// that reaches a model provider and is recorded in ledgers and transcripts.
+	// The judge resolves against campaign_root, which appears once.
 	Path string `json:"path"`
-	// AbsolutePath is resolved for the judge's convenience; it is the campaign
-	// root joined with Path, and is empty when the campaign root is unknown.
-	AbsolutePath string `json:"absolute_path,omitempty"`
+}
+
+// workingDirSkip is a fest_working_dir declaration that was present but could
+// not be used.
+//
+// Reporting these matters because the failure is otherwise invisible: a
+// sequence with a typo'd or escaping working dir looks exactly like a design
+// phase that declared none, and if every sequence fails that way the judge
+// silently receives no working dirs at all, which is the incomplete-request
+// failure this whole path exists to fix.
+type workingDirSkip struct {
+	Sequence string
+	Value    string
+	Reason   string
 }
 
 // collectPhaseWorkingDirs reads fest_working_dir from every sequence in the
@@ -37,15 +57,16 @@ type judgeWorkingDir struct {
 //
 // Best-effort by design. An unreadable sequence or a malformed value is skipped
 // rather than failing the checkpoint, because a judge with partial working-dir
-// context is strictly better than a gate that will not run.
-func collectPhaseWorkingDirs(phasePath, campaignRoot string) []judgeWorkingDir {
+// context is strictly better than a gate that will not run. Skips carrying a
+// non-empty declaration are returned so the caller can report them.
+func collectPhaseWorkingDirs(phasePath string) ([]judgeWorkingDir, []workingDirSkip) {
 	entries, err := os.ReadDir(phasePath)
 	if err != nil {
-		return nil
+		return nil, nil
 	}
 
-	seen := make(map[string]struct{})
 	var dirs []judgeWorkingDir
+	var skips []workingDirSkip
 	for _, entry := range entries {
 		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
 			continue
@@ -59,21 +80,26 @@ func collectPhaseWorkingDirs(phasePath, campaignRoot string) []judgeWorkingDir {
 		if err != nil || fm == nil {
 			continue
 		}
-		rel, err := pathutil.NormalizeWorkingDir(fm.WorkingDir)
-		if err != nil || rel == "" {
+		declared := strings.TrimSpace(fm.WorkingDir)
+		if declared == "" {
 			continue
 		}
-		key := entry.Name() + "\x00" + rel
-		if _, dup := seen[key]; dup {
-			continue
-		}
-		seen[key] = struct{}{}
 
-		wd := judgeWorkingDir{Sequence: entry.Name(), Path: rel}
-		if campaignRoot != "" {
-			wd.AbsolutePath = filepath.Join(campaignRoot, rel)
+		rel, err := pathutil.NormalizeWorkingDir(fm.WorkingDir)
+		if err != nil {
+			skips = append(skips, workingDirSkip{Sequence: entry.Name(), Value: declared, Reason: err.Error()})
+			continue
 		}
-		dirs = append(dirs, wd)
+		if rel == "" {
+			skips = append(skips, workingDirSkip{
+				Sequence: entry.Name(),
+				Value:    declared,
+				Reason:   "normalized to an empty path",
+			})
+			continue
+		}
+
+		dirs = append(dirs, judgeWorkingDir{Sequence: entry.Name(), Path: rel})
 	}
 
 	sort.Slice(dirs, func(i, j int) bool {
@@ -82,26 +108,31 @@ func collectPhaseWorkingDirs(phasePath, campaignRoot string) []judgeWorkingDir {
 		}
 		return dirs[i].Path < dirs[j].Path
 	})
-	return dirs
+	sort.Slice(skips, func(i, j int) bool { return skips[i].Sequence < skips[j].Sequence })
+	return dirs, skips
 }
 
-// campaignRootFor walks up from the festival path looking for the campaign
-// marker, so working dirs can be handed to the judge as absolute paths it can
-// actually open. Empty when no campaign root is found, which leaves the
-// relative paths intact and costs the judge only the join.
-func campaignRootFor(festivalPath string) string {
-	dir := festivalPath
-	for {
-		if dir == "" || dir == string(filepath.Separator) {
-			return ""
-		}
-		if info, err := os.Stat(filepath.Join(dir, ".campaign")); err == nil && info.IsDir() {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return ""
-		}
-		dir = parent
+// reportWorkingDirSkips warns about declarations that were dropped, loudest
+// when dropping them left the judge with nothing.
+func reportWorkingDirSkips(w io.Writer, skips []workingDirSkip, kept int) {
+	for _, skip := range skips {
+		_, _ = fmt.Fprintf(w, "fest: ignoring fest_working_dir %q in %s: %s\n", skip.Value, skip.Sequence, skip.Reason)
 	}
+	if len(skips) > 0 && kept == 0 {
+		_, _ = fmt.Fprintln(w, "fest: the judge will see no working directories for this phase")
+	}
+}
+
+// campaignRootFor resolves the campaign containing the festival.
+//
+// Delegates to workspace.DetectCampaign so the judge's notion of the campaign
+// root is the same one the rest of fest uses, including the CAMP_ROOT override
+// and absolute-path resolution. Empty when detection fails, which leaves the
+// relative working-dir paths intact and costs the judge only the join.
+func campaignRootFor(ctx context.Context, festivalPath string) string {
+	root, err := workspace.DetectCampaign(ctx, festivalPath)
+	if err != nil {
+		return ""
+	}
+	return root
 }

--- a/internal/commands/workflow/judge_workdirs_test.go
+++ b/internal/commands/workflow/judge_workdirs_test.go
@@ -1,0 +1,113 @@
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeSequence(t *testing.T, phasePath, name, workingDir string) {
+	t.Helper()
+	dir := filepath.Join(phasePath, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fm := "---\nfest_type: sequence\nfest_id: " + name + "\n"
+	if workingDir != "" {
+		fm += "fest_working_dir: " + workingDir + "\n"
+	}
+	fm += "---\n\n# Sequence Goal\n"
+	if err := os.WriteFile(filepath.Join(dir, "SEQUENCE_GOAL.md"), []byte(fm), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCollectPhaseWorkingDirs(t *testing.T) {
+	phase := t.TempDir()
+	campaign := "/campaigns/demo"
+
+	writeSequence(t, phase, "01_impl", "projects/camp")
+	writeSequence(t, phase, "02_other_repo", "projects/fest")
+	// A design sequence declares none; the judge already sees the festival.
+	writeSequence(t, phase, "03_design", "")
+	// Hidden dirs and loose files must not be mistaken for sequences.
+	if err := os.MkdirAll(filepath.Join(phase, ".fest"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(phase, "PHASE_GOAL.md"), []byte("# goal\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := collectPhaseWorkingDirs(phase, campaign)
+	if len(got) != 2 {
+		t.Fatalf("got %d working dirs, want 2: %+v", len(got), got)
+	}
+	// A phase spanning two repos must report both, tagged by sequence, or a
+	// judge cannot tell which deliverable belongs where.
+	if got[0].Sequence != "01_impl" || got[0].Path != "projects/camp" {
+		t.Errorf("first = %+v", got[0])
+	}
+	if got[1].Sequence != "02_other_repo" || got[1].Path != "projects/fest" {
+		t.Errorf("second = %+v", got[1])
+	}
+	if got[0].AbsolutePath != filepath.Join(campaign, "projects/camp") {
+		t.Errorf("absolute path = %q", got[0].AbsolutePath)
+	}
+}
+
+func TestCollectPhaseWorkingDirsIsBestEffort(t *testing.T) {
+	// A gate must never fail because a sequence is malformed; partial context
+	// beats a checkpoint that cannot run.
+	phase := t.TempDir()
+	writeSequence(t, phase, "01_good", "projects/camp")
+
+	bad := filepath.Join(phase, "02_bad")
+	if err := os.MkdirAll(bad, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bad, "SEQUENCE_GOAL.md"), []byte("not: [valid: yaml\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	escaping := filepath.Join(phase, "03_escaping")
+	if err := os.MkdirAll(escaping, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// An absolute or traversing working dir is rejected by normalization rather
+	// than handed to the judge as a path to open.
+	if err := os.WriteFile(filepath.Join(escaping, "SEQUENCE_GOAL.md"),
+		[]byte("---\nfest_type: sequence\nfest_working_dir: ../../etc\n---\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := collectPhaseWorkingDirs(phase, "/campaigns/demo")
+	if len(got) != 1 || got[0].Path != "projects/camp" {
+		t.Errorf("malformed sequences must be skipped, got %+v", got)
+	}
+}
+
+func TestCollectPhaseWorkingDirsUnreadablePhase(t *testing.T) {
+	if got := collectPhaseWorkingDirs(filepath.Join(t.TempDir(), "missing"), ""); got != nil {
+		t.Errorf("an unreadable phase must yield nothing, got %+v", got)
+	}
+}
+
+func TestCampaignRootFor(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".campaign"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	festival := filepath.Join(root, "festivals", "active", "demo-D0001")
+	if err := os.MkdirAll(festival, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := campaignRootFor(festival); got != root {
+		t.Errorf("campaignRootFor = %q, want %q", got, root)
+	}
+	// No campaign marker anywhere: relative paths still work, so this must
+	// return empty rather than guessing.
+	if got := campaignRootFor(t.TempDir()); got != "" {
+		t.Errorf("want empty for a non-campaign path, got %q", got)
+	}
+}

--- a/internal/commands/workflow/judge_workdirs_test.go
+++ b/internal/commands/workflow/judge_workdirs_test.go
@@ -1,8 +1,12 @@
 package workflow
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -24,7 +28,6 @@ func writeSequence(t *testing.T, phasePath, name, workingDir string) {
 
 func TestCollectPhaseWorkingDirs(t *testing.T) {
 	phase := t.TempDir()
-	campaign := "/campaigns/demo"
 
 	writeSequence(t, phase, "01_impl", "projects/camp")
 	writeSequence(t, phase, "02_other_repo", "projects/fest")
@@ -38,9 +41,12 @@ func TestCollectPhaseWorkingDirs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := collectPhaseWorkingDirs(phase, campaign)
+	got, skipped := collectPhaseWorkingDirs(phase)
 	if len(got) != 2 {
 		t.Fatalf("got %d working dirs, want 2: %+v", len(got), got)
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("declaring none is not a skip, got %+v", skipped)
 	}
 	// A phase spanning two repos must report both, tagged by sequence, or a
 	// judge cannot tell which deliverable belongs where.
@@ -50,8 +56,30 @@ func TestCollectPhaseWorkingDirs(t *testing.T) {
 	if got[1].Sequence != "02_other_repo" || got[1].Path != "projects/fest" {
 		t.Errorf("second = %+v", got[1])
 	}
-	if got[0].AbsolutePath != filepath.Join(campaign, "projects/camp") {
-		t.Errorf("absolute path = %q", got[0].AbsolutePath)
+}
+
+// Paths must stay campaign-relative. An absolute path per working dir would
+// carry the operator's home directory and username into the judge prompt, the
+// provider's logs, and every ledger entry and transcript that records the run.
+func TestCollectPhaseWorkingDirsEmitsRelativePathsOnly(t *testing.T) {
+	phase := t.TempDir()
+	writeSequence(t, phase, "01_impl", "projects/camp")
+
+	got, _ := collectPhaseWorkingDirs(phase)
+	if len(got) != 1 {
+		t.Fatalf("got %d working dirs, want 1", len(got))
+	}
+	if filepath.IsAbs(got[0].Path) {
+		t.Fatalf("path %q is absolute; working dirs must stay campaign-relative", got[0].Path)
+	}
+
+	// The JSON contract must not carry an absolute path field either.
+	raw, err := json.Marshal(got[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(raw, []byte("absolute_path")) {
+		t.Fatalf("working dir JSON still exposes absolute_path: %s", raw)
 	}
 }
 
@@ -69,30 +97,67 @@ func TestCollectPhaseWorkingDirsIsBestEffort(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	escaping := filepath.Join(phase, "03_escaping")
-	if err := os.MkdirAll(escaping, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	// An absolute or traversing working dir is rejected by normalization rather
-	// than handed to the judge as a path to open.
-	if err := os.WriteFile(filepath.Join(escaping, "SEQUENCE_GOAL.md"),
-		[]byte("---\nfest_type: sequence\nfest_working_dir: ../../etc\n---\n"), 0o600); err != nil {
-		t.Fatal(err)
+	// Values normalization must reject rather than hand to the judge to open.
+	for name, value := range map[string]string{
+		"03_traversing": "../../etc",
+		"04_absolute":   "/etc",
+		"05_home":       "~/secrets",
+	} {
+		writeSequence(t, phase, name, value)
 	}
 
-	got := collectPhaseWorkingDirs(phase, "/campaigns/demo")
+	got, skipped := collectPhaseWorkingDirs(phase)
 	if len(got) != 1 || got[0].Path != "projects/camp" {
 		t.Errorf("malformed sequences must be skipped, got %+v", got)
+	}
+	// A declaration that was present but rejected is not the same as none, and
+	// must be reported rather than vanishing.
+	if len(skipped) != 3 {
+		t.Fatalf("got %d reported skips, want 3: %+v", len(skipped), skipped)
+	}
+	for _, skip := range skipped {
+		if skip.Value == "" || skip.Reason == "" {
+			t.Errorf("skip must carry the offending value and a reason: %+v", skip)
+		}
+	}
+}
+
+// The failure that matters is a phase where every declaration was rejected: the
+// judge then sees no working dirs at all, which is indistinguishable from a
+// design phase unless it is said out loud.
+func TestReportWorkingDirSkipsWarnsLoudlyWhenNothingKept(t *testing.T) {
+	var out bytes.Buffer
+	reportWorkingDirSkips(&out, []workingDirSkip{
+		{Sequence: "01_impl", Value: "/etc", Reason: "must be relative"},
+	}, 0)
+
+	got := out.String()
+	if !strings.Contains(got, "01_impl") || !strings.Contains(got, "/etc") {
+		t.Errorf("warning must name the sequence and the value: %q", got)
+	}
+	if !strings.Contains(got, "no working directories") {
+		t.Errorf("warning must say the judge got nothing: %q", got)
+	}
+
+	// When something was kept, the phase is only partially degraded.
+	out.Reset()
+	reportWorkingDirSkips(&out, []workingDirSkip{
+		{Sequence: "01_impl", Value: "/etc", Reason: "must be relative"},
+	}, 1)
+	if strings.Contains(out.String(), "no working directories") {
+		t.Errorf("must not claim the judge got nothing when a dir was kept: %q", out.String())
 	}
 }
 
 func TestCollectPhaseWorkingDirsUnreadablePhase(t *testing.T) {
-	if got := collectPhaseWorkingDirs(filepath.Join(t.TempDir(), "missing"), ""); got != nil {
-		t.Errorf("an unreadable phase must yield nothing, got %+v", got)
+	got, skipped := collectPhaseWorkingDirs(filepath.Join(t.TempDir(), "missing"))
+	if got != nil || skipped != nil {
+		t.Errorf("an unreadable phase must yield nothing, got %+v / %+v", got, skipped)
 	}
 }
 
 func TestCampaignRootFor(t *testing.T) {
+	ctx := context.Background()
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, ".campaign"), 0o755); err != nil {
 		t.Fatal(err)
@@ -102,12 +167,66 @@ func TestCampaignRootFor(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got := campaignRootFor(festival); got != root {
+	if got := campaignRootFor(ctx, festival); got != root {
 		t.Errorf("campaignRootFor = %q, want %q", got, root)
 	}
 	// No campaign marker anywhere: relative paths still work, so this must
 	// return empty rather than guessing.
-	if got := campaignRootFor(t.TempDir()); got != "" {
+	if got := campaignRootFor(ctx, t.TempDir()); got != "" {
 		t.Errorf("want empty for a non-campaign path, got %q", got)
+	}
+}
+
+// The judge's campaign root must be the one the rest of fest resolves, or the
+// relative working dirs are relative to a different tree than the judge opens.
+func TestCampaignRootForHonorsCampRoot(t *testing.T) {
+	ctx := context.Background()
+	override := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(override, ".campaign"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// A festival that would otherwise resolve to its own enclosing campaign.
+	other := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(other, ".campaign"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	festival := filepath.Join(other, "festivals", "active", "demo-D0001")
+	if err := os.MkdirAll(festival, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("CAMP_ROOT", override)
+	if got := campaignRootFor(ctx, festival); got != override {
+		t.Errorf("campaignRootFor ignored CAMP_ROOT: got %q, want %q", got, override)
+	}
+}
+
+// The request shape is the contract the obey judge pins against.
+func TestApprovalJudgeRequestJSONKeys(t *testing.T) {
+	raw, err := json.Marshal(approvalJudgeRequest{
+		SchemaVersion: approvalJudgeSchemaVersion,
+		CampaignRoot:  "/campaigns/demo",
+		WorkingDirs:   []judgeWorkingDir{{Sequence: "01_impl", Path: "projects/camp"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{`"campaign_root"`, `"working_dirs"`, `"sequence"`, `"path"`} {
+		if !bytes.Contains(raw, []byte(key)) {
+			t.Errorf("request JSON missing %s: %s", key, raw)
+		}
+	}
+
+	// Both fields are additive; an older judge must see the request unchanged
+	// when a phase declares no working dirs.
+	raw, err = json.Marshal(approvalJudgeRequest{SchemaVersion: approvalJudgeSchemaVersion})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"campaign_root", "working_dirs"} {
+		if bytes.Contains(raw, []byte(key)) {
+			t.Errorf("empty %s must be omitted: %s", key, raw)
+		}
 	}
 }


### PR DESCRIPTION
> Pairs with a change in `obey` (`ob judge` must read the new fields). This PR is the sending half; it is additive and safe to merge alone.

A judge evaluating an implementation phase **cannot see the implementation.**

## The gap

`approvalJudgeRequest` carries `festival_path` and `phase_path`. Implementation phases produce code in `projects/*`. Nothing in the request mentions that directory exists.

So the judge is asked *"does the implementation satisfy the PHASE_GOAL objectives?"* while structurally unable to open one file of what was built. It cannot check the branch, read the diff, confirm the gate passed, or see that PRs exist.

What it can read is whatever the executor wrote **into the festival** about its own work. Driving festival MN0001 to completion, every implementation verdict rested on `results-summary.md` and `results/*.md` — prose I authored describing a repository the request never mentioned. The judge approved my account of the work rather than the work. That is a fair judge doing its best with an incomplete request.

## The change

Two additive fields:

```go
CampaignRoot string            `json:"campaign_root,omitempty"`
WorkingDirs  []judgeWorkingDir `json:"working_dirs,omitempty"`
```

`working_dirs` is derived from each sequence's `fest_working_dir` and **tagged with the sequence that declared it**, so a phase spanning two repositories tells the judge which deliverable belongs where. Absolute paths are resolved so the judge can open them directly.

Against the real MN0001 festival:

```
campaign_root = "/Users/lancerogers/Dev/AI/obey-campaign"
004_IMPLEMENT_NAVIGATION working_dirs = [
  {"sequence":"01_origin_threading","path":"projects/camp","absolute_path":"/Users/.../projects/camp"},
  {"sequence":"02_adopt_origin","path":"projects/camp","absolute_path":"/Users/.../projects/camp"},
  {"sequence":"03_skew_visibility","path":"projects/camp","absolute_path":"/Users/.../projects/camp"}
]
```

## Deliberate choices

- **Best-effort collection.** An unreadable or malformed sequence is skipped rather than failing the checkpoint. A judge with partial context beats a gate that will not run.
- **Normalization is a gate, not a formality.** A working dir that is absolute or escapes the campaign root is rejected instead of being handed over as a path to open.
- **A phase that declares none sends none.** Design and docs phases keep today's behavior exactly; the festival is already visible through `phase_path`.
- **Additive to `fest.approval.judge/v1`.** An older judge ignores both fields.

## Tests

`just gate` green: 2687.

`TestCollectPhaseWorkingDirs` (multi-repo phase, sequence tagging, hidden dirs and loose files ignored), `TestCollectPhaseWorkingDirsIsBestEffort` (malformed YAML and a traversing path both skipped, the good one survives), `TestCollectPhaseWorkingDirsUnreadablePhase`, `TestCampaignRootFor` (found, and empty rather than guessed when absent).

## The obey half

`ob judge` currently reads `document` plus `evidence`. To use this it needs to read `working_dirs` and actually inspect them — at minimum branch and dirty state per dir, and the ability to read files there when the step's criteria are about code. I will open that separately.

## Related

[fest#299](https://github.com/Obedience-Corp/fest/pull/299) fixes the adjacent defect where evidence bullets the parser could not read were silently dropped, so the judge was launched holding only an unchecked goal template.
