### PR TITLE
fix(shared): standing inside a festival wins over a project link

### DIFF
--- a/internal/commands/shared/festival_path.go
+++ b/internal/commands/shared/festival_path.go
@@ -12,34 +12,49 @@ import (
 
 // ResolveFestivalPath resolves the festival path from multiple sources in priority order:
 //  1. Explicit path (--festival flag, highest priority)
-//  2. Navigation link for current directory (fest link)
-//  3. FindFestivalRoot from current directory (fallback - looks for fest.yaml)
+//  2. FindFestivalRoot from current directory (standing inside a festival)
+//  3. Navigation link for current directory (fest link)
 //
-// This allows fest commands to work from linked project directories without
-// requiring the user to cd into the festival directory.
+// Standing inside a festival must outrank a project link. FindFestivalForPath
+// walks up the directory tree, so a festival linked to a directory that
+// contains other festivals claims every path beneath it. The campaign root is
+// the case that bites: a sequence with fest_working_dir "." links its festival
+// to the root, and the root contains festivals/, so every other festival in the
+// campaign resolves to the linked one. That sent `fest next` into a different
+// festival than the one the caller was standing in.
+//
+// Links still work from anywhere they are supposed to: a linked project or
+// worktree is not itself a festival, so FindFestivalRoot fails there and
+// resolution falls through to the link.
 func ResolveFestivalPath(cwd, explicitPath string) (string, error) {
 	// 1. Explicit flag takes precedence
 	if explicitPath != "" {
 		return explicitPath, nil
 	}
 
-	// 2. Check for linked festival
+	// 2. Standing inside a festival wins over any link covering this path.
+	festivalPath, rootErr := template.FindFestivalRoot(cwd)
+	if rootErr == nil && festivalPath != "" {
+		return festivalPath, nil
+	}
+
+	// 3. Check for linked festival (running from a linked project or worktree)
 	nav, err := navigation.LoadNavigation()
 	if err == nil {
 		if linkedFestivalName := nav.FindFestivalForPath(cwd); linkedFestivalName != "" {
 			// Found a linked festival name, now search for its actual path
 			festivalsRoot, err := workspace.FindFestivals(cwd)
 			if err == nil && festivalsRoot != "" {
-				festivalPath, err := findFestivalByName(festivalsRoot, linkedFestivalName)
+				linkedPath, err := findFestivalByName(festivalsRoot, linkedFestivalName)
 				if err == nil {
-					return festivalPath, nil
+					return linkedPath, nil
 				}
 			}
 		}
 	}
 
-	// 3. Fall back to festival root detection
-	return template.FindFestivalRoot(cwd)
+	// 4. No festival at cwd and no usable link: report the original detection error.
+	return festivalPath, rootErr
 }
 
 // findFestivalByName searches for a festival by name in all status directories

--- a/internal/commands/shared/festival_path_test.go
+++ b/internal/commands/shared/festival_path_test.go
@@ -170,6 +170,104 @@ func TestResolveFestivalPath_NoFestival(t *testing.T) {
 	}
 }
 
