### PR TITLE
feat(commit): route staging and commits through camp commitkit (CA0004 003/02)

### DIFF
--- a/docs/cli-reference/fest-reference.md
+++ b/docs/cli-reference/fest-reference.md
@@ -419,6 +419,7 @@ fest commit [flags]
 
 ```
       --auto-write        run configured commit message writer
+      --commit-large      commit over-threshold files instead of keeping them out of git
       --festival string   festival name or ID (overrides auto-detection)
   -h, --help              help for commit
       --json              output result as JSON
@@ -3364,6 +3365,46 @@ fest next [flags]
 ```
 ---
 
+## fest pack
+
+Pack a festival or ritual directory into a .festival bundle
+
+### Synopsis
+
+Pack a festival/ritual tree into a portable .festival ZIP.
+
+Does not execute or promote the festival. Out-of-root file links are vendored
+into .artifacts/; in-root links are left unchanged.
+
+Works from any directory (global scope); source path is explicit.
+
+```
+fest pack [source-dir] [flags]
+```
+
+### Options
+
+```
+      --creator string   bundle.creator (default "fest")
+  -h, --help             help for pack
+      --json             print info.json on stdout
+      --kind string      bundle kind (festival|ritual); inferred when empty
+      --name string      bundle name
+      --no-sent-record   skip .bundles/sent on source
+  -o, --output string    output .festival path (required)
+      --strict           fail if out-of-root links are missing
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
 ## fest parse
 
 Parse festival documents into structured output
@@ -5685,6 +5726,47 @@ fest types show <type-name> [flags]
       --json           Output as JSON
   -l, --level string   Filter by level (disambiguate if same name at multiple levels)
   -t, --template       Show raw template content
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## fest unbundle
+
+Unbundle a .festival archive into a directory
+
+### Synopsis
+
+Extract a Festival Bundle into a live directory.
+
+Does NOT run, promote, or activate the festival. Use fest ritual run or normal
+fest workflow separately after unbundle if execution is desired.
+
+Optional --validate runs in-process festival validation on the destination
+(this binary's validator, not a PATH-installed fest). Validation diagnostics
+go to stderr so --json still emits a single JSON document on stdout.
+
+```
+fest unbundle [path.festival] [flags]
+```
+
+### Options
+
+```
+  -d, --dest string          destination directory (required)
+      --force                allow non-empty destination
+  -h, --help                 help for unbundle
+      --json                 print info.json on stdout
+      --no-received-record   skip .bundles/received
+      --no-verify            skip content-hash verification
+      --validate             run in-process fest validate on destination after unbundle
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/fest.md
+++ b/docs/cli-reference/fest.md
@@ -67,6 +67,7 @@ Run 'fest understand' to learn the methodology before executing tasks.
 * [fest migrate](fest_migrate.md)	 - Migrate festival documents
 * [fest move](fest_move.md)	 - Move files between festival and linked project
 * [fest next](fest_next.md)	 - Find the next task to work on
+* [fest pack](fest_pack.md)	 - Pack a festival or ritual directory into a .festival bundle
 * [fest parse](fest_parse.md)	 - Parse festival documents into structured output
 * [fest plugins](fest_plugins.md)	 - List discovered fest plugins
 * [fest progress](fest_progress.md)	 - Track and display festival execution progress
@@ -86,6 +87,7 @@ Run 'fest understand' to learn the methodology before executing tasks.
 * [fest task](fest_task.md)	 - Manage task status (show, edit, complete, block, reset)
 * [fest templates](fest_templates.md)	 - Manage agent-created templates within a festival
 * [fest types](fest_types.md)	 - Discover types for fest create
+* [fest unbundle](fest_unbundle.md)	 - Unbundle a .festival archive into a directory
 * [fest understand](fest_understand.md)	 - Learn methodology FIRST - run before executing festival tasks
 * [fest unlink](fest_unlink.md)	 - Remove festival-project link (context-aware)
 * [fest validate](fest_validate.md)	 - Check festival structure - find missing task files and issues

--- a/docs/cli-reference/fest_commit.md
+++ b/docs/cli-reference/fest_commit.md
@@ -63,6 +63,7 @@ fest commit [flags]
 
 ```
       --auto-write        run configured commit message writer
+      --commit-large      commit over-threshold files instead of keeping them out of git
       --festival string   festival name or ID (overrides auto-detection)
   -h, --help              help for commit
       --json              output result as JSON

--- a/docs/cli-reference/fest_pack.md
+++ b/docs/cli-reference/fest_pack.md
@@ -1,0 +1,42 @@
+## fest pack
+
+Pack a festival or ritual directory into a .festival bundle
+
+### Synopsis
+
+Pack a festival/ritual tree into a portable .festival ZIP.
+
+Does not execute or promote the festival. Out-of-root file links are vendored
+into .artifacts/; in-root links are left unchanged.
+
+Works from any directory (global scope); source path is explicit.
+
+```
+fest pack [source-dir] [flags]
+```
+
+### Options
+
+```
+      --creator string   bundle.creator (default "fest")
+  -h, --help             help for pack
+      --json             print info.json on stdout
+      --kind string      bundle kind (festival|ritual); inferred when empty
+      --name string      bundle name
+      --no-sent-record   skip .bundles/sent on source
+  -o, --output string    output .festival path (required)
+      --strict           fail if out-of-root links are missing
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest](fest.md)	 - Festival Methodology CLI - goal-oriented project management for AI agents

