### PR TITLE
fix(tui): drop phantom festival type "quick" from create pickers

### DIFF
--- a/internal/commands/tui/charm_festival.go
+++ b/internal/commands/tui/charm_festival.go
@@ -24,7 +24,8 @@ func charmCreateFestival(ctx context.Context) error {
 	}
 
 	var name, goal, tags string
-	festivalTypes := []string{"standard", "implementation", "research", "quick", "ritual"}
+	// Keep in sync with festival_types.yaml / fest types festival — no phantom types.
+	festivalTypes := []string{"standard", "implementation", "research", "ritual"}
 	var festType = festivalTypes[0]
 	form := huh.NewForm(
 		huh.NewGroup(
@@ -94,7 +95,8 @@ func charmPlanFestivalWizard(ctx context.Context) error {
 		return err
 	}
 	var name, goal, tags string
-	festivalTypes := []string{"standard", "implementation", "research", "quick", "ritual"}
+	// Keep in sync with festival_types.yaml / fest types festival — no phantom types.
+	festivalTypes := []string{"standard", "implementation", "research", "ritual"}
 	var festType = festivalTypes[0]
 	base := huh.NewForm(
 		huh.NewGroup(

--- a/internal/commands/tui/fallback_festival.go
+++ b/internal/commands/tui/fallback_festival.go
@@ -28,7 +28,8 @@ func tuiCreateFestival(ctx context.Context, display *ui.UI) error {
 	}
 	goal := strings.TrimSpace(display.PromptDefault("Festival goal", ""))
 	tags := strings.TrimSpace(display.PromptDefault("Tags (comma-separated)", ""))
-	festTypes := []string{"standard", "implementation", "research", "quick", "ritual"}
+	// Keep in sync with festival_types.yaml / fest types festival — no phantom types.
+	festTypes := []string{"standard", "implementation", "research", "ritual"}
 	tIdx := display.Choose("Festival type:", festTypes)
 	if tIdx < 0 || tIdx >= len(festTypes) {
 		tIdx = 0
@@ -101,7 +102,8 @@ func tuiPlanFestivalWizard(ctx context.Context, display *ui.UI) error {
 	}
 	goal := strings.TrimSpace(display.PromptDefault("Festival goal", ""))
 	tags := strings.TrimSpace(display.PromptDefault("Tags (comma-separated)", ""))
-	festTypes := []string{"standard", "implementation", "research", "quick", "ritual"}
+	// Keep in sync with festival_types.yaml / fest types festival — no phantom types.
+	festTypes := []string{"standard", "implementation", "research", "ritual"}
 	tIdx := display.Choose("Festival type:", festTypes)
 	if tIdx < 0 || tIdx >= len(festTypes) {
 		tIdx = 0


### PR DESCRIPTION
## Summary
Follow-up to #301. CLI type discovery no longer advertises `quick`, but the charm/fallback festival create pickers still offered it as a selectable type.

## Changes
- Remove `quick` from TUI festival type lists in `charm_festival.go` and `fallback_festival.go`
- Align pickers with `festival_types.yaml` / `fest types festival`

## Test plan
- [x] `go test ./internal/commands/tui/`
- [ ] Interactive: festival create picker no longer shows `quick`