+// setupRootLinkedCampaign builds a campaign whose "linked" festival is linked to
+// the campaign root itself, the shape produced by a sequence with
+// fest_working_dir ".". It returns the campaign root and the two festival paths.
+func setupRootLinkedCampaign(t *testing.T) (root, linkedFest, otherFest string) {
+	t.Helper()
+	root = t.TempDir()
+
+	linkedFest = filepath.Join(root, "festivals", "active", "linked-festival-LK0001")
+	otherFest = filepath.Join(root, "festivals", "ready", "other-festival-OT0001")
+	for _, dir := range []string{linkedFest, otherFest} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "fest.yaml"), []byte("name: test\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Join(root, ".campaign", "fest"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Mark the festivals root so workspace.FindFestivals resolves it, as it
+	// would in a real campaign.
+	dotFestival := filepath.Join(root, "festivals", ".festival")
+	if err := os.MkdirAll(dotFestival, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dotFestival, ".workspace"), []byte("{}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CAMP_ROOT", root)
+
+	nav, err := navigation.LoadNavigation()
+	if err != nil {
+		t.Fatalf("failed to load navigation: %v", err)
+	}
+	// Link the festival to the campaign root, so its link covers every other
+	// festival in the campaign.
+	nav.SetLinkWithPath("linked-festival-LK0001", root, linkedFest)
+	if err := nav.Save(); err != nil {
+		t.Fatalf("failed to save navigation: %v", err)
+	}
+	return root, linkedFest, otherFest
+}
+
+// A festival linked to the campaign root must not capture other festivals.
+// FindFestivalForPath walks up the tree, so before the precedence fix standing
+// inside any festival resolved to the root-linked one, sending fest next into
+// the wrong festival entirely.
+func TestResolveFestivalPath_FestivalCwdBeatsRootLink(t *testing.T) {
+	_, _, otherFest := setupRootLinkedCampaign(t)
+
+	got, err := ResolveFestivalPath(otherFest, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != otherFest {
+		t.Errorf("standing inside %q resolved to %q; the root link must not win", otherFest, got)
+	}
+}
+
+// The same must hold from a subdirectory of the festival you are standing in.
+func TestResolveFestivalPath_FestivalSubdirBeatsRootLink(t *testing.T) {
+	_, _, otherFest := setupRootLinkedCampaign(t)
+
+	phaseDir := filepath.Join(otherFest, "001_IMPLEMENT")
+	if err := os.MkdirAll(phaseDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ResolveFestivalPath(phaseDir, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != otherFest {
+		t.Errorf("standing inside %q resolved to %q; the root link must not win", phaseDir, got)
+	}
+}
+
+// Links must still resolve from a directory that is not itself a festival,
+// which is the reason links exist.
+func TestResolveFestivalPath_LinkStillWinsOutsideAnyFestival(t *testing.T) {
+	root, linkedFest, _ := setupRootLinkedCampaign(t)
+
+	workDir := filepath.Join(root, "projects", "some-project")
+	if err := os.MkdirAll(workDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ResolveFestivalPath(workDir, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != linkedFest {
+		t.Errorf("from non-festival %q resolved to %q, want the linked festival %q", workDir, got, linkedFest)
+	}
+}
+
 func TestFindFestivalByName(t *testing.T) {
 	tmpDir := t.TempDir()
 	festivalsDir := filepath.Join(tmpDir, "festivals")


### PR DESCRIPTION
## The bug

`fest next` run from inside one festival hands back a task from a different festival, and `fest validate` reports that festival's errors while the one you are standing in goes unchecked.

Reproduced live in the campaign, same directory, two commands:

```
$ pwd
/Users/lancerogers/Dev/AI/obey-campaign/festivals/ready/judge-evidence-orientation-JE0001

$ fest id
JE0001

$ fest next --cd
/Users/lancerogers/Dev/AI/obey-campaign/festivals/active/file-watcher-correctness-and-efficiency-FW0003/001_IMPLEMENT/01_filesystem_layout_contract
```

## Cause

`ResolveFestivalPath` (`internal/commands/shared/festival_path.go`) checked navigation links **before** festival-root detection:

1. explicit path
2. navigation link for cwd
3. `FindFestivalRoot(cwd)`

`Navigation.FindFestivalForPath` (`internal/navigation/state.go:311`) walks **up** the directory tree looking for a linked path. So any festival linked to a directory that contains other festivals claims every path beneath it.

The campaign root is the case that bites. A sequence with `fest_working_dir: "."` links its festival to the campaign root:

```yaml
file-watcher-correctness-and-efficiency-FW0003:
  path: .
  festival_path: festivals/active/file-watcher-correctness-and-efficiency-FW0003
```

The root contains `festivals/`, so from that moment every other festival in the campaign resolved to FW0003. `fest id` uses `FindFestivalRoot` directly and stayed correct, which is why the two commands disagree.

## Why this is worse than wrong output

The masking is the dangerous half. A festival that was never validated reports that it passes, because the validator read a different festival. That is exactly what happened here: `fest validate` printed `✓ Festival structure passes all checks` for a festival carrying unfilled `[FILL:` markers and no quality gates on any sequence. Those defects only surfaced once this fix made validation read the right festival.

For an agent driving `fest next` in a loop, the failure mode is executing another festival's task while believing it is working on the current one.

## Fix

Reorder resolution so cwd wins:

1. explicit path
2. **`FindFestivalRoot(cwd)`** — standing inside a festival
3. navigation link
4. otherwise, return the original detection error

Links keep working everywhere they are meant to. A linked project or worktree is not itself a festival, so `FindFestivalRoot` fails there and resolution falls through to the link exactly as before.

## Tests

Three added to `festival_path_test.go`, built on a fixture whose linked festival is linked to the campaign root, reproducing the real shape:

- `TestResolveFestivalPath_FestivalCwdBeatsRootLink` — standing in another festival resolves to that festival
- `TestResolveFestivalPath_FestivalSubdirBeatsRootLink` — same from a phase subdirectory
- `TestResolveFestivalPath_LinkStillWinsOutsideAnyFestival` — a non-festival directory under the root still resolves through the link

Confirmed the first two fail without the fix and pass with it:

```
$ git stash push internal/commands/shared/festival_path.go
--- FAIL: TestResolveFestivalPath_FestivalCwdBeatsRootLink (0.02s)
--- FAIL: TestResolveFestivalPath_FestivalSubdirBeatsRootLink (0.00s)
```

Note the pre-existing `TestResolveFestivalPath_LinkedProject` never called `ResolveFestivalPath` for the link case; it asserted on `FindFestivalForPath` directly with a comment saying the rest needed mocking. The third test above closes that gap, which is why the link path also needed a `festivals/.festival/.workspace` marker in the fixture.

## Verification

`just lint all` clean. `just test unit` 2705/2705 pass.

Behavioral check with a built binary from the same directory as the reproduction above: the old binary returns the FW0003 task path, the fixed binary resolves JE0001 and reports JE0001's own real validation errors.