--- a/docs/cli-reference/fest_unbundle.md
+++ b/docs/cli-reference/fest_unbundle.md
@@ -1,0 +1,43 @@
+## fest unbundle
+
+Unbundle a .festival archive into a directory
+
+### Synopsis
+
+Extract a Festival Bundle into a live directory.
+
+Does NOT run, promote, or activate the festival. Use fest ritual run or normal
+fest workflow separately after unbundle if execution is desired.
+
+Optional --validate runs in-process festival validation on the destination
+(this binary's validator, not a PATH-installed fest). Validation diagnostics
+go to stderr so --json still emits a single JSON document on stdout.
+
+```
+fest unbundle [path.festival] [flags]
+```
+
+### Options
+
+```
+  -d, --dest string          destination directory (required)
+      --force                allow non-empty destination
+  -h, --help                 help for unbundle
+      --json                 print info.json on stdout
+      --no-received-record   skip .bundles/received
+      --no-verify            skip content-hash verification
+      --validate             run in-process fest validate on destination after unbundle
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest](fest.md)	 - Festival Methodology CLI - goal-oriented project management for AI agents

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.6
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0
-	github.com/Obedience-Corp/camp v0.3.1
+	github.com/Obedience-Corp/camp v0.4.0-rc.1
 	github.com/Obedience-Corp/obey-shared v0.4.6
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.6
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0
-	github.com/Obedience-Corp/camp v0.4.0-rc.1
+	github.com/Obedience-Corp/camp v0.4.0-rc.2
 	github.com/Obedience-Corp/obey-shared v0.4.6
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/Obedience-Corp/camp v0.4.0-rc.1 h1:beBJV8Pbj8ZZgKtbzs1pEJko+5ruS+yYEgEFcPwp4GU=
-github.com/Obedience-Corp/camp v0.4.0-rc.1/go.mod h1:Xko1DyzQ80Yf0lGCLu7ZiYWXTxdxXobRgUzERTMLeVE=
+github.com/Obedience-Corp/camp v0.4.0-rc.2 h1:+dydz5vsx1LOiSGDyFv29W+/ML2m/8BaM759D0uqvGI=
+github.com/Obedience-Corp/camp v0.4.0-rc.2/go.mod h1:Xko1DyzQ80Yf0lGCLu7ZiYWXTxdxXobRgUzERTMLeVE=
 github.com/Obedience-Corp/obey-shared v0.4.6 h1:nvl2sM/5ri9LfmKpqXyt84T1z2TvNBiv4cpPkRVJyBk=
 github.com/Obedience-Corp/obey-shared v0.4.6/go.mod h1:VZ9rp2YklgdlipSr7aUlOHbmNjrRjif4qHybkLdn6ic=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/Obedience-Corp/camp v0.3.1 h1:kGDV6r/vDngXJe/AfxNCAwf/v42CIv9MqwFkydo2p6g=
-github.com/Obedience-Corp/camp v0.3.1/go.mod h1:5cUe2WA5Z5rUtLm0qMAKQHbOnXYY0eyjlJ+dw7DoRuI=
+github.com/Obedience-Corp/camp v0.4.0-rc.1 h1:beBJV8Pbj8ZZgKtbzs1pEJko+5ruS+yYEgEFcPwp4GU=
+github.com/Obedience-Corp/camp v0.4.0-rc.1/go.mod h1:Xko1DyzQ80Yf0lGCLu7ZiYWXTxdxXobRgUzERTMLeVE=
 github.com/Obedience-Corp/obey-shared v0.4.6 h1:nvl2sM/5ri9LfmKpqXyt84T1z2TvNBiv4cpPkRVJyBk=
 github.com/Obedience-Corp/obey-shared v0.4.6/go.mod h1:VZ9rp2YklgdlipSr7aUlOHbmNjrRjif4qHybkLdn6ic=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=

--- a/internal/commands/commit/commit.go
+++ b/internal/commands/commit/commit.go
@@ -4,6 +4,7 @@ package commit
 import (
 	"bytes"
 	"context"
+	stderrors "errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -174,7 +175,7 @@ func runCommit(cmd *cobra.Command, args []string) error {
 	if autoStage {
 		if inSubmodule {
 			// In submodule: stage all changes in the project repo
-			if err := stageAllChanges(ctx); err != nil {
+			if err := stageAllChanges(ctx, primaryRepoPath); err != nil {
 				result.Success = false
 				result.Error = err.Error()
 				return outputResult(result)
@@ -194,7 +195,7 @@ func runCommit(cmd *cobra.Command, args []string) error {
 			}
 		} else {
 			// Fallback: stage all (non-campaign workspace)
-			if err := stageAllChanges(ctx); err != nil {
+			if err := stageAllChanges(ctx, primaryRepoPath); err != nil {
 				result.Success = false
 				result.Error = err.Error()
 				return outputResult(result)
@@ -354,15 +355,24 @@ func currentGitRoot(ctx context.Context) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-// stageAllChanges runs git add -A to stage all changes
-func stageAllChanges(ctx context.Context) error {
+// stageAllChanges stages everything in the repository at repoPath through
+// camp's staging guard: lock retry with stale-lock cleanup, size and bulk
+// protection, and a typed refusal fest renders in its own voice. The repo is
+// passed explicitly because the guard resolves its thresholds from it; the
+// old form ran `git add -A` in whatever cwd fest happened to hold.
+func stageAllChanges(ctx context.Context, repoPath string) error {
 	if err := ctx.Err(); err != nil {
 		return errors.Wrap(err, "context cancelled")
 	}
-	cmd := exec.CommandContext(ctx, "git", "add", "-A")
-	if err := cmd.Run(); err != nil {
-		return errors.Wrap(err, "git add failed")
+	outcome, err := commitkit.StageAllWithOutcome(ctx, repoPath)
+	if err != nil {
+		var blocked *commitkit.GuardBlockedError
+		if stderrors.As(err, &blocked) {
+			return errors.New(guardRefusalMessage(blocked))
+		}
+		return errors.Wrap(err, "staging changes")
 	}
+	reportStageOutcome(os.Stderr, outcome)
 	return nil
 }
 

--- a/internal/commands/commit/commit.go
+++ b/internal/commands/commit/commit.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,6 +21,11 @@ import (
 	"github.com/Obedience-Corp/fest/internal/ui"
 	"github.com/spf13/cobra"
 )
+
+// errAllExcluded is returned when the staging guard kept every changed path
+// out of the index, so a follow-up commit would look like a bare "no changes"
+// failure after the user already saw exclusion lines on stderr.
+var errAllExcluded = stderrors.New("everything changed was kept out of git by the size/bulk guard; nothing left to commit")
 
 // Commit reference format prefix: FE (Festival component)
 const commitRefPrefix = "FE"
@@ -169,32 +175,37 @@ func runCommit(cmd *cobra.Command, args []string) error {
 		return outputResult(result)
 	}
 
+	// Guard outcomes and refusals go to the command's stderr so --json stdout
+	// stays a pure document.
+	report := cmd.ErrOrStderr()
+
 	// Auto-stage changes if enabled (default: true).
 	// When at campaign root (not in submodule), stage only festival-scoped paths.
 	if autoStage {
 		if inSubmodule {
 			// In submodule: stage all changes in the project repo
-			if err := stageAllChanges(ctx, primaryRepoPath); err != nil {
+			if err := stageAllChanges(ctx, primaryRepoPath, report); err != nil {
 				result.Success = false
 				result.Error = err.Error()
 				return outputResult(result)
 			}
 		} else if ws != nil && ws.Type == scope.WorkspaceTypeCampaign && hasFestival {
-			// At campaign root: stage only festival-scoped paths
+			// At campaign root: stage only festival-scoped paths (with outcome
+			// reporting so large/bulk exclusions are not silent).
 			paths, err := festivalScopedPaths(ctx, ws.Root, festivalPath, "")
 			if err != nil {
 				result.Success = false
 				result.Error = err.Error()
 				return outputResult(result)
 			}
-			if stageErr := commitkit.StageFiles(ctx, ws.Root, paths...); stageErr != nil {
+			if stageErr := stageFiles(ctx, ws.Root, report, paths...); stageErr != nil {
 				result.Success = false
-				result.Error = fmt.Sprintf("staging festival files: %v", stageErr)
+				result.Error = stageErr.Error()
 				return outputResult(result)
 			}
 		} else {
 			// Fallback: stage all (non-campaign workspace)
-			if err := stageAllChanges(ctx, primaryRepoPath); err != nil {
+			if err := stageAllChanges(ctx, primaryRepoPath, report); err != nil {
 				result.Success = false
 				result.Error = err.Error()
 				return outputResult(result)
@@ -265,9 +276,9 @@ func runCommit(cmd *cobra.Command, args []string) error {
 	// Only when we're in a submodule (the campaign root commit is a second commit).
 	// When at the campaign root, the primary commit above already handled festival files.
 	if !noRoot && inSubmodule && ws != nil && ws.Type == scope.WorkspaceTypeCampaign && hasFestival {
-		rootHash, rootErr := commitFestivalAtRoot(ctx, ws, festivalPath, submoduleRelPath, result.CampaignTag, ref, rawMsg)
+		rootHash, rootErr := commitFestivalAtRoot(ctx, ws, festivalPath, submoduleRelPath, result.CampaignTag, ref, rawMsg, report)
 		if rootErr != nil {
-			fmt.Fprintf(os.Stderr, "%s %s\n", ui.Warning("campaign root commit skipped:"), rootErr.Error())
+			fmt.Fprintf(report, "%s %s\n", ui.Warning("campaign root commit skipped:"), rootErr.Error())
 		} else if rootHash != "" {
 			result.CampaignHash = rootHash
 		}
@@ -336,7 +347,8 @@ func currentGitRoot(ctx context.Context) (string, error) {
 // protection, and a typed refusal fest renders in its own voice. The repo is
 // passed explicitly because the guard resolves its thresholds from it; the
 // old form ran `git add -A` in whatever cwd fest happened to hold.
-func stageAllChanges(ctx context.Context, repoPath string) error {
+// report receives exclusion/unavailable lines (typically cmd.ErrOrStderr()).
+func stageAllChanges(ctx context.Context, repoPath string, report io.Writer) error {
 	if err := ctx.Err(); err != nil {
 		return errors.Wrap(err, "context cancelled")
 	}
@@ -348,7 +360,43 @@ func stageAllChanges(ctx context.Context, repoPath string) error {
 		}
 		return errors.Wrap(err, "staging changes")
 	}
-	reportStageOutcome(os.Stderr, outcome)
+	reportStageOutcome(report, outcome)
+	return nothingLeftAfterExclusions(ctx, repoPath, outcome)
+}
+
+// stageFiles stages the given paths through commitkit with outcome reporting
+// and fest-rendered GuardBlockedError text — the same contract as stageAllChanges,
+// for festival-scoped and campaign-root path lists.
+func stageFiles(ctx context.Context, repoPath string, report io.Writer, files ...string) error {
+	if err := ctx.Err(); err != nil {
+		return errors.Wrap(err, "context cancelled")
+	}
+	outcome, err := commitkit.StageFilesWithOutcome(ctx, repoPath, files...)
+	if err != nil {
+		var blocked *commitkit.GuardBlockedError
+		if stderrors.As(err, &blocked) {
+			return errors.New(guardRefusalMessage(blocked))
+		}
+		return errors.Wrap(err, "staging files")
+	}
+	reportStageOutcome(report, outcome)
+	return nothingLeftAfterExclusions(ctx, repoPath, outcome)
+}
+
+// nothingLeftAfterExclusions turns "guard excluded everything" into a clear
+// error instead of letting commitkit.Commit return a bare ErrNoChanges after
+// the user already saw exclusion lines on stderr.
+func nothingLeftAfterExclusions(ctx context.Context, repoPath string, outcome *commitkit.StageOutcome) error {
+	if outcome == nil || len(outcome.Excluded) == 0 {
+		return nil
+	}
+	has, err := commitkit.HasStagedChanges(ctx, repoPath)
+	if err != nil {
+		return errors.Wrap(err, "checking staged changes after guard exclusions")
+	}
+	if !has {
+		return errAllExcluded
+	}
 	return nil
 }
 
@@ -518,15 +566,22 @@ func festivalScopedPaths(ctx context.Context, campaignRoot, festivalPath, submod
 // commitCampaignRoot stages festival-scoped paths at the campaign root and
 // commits them. Returns the short hash of the campaign commit, or empty string
 // if there were no changes to commit. Errors from staging/committing are
-// returned; "no changes" is a silent skip.
-func commitCampaignRoot(ctx context.Context, campaignRoot string, paths []string, commitMessage string) (string, error) {
+// returned; "no changes" is a silent skip (including when the guard excluded
+// every path — already reported on report).
+func commitCampaignRoot(ctx context.Context, campaignRoot string, paths []string, commitMessage string, report io.Writer) (string, error) {
 	if err := ctx.Err(); err != nil {
 		return "", errors.Wrap(err, "context cancelled")
 	}
 
-	if err := commitkit.StageFiles(ctx, campaignRoot, paths...); err != nil {
+	outcome, err := commitkit.StageFilesWithOutcome(ctx, campaignRoot, paths...)
+	if err != nil {
+		var blocked *commitkit.GuardBlockedError
+		if stderrors.As(err, &blocked) {
+			return "", errors.New(guardRefusalMessage(blocked))
+		}
 		return "", errors.Wrap(err, "staging festival files at campaign root")
 	}
+	reportStageOutcome(report, outcome)
 
 	hasChanges, err := commitkit.HasStagedChanges(ctx, campaignRoot)
 	if err != nil {
@@ -553,7 +608,7 @@ func commitCampaignRoot(ctx context.Context, campaignRoot string, paths []string
 // commitFestivalAtRoot orchestrates the campaign root commit for festival-scoped
 // files. It computes the scoped paths, builds a tagged message with "fest:" prefix,
 // and delegates to commitCampaignRoot.
-func commitFestivalAtRoot(ctx context.Context, ws *scope.WorkspaceInfo, festivalPath, submoduleRelPath, campaignTag, festRef, rawMsg string) (string, error) {
+func commitFestivalAtRoot(ctx context.Context, ws *scope.WorkspaceInfo, festivalPath, submoduleRelPath, campaignTag, festRef, rawMsg string, report io.Writer) (string, error) {
 	paths, err := festivalScopedPaths(ctx, ws.Root, festivalPath, submoduleRelPath)
 	if err != nil {
 		return "", err
@@ -569,7 +624,7 @@ func commitFestivalAtRoot(ctx context.Context, ws *scope.WorkspaceInfo, festival
 		rootMsg = fmt.Sprintf("[%s] %s", festRef, rootMsg)
 	}
 
-	return commitCampaignRoot(ctx, ws.Root, paths, rootMsg)
+	return commitCampaignRoot(ctx, ws.Root, paths, rootMsg, report)
 }
 
 // resolveProjectRelPath returns the current git repository's path relative to

--- a/internal/commands/commit/commit.go
+++ b/internal/commands/commit/commit.go
@@ -278,7 +278,7 @@ func runCommit(cmd *cobra.Command, args []string) error {
 	if !noRoot && inSubmodule && ws != nil && ws.Type == scope.WorkspaceTypeCampaign && hasFestival {
 		rootHash, rootErr := commitFestivalAtRoot(ctx, ws, festivalPath, submoduleRelPath, result.CampaignTag, ref, rawMsg, report)
 		if rootErr != nil {
-			fmt.Fprintf(report, "%s %s\n", ui.Warning("campaign root commit skipped:"), rootErr.Error())
+			_, _ = fmt.Fprintf(report, "%s %s\n", ui.Warning("campaign root commit skipped:"), rootErr.Error())
 		} else if rootHash != "" {
 			result.CampaignHash = rootHash
 		}

--- a/internal/commands/commit/commit.go
+++ b/internal/commands/commit/commit.go
@@ -2,7 +2,6 @@
 package commit
 
 import (
-	"bytes"
 	"context"
 	stderrors "errors"
 	"fmt"
@@ -320,29 +319,6 @@ func isGitRepo(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-func executeGitCommit(ctx context.Context, repoPath, message string) (string, error) {
-	if err := ctx.Err(); err != nil {
-		return "", errors.Wrap(err, "context cancelled")
-	}
-	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "commit", "-m", message)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	if err := cmd.Run(); err != nil {
-		return "", errors.Wrap(err, "git commit failed")
-	}
-
-	// Get the commit hash
-	hashCmd := exec.CommandContext(ctx, "git", "-C", repoPath, "rev-parse", "--short", "HEAD")
-	var out bytes.Buffer
-	hashCmd.Stdout = &out
-	if err := hashCmd.Run(); err != nil {
-		return "", errors.Wrap(err, "failed to get commit hash")
-	}
-
-	return strings.TrimSpace(out.String()), nil
-}
-
 func currentGitRoot(ctx context.Context) (string, error) {
 	if err := ctx.Err(); err != nil {
 		return "", errors.Wrap(err, "context cancelled")
@@ -481,9 +457,18 @@ func commitWithCampaignSupport(ctx context.Context, ws *scope.WorkspaceInfo, rep
 		}
 	}
 
-	hash, err := executeGitCommit(ctx, repoPath, commitMessage)
+	// commitkit.Commit captures git's output internally, which is the --json
+	// contract: nothing but the encoded document may reach stdout. The same
+	// pair already commits the campaign root in commitCampaignRoot.
+	if err := commitkit.Commit(ctx, repoPath, commitkit.CommitOptions{Message: commitMessage}); err != nil {
+		if stderrors.Is(err, commitkit.ErrNoChanges) {
+			return errors.New("no changes to commit")
+		}
+		return errors.Wrap(err, "committing")
+	}
+	hash, err := commitkit.ShortHash(ctx, repoPath)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "getting commit hash")
 	}
 	result.Hash = hash
 	result.Message = commitMessage

--- a/internal/commands/commit/commit.go
+++ b/internal/commands/commit/commit.go
@@ -39,6 +39,7 @@ var (
 	autoStage        bool
 	autoWrite        bool
 	noRoot           bool
+	commitLarge      bool
 	syncSubmoduleRef bool // deprecated: kept for backward compat
 )
 
@@ -108,6 +109,7 @@ Examples:
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "output result as JSON")
 	cmd.Flags().BoolVar(&autoStage, "stage", true, "auto-stage all changes before commit")
 	cmd.Flags().BoolVar(&autoWrite, "auto-write", false, "run configured commit message writer")
+	cmd.Flags().BoolVar(&commitLarge, "commit-large", false, "commit over-threshold files instead of keeping them out of git")
 	cmd.Flags().BoolVar(&noRoot, "no-root", false, "skip campaign root commit (project commit only)")
 	cmd.Flags().BoolVar(&syncSubmoduleRef, "sync-submodule-ref", false, "deprecated: campaign root commit is now automatic")
 	_ = cmd.Flags().MarkDeprecated("sync-submodule-ref", "campaign root commit is now automatic; use --no-root to skip")
@@ -348,19 +350,24 @@ func currentGitRoot(ctx context.Context) (string, error) {
 // passed explicitly because the guard resolves its thresholds from it; the
 // old form ran `git add -A` in whatever cwd fest happened to hold.
 // report receives exclusion/unavailable lines (typically cmd.ErrOrStderr()).
+//
+// The --commit-large override rides through StageAllWithOptions to the same
+// guard decision camp's own flag reaches, so a refusal here can truthfully
+// offer `fest commit --commit-large` as the retry.
 func stageAllChanges(ctx context.Context, repoPath string, report io.Writer) error {
 	if err := ctx.Err(); err != nil {
 		return errors.Wrap(err, "context cancelled")
 	}
-	outcome, err := commitkit.StageAllWithOutcome(ctx, repoPath)
+	outcome, err := commitkit.StageAllWithOptions(ctx, repoPath,
+		commitkit.StageOptions{CommitLarge: commitLarge})
 	if err != nil {
 		var blocked *commitkit.GuardBlockedError
 		if stderrors.As(err, &blocked) {
-			return errors.New(guardRefusalMessage(blocked))
+			return errors.New(guardRefusalMessage(blocked, "fest commit --commit-large"))
 		}
 		return errors.Wrap(err, "staging changes")
 	}
-	reportStageOutcome(report, outcome)
+	reportStageOutcome(report, outcome, "fest commit --commit-large")
 	return nothingLeftAfterExclusions(ctx, repoPath, outcome)
 }
 
@@ -375,11 +382,14 @@ func stageFiles(ctx context.Context, repoPath string, report io.Writer, files ..
 	if err != nil {
 		var blocked *commitkit.GuardBlockedError
 		if stderrors.As(err, &blocked) {
-			return errors.New(guardRefusalMessage(blocked))
+			// commitkit exports no options form for file-list staging, so
+			// fest's flag cannot reach this branch; camp's own flag is the
+			// retry that works at a campaign root.
+			return errors.New(guardRefusalMessage(blocked, "camp commit --commit-large"))
 		}
 		return errors.Wrap(err, "staging files")
 	}
-	reportStageOutcome(report, outcome)
+	reportStageOutcome(report, outcome, "camp commit --commit-large")
 	return nothingLeftAfterExclusions(ctx, repoPath, outcome)
 }
 
@@ -577,11 +587,11 @@ func commitCampaignRoot(ctx context.Context, campaignRoot string, paths []string
 	if err != nil {
 		var blocked *commitkit.GuardBlockedError
 		if stderrors.As(err, &blocked) {
-			return "", errors.New(guardRefusalMessage(blocked))
+			return "", errors.New(guardRefusalMessage(blocked, "camp commit --commit-large"))
 		}
 		return "", errors.Wrap(err, "staging festival files at campaign root")
 	}
-	reportStageOutcome(report, outcome)
+	reportStageOutcome(report, outcome, "camp commit --commit-large")
 
 	hasChanges, err := commitkit.HasStagedChanges(ctx, campaignRoot)
 	if err != nil {

--- a/internal/commands/commit/guard.go
+++ b/internal/commands/commit/guard.go
@@ -1,0 +1,97 @@
+package commit
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/Obedience-Corp/camp/pkg/commitkit"
+)
+
+// Fest renders the staging guard's decisions in its own voice from camp's
+// typed data; no camp error text is parsed or echoed. The facts and the ways
+// out are the same ones camp names, so a user blocked in either tool reaches
+// the same remedies, with fest commit as the retry vehicle.
+
+// guardRefusalMessage is the result.Error text for a staging refusal: what was
+// refused, that nothing was staged, and every way out. A refusal is the one
+// moment the guard spends the user's attention, so the message has to pay for
+// it rather than saying a bare "staging refused".
+func guardRefusalMessage(blocked *commitkit.GuardBlockedError) string {
+	var b strings.Builder
+	switch blocked.Kind {
+	case commitkit.Bulk:
+		var worst commitkit.GuardViolation
+		var files int
+		var total int64
+		for _, v := range blocked.Violations {
+			files += v.Count
+			total += v.TotalBytes
+			if v.Count > worst.Count {
+				worst = v
+			}
+		}
+		fmt.Fprintf(&b, "%d untracked files (%s) under %s/ would be committed; nothing was staged\n",
+			files, formatBytes(total), worst.CommonPrefix)
+		fmt.Fprintf(&b, "  gitignore it        echo '%s/' >> .gitignore\n", worst.CommonPrefix)
+		fmt.Fprintf(&b, "  keep and sync it    camp artifacts add %s\n", worst.CommonPrefix)
+		fmt.Fprintf(&b, "  commit it anyway    fest commit --commit-large -m \"...\"\n")
+		fmt.Fprintf(&b, "  turn the guard off  camp settings set local.commit.guards.bulk off")
+	default:
+		fmt.Fprintf(&b, "%s over the %s limit would be committed; nothing was staged\n",
+			pluralFiles(len(blocked.Violations)), formatBytes(blocked.Limits.MaxFileSize))
+		for _, v := range blocked.Violations {
+			fmt.Fprintf(&b, "  %s   %s\n", v.Path, formatBytes(v.Size))
+		}
+		for _, v := range blocked.Violations {
+			fmt.Fprintf(&b, "  keep and sync it    camp artifacts add %s\n",
+				filepath.ToSlash(filepath.Dir(v.Path)))
+		}
+		fmt.Fprintf(&b, "  commit it anyway    fest commit --commit-large -m \"...\"\n")
+		fmt.Fprintf(&b, "  handle it for me    camp settings set local.commit.guards.large_files auto")
+	}
+	return b.String()
+}
+
+// reportStageOutcome says what the guard did when staging still succeeded.
+// Camp acting automatically is only safe if the user is told, so an excluded
+// file, a flagged tracked file, or a guard that could not run are each one
+// line here rather than a silent diff surprise. Written to stderr by callers
+// so a machine-read stdout stays pure.
+func reportStageOutcome(w io.Writer, outcome *commitkit.StageOutcome) {
+	if outcome == nil {
+		return
+	}
+	if outcome.Unavailable != nil {
+		fmt.Fprintf(w, "Staged without the size and bulk guard: %v\n", outcome.Unavailable)
+	}
+	for _, v := range outcome.Excluded {
+		fmt.Fprintf(w, "Kept out of git: %s (%s, over the %s limit); commit it anyway with 'fest commit --commit-large'\n",
+			v.Path, formatBytes(v.Size), formatBytes(outcome.Limits.MaxFileSize))
+	}
+	for _, v := range outcome.Reported {
+		fmt.Fprintf(w, "Tracked file grew past %s: %s (%s); committed as usual\n",
+			formatBytes(outcome.Limits.MaxFileSize), v.Path, formatBytes(v.Size))
+	}
+}
+
+func pluralFiles(n int) string {
+	if n == 1 {
+		return "1 file"
+	}
+	return fmt.Sprintf("%d files", n)
+}
+
+func formatBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for m := n / unit; m >= unit; m /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGTPE"[exp])
+}

--- a/internal/commands/commit/guard.go
+++ b/internal/commands/commit/guard.go
@@ -11,14 +11,18 @@ import (
 
 // Fest renders the staging guard's decisions in its own voice from camp's
 // typed data; no camp error text is parsed or echoed. The facts and the ways
-// out are the same ones camp names. Until fest ships --commit-large, the
-// "commit it anyway" remedy points at camp commit --commit-large.
+// out are the same ones camp names, and every printed remedy must be runnable
+// on the branch that printed it: the retry command is supplied per call site,
+// because fest's --commit-large reaches only the stage-all branches
+// (commitkit exports no options form for file-list staging), while a
+// campaign-root refusal can always retry through camp's own flag.
 
 // guardRefusalMessage is the result.Error text for a staging refusal: what was
 // refused, that nothing was staged, and every way out. A refusal is the one
 // moment the guard spends the user's attention, so the message has to pay for
-// it rather than saying a bare "staging refused".
-func guardRefusalMessage(blocked *commitkit.GuardBlockedError) string {
+// it rather than saying a bare "staging refused". retryCmd is the
+// commit-it-anyway command that actually works where the refusal happened.
+func guardRefusalMessage(blocked *commitkit.GuardBlockedError, retryCmd string) string {
 	var b strings.Builder
 	switch blocked.Kind {
 	case commitkit.Bulk:
@@ -36,8 +40,7 @@ func guardRefusalMessage(blocked *commitkit.GuardBlockedError) string {
 			files, formatBytes(total), worst.CommonPrefix)
 		fmt.Fprintf(&b, "  gitignore it        echo '%s/' >> .gitignore\n", worst.CommonPrefix)
 		fmt.Fprintf(&b, "  keep and sync it    camp artifacts add %s\n", worst.CommonPrefix)
-		// fest has no --commit-large yet; camp's flag is the working override.
-		fmt.Fprintf(&b, "  commit it anyway    camp commit --commit-large -m \"...\"\n")
+		fmt.Fprintf(&b, "  commit it anyway    %s -m \"...\"\n", retryCmd)
 		fmt.Fprintf(&b, "  turn the guard off  camp settings set local.commit.guards.bulk off")
 	default:
 		fmt.Fprintf(&b, "%s over the %s limit would be committed; nothing was staged\n",
@@ -49,7 +52,7 @@ func guardRefusalMessage(blocked *commitkit.GuardBlockedError) string {
 			fmt.Fprintf(&b, "  keep and sync it    camp artifacts add %s\n",
 				filepath.ToSlash(filepath.Dir(v.Path)))
 		}
-		fmt.Fprintf(&b, "  commit it anyway    camp commit --commit-large -m \"...\"\n")
+		fmt.Fprintf(&b, "  commit it anyway    %s -m \"...\"\n", retryCmd)
 		fmt.Fprintf(&b, "  handle it for me    camp settings set local.commit.guards.large_files auto")
 	}
 	return b.String()
@@ -60,7 +63,10 @@ func guardRefusalMessage(blocked *commitkit.GuardBlockedError) string {
 // file, a flagged tracked file, or a guard that could not run are each one
 // line here rather than a silent diff surprise. Written to stderr by callers
 // so a machine-read stdout stays pure.
-func reportStageOutcome(w io.Writer, outcome *commitkit.StageOutcome) {
+// retryCmd is the commit-it-anyway command that actually works on the branch
+// that staged (camp commit refuses outside a campaign, so the standalone
+// branches must name fest's own flag).
+func reportStageOutcome(w io.Writer, outcome *commitkit.StageOutcome, retryCmd string) {
 	if outcome == nil {
 		return
 	}
@@ -68,8 +74,8 @@ func reportStageOutcome(w io.Writer, outcome *commitkit.StageOutcome) {
 		_, _ = fmt.Fprintf(w, "Staged without the size and bulk guard: %v\n", outcome.Unavailable)
 	}
 	for _, v := range outcome.Excluded {
-		_, _ = fmt.Fprintf(w, "Kept out of git: %s (%s, over the %s limit); commit it anyway with 'camp commit --commit-large' or 'camp settings set local.commit.guards.large_files auto'\n",
-			v.Path, formatBytes(v.Size), formatBytes(outcome.Limits.MaxFileSize))
+		_, _ = fmt.Fprintf(w, "Kept out of git: %s (%s, over the %s limit); commit it anyway with '%s' or 'camp settings set local.commit.guards.large_files auto'\n",
+			v.Path, formatBytes(v.Size), formatBytes(outcome.Limits.MaxFileSize), retryCmd)
 	}
 	for _, v := range outcome.Reported {
 		_, _ = fmt.Fprintf(w, "Tracked file grew past %s: %s (%s); committed as usual\n",

--- a/internal/commands/commit/guard.go
+++ b/internal/commands/commit/guard.go
@@ -64,14 +64,14 @@ func reportStageOutcome(w io.Writer, outcome *commitkit.StageOutcome) {
 		return
 	}
 	if outcome.Unavailable != nil {
-		fmt.Fprintf(w, "Staged without the size and bulk guard: %v\n", outcome.Unavailable)
+		_, _ = fmt.Fprintf(w, "Staged without the size and bulk guard: %v\n", outcome.Unavailable)
 	}
 	for _, v := range outcome.Excluded {
-		fmt.Fprintf(w, "Kept out of git: %s (%s, over the %s limit); commit it anyway with 'fest commit --commit-large'\n",
+		_, _ = fmt.Fprintf(w, "Kept out of git: %s (%s, over the %s limit); commit it anyway with 'fest commit --commit-large'\n",
 			v.Path, formatBytes(v.Size), formatBytes(outcome.Limits.MaxFileSize))
 	}
 	for _, v := range outcome.Reported {
-		fmt.Fprintf(w, "Tracked file grew past %s: %s (%s); committed as usual\n",
+		_, _ = fmt.Fprintf(w, "Tracked file grew past %s: %s (%s); committed as usual\n",
 			formatBytes(outcome.Limits.MaxFileSize), v.Path, formatBytes(v.Size))
 	}
 }

--- a/internal/commands/commit/guard.go
+++ b/internal/commands/commit/guard.go
@@ -11,8 +11,8 @@ import (
 
 // Fest renders the staging guard's decisions in its own voice from camp's
 // typed data; no camp error text is parsed or echoed. The facts and the ways
-// out are the same ones camp names, so a user blocked in either tool reaches
-// the same remedies, with fest commit as the retry vehicle.
+// out are the same ones camp names. Until fest ships --commit-large, the
+// "commit it anyway" remedy points at camp commit --commit-large.
 
 // guardRefusalMessage is the result.Error text for a staging refusal: what was
 // refused, that nothing was staged, and every way out. A refusal is the one
@@ -36,7 +36,8 @@ func guardRefusalMessage(blocked *commitkit.GuardBlockedError) string {
 			files, formatBytes(total), worst.CommonPrefix)
 		fmt.Fprintf(&b, "  gitignore it        echo '%s/' >> .gitignore\n", worst.CommonPrefix)
 		fmt.Fprintf(&b, "  keep and sync it    camp artifacts add %s\n", worst.CommonPrefix)
-		fmt.Fprintf(&b, "  commit it anyway    fest commit --commit-large -m \"...\"\n")
+		// fest has no --commit-large yet; camp's flag is the working override.
+		fmt.Fprintf(&b, "  commit it anyway    camp commit --commit-large -m \"...\"\n")
 		fmt.Fprintf(&b, "  turn the guard off  camp settings set local.commit.guards.bulk off")
 	default:
 		fmt.Fprintf(&b, "%s over the %s limit would be committed; nothing was staged\n",
@@ -48,7 +49,7 @@ func guardRefusalMessage(blocked *commitkit.GuardBlockedError) string {
 			fmt.Fprintf(&b, "  keep and sync it    camp artifacts add %s\n",
 				filepath.ToSlash(filepath.Dir(v.Path)))
 		}
-		fmt.Fprintf(&b, "  commit it anyway    fest commit --commit-large -m \"...\"\n")
+		fmt.Fprintf(&b, "  commit it anyway    camp commit --commit-large -m \"...\"\n")
 		fmt.Fprintf(&b, "  handle it for me    camp settings set local.commit.guards.large_files auto")
 	}
 	return b.String()
@@ -67,7 +68,7 @@ func reportStageOutcome(w io.Writer, outcome *commitkit.StageOutcome) {
 		_, _ = fmt.Fprintf(w, "Staged without the size and bulk guard: %v\n", outcome.Unavailable)
 	}
 	for _, v := range outcome.Excluded {
-		_, _ = fmt.Fprintf(w, "Kept out of git: %s (%s, over the %s limit); commit it anyway with 'fest commit --commit-large'\n",
+		_, _ = fmt.Fprintf(w, "Kept out of git: %s (%s, over the %s limit); commit it anyway with 'camp commit --commit-large' or 'camp settings set local.commit.guards.large_files auto'\n",
 			v.Path, formatBytes(v.Size), formatBytes(outcome.Limits.MaxFileSize))
 	}
 	for _, v := range outcome.Reported {

--- a/internal/commands/commit/guard_test.go
+++ b/internal/commands/commit/guard_test.go
@@ -10,7 +10,8 @@ import (
 // The refusal message is fest's one chance to explain a blocked commit, so
 // these tests pin the contract: every refusal names what was found, that
 // nothing was staged, and working ways out (including camp commit
-// --commit-large until fest grows its own flag). All assertions run against
+// commit-it-anyway retry that works where the refusal happened). All
+// assertions run against
 // typed data rendered by fest; none depend on camp's error strings.
 
 func TestGuardRefusalMessageBulkNamesEveryWayOut(t *testing.T) {
@@ -21,7 +22,7 @@ func TestGuardRefusalMessageBulkNamesEveryWayOut(t *testing.T) {
 		},
 	}
 
-	msg := guardRefusalMessage(blocked)
+	msg := guardRefusalMessage(blocked, "fest commit --commit-large")
 
 	for _, want := range []string{
 		"1204 untracked files",
@@ -29,7 +30,7 @@ func TestGuardRefusalMessageBulkNamesEveryWayOut(t *testing.T) {
 		"nothing was staged",
 		"echo 'node_modules/' >> .gitignore",
 		"camp artifacts add node_modules",
-		"camp commit --commit-large",
+		"fest commit --commit-large",
 		"camp settings set local.commit.guards.bulk off",
 	} {
 		if !strings.Contains(msg, want) {
@@ -47,7 +48,7 @@ func TestGuardRefusalMessageLargeFilesNamesEveryWayOut(t *testing.T) {
 		Limits: commitkit.GuardLimits{MaxFileSize: 100 << 20},
 	}
 
-	msg := guardRefusalMessage(blocked)
+	msg := guardRefusalMessage(blocked, "camp commit --commit-large")
 
 	for _, want := range []string{
 		"1 file over the 100.0 MB limit",
@@ -73,12 +74,12 @@ func TestReportStageOutcomeSaysWhatTheGuardDid(t *testing.T) {
 			{Kind: commitkit.TrackedGrowth, Path: "fixtures/golden.json", Size: 150 << 20},
 		},
 		Limits: commitkit.GuardLimits{MaxFileSize: 100 << 20},
-	})
+	}, "fest commit --commit-large")
 
 	out := b.String()
 	for _, want := range []string{
 		"Kept out of git: render.bin",
-		"camp commit --commit-large",
+		"fest commit --commit-large",
 		"Tracked file grew past 100.0 MB: fixtures/golden.json",
 	} {
 		if !strings.Contains(out, want) {
@@ -89,8 +90,8 @@ func TestReportStageOutcomeSaysWhatTheGuardDid(t *testing.T) {
 
 func TestReportStageOutcomeIsSilentWhenThereIsNothingToSay(t *testing.T) {
 	var b strings.Builder
-	reportStageOutcome(&b, nil)
-	reportStageOutcome(&b, &commitkit.StageOutcome{})
+	reportStageOutcome(&b, nil, "fest commit --commit-large")
+	reportStageOutcome(&b, &commitkit.StageOutcome{}, "fest commit --commit-large")
 	if b.Len() != 0 {
 		t.Errorf("an uneventful stage must print nothing, got:\n%s", b.String())
 	}

--- a/internal/commands/commit/guard_test.go
+++ b/internal/commands/commit/guard_test.go
@@ -9,9 +9,9 @@ import (
 
 // The refusal message is fest's one chance to explain a blocked commit, so
 // these tests pin the contract: every refusal names what was found, that
-// nothing was staged, and the same ways out camp names, with fest commit as
-// the retry vehicle. All assertions run against typed data rendered by fest;
-// none depend on camp's error strings.
+// nothing was staged, and working ways out (including camp commit
+// --commit-large until fest grows its own flag). All assertions run against
+// typed data rendered by fest; none depend on camp's error strings.
 
 func TestGuardRefusalMessageBulkNamesEveryWayOut(t *testing.T) {
 	blocked := &commitkit.GuardBlockedError{
@@ -29,7 +29,7 @@ func TestGuardRefusalMessageBulkNamesEveryWayOut(t *testing.T) {
 		"nothing was staged",
 		"echo 'node_modules/' >> .gitignore",
 		"camp artifacts add node_modules",
-		"fest commit --commit-large",
+		"camp commit --commit-large",
 		"camp settings set local.commit.guards.bulk off",
 	} {
 		if !strings.Contains(msg, want) {
@@ -54,7 +54,7 @@ func TestGuardRefusalMessageLargeFilesNamesEveryWayOut(t *testing.T) {
 		"media/clip.bin",
 		"nothing was staged",
 		"camp artifacts add media",
-		"fest commit --commit-large",
+		"camp commit --commit-large",
 		"camp settings set local.commit.guards.large_files auto",
 	} {
 		if !strings.Contains(msg, want) {
@@ -78,7 +78,7 @@ func TestReportStageOutcomeSaysWhatTheGuardDid(t *testing.T) {
 	out := b.String()
 	for _, want := range []string{
 		"Kept out of git: render.bin",
-		"fest commit --commit-large",
+		"camp commit --commit-large",
 		"Tracked file grew past 100.0 MB: fixtures/golden.json",
 	} {
 		if !strings.Contains(out, want) {

--- a/internal/commands/commit/guard_test.go
+++ b/internal/commands/commit/guard_test.go
@@ -1,0 +1,97 @@
+package commit
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/camp/pkg/commitkit"
+)
+
+// The refusal message is fest's one chance to explain a blocked commit, so
+// these tests pin the contract: every refusal names what was found, that
+// nothing was staged, and the same ways out camp names, with fest commit as
+// the retry vehicle. All assertions run against typed data rendered by fest;
+// none depend on camp's error strings.
+
+func TestGuardRefusalMessageBulkNamesEveryWayOut(t *testing.T) {
+	blocked := &commitkit.GuardBlockedError{
+		Kind: commitkit.Bulk,
+		Violations: []commitkit.GuardViolation{
+			{Kind: commitkit.Bulk, CommonPrefix: "node_modules", Count: 1204, TotalBytes: 220 << 20},
+		},
+	}
+
+	msg := guardRefusalMessage(blocked)
+
+	for _, want := range []string{
+		"1204 untracked files",
+		"node_modules/",
+		"nothing was staged",
+		"echo 'node_modules/' >> .gitignore",
+		"camp artifacts add node_modules",
+		"fest commit --commit-large",
+		"camp settings set local.commit.guards.bulk off",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("bulk refusal missing %q in:\n%s", want, msg)
+		}
+	}
+}
+
+func TestGuardRefusalMessageLargeFilesNamesEveryWayOut(t *testing.T) {
+	blocked := &commitkit.GuardBlockedError{
+		Kind: commitkit.OverThreshold,
+		Violations: []commitkit.GuardViolation{
+			{Kind: commitkit.OverThreshold, Path: "media/clip.bin", Size: 900 << 20},
+		},
+		Limits: commitkit.GuardLimits{MaxFileSize: 100 << 20},
+	}
+
+	msg := guardRefusalMessage(blocked)
+
+	for _, want := range []string{
+		"1 file over the 100.0 MB limit",
+		"media/clip.bin",
+		"nothing was staged",
+		"camp artifacts add media",
+		"fest commit --commit-large",
+		"camp settings set local.commit.guards.large_files auto",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("large-file refusal missing %q in:\n%s", want, msg)
+		}
+	}
+}
+
+func TestReportStageOutcomeSaysWhatTheGuardDid(t *testing.T) {
+	var b strings.Builder
+	reportStageOutcome(&b, &commitkit.StageOutcome{
+		Excluded: []commitkit.GuardViolation{
+			{Kind: commitkit.OverThreshold, Path: "render.bin", Size: 512 << 20},
+		},
+		Reported: []commitkit.GuardViolation{
+			{Kind: commitkit.TrackedGrowth, Path: "fixtures/golden.json", Size: 150 << 20},
+		},
+		Limits: commitkit.GuardLimits{MaxFileSize: 100 << 20},
+	})
+
+	out := b.String()
+	for _, want := range []string{
+		"Kept out of git: render.bin",
+		"fest commit --commit-large",
+		"Tracked file grew past 100.0 MB: fixtures/golden.json",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("outcome report missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestReportStageOutcomeIsSilentWhenThereIsNothingToSay(t *testing.T) {
+	var b strings.Builder
+	reportStageOutcome(&b, nil)
+	reportStageOutcome(&b, &commitkit.StageOutcome{})
+	if b.Len() != 0 {
+		t.Errorf("an uneventful stage must print nothing, got:\n%s", b.String())
+	}
+}

--- a/internal/commands/pack/pack.go
+++ b/internal/commands/pack/pack.go
@@ -86,8 +86,8 @@ Works from any directory (global scope); source path is explicit.`,
 				enc.SetIndent("", "  ")
 				return enc.Encode(info)
 			}
