### PR TITLE
fix(commit): use FE reference prefix

### DIFF
--- a/docs/cli-reference/fest-reference.md
+++ b/docs/cli-reference/fest-reference.md
@@ -379,8 +379,7 @@ with only festival-scoped files staged (not git add -A).
 
 Use --no-root to skip the campaign root commit.
 
-Reference format: [OBEY-FE-{id}]
-  - OBEY: Obey workflow tool prefix
+Reference format: [FE-{id}]
   - FE: Festival component identifier
   - {id}: Task ref (FEST-xxxxxx) or festival ID (e.g., CS0001)
 
@@ -393,14 +392,14 @@ Detection priority:
 Examples:
 ```bash
   fest commit -m "Implement feature"
-  # In linked project → [OBEY-FE-CS0001] Implement feature
-  # In festival task  → [OBEY-FE-FEST-a3b2c1] Implement feature
+  # In linked project → [FE-CS0001] Implement feature
+  # In festival task  → [FE-FEST-a3b2c1] Implement feature
 
   fest commit --task FEST-b4c5d6 -m "Related work"
-  # → [OBEY-FE-FEST-b4c5d6] Related work
+  # → [FE-FEST-b4c5d6] Related work
 
   fest commit --festival OA0001 -m "Work from unlinked dir"
-  # → [OBEY-FE-OA0001] Work from unlinked dir
+  # → [FE-OA0001] Work from unlinked dir
 
   fest commit --no-tag -m "No reference"
   # → No reference

--- a/docs/cli-reference/fest_commit.md
+++ b/docs/cli-reference/fest_commit.md
@@ -23,8 +23,7 @@ with only festival-scoped files staged (not git add -A).
 
 Use --no-root to skip the campaign root commit.
 
-Reference format: [OBEY-FE-{id}]
-  - OBEY: Obey workflow tool prefix
+Reference format: [FE-{id}]
   - FE: Festival component identifier
   - {id}: Task ref (FEST-xxxxxx) or festival ID (e.g., CS0001)
 
@@ -37,14 +36,14 @@ Detection priority:
 Examples:
 ```bash
   fest commit -m "Implement feature"
-  # In linked project → [OBEY-FE-CS0001] Implement feature
-  # In festival task  → [OBEY-FE-FEST-a3b2c1] Implement feature
+  # In linked project → [FE-CS0001] Implement feature
+  # In festival task  → [FE-FEST-a3b2c1] Implement feature
 
   fest commit --task FEST-b4c5d6 -m "Related work"
-  # → [OBEY-FE-FEST-b4c5d6] Related work
+  # → [FE-FEST-b4c5d6] Related work
 
   fest commit --festival OA0001 -m "Work from unlinked dir"
-  # → [OBEY-FE-OA0001] Work from unlinked dir
+  # → [FE-OA0001] Work from unlinked dir
 
   fest commit --no-tag -m "No reference"
   # → No reference

--- a/docs/commit_reference_format.md
+++ b/docs/commit_reference_format.md
@@ -1,20 +1,14 @@
 # Commit Reference Format
 
-This document describes the standardized commit reference format used by `fest commit` and other Obey workflow tools.
+This document describes the standardized commit reference format used by `fest commit`.
 
 ## Format Specification
 
 ```
-[OBEY-{COMPONENT}-{ID}]
+[FE-{ID}]
 ```
 
-### Components
-
-| Component | Code | Description |
-|-----------|------|-------------|
-| Festival  | `FE` | Festival methodology workflow tool |
-
-*Additional components will be added as the Obey ecosystem expands.*
+`FE` identifies a Festival methodology reference.
 
 ### ID Types
 
@@ -28,9 +22,9 @@ The `{ID}` portion varies by context:
 ### Full Examples
 
 ```
-[OBEY-FE-CS0001] Add user authentication
-[OBEY-FE-FEST-a3b2c1] Fix login validation bug
-[OBEY-FE-TODO0001] Update documentation
+[FE-CS0001] Add user authentication
+[FE-FEST-a3b2c1] Fix login validation bug
+[FE-TODO0001] Update documentation
 ```
 
 ## Detection Priority
