### PR TITLE
feat(tui): standalone WORKFLOW.md create wizard

### DIFF
--- a/internal/commands/tui/charm.go
+++ b/internal/commands/tui/charm.go
@@ -4,7 +4,6 @@ package tui
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
@@ -170,14 +169,9 @@ func StartCreateTUI(ctx context.Context) error {
 				return err
 			}
 		case "workflow":
-			// Full human wizard deferred (intent). Peer must appear on the menu.
-			fmt.Println()
-			fmt.Println("Standalone workflow TUI is not ready yet.")
-			fmt.Println("  Agents/humans can create with:")
-			fmt.Println("    fest create workflow <name>")
-			fmt.Println("  Or with structured steps:")
-			fmt.Println("    fest create workflow <name> --steps-file steps.json")
-			fmt.Println()
+			if err := charmCreateWorkflow(ctx); err != nil {
+				return err
+			}
 		case "phase":
 			if err := charmCreatePhase(ctx); err != nil {
 				return err

--- a/internal/commands/tui/charm_workflow.go
+++ b/internal/commands/tui/charm_workflow.go
@@ -5,7 +5,6 @@ package tui
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/Obedience-Corp/fest/internal/commands/festival"
@@ -21,9 +20,9 @@ func charmCreateWorkflow(ctx context.Context) error {
 		return err
 	}
 
-	// Refuse early when cwd already has a workflow doc (avoid multi-step then fail).
-	if _, err := os.Stat("WORKFLOW.md"); err == nil {
-		return fmt.Errorf("WORKFLOW.md already exists in the current directory — remove it or cd elsewhere")
+	// Refuse early when cwd already has a workflow doc or runtime (avoid multi-step then fail).
+	if err := refuseExistingStandaloneWorkflow("."); err != nil {
+		return err
 	}
 
 	draft := workflowDraft{}
@@ -146,7 +145,7 @@ func stepWorkflowIdentity(ctx context.Context, d *workflowDraft) (bool, error) {
 func stepWorkflowSteps(ctx context.Context, d *workflowDraft) (string, error) {
 	text := d.StepsText
 	if text == "" {
-		text = "Plan|Define the work and success criteria\nImplement|Do the work\nVerify|Confirm done"
+		text = defaultWorkflowStepsText
 	}
 	input := huh.NewForm(
 		huh.NewGroup(
@@ -227,16 +226,13 @@ func submitWorkflowCreate(ctx context.Context, d *workflowDraft) error {
 	if err != nil {
 		return err
 	}
+	// Match CLI BindCreateWorkflowFlags defaults (position=after) so festival-mode
+	// dispatch from a festival cwd works the same as `fest create workflow --steps`.
 	opts := &festival.CreateWorkflowOptions{
-		Name:  strings.TrimSpace(d.Name),
-		Steps: stepsJSON,
+		Name:     strings.TrimSpace(d.Name),
+		Steps:    stepsJSON,
+		Position: "after",
 	}
-	if err := festival.RunCreateWorkflow(ctx, opts); err != nil {
-		return err
-	}
-	fmt.Println()
-	fmt.Println("Standalone workflow ready.")
-	fmt.Println("  next: fest next")
-	fmt.Println()
-	return nil
+	// RunCreateWorkflow owns success output (created / next: fest next).
+	return festival.RunCreateWorkflow(ctx, opts)
 }

--- a/internal/commands/tui/charm_workflow.go
+++ b/internal/commands/tui/charm_workflow.go
@@ -1,0 +1,242 @@
+//go:build !no_charm
+
+package tui
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Obedience-Corp/fest/internal/commands/festival"
+	uitheme "github.com/Obedience-Corp/fest/internal/ui/theme"
+	"github.com/charmbracelet/huh"
+)
+
+// charmCreateWorkflow runs the multi-step human wizard for standalone WORKFLOW.md.
+// Creates in the current directory via festival.RunCreateWorkflow (same path as
+// fest create workflow <name> --steps '{...}').
+func charmCreateWorkflow(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	// Refuse early when cwd already has a workflow doc (avoid multi-step then fail).
+	if _, err := os.Stat("WORKFLOW.md"); err == nil {
+		return fmt.Errorf("WORKFLOW.md already exists in the current directory — remove it or cd elsewhere")
+	}
+
+	draft := workflowDraft{}
+	step := 1
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		switch step {
+		case 1:
+			ok, err := stepWorkflowIdentity(ctx, &draft)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
+			}
+			step = 2
+		case 2:
+			action, err := stepWorkflowSteps(ctx, &draft)
+			if err != nil {
+				return err
+			}
+			switch action {
+			case "next":
+				step = 3
+			case "back":
+				step = 1
+			default:
+				return nil
+			}
+		case 3:
+			action, err := stepWorkflowConfirm(ctx, &draft)
+			if err != nil {
+				return err
+			}
+			switch action {
+			case "create":
+				return submitWorkflowCreate(ctx, &draft)
+			case "back":
+				step = 2
+			default:
+				return nil
+			}
+		default:
+			return fmt.Errorf("unknown workflow create step %d", step)
+		}
+	}
+}
+
+func stepWorkflowIdentity(ctx context.Context, d *workflowDraft) (bool, error) {
+	// Inputs and nav are separate so Back is never blocked by name validation.
+	name, title, desc := d.Name, d.Title, d.Description
+	input := huh.NewForm(
+		huh.NewGroup(
+			huh.NewNote().
+				Title("New standalone workflow · Identity").
+				Description("Creates WORKFLOW.md in the current directory (thin start — not a festival)."),
+			huh.NewInput().
+				Title("Name").
+				Description("Used for workflow_id (wf-<slug>)").
+				Placeholder("my-feature-loop").
+				Value(&name).
+				Validate(func(s string) error {
+					if strings.TrimSpace(s) == "" {
+						return fmt.Errorf("name is required")
+					}
+					return nil
+				}),
+			huh.NewInput().
+				Title("Title").
+				Description("WORKFLOW.md heading (default: name)").
+				Placeholder("optional").
+				Value(&title),
+			huh.NewInput().
+				Title("Intent").
+				Description("One-line purpose (optional)").
+				Placeholder("What this loop is for").
+				Value(&desc),
+		),
+	)
+	if err := uitheme.RunForm(ctx, input); err != nil {
+		if uitheme.IsCancelled(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	nav := "next"
+	navForm := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Continue?").
+				Description("j/k · enter · esc cancel").
+				Options(
+					huh.NewOption("Next: steps", "next"),
+					huh.NewOption("Back", "back"),
+					huh.NewOption("Cancel", "cancel"),
+				).
+				Value(&nav),
+		),
+	)
+	if err := uitheme.RunForm(ctx, navForm); err != nil {
+		if uitheme.IsCancelled(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	switch nav {
+	case "next":
+		d.Name = strings.TrimSpace(name)
+		d.Title = strings.TrimSpace(title)
+		d.Description = strings.TrimSpace(desc)
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+func stepWorkflowSteps(ctx context.Context, d *workflowDraft) (string, error) {
+	text := d.StepsText
+	if text == "" {
+		text = "Plan|Define the work and success criteria\nImplement|Do the work\nVerify|Confirm done"
+	}
+	input := huh.NewForm(
+		huh.NewGroup(
+			huh.NewNote().
+				Title("New standalone workflow · Steps").
+				Description("One step per line: Name|Goal\nExample: Review PR|Check tests and leave comments"),
+			huh.NewText().
+				Title("Steps").
+				Description("Name|Goal per line · empty goal gets a placeholder").
+				Value(&text).
+				CharLimit(4000).
+				Validate(func(s string) error {
+					_, err := parseWorkflowStepsText(s)
+					return err
+				}),
+		),
+	)
+	if err := uitheme.RunForm(ctx, input); err != nil {
+		if uitheme.IsCancelled(err) {
+			return "cancel", nil
+		}
+		return "", err
+	}
+	d.StepsText = text
+
+	nav := "next"
+	navForm := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Continue?").
+				Description("j/k · enter · esc cancel").
+				Options(
+					huh.NewOption("Next: confirm", "next"),
+					huh.NewOption("Back", "back"),
+					huh.NewOption("Cancel", "cancel"),
+				).
+				Value(&nav),
+		),
+	)
+	if err := uitheme.RunForm(ctx, navForm); err != nil {
+		if uitheme.IsCancelled(err) {
+			return "cancel", nil
+		}
+		return "", err
+	}
+	return nav, nil
+}
+
+func stepWorkflowConfirm(ctx context.Context, d *workflowDraft) (string, error) {
+	action := "create"
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewNote().
+				Title("New standalone workflow · Confirm").
+				Description(workflowConfirmSummary(d)),
+			huh.NewSelect[string]().
+				Title("Create WORKFLOW.md?").
+				Description("j/k · enter · esc cancel").
+				Options(
+					huh.NewOption("Create", "create"),
+					huh.NewOption("Back", "back"),
+					huh.NewOption("Cancel", "cancel"),
+				).
+				Value(&action),
+		),
+	)
+	if err := uitheme.RunForm(ctx, form); err != nil {
+		if uitheme.IsCancelled(err) {
+			return "cancel", nil
+		}
+		return "", err
+	}
+	return action, nil
+}
+
+func submitWorkflowCreate(ctx context.Context, d *workflowDraft) error {
+	stepsJSON, err := workflowStepsJSON(d)
+	if err != nil {
+		return err
+	}
+	opts := &festival.CreateWorkflowOptions{
+		Name:  strings.TrimSpace(d.Name),
+		Steps: stepsJSON,
+	}
+	if err := festival.RunCreateWorkflow(ctx, opts); err != nil {
+		return err
+	}
+	fmt.Println()
+	fmt.Println("Standalone workflow ready.")
+	fmt.Println("  next: fest next")
+	fmt.Println()
+	return nil
+}

--- a/internal/commands/tui/fallback.go
+++ b/internal/commands/tui/fallback.go
@@ -97,9 +97,9 @@ func StartCreateTUI(ctx context.Context) error {
 				return err
 			}
 		case 1:
-			display.Info("Standalone workflow TUI is not ready yet.")
-			display.Info("  Use: fest create workflow <name>")
-			display.Info("  Or:  fest create workflow <name> --steps-file steps.json")
+			if err := tuiCreateWorkflow(ctx, display); err != nil {
+				return err
+			}
 		case 2:
 			if err := tuiCreatePhase(ctx, display); err != nil {
 				return err

--- a/internal/commands/tui/fallback_workflow.go
+++ b/internal/commands/tui/fallback_workflow.go
@@ -4,8 +4,6 @@ package tui
 
 import (
 	"context"
-	"fmt"
-	"os"
 	"strings"
 
 	"github.com/Obedience-Corp/fest/internal/commands/festival"
@@ -18,9 +16,8 @@ func tuiCreateWorkflow(ctx context.Context, display *ui.UI) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if _, err := os.Stat("WORKFLOW.md"); err == nil {
-		return errors.Validation("WORKFLOW.md already exists in the current directory").
-			WithHint("remove it or change directory before creating")
+	if err := refuseExistingStandaloneWorkflow("."); err != nil {
+		return err
 	}
 
 	display.Info("New standalone workflow (WORKFLOW.md in current directory)")
@@ -35,6 +32,7 @@ func tuiCreateWorkflow(ctx context.Context, display *ui.UI) error {
 	desc := strings.TrimSpace(display.PromptDefault("Intent (optional)", ""))
 
 	display.Info("Steps: enter Name|Goal per line; empty line ends.")
+	display.Info("Leave empty for starter steps: Plan → Implement → Verify")
 	var lines []string
 	for {
 		if err := ctx.Err(); err != nil {
@@ -46,15 +44,22 @@ func tuiCreateWorkflow(ctx context.Context, display *ui.UI) error {
 		}
 		lines = append(lines, line)
 	}
-	if len(lines) == 0 {
-		return errors.Validation("at least one workflow step is required")
+	stepsText := strings.Join(lines, "\n")
+	if strings.TrimSpace(stepsText) == "" {
+		// Match Charm's starter recipe when the user enters no lines.
+		stepsText = defaultWorkflowStepsText
+		display.Info("Using starter steps: Plan, Implement, Verify")
+	}
+	// Validate before confirm (parity with Charm live validation).
+	if _, err := parseWorkflowStepsText(stepsText); err != nil {
+		return err
 	}
 
 	draft := &workflowDraft{
 		Name:        name,
 		Title:       title,
 		Description: desc,
-		StepsText:   strings.Join(lines, "\n"),
+		StepsText:   stepsText,
 	}
 	display.Info(workflowConfirmSummary(draft))
 	if !display.Confirm("Create WORKFLOW.md now?") {
@@ -66,14 +71,12 @@ func tuiCreateWorkflow(ctx context.Context, display *ui.UI) error {
 	if err != nil {
 		return err
 	}
+	// Match CLI BindCreateWorkflowFlags defaults (position=after).
 	opts := &festival.CreateWorkflowOptions{
-		Name:  name,
-		Steps: stepsJSON,
+		Name:     name,
+		Steps:    stepsJSON,
+		Position: "after",
 	}
-	if err := festival.RunCreateWorkflow(ctx, opts); err != nil {
-		return err
-	}
-	fmt.Println()
-	display.Info("Standalone workflow ready. next: fest next")
-	return nil
+	// RunCreateWorkflow owns success output (created / next: fest next).
+	return festival.RunCreateWorkflow(ctx, opts)
 }

--- a/internal/commands/tui/fallback_workflow.go
+++ b/internal/commands/tui/fallback_workflow.go
@@ -1,0 +1,79 @@
+//go:build no_charm
+
+package tui
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Obedience-Corp/fest/internal/commands/festival"
+	"github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/ui"
+)
+
+// tuiCreateWorkflow is the no_charm linear path for standalone WORKFLOW.md.
+func tuiCreateWorkflow(ctx context.Context, display *ui.UI) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if _, err := os.Stat("WORKFLOW.md"); err == nil {
+		return errors.Validation("WORKFLOW.md already exists in the current directory").
+			WithHint("remove it or change directory before creating")
+	}
+
+	display.Info("New standalone workflow (WORKFLOW.md in current directory)")
+	name := strings.TrimSpace(display.Prompt("Workflow name"))
+	if name == "" {
+		return errors.Validation("workflow name is required")
+	}
+	title := strings.TrimSpace(display.PromptDefault("Title (default: name)", name))
+	if title == "" {
+		title = name
+	}
+	desc := strings.TrimSpace(display.PromptDefault("Intent (optional)", ""))
+
+	display.Info("Steps: enter Name|Goal per line; empty line ends.")
+	var lines []string
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		line := strings.TrimSpace(display.Prompt("  step (empty to finish)"))
+		if line == "" {
+			break
+		}
+		lines = append(lines, line)
+	}
+	if len(lines) == 0 {
+		return errors.Validation("at least one workflow step is required")
+	}
+
+	draft := &workflowDraft{
+		Name:        name,
+		Title:       title,
+		Description: desc,
+		StepsText:   strings.Join(lines, "\n"),
+	}
+	display.Info(workflowConfirmSummary(draft))
+	if !display.Confirm("Create WORKFLOW.md now?") {
+		display.Info("Cancelled.")
+		return nil
+	}
+
+	stepsJSON, err := workflowStepsJSON(draft)
+	if err != nil {
+		return err
+	}
+	opts := &festival.CreateWorkflowOptions{
+		Name:  name,
+		Steps: stepsJSON,
+	}
+	if err := festival.RunCreateWorkflow(ctx, opts); err != nil {
+		return err
+	}
+	fmt.Println()
+	display.Info("Standalone workflow ready. next: fest next")
+	return nil
+}

--- a/internal/commands/tui/workflow_wizard_logic.go
+++ b/internal/commands/tui/workflow_wizard_logic.go
@@ -3,11 +3,18 @@ package tui
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/Obedience-Corp/fest/internal/commands/festival"
 	"github.com/Obedience-Corp/fest/internal/errors"
 )
+
+// defaultWorkflowStepsText is the starter recipe used when the user has not
+// entered steps yet (Charm pre-fills the form; fallback uses it if they
+// finish the step loop with no lines).
+const defaultWorkflowStepsText = "Plan|Define the work and success criteria\nImplement|Do the work\nVerify|Confirm done"
 
 // workflowDraft holds human answers for the standalone WORKFLOW.md create wizard.
 type workflowDraft struct {
@@ -15,6 +22,30 @@ type workflowDraft struct {
 	Title       string // WORKFLOW.md H1 (defaults to Name)
 	Description string // one-line intent
 	StepsText   string // Name|Goal per line
+}
+
+// refuseExistingStandaloneWorkflow fails closed when cwd already has a
+// WORKFLOW.md or .workflow/ runtime, matching runStandaloneCreateWorkflow
+// preconditions so the wizard does not multi-step then fail.
+func refuseExistingStandaloneWorkflow(cwd string) error {
+	if cwd == "" {
+		cwd = "."
+	}
+	doc := filepath.Join(cwd, "WORKFLOW.md")
+	if _, err := os.Stat(doc); err == nil {
+		return errors.Validation("WORKFLOW.md already exists in the current directory").
+			WithHint("remove it or change directory before creating")
+	} else if err != nil && !os.IsNotExist(err) {
+		return errors.IO("checking WORKFLOW.md", err).WithField("path", doc)
+	}
+	runtimeDir := filepath.Join(cwd, ".workflow")
+	if _, err := os.Stat(runtimeDir); err == nil {
+		return errors.Validation(".workflow/ already exists in the current directory").
+			WithHint("use fest workflow start for an existing tracked workflow, or remove .workflow/ before creating a new one")
+	} else if err != nil && !os.IsNotExist(err) {
+		return errors.IO("checking .workflow/", err).WithField("path", runtimeDir)
+	}
+	return nil
 }
 
 // parseWorkflowStepsText parses "Name|Goal" lines (empty lines skipped).

--- a/internal/commands/tui/workflow_wizard_logic.go
+++ b/internal/commands/tui/workflow_wizard_logic.go
@@ -1,0 +1,105 @@
+package tui
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Obedience-Corp/fest/internal/commands/festival"
+	"github.com/Obedience-Corp/fest/internal/errors"
+)
+
+// workflowDraft holds human answers for the standalone WORKFLOW.md create wizard.
+type workflowDraft struct {
+	Name        string // directory-facing name → workflow_id slug
+	Title       string // WORKFLOW.md H1 (defaults to Name)
+	Description string // one-line intent
+	StepsText   string // Name|Goal per line
+}
+
+// parseWorkflowStepsText parses "Name|Goal" lines (empty lines skipped).
+// A line without "|" uses the whole line as the name and a default goal.
+func parseWorkflowStepsText(raw string) ([]festival.WorkflowStepInput, error) {
+	var steps []festival.WorkflowStepInput
+	for i, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "|", 2)
+		name := strings.TrimSpace(parts[0])
+		if name == "" {
+			return nil, errors.Validation(fmt.Sprintf("step line %d: name is required", i+1)).
+				WithHint("use Name|Goal per line")
+		}
+		goal := "Describe this step."
+		if len(parts) == 2 {
+			if g := strings.TrimSpace(parts[1]); g != "" {
+				goal = g
+			}
+		}
+		steps = append(steps, festival.WorkflowStepInput{Name: name, Goal: goal})
+	}
+	if len(steps) == 0 {
+		return nil, errors.Validation("at least one workflow step is required").
+			WithHint("enter Name|Goal lines, one step per line")
+	}
+	return steps, nil
+}
+
+// workflowInputFromDraft builds the CLI WorkflowInput used by RunCreateWorkflow.
+func workflowInputFromDraft(d *workflowDraft) (*festival.WorkflowInput, error) {
+	if d == nil {
+		return nil, errors.Validation("workflow draft is required")
+	}
+	name := strings.TrimSpace(d.Name)
+	if name == "" {
+		return nil, errors.Validation("workflow name is required")
+	}
+	title := strings.TrimSpace(d.Title)
+	if title == "" {
+		title = name
+	}
+	steps, err := parseWorkflowStepsText(d.StepsText)
+	if err != nil {
+		return nil, err
+	}
+	return &festival.WorkflowInput{
+		Title:       title,
+		Description: strings.TrimSpace(d.Description),
+		Steps:       steps,
+	}, nil
+}
+
+// workflowStepsJSON marshals the draft into --steps JSON for RunCreateWorkflow.
+func workflowStepsJSON(d *workflowDraft) (string, error) {
+	input, err := workflowInputFromDraft(d)
+	if err != nil {
+		return "", err
+	}
+	b, err := json.Marshal(input)
+	if err != nil {
+		return "", errors.Wrap(err, "marshal workflow steps")
+	}
+	return string(b), nil
+}
+
+// workflowConfirmSummary is a short multi-line note for the confirm step.
+func workflowConfirmSummary(d *workflowDraft) string {
+	input, err := workflowInputFromDraft(d)
+	if err != nil {
+		return err.Error()
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "Name:  %s\n", strings.TrimSpace(d.Name))
+	fmt.Fprintf(&b, "Title: %s\n", input.Title)
+	if input.Description != "" {
+		fmt.Fprintf(&b, "Intent: %s\n", input.Description)
+	}
+	fmt.Fprintf(&b, "Steps (%d):\n", len(input.Steps))
+	for i, s := range input.Steps {
+		fmt.Fprintf(&b, "  %d. %s — %s\n", i+1, s.Name, s.Goal)
+	}
+	b.WriteString("\nWrites WORKFLOW.md in the current directory and starts a run (fest next).")
+	return b.String()
+}

--- a/internal/commands/tui/workflow_wizard_test.go
+++ b/internal/commands/tui/workflow_wizard_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -30,6 +32,35 @@ func TestParseWorkflowStepsTextDefaultGoal(t *testing.T) {
 	}
 	if len(steps) != 1 || steps[0].Name != "Only name" || steps[0].Goal == "" {
 		t.Fatalf("got %+v", steps)
+	}
+}
+
+func TestParseWorkflowStepsTextEmptyGoalAfterPipe(t *testing.T) {
+	t.Parallel()
+	steps, err := parseWorkflowStepsText("Name|")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(steps) != 1 || steps[0].Name != "Name" || steps[0].Goal != "Describe this step." {
+		t.Fatalf("got %+v", steps)
+	}
+	// Whitespace-only goal also defaults.
+	steps, err = parseWorkflowStepsText("Name|  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if steps[0].Goal != "Describe this step." {
+		t.Fatalf("got %+v", steps[0])
+	}
+}
+
+func TestParseWorkflowStepsTextEmptyName(t *testing.T) {
+	t.Parallel()
+	if _, err := parseWorkflowStepsText("|goal"); err == nil {
+		t.Fatal("expected error for empty name after |")
+	}
+	if _, err := parseWorkflowStepsText("  |x"); err == nil {
+		t.Fatal("expected error for whitespace-only name")
 	}
 }
 
@@ -72,6 +103,16 @@ func TestWorkflowInputFromDraftDefaultsTitle(t *testing.T) {
 	}
 }
 
+func TestWorkflowInputFromDraftMissingName(t *testing.T) {
+	t.Parallel()
+	if _, err := workflowInputFromDraft(nil); err == nil {
+		t.Fatal("expected error for nil draft")
+	}
+	if _, err := workflowInputFromDraft(&workflowDraft{StepsText: "A|B"}); err == nil {
+		t.Fatal("expected error for missing name")
+	}
+}
+
 func TestWorkflowConfirmSummary(t *testing.T) {
 	t.Parallel()
 	s := workflowConfirmSummary(&workflowDraft{
@@ -80,5 +121,48 @@ func TestWorkflowConfirmSummary(t *testing.T) {
 	})
 	if !strings.Contains(s, "demo") || !strings.Contains(s, "A — B") {
 		t.Fatalf("summary=%q", s)
+	}
+}
+
+func TestRefuseExistingStandaloneWorkflow(t *testing.T) {
+	t.Parallel()
+	empty := t.TempDir()
+	if err := refuseExistingStandaloneWorkflow(empty); err != nil {
+		t.Fatalf("empty dir should be ok: %v", err)
+	}
+
+	withDoc := t.TempDir()
+	if err := os.WriteFile(filepath.Join(withDoc, "WORKFLOW.md"), []byte("# x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := refuseExistingStandaloneWorkflow(withDoc)
+	if err == nil {
+		t.Fatal("expected WORKFLOW.md refusal")
+	}
+	if !strings.Contains(err.Error(), "WORKFLOW.md") {
+		t.Fatalf("err=%v", err)
+	}
+
+	withRuntime := t.TempDir()
+	if err := os.Mkdir(filepath.Join(withRuntime, ".workflow"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	err = refuseExistingStandaloneWorkflow(withRuntime)
+	if err == nil {
+		t.Fatal("expected .workflow/ refusal")
+	}
+	if !strings.Contains(err.Error(), ".workflow") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestDefaultWorkflowStepsTextParses(t *testing.T) {
+	t.Parallel()
+	steps, err := parseWorkflowStepsText(defaultWorkflowStepsText)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(steps) != 3 {
+		t.Fatalf("len=%d want 3", len(steps))
 	}
 }

--- a/internal/commands/tui/workflow_wizard_test.go
+++ b/internal/commands/tui/workflow_wizard_test.go
@@ -1,0 +1,84 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseWorkflowStepsText(t *testing.T) {
+	t.Parallel()
+	steps, err := parseWorkflowStepsText("Review|Check the PR\n\nShip|Tag and release\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(steps) != 2 {
+		t.Fatalf("len=%d want 2", len(steps))
+	}
+	if steps[0].Name != "Review" || steps[0].Goal != "Check the PR" {
+		t.Fatalf("step0=%+v", steps[0])
+	}
+	if steps[1].Name != "Ship" {
+		t.Fatalf("step1=%+v", steps[1])
+	}
+}
+
+func TestParseWorkflowStepsTextDefaultGoal(t *testing.T) {
+	t.Parallel()
+	steps, err := parseWorkflowStepsText("Only name")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(steps) != 1 || steps[0].Name != "Only name" || steps[0].Goal == "" {
+		t.Fatalf("got %+v", steps)
+	}
+}
+
+func TestParseWorkflowStepsTextEmpty(t *testing.T) {
+	t.Parallel()
+	if _, err := parseWorkflowStepsText("  \n\n"); err == nil {
+		t.Fatal("expected error for empty steps")
+	}
+}
+
+func TestWorkflowStepsJSON(t *testing.T) {
+	t.Parallel()
+	raw, err := workflowStepsJSON(&workflowDraft{
+		Name:        "demo",
+		Title:       "Demo flow",
+		Description: "thin start",
+		StepsText:   "One|Do the thing\nTwo|Finish",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`"title":"Demo flow"`, `"name":"One"`, `"goal":"Do the thing"`} {
+		if !strings.Contains(raw, want) {
+			t.Fatalf("json missing %s: %s", want, raw)
+		}
+	}
+}
+
+func TestWorkflowInputFromDraftDefaultsTitle(t *testing.T) {
+	t.Parallel()
+	in, err := workflowInputFromDraft(&workflowDraft{
+		Name:      "my-flow",
+		StepsText: "Start|Go",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if in.Title != "my-flow" {
+		t.Fatalf("title=%q", in.Title)
+	}
+}
+
+func TestWorkflowConfirmSummary(t *testing.T) {
+	t.Parallel()
+	s := workflowConfirmSummary(&workflowDraft{
+		Name:      "demo",
+		StepsText: "A|B",
+	})
+	if !strings.Contains(s, "demo") || !strings.Contains(s, "A — B") {
+		t.Fatalf("summary=%q", s)
+	}
+}


### PR DESCRIPTION
## Summary

- Implements the human **Standalone workflow** wizard on `fest create` → Create what? (replaces the stub).
- Multi-step Charm flow: identity → steps (`Name|Goal` per line) → confirm → `festival.RunCreateWorkflow` (same path as `fest create workflow --steps`).
- `no_charm` linear fallback + shared draft/parser tests.
- Stacked on `fest-create-tui-2026-07-28` (PR #307) so menu chrome and full-width frames stay consistent.

## Test plan

- [x] `go test ./internal/commands/tui/`
- [x] `fest create workflow smoke-demo --steps '...'` still works
- [ ] Interactive: `fest create` → Standalone workflow → create in empty dir → `fest next`
- [ ] Esc/Back navigation; refuse when `WORKFLOW.md` already exists

## Workitem

WI-0304ca — design `workflow/design/fest-create-workflow-tui`