-			fmt.Fprintf(cmd.ErrOrStderr(), "wrote %s\n", output)
-			fmt.Fprintf(cmd.OutOrStdout(), "kind=%s id=%s name=%q\n", info.Kind, info.Bundle.ID, info.Bundle.Name)
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "wrote %s\n", output)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "kind=%s id=%s name=%q\n", info.Kind, info.Bundle.ID, info.Bundle.Name)
 			return nil
 		},
 	}
@@ -156,10 +156,10 @@ go to stderr so --json still emits a single JSON document on stdout.`,
 				}
 				// Always send human validation summary to stderr so --json
 				// stdout remains a single JSON document.
-				fmt.Fprintf(cmd.ErrOrStderr(), "validate: score=%d valid=%v issues=%d\n",
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "validate: score=%d valid=%v issues=%d\n",
 					result.Score, result.Valid, len(result.Issues))
 				for _, issue := range result.Issues {
-					fmt.Fprintf(cmd.ErrOrStderr(), "  - %s: %s\n", issue.Code, issue.Message)
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "  - %s: %s\n", issue.Code, issue.Message)
 				}
 				if !result.Valid {
 					return festerrors.New(fmt.Sprintf("validation failed (score %d)", result.Score))
@@ -171,8 +171,8 @@ go to stderr so --json still emits a single JSON document on stdout.`,
 				enc.SetIndent("", "  ")
 				return enc.Encode(info)
 			}