@@ -51,7 +45,7 @@ When working in a project linked to a festival (via fest.yaml `project_path` or 
 ```bash
 # In linked project ~/projects/my-app
 fest commit -m "Add feature"
-# → [OBEY-FE-CS0001] Add feature
+# → [FE-CS0001] Add feature
 ```
 
 ### Inside Festival Tasks
@@ -61,29 +55,16 @@ When working inside a festival's task directory, `fest commit` uses the **task r
 ```bash
 # In ~/festivals/active/client-sync/01_setup/01_auth/03_oauth.md
 fest commit -m "Implement OAuth flow"
-# → [OBEY-FE-FEST-a3b2c1] Implement OAuth flow
+# → [FE-FEST-a3b2c1] Implement OAuth flow
 ```
 
 ## Design Rationale
 
 ### Why This Format?
 
-1. **Namespace isolation**: The `OBEY-` prefix prevents conflicts with other tooling
-2. **Component identification**: The two-letter component code (`FE`) allows multiple tools to share the format
-3. **Traceability**: Every commit links back to its planning context
-4. **Machine-parseable**: Consistent format enables automated reporting and tracking
-
-### Future Components
-
-The format is designed to accommodate additional Obey workflow components:
-
-| Component | Code | Purpose |
-|-----------|------|---------|
-| Camp | `CA` | Campaign navigation and scaffolding |
-| Intent | `IN` | Intent tracking system |
-| Review | `RV` | Code review workflow |
-
-These are reserved codes that may be implemented in future versions.
+1. **Component identification**: The `FE` prefix identifies Festival references without a redundant product namespace
+2. **Traceability**: Every commit links back to its planning context
+3. **Machine-parseable**: Consistent format enables automated reporting and tracking
 
 ## Configuration
 
@@ -110,13 +91,13 @@ Use standard git tools to find commits by reference:
 
 ```bash
 # Find all commits for a festival
-git log --grep="OBEY-FE-CS0001"
+git log --grep="FE-CS0001"
 
 # Find commits for a specific task
-git log --grep="OBEY-FE-FEST-a3b2c1"
+git log --grep="FE-FEST-a3b2c1"
 
 # Count commits per festival
-git log --oneline | grep -oE '\[OBEY-FE-[A-Z0-9]+\]' | sort | uniq -c
+git log --oneline | grep -oE '\[FE-[A-Z0-9]+\]' | sort | uniq -c
 ```
 
 ## Integration with CI/CD
@@ -128,7 +109,7 @@ The standardized format enables automation:
 - name: Get Festival Context
   run: |
     COMMIT_MSG=$(git log -1 --format=%s)
-    if [[ $COMMIT_MSG =~ \[OBEY-FE-([A-Z0-9-]+)\] ]]; then
+    if [[ $COMMIT_MSG =~ \[FE-([A-Z0-9-]+)\] ]]; then
       echo "FEST_ID=${BASH_REMATCH[1]}" >> $GITHUB_ENV
     fi
 ```

--- a/internal/commands/commit/commit.go
+++ b/internal/commands/commit/commit.go
@@ -21,8 +21,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Commit reference format prefix: OBEY-FE (Obey Festival component)
-const commitRefPrefix = "OBEY-FE"
+// Commit reference format prefix: FE (Festival component)
+const commitRefPrefix = "FE"
 
 var (
 	message          string
@@ -63,8 +63,7 @@ with only festival-scoped files staged (not git add -A).
 
 Use --no-root to skip the campaign root commit.
 
-Reference format: [OBEY-FE-{id}]
-  - OBEY: Obey workflow tool prefix
+Reference format: [FE-{id}]
   - FE: Festival component identifier
   - {id}: Task ref (FEST-xxxxxx) or festival ID (e.g., CS0001)
 
@@ -76,14 +75,14 @@ Detection priority:
 
 Examples:
   fest commit -m "Implement feature"
-  # In linked project → [OBEY-FE-CS0001] Implement feature
-  # In festival task  → [OBEY-FE-FEST-a3b2c1] Implement feature
+  # In linked project → [FE-CS0001] Implement feature
+  # In festival task  → [FE-FEST-a3b2c1] Implement feature
 
   fest commit --task FEST-b4c5d6 -m "Related work"
-  # → [OBEY-FE-FEST-b4c5d6] Related work
+  # → [FE-FEST-b4c5d6] Related work
 
   fest commit --festival OA0001 -m "Work from unlinked dir"
-  # → [OBEY-FE-OA0001] Work from unlinked dir
+  # → [FE-OA0001] Work from unlinked dir
 
   fest commit --no-tag -m "No reference"
   # → No reference
@@ -368,7 +367,7 @@ func stageAllChanges(ctx context.Context) error {
 }
 
 // formatCommitRef formats an ID with the standard commit reference prefix.
-// Format: [OBEY-FE-{id}] where FE = Festival component
+// Format: [FE-{id}] where FE = Festival component
 func formatCommitRef(id string) string {
 	return fmt.Sprintf("%s-%s", commitRefPrefix, id)
 }
@@ -459,8 +458,8 @@ func commitWithCampaignSupport(ctx context.Context, ws *scope.WorkspaceInfo, rep
 		if err == nil && cid != "" {
 			name, _ := commitkit.DetectCampaignName(ctx)
 			if festRef != "" {
-				// festRef is "OBEY-FE-<id>"; pass the bare id (the formatter re-adds FE-).
-				festID := strings.TrimPrefix(strings.TrimPrefix(festRef, "OBEY-"), "FE-")
+				// festRef is "FE-<id>"; pass the bare id (the formatter re-adds FE-).
+				festID := strings.TrimPrefix(festRef, commitRefPrefix+"-")
 				tag := commitkit.FormatContextTagsFullNamed(name, cid, "", festID, "")
 				commitMessage = tag + " " + rawMsg
 				result.CampaignTag = tag

--- a/internal/commands/commit/commit_test.go
+++ b/internal/commands/commit/commit_test.go
@@ -6,6 +6,14 @@ import (
 	"testing"
 )
 
+func TestFormatCommitRef(t *testing.T) {
+	t.Parallel()
+
+	if got, want := formatCommitRef("CA0004"), "FE-CA0004"; got != want {
+		t.Errorf("formatCommitRef() = %q, want %q", got, want)
+	}
+}
+
 func TestNewCommitCommand_NoRootFlag(t *testing.T) {
 	cmd := NewCommitCommand()
 


### PR DESCRIPTION
## Summary

- replace Fest's standalone `OBEY-FE` commit-reference prefix with `FE`
- preserve campaign tag consolidation by extracting festival IDs from the new prefix
- update generated CLI references and commit-format documentation
- add regression coverage for `FE-CA0004` formatting

## Why

Fest was still exposing the retired Obey namespace in standalone references and post-commit output even though campaign commits already use consolidated name-style tags. The Festival component prefix should be `FE` directly.

## User impact

Standalone Fest commits and the `Task` field in commit output now use references such as `FE-CA0004`. Campaign commits continue to use consolidated tags such as `[obey-campaign:8deed8b4-FE-CA0004]`.

## Validation

- `just gate`
  - stable and dev builds
  - stable, dev, and integration vet
  - golangci-lint: 0 issues
  - 2,703/2,703 unit tests
  - 71/71 containerized integration tests