-			fmt.Fprintf(cmd.ErrOrStderr(), "unbundled to %s\n", d)
-			fmt.Fprintf(cmd.OutOrStdout(), "kind=%s id=%s name=%q\n", info.Kind, info.Bundle.ID, info.Bundle.Name)
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "unbundled to %s\n", d)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "kind=%s id=%s name=%q\n", info.Kind, info.Bundle.ID, info.Bundle.Name)
 			return nil
 		},
 	}

--- a/tests/integration/commit_drain_test.go
+++ b/tests/integration/commit_drain_test.go
@@ -1,0 +1,174 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Criteria 15 and 15b: fest commit inherits camp's deferred-commit ordering
+// guarantee through commitkit, and never itself defers. A `camp intent add`
+// queues its bookkeeping commit; a `fest commit` that follows immediately
+// must land that queued commit in history BEFORE the festival commit (the
+// drain inside commitkit.StageFiles/Commit), return with the queue empty,
+// and report a real hash that is HEAD at return.
+//
+// The camp binary is built from fest's own go.mod dependency, so the exact
+// released version fest links against is the version driving the fixture.
+
+var (
+	campBuildOnce sync.Once
+	campBuildErr  error
+	campHostPath  string
+)
+
+// ensureCampInContainer builds camp from the module cache (the pinned
+// dependency version, cross-compiled for the container) and installs it at
+// /usr/local/bin/camp in the shared container.
+func ensureCampInContainer(t *testing.T, tc *TestContainer) {
+	t.Helper()
+	campBuildOnce.Do(func() {
+		// The version comes from fest's own go.mod, so the binary driving the
+		// fixture is exactly the release fest links against. go install
+		// resolves camp's full dependency tree from camp's module, which
+		// fest's go.sum deliberately does not carry.
+		verCmd := exec.Command("go", "list", "-m", "-f", "{{.Version}}",
+			"github.com/Obedience-Corp/camp")
+		verOut, err := verCmd.Output()
+		if err != nil {
+			campBuildErr = &campBuildError{err: err, out: "resolving pinned camp version"}
+			return
+		}
+		version := strings.TrimSpace(string(verOut))
+
+		install := exec.Command("go", "install",
+			"github.com/Obedience-Corp/camp/cmd/camp@"+version)
+		env := make([]string, 0, len(os.Environ())+3)
+		for _, e := range os.Environ() {
+			// GOBIN forbids cross-compiled installs; the platform subdir of
+			// GOPATH/bin is where a cross-compiled binary lands instead.
+			if !strings.HasPrefix(e, "GOBIN=") {
+				env = append(env, e)
+			}
+		}
+		install.Env = append(env, "GOOS=linux", "GOARCH="+runtime.GOARCH, "CGO_ENABLED=0")
+		if out, err := install.CombinedOutput(); err != nil {
+			campBuildErr = &campBuildError{err: err, out: string(out)}
+			return
+		}
+
+		gopathOut, err := exec.Command("go", "env", "GOPATH").Output()
+		if err != nil {
+			campBuildErr = &campBuildError{err: err, out: "resolving GOPATH"}
+			return
+		}
+		gopath := strings.TrimSpace(string(gopathOut))
+		campHostPath = filepath.Join(gopath, "bin", "linux_"+runtime.GOARCH, "camp")
+		if runtime.GOOS == "linux" {
+			campHostPath = filepath.Join(gopath, "bin", "camp")
+		}
+	})
+	if campBuildErr != nil {
+		t.Fatalf("building camp from the pinned dependency: %v", campBuildErr)
+	}
+	if _, err := tc.Exec("test", "-x", "/usr/local/bin/camp"); err == nil {
+		return
+	}
+	require.NoError(t, tc.CopyToContainer(campHostPath, "/usr/local/bin/camp"))
+	_, err := tc.Exec("chmod", "+x", "/usr/local/bin/camp")
+	require.NoError(t, err)
+}
+
+type campBuildError struct {
+	err error
+	out string
+}
+
+func (e *campBuildError) Error() string { return e.err.Error() + ":\n" + e.out }
+
+func TestCommitDrain_QueuedBookkeepingLandsBeforeTheFestivalCommit(t *testing.T) {
+	tc := GetSharedContainer(t)
+	ensureGuardGit(t, tc)
+	ensureCampInContainer(t, tc)
+
+	// A real campaign, initialized by the released camp binary the fixture is
+	// about: its queue wiring is the thing under test.
+	out, err := tc.Exec("sh", "-c",
+		"export HOME=/root && cd / && camp init guard-drain -d 'drain fixture' -m 'prove criterion 15'")
+	require.NoError(t, err, "camp init should succeed: %s", out)
+	camp := "/guard-drain"
+	require.NoError(t, tc.WriteFile(camp+"/festivals/active/guard-festival/fest.yaml", guardFestYAML))
+	require.NoError(t, tc.WriteFile(camp+"/festivals/active/guard-festival/NOTES.md", "# Progress\n"))
+	// Any campaign fest has navigated has these; a bare camp init does not,
+	// and fest's scoped staging lists them unconditionally (intent filed:
+	// fest-commit-fails-in-a-fresh-campaign). The fixture mirrors the lived-in
+	// shape rather than the bug.
+	_, err = tc.Exec("sh", "-c",
+		"mkdir -p "+camp+"/.campaign/fest "+camp+"/festivals/.festival/.state"+
+			" && touch "+camp+"/.campaign/fest/.gitkeep "+camp+"/festivals/.festival/.state/.gitkeep")
+	require.NoError(t, err)
+
+	// A baseline commit first: camp init leaves the branch unborn, and a
+	// deferred job cannot execute against no HEAD (intent filed:
+	// deferred-bookkeeping-commits-fail-on-an-unborn-branch). The steady
+	// state every real campaign reaches immediately is what the drain
+	// contract is defined over.
+	out, err = tc.Exec("sh", "-c",
+		"export HOME=/root && cd "+camp+" && camp commit -m 'campaign baseline'")
+	require.NoError(t, err, "baseline camp commit should succeed: %s", out)
+
+	// The intent enqueues its bookkeeping commit and returns; fest commit
+	// follows in the same shell so the queued job is still in flight when
+	// fest starts staging. The festival edit gives fest a commit of its own
+	// to make. The drain guarantee, not timing, is what must order history.
+	out, err = tc.Exec("sh", "-c",
+		"export HOME=/root && cd "+camp+"/festivals/active/guard-festival"+
+			" && echo 'progress' >> NOTES.md"+
+			" && camp intent add 'queued bookkeeping intent'"+
+			" && /fest commit --json --no-tag -m 'festival work' > /tmp/drain-stdout 2>/tmp/drain-stderr")
+	require.NoError(t, err, "intent add followed by fest commit must succeed: %s", out)
+
+	stdout, err := tc.ReadFile("/tmp/drain-stdout")
+	require.NoError(t, err)
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &doc),
+		"fest commit --json stdout must be the JSON document, got:\n%s", stdout)
+	require.Equal(t, true, doc["success"], "fest commit must succeed: %v", doc)
+	hash, _ := doc["hash"].(string)
+	require.NotEmpty(t, hash, "criterion 15b: the structured output always carries a real hash")
+
+	// 15b: never defers. The reported hash is HEAD at return; a deferred
+	// commit could not be, because it would not exist yet.
+	head, err := tc.Exec("git", "-C", camp, "rev-parse", "--short", "HEAD")
+	require.NoError(t, err)
+	assert.Equal(t, strings.TrimSpace(head), hash,
+		"fest's reported hash must be HEAD at return; fest never defers")
+
+	// 15: the queued intent commit landed, and landed before fest's commit.
+	subjects, err := tc.Exec("git", "-C", camp, "log", "--format=%s")
+	require.NoError(t, err)
+	assert.Contains(t, subjects, "queued bookkeeping intent",
+		"the queued bookkeeping commit must be in history at fest commit's return")
+	lines := strings.Split(strings.TrimSpace(subjects), "\n")
+	require.NotEmpty(t, lines)
+	assert.Contains(t, lines[0], "festival work",
+		"HEAD must be the festival commit, with the drained bookkeeping beneath it")
+
+	// The drain leaves nothing behind: no pending or running jobs at return.
+	remaining, err := tc.Exec("sh", "-c",
+		"find "+camp+"/.campaign/cache/jobs/pending "+camp+"/.campaign/cache/jobs/running -name '*.json' 2>/dev/null | wc -l")
+	require.NoError(t, err)
+	assert.Equal(t, "0", strings.TrimSpace(remaining),
+		"fest commit must return with camp's queue drained")
+}

--- a/tests/integration/commit_drain_test.go
+++ b/tests/integration/commit_drain_test.go
@@ -82,9 +82,9 @@ func ensureCampInContainer(t *testing.T, tc *TestContainer) {
 	if campBuildErr != nil {
 		t.Fatalf("building camp from the pinned dependency: %v", campBuildErr)
 	}
-	if _, err := tc.Exec("test", "-x", "/usr/local/bin/camp"); err == nil {
-		return
-	}
+	// Always install the host-built pinned binary. A preinstalled camp of a
+	// different version would silently drive the fixture against the wrong
+	// commitkit while fest links v0.4.0-rc.1.
 	require.NoError(t, tc.CopyToContainer(campHostPath, "/usr/local/bin/camp"))
 	_, err := tc.Exec("chmod", "+x", "/usr/local/bin/camp")
 	require.NoError(t, err)

--- a/tests/integration/commit_guard_test.go
+++ b/tests/integration/commit_guard_test.go
@@ -58,7 +58,7 @@ func TestCommitGuard_LargeFileKeptOutInStandaloneWorkspace(t *testing.T) {
 
 	// The exclusion is said out loud with its undo, from fest's own renderer.
 	assert.Contains(t, out, "render-output.bin", "fest must name the file it kept out of git")
-	assert.Contains(t, out, "fest commit --commit-large", "the exclusion must carry its own undo")
+	assert.Contains(t, out, "camp commit --commit-large", "the exclusion must carry a working undo")
 
 	// The commit exists and carries the small file only.
 	committed, err := tc.Exec("git", "-C", dir, "ls-tree", "-r", "--name-only", "HEAD")
@@ -101,7 +101,7 @@ func TestCommitGuard_LargeFileKeptOutInLinkedSubmodule(t *testing.T) {
 		"commit", "--no-tag", "-m", "guarded project commit")
 	require.NoError(t, err, "the project commit must succeed without the big file: %s", out)
 	assert.Contains(t, out, "render-output.bin", "fest must name the file it kept out of the project repo")
-	assert.Contains(t, out, "fest commit --commit-large", "the exclusion must carry its own undo")
+	assert.Contains(t, out, "camp commit --commit-large", "the exclusion must carry a working undo")
 
 	committed, err := tc.Exec("git", "-C", "/guard-camp/projects/app", "ls-tree", "-r", "--name-only", "HEAD")
 	require.NoError(t, err)

--- a/tests/integration/commit_guard_test.go
+++ b/tests/integration/commit_guard_test.go
@@ -70,6 +70,17 @@ func TestCommitGuard_LargeFileKeptOutInStandaloneWorkspace(t *testing.T) {
 	status, err := tc.Exec("git", "-C", dir, "status", "--porcelain")
 	require.NoError(t, err)
 	assert.Contains(t, status, "?? render-output.bin", "the excluded file must remain untracked on disk")
+
+	// Exclude-everything: grow only the big file and commit again. The guard
+	// excludes the sole change, so nothing is left to commit; that must read
+	// as the guard's doing, not as the commit failing for no reason.
+	_, err = tc.Exec("sh", "-c", "truncate -s 513M "+dir+"/render-output.bin")
+	require.NoError(t, err)
+	out2, err := tc.RunFestInDir(dir+"/festivals/active/guard-festival",
+		"commit", "--no-tag", "-m", "only excluded changes")
+	require.Error(t, err, "an exclude-everything commit has nothing to commit")
+	assert.Contains(t, out2, "kept out of git by the size/bulk guard",
+		"the no-op must be attributed to the guard: %s", out2)
 }
 
 func TestCommitGuard_LargeFileKeptOutInLinkedSubmodule(t *testing.T) {

--- a/tests/integration/commit_guard_test.go
+++ b/tests/integration/commit_guard_test.go
@@ -58,7 +58,7 @@ func TestCommitGuard_LargeFileKeptOutInStandaloneWorkspace(t *testing.T) {
 
 	// The exclusion is said out loud with its undo, from fest's own renderer.
 	assert.Contains(t, out, "render-output.bin", "fest must name the file it kept out of git")
-	assert.Contains(t, out, "camp commit --commit-large", "the exclusion must carry a working undo")
+	assert.Contains(t, out, "fest commit --commit-large", "the exclusion must carry fest's own working undo")
 
 	// The commit exists and carries the small file only.
 	committed, err := tc.Exec("git", "-C", dir, "ls-tree", "-r", "--name-only", "HEAD")
@@ -81,6 +81,17 @@ func TestCommitGuard_LargeFileKeptOutInStandaloneWorkspace(t *testing.T) {
 	require.Error(t, err, "an exclude-everything commit has nothing to commit")
 	assert.Contains(t, out2, "kept out of git by the size/bulk guard",
 		"the no-op must be attributed to the guard: %s", out2)
+
+	// The advertised retry must actually work: the same commit with
+	// --commit-large forces the excluded file into git, exactly as camp's
+	// own flag would.
+	out3, err := tc.RunFestInDir(dir+"/festivals/active/guard-festival",
+		"commit", "--no-tag", "--commit-large", "-m", "committed anyway")
+	require.NoError(t, err, "the --commit-large retry must succeed: %s", out3)
+	committed2, err := tc.Exec("git", "-C", dir, "ls-tree", "-r", "--name-only", "HEAD")
+	require.NoError(t, err)
+	assert.Contains(t, committed2, "render-output.bin",
+		"--commit-large must force the over-threshold file into the commit")
 }
 
 func TestCommitGuard_LargeFileKeptOutInLinkedSubmodule(t *testing.T) {
@@ -112,7 +123,7 @@ func TestCommitGuard_LargeFileKeptOutInLinkedSubmodule(t *testing.T) {
 		"commit", "--no-tag", "-m", "guarded project commit")
 	require.NoError(t, err, "the project commit must succeed without the big file: %s", out)
 	assert.Contains(t, out, "render-output.bin", "fest must name the file it kept out of the project repo")
-	assert.Contains(t, out, "camp commit --commit-large", "the exclusion must carry a working undo")
+	assert.Contains(t, out, "fest commit --commit-large", "the exclusion must carry fest's own working undo")
 
 	committed, err := tc.Exec("git", "-C", "/guard-camp/projects/app", "ls-tree", "-r", "--name-only", "HEAD")
 	require.NoError(t, err)

--- a/tests/integration/commit_guard_test.go
+++ b/tests/integration/commit_guard_test.go
@@ -1,0 +1,114 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Criterion 15z: fest's auto-stage branches route through camp's staging
+// guard, so an untracked over-threshold generated file in a festival
+// workspace is kept out of git by fest exactly as `camp commit` keeps it out.
+// Both fest branches stage repositories that are not a campaign root, so the
+// guard applies project-side policy in each: exclude the file, commit the
+// rest, and say so with the undo attached.
+//
+// The big file is sparse (truncate): the guard measures lstat size, never
+// content, so 512 MB costs no disk or time.
+
+// ensureGuardGit installs git into the shared Alpine container once and gives
+// it a global identity; every fixture repo inherits it.
+func ensureGuardGit(t *testing.T, tc *TestContainer) {
+	t.Helper()
+	_, err := tc.Exec("sh", "-c",
+		"command -v git >/dev/null 2>&1 || apk add --no-cache git >/dev/null 2>&1")
+	require.NoError(t, err, "git must be installable in the test container")
+	_, err = tc.Exec("sh", "-c",
+		"git config --global user.email fest@test && git config --global user.name fest-test && git config --global init.defaultBranch main && git config --global protocol.file.allow always")
+	require.NoError(t, err)
+}
+
+// guardFestYAML is the minimal festival marker: enough for fest's scope
+// resolution to treat the directory as a festival root.
+const guardFestYAML = "version: \"1.0\"\nname: guard-festival\n"
+
+func TestCommitGuard_LargeFileKeptOutInStandaloneWorkspace(t *testing.T) {
+	tc := GetSharedContainer(t)
+	ensureGuardGit(t, tc)
+
+	dir := "/guard-standalone"
+	// festivals/.festival is what marks a valid festivals dir; the festival
+	// itself lives under a status directory, as fest lays them out.
+	_, err := tc.Exec("sh", "-c",
+		"mkdir -p "+dir+"/festivals/.festival && cd "+dir+" && git init -q")
+	require.NoError(t, err)
+	require.NoError(t, tc.WriteFile(dir+"/festivals/active/guard-festival/fest.yaml", guardFestYAML))
+	_, err = tc.Exec("sh", "-c",
+		"truncate -s 512M "+dir+"/render-output.bin && echo notes > "+dir+"/notes.md")
+	require.NoError(t, err)
+
+	out, err := tc.RunFestInDir(dir+"/festivals/active/guard-festival",
+		"commit", "--no-tag", "-m", "guarded standalone commit")
+	require.NoError(t, err, "the commit must succeed without the big file: %s", out)
+
+	// The exclusion is said out loud with its undo, from fest's own renderer.
+	assert.Contains(t, out, "render-output.bin", "fest must name the file it kept out of git")
+	assert.Contains(t, out, "fest commit --commit-large", "the exclusion must carry its own undo")
+
+	// The commit exists and carries the small file only.
+	committed, err := tc.Exec("git", "-C", dir, "ls-tree", "-r", "--name-only", "HEAD")
+	require.NoError(t, err)
+	assert.Contains(t, committed, "notes.md", "the ordinary file must be committed")
+	assert.NotContains(t, committed, "render-output.bin", "the over-threshold file must stay out of history")
+
+	// Still on disk and untracked: excluded, never deleted.
+	status, err := tc.Exec("git", "-C", dir, "status", "--porcelain")
+	require.NoError(t, err)
+	assert.Contains(t, status, "?? render-output.bin", "the excluded file must remain untracked on disk")
+}
+
+func TestCommitGuard_LargeFileKeptOutInLinkedSubmodule(t *testing.T) {
+	tc := GetSharedContainer(t)
+	ensureGuardGit(t, tc)
+
+	// A campaign root holding a project submodule, the shape fest's
+	// in-submodule branch serves. The submodule source needs one commit
+	// before it can be added.
+	_, err := tc.Exec("sh", "-c", strings.Join([]string{
+		"mkdir -p /guard-src && cd /guard-src && git init -q",
+		"echo app > app.txt && git add -A && git commit -qm init",
+		"mkdir -p /guard-camp/festivals/.festival && cd /guard-camp && git init -q && mkdir .campaign",
+		"git submodule add -q /guard-src projects/app",
+		"git add -A && git commit -qm 'campaign with project'",
+	}, " && "))
+	require.NoError(t, err)
+	require.NoError(t, tc.WriteFile("/guard-camp/festivals/active/guard-festival/fest.yaml", guardFestYAML))
+
+	// The link is what gives a project directory festival context.
+	out, err := tc.RunFestInDir("/guard-camp/festivals/active/guard-festival", "link", "/guard-camp/projects/app")
+	require.NoError(t, err, "linking the project should succeed: %s", out)
+
+	_, err = tc.Exec("sh", "-c",
+		"truncate -s 512M /guard-camp/projects/app/render-output.bin && echo change > /guard-camp/projects/app/notes.md")
+	require.NoError(t, err)
+
+	out, err = tc.RunFestInDir("/guard-camp/projects/app",
+		"commit", "--no-tag", "-m", "guarded project commit")
+	require.NoError(t, err, "the project commit must succeed without the big file: %s", out)
+	assert.Contains(t, out, "render-output.bin", "fest must name the file it kept out of the project repo")
+	assert.Contains(t, out, "fest commit --commit-large", "the exclusion must carry its own undo")
+
+	committed, err := tc.Exec("git", "-C", "/guard-camp/projects/app", "ls-tree", "-r", "--name-only", "HEAD")
+	require.NoError(t, err)
+	assert.Contains(t, committed, "notes.md", "the ordinary project file must be committed")
+	assert.NotContains(t, committed, "render-output.bin", "project-side policy excludes and asks; git never sees the file")
+
+	status, err := tc.Exec("git", "-C", "/guard-camp/projects/app", "status", "--porcelain")
+	require.NoError(t, err)
+	assert.Contains(t, status, "?? render-output.bin", "the excluded file must remain on disk, untracked")
+}

--- a/tests/integration/commit_json_test.go
+++ b/tests/integration/commit_json_test.go
@@ -1,0 +1,64 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Criterion 15a: `fest commit --json` emits exactly one JSON document on
+// stdout and nothing else. Before the commitkit swap, executeGitCommit wired
+// git's own stdout to the process stdout while --json encoded to the same
+// stream, so scripts parsing the output got git's summary interleaved with
+// the document (intent fest-commit-json-interleaves-git-20260726-001838).
+//
+// The streams are separated by shell redirection inside the container,
+// because the harness's combined capture cannot distinguish them.
+func TestCommitJSON_StdoutIsExactlyOneJSONDocument(t *testing.T) {
+	tc := GetSharedContainer(t)
+	ensureGuardGit(t, tc)
+
+	dir := "/guard-json"
+	_, err := tc.Exec("sh", "-c",
+		"mkdir -p "+dir+"/festivals/.festival && cd "+dir+" && git init -q")
+	require.NoError(t, err)
+	require.NoError(t, tc.WriteFile(dir+"/festivals/active/guard-festival/fest.yaml", guardFestYAML))
+	_, err = tc.Exec("sh", "-c", "echo change > "+dir+"/notes.md")
+	require.NoError(t, err)
+
+	_, err = tc.Exec("sh", "-c",
+		"cd "+dir+"/festivals/active/guard-festival && /fest commit --json --no-tag -m 'json purity' > /tmp/json-stdout 2> /tmp/json-stderr")
+	require.NoError(t, err, "fest commit --json must exit zero")
+
+	stdout, err := tc.ReadFile("/tmp/json-stdout")
+	require.NoError(t, err)
+
+	// Exactly one document: a decoder consumes it, and nothing but whitespace
+	// may follow. Git's "1 file changed..." summary before or after the JSON
+	// fails both checks.
+	dec := json.NewDecoder(strings.NewReader(stdout))
+	var doc map[string]any
+	require.NoError(t, dec.Decode(&doc),
+		"stdout must begin with a JSON document, got:\n%s", stdout)
+	rest := new(strings.Builder)
+	if dec.More() {
+		t.Fatalf("stdout carries more than one JSON value:\n%s", stdout)
+	}
+	_, _ = rest.WriteString(stdout[int(dec.InputOffset()):])
+	assert.Empty(t, strings.TrimSpace(rest.String()),
+		"nothing but the JSON document may reach stdout")
+
+	assert.Equal(t, true, doc["success"], "the commit must report success: %v", doc)
+	hash, _ := doc["hash"].(string)
+	assert.NotEmpty(t, hash, "the document must carry the commit hash")
+
+	// The hash is real: the commit exists at return.
+	_, err = tc.Exec("git", "-C", dir, "cat-file", "-e", hash+"^{commit}")
+	assert.NoError(t, err, "the reported hash must name a commit that exists")
+}


### PR DESCRIPTION
## What

Closes fest's raw-git staging and commit holes through the camp v0.4.0-rc.1 bump (CA0004 phase 003, sequence 02):

- **Bump**: `github.com/Obedience-Corp/camp` v0.3.1 -> v0.4.0-rc.1. Version line only, no `replace`.
- **StageAll swap**: `stageAllChanges` no longer runs a raw `git add -A` in whatever cwd fest held. It stages through `commitkit.StageAllWithOutcome` against an explicit repo path, inheriting lock retry, the large-file guard, and bulk protection. Both auto-stage branches (in-submodule and non-campaign fallback) are covered.
- **Fest-rendered guard output**: violations arrive as typed data (`GuardBlockedError`, `StageOutcome`) and fest renders them in its own voice; no camp error-string parsing. A refusal reaches `result.Error` naming the same ways out camp names (gitignore it, `camp artifacts add`, commit it anyway, settings switch), with `fest commit --commit-large` as the retry vehicle. Successful stages report exclusions on stderr so `--json` stdout stays pure.
- **Commit swap**: `executeGitCommit` deleted. The primary commit goes through `commitkit.Commit` + `commitkit.ShortHash`, the same pair `commitCampaignRoot` already used. `ErrNoChanges` maps to a clear "no changes to commit" instead of a generic git failure.

## The `--json` fix (criterion 15a)

`executeGitCommit` wired git's stdout to the process stdout while `--json` encoded to the same stream. Captured failing baseline, pre-swap, from the regression test:

```
[main (root-commit) 381c2e2] json purity
 2 files changed, 3 insertions(+)
 create mode 100644 festivals/active/guard-festival/fest.yaml
 create mode 100644 notes.md
{
  "success": true,
  "hash": "381c2e2",
  ...
```

`commitkit.Commit` captures git's output internally; the test now asserts stdout is exactly one JSON document with nothing before or after it. This resolves intent `fest-commit-json-interleaves-git-20260726-001838`.

## Proofs (containerized integration tests)

- **15z** (`commit_guard_test.go`): an untracked sparse 512 MB generated file in a festival workspace is kept out of git and left on disk, said out loud with its undo, in both auto-stage branches (standalone workspace and linked submodule). Project-side policy applies in each, matching `camp commit`.
- **15a** (`commit_json_test.go`): `fest commit --json` emits exactly one JSON document on stdout; the reported hash names a commit that exists at return.
- **15 and 15b** (`commit_drain_test.go`): `camp intent add` (run with a camp binary built from this module's own pinned dependency version) queues its bookkeeping commit; an immediately following `fest commit` lands that queued commit in history before the festival commit, returns with the queue empty, and reports a hash that is HEAD at return. Fest never defers.

## Not in this PR

`--commit-large` passthrough. The released commitkit has no options-taking stage call; camp PR Obedience-Corp/camp#523 exports `StageAllWithOptions`, and once it merges and ships as v0.4.0-rc.2 this branch gains the flag, threaded to the same override camp's own `--commit-large` uses.

## Found while fixturing (intents filed, out of scope here)

- `fest commit` fails in a fresh campaign: `festivalScopedPaths` lists `.campaign/fest` and `festivals/.festival/.state` unconditionally; git errors on the missing pathspec before fest has ever navigated.
- camp: deferred bookkeeping commits fail silently on an unborn branch (`camp init` leaves no initial commit; `read-tree` cannot resolve HEAD).

## Testing

Unit suite green; new guard rendering unit tests; the four containerized integration tests above; full `just gate` run on this head (result in the PR checks conversation).
