### PR TITLE
feat(list,go): surface lifecycle residents in status, list, and go (WF0001 P4/S2)

### DIFF
--- a/internal/commands/list/list.go
+++ b/internal/commands/list/list.go
@@ -405,6 +405,13 @@ func listDungeon(ctx context.Context, festivalsDir string, opts *listOptions, ca
 			result[status] = festivalsToMapWithProgress(festivals, board.Progress)
 		}
 		result["total"] = board.Total
+		if len(board.Residents) > 0 {
+			residents := make(map[string]interface{}, len(board.Residents))
+			for status, cards := range board.Residents {
+				residents[status] = cards
+			}
+			result["residents"] = residents
+		}
 		return outputJSON(result)
 	}
 	fmt.Print(formatDungeonHuman(board.Festivals, board.Order, board.Progress, board.Total, opts.progress))
@@ -417,13 +424,17 @@ func listByStatus(ctx context.Context, festivalsDir, status string, opts *listOp
 		return err
 	}
 	if opts.json {
-		return outputJSON(map[string]interface{}{
+		payload := map[string]interface{}{
 			"status":    status,
 			"count":     len(board.Festivals),
 			"festivals": festivalsToMapWithProgress(board.Festivals, board.Progress),
-		})
+		}
+		if len(board.Residents) > 0 {
+			payload["residents"] = board.Residents
+		}
+		return outputJSON(payload)
 	}
-	fmt.Print(formatStatusHuman(status, board.Festivals, board.Progress, opts.progress))
+	fmt.Print(formatStatusHuman(status, board.Festivals, board.Residents, board.Progress, opts.progress))
 	return nil
 }
 
@@ -438,9 +449,16 @@ func listAll(ctx context.Context, festivalsDir string, opts *listOptions, campai
 			result[status] = festivalsToMapWithProgress(festivals, board.Progress)
 		}
 		result["total"] = board.Total
+		if len(board.Residents) > 0 {
+			residents := make(map[string]interface{}, len(board.Residents))
+			for status, cards := range board.Residents {
+				residents[status] = cards
+			}
+			result["residents"] = residents
+		}
 		return outputJSON(result)
 	}
-	fmt.Print(formatAllHuman(board.Festivals, board.Order, board.Progress, board.Total, opts.progress))
+	fmt.Print(formatAllHuman(board.Festivals, board.Residents, board.Order, board.Progress, board.Total, opts.progress))
 	return nil
 }
 
@@ -543,20 +561,32 @@ func formatDungeonHuman(allFestivals map[string][]*show.FestivalInfo, order []st
 	return show.FormatAllFestivals(allFestivals, order)
 }
 
-func formatStatusHuman(status string, festivals []*show.FestivalInfo, progressMap map[string]*progress.FestivalProgress, withProgress bool) string {
+func formatStatusHuman(status string, festivals []*show.FestivalInfo, residents []*show.ResidentCard, progressMap map[string]*progress.FestivalProgress, withProgress bool) string {
+	var out string
 	if withProgress {
-		return show.FormatFestivalListWithProgress(status, festivals, progressMap)
+		out = show.FormatFestivalListWithProgress(status, festivals, progressMap)
+	} else {
+		out = show.FormatFestivalList(status, festivals)
 	}
-	return show.FormatFestivalList(status, festivals)
+	// Empty when there are no residents, which keeps a resident-free stage
+	// byte-identical to the pre-rail output.
+	if block := show.FormatResidentList(status, residents); block != "" {
+		out += "\n" + block
+	}
+	return out
 }
 
-func formatAllHuman(allFestivals map[string][]*show.FestivalInfo, statusOrder []string, progressMap map[string]*progress.FestivalProgress, totalCount int, withProgress bool) string {
-	if totalCount == 0 {
+func formatAllHuman(allFestivals map[string][]*show.FestivalInfo, allResidents map[string][]*show.ResidentCard, statusOrder []string, progressMap map[string]*progress.FestivalProgress, totalCount int, withProgress bool) string {
+	if totalCount == 0 && len(allResidents) == 0 {
 		return ui.Warning("No festivals found.") + "\n" +
 			ui.Info("Create a festival with: fest create festival") + "\n"
 	}
-	if withProgress {
-		return show.FormatAllFestivalsWithProgress(allFestivals, statusOrder, progressMap)
+	if len(allResidents) == 0 {
+		// No residents anywhere: emit exactly what the pre-rail binary emitted.
+		if withProgress {
+			return show.FormatAllFestivalsWithProgress(allFestivals, statusOrder, progressMap)
+		}
+		return show.FormatAllFestivals(allFestivals, statusOrder)
 	}
-	return show.FormatAllFestivals(allFestivals, statusOrder)
+	return show.FormatAllWithResidents(allFestivals, allResidents, statusOrder, progressMap, withProgress)
 }

--- a/internal/commands/list/list_board.go
+++ b/internal/commands/list/list_board.go
@@ -149,16 +149,11 @@ func collectAllBoard(ctx context.Context, festivalsDir string, opts *listOptions
 		if residents := show.ListResidentsByStatus(ctx, festivalsDir, status); len(residents) > 0 {
 			allResidents[status] = residents
 		}
-		festivals, err := show.ListFestivalsByStatus(ctx, festivalsDir, status, campaignRoot)
-		if err != nil {
-			continue
-		}
-		festivals, err = applyFilters(festivals, opts)
+		festivals, err := collectStatusFestivals(ctx, festivalsDir, status, opts, campaignRoot)
 		if err != nil {
 			return multiStatusBoard{}, err
 		}
 		if len(festivals) > 0 {
-			applySorting(festivals, opts.sortBy, opts.alpha)
 			allFestivals[status] = festivals
 			totalCount += len(festivals)
 			allFestivalsList = append(allFestivalsList, festivals...)
@@ -180,4 +175,20 @@ func collectAllBoard(ctx context.Context, festivalsDir string, opts *listOptions
 		Total:     totalCount,
 		Progress:  progressMap,
 	}, nil
+}
+
+// collectStatusFestivals lists, filters, and sorts one status's festivals. An
+// unreadable status directory yields none rather than failing the whole board,
+// matching the previous inline behavior.
+func collectStatusFestivals(ctx context.Context, festivalsDir, status string, opts *listOptions, campaignRoot string) ([]*show.FestivalInfo, error) {
+	festivals, err := show.ListFestivalsByStatus(ctx, festivalsDir, status, campaignRoot)
+	if err != nil {
+		return nil, nil
+	}
+	festivals, err = applyFilters(festivals, opts)
+	if err != nil {
+		return nil, err
+	}
+	applySorting(festivals, opts.sortBy, opts.alpha)
+	return festivals, nil
 }

--- a/internal/commands/list/list_board.go
+++ b/internal/commands/list/list_board.go
@@ -17,11 +17,13 @@ type multiStatusBoard struct {
 	Order     []string
 	Total     int
 	Progress  map[string]*progress.FestivalProgress
+	Residents map[string][]*show.ResidentCard
 }
 
 // statusBoard is the single-status collection model.
 type statusBoard struct {
 	Festivals []*show.FestivalInfo
+	Residents []*show.ResidentCard
 	Progress  map[string]*progress.FestivalProgress
 }
 
@@ -40,13 +42,13 @@ func formatListBoard(ctx context.Context, festivalsDir, filterStatus string, opt
 		if err != nil {
 			return "", err
 		}
-		return formatStatusHuman(filterStatus, board.Festivals, board.Progress, opts.progress), nil
+		return formatStatusHuman(filterStatus, board.Festivals, board.Residents, board.Progress, opts.progress), nil
 	}
 	board, err := collectAllBoard(ctx, festivalsDir, opts, campaignRoot)
 	if err != nil {
 		return "", err
 	}
-	return formatAllHuman(board.Festivals, board.Order, board.Progress, board.Total, opts.progress), nil
+	return formatAllHuman(board.Festivals, board.Residents, board.Order, board.Progress, board.Total, opts.progress), nil
 }
 
 func collectDungeonBoard(ctx context.Context, festivalsDir string, opts *listOptions, campaignRoot string) (multiStatusBoard, error) {
@@ -121,7 +123,11 @@ func collectStatusBoard(ctx context.Context, festivalsDir, status string, opts *
 	if opts.progress {
 		progressMap = fetchProgressForFestivals(ctx, festivals)
 	}
-	return statusBoard{Festivals: festivals, Progress: progressMap}, nil
+	return statusBoard{
+		Festivals: festivals,
+		Residents: show.ListResidentsByStatus(ctx, festivalsDir, status),
+		Progress:  progressMap,
+	}, nil
 }
 
 func collectAllBoard(ctx context.Context, festivalsDir string, opts *listOptions, campaignRoot string) (multiStatusBoard, error) {
@@ -135,10 +141,14 @@ func collectAllBoard(ctx context.Context, festivalsDir string, opts *listOptions
 
 	var totalCount int
 	allFestivals := make(map[string][]*show.FestivalInfo)
+	allResidents := make(map[string][]*show.ResidentCard)
 	statusOrder := make([]string, 0, len(statuses))
 	var allFestivalsList []*show.FestivalInfo
 
 	for _, status := range statuses {
+		if residents := show.ListResidentsByStatus(ctx, festivalsDir, status); len(residents) > 0 {
+			allResidents[status] = residents
+		}
 		festivals, err := show.ListFestivalsByStatus(ctx, festivalsDir, status, campaignRoot)
 		if err != nil {
 			continue
@@ -150,9 +160,12 @@ func collectAllBoard(ctx context.Context, festivalsDir string, opts *listOptions
 		if len(festivals) > 0 {
 			applySorting(festivals, opts.sortBy, opts.alpha)
 			allFestivals[status] = festivals
-			statusOrder = append(statusOrder, status)
 			totalCount += len(festivals)
 			allFestivalsList = append(allFestivalsList, festivals...)
+		}
+		// A stage holding only residents still deserves a column.
+		if len(festivals) > 0 || len(allResidents[status]) > 0 {
+			statusOrder = append(statusOrder, status)
 		}
 	}
 
@@ -162,6 +175,7 @@ func collectAllBoard(ctx context.Context, festivalsDir string, opts *listOptions
 	}
 	return multiStatusBoard{
 		Festivals: allFestivals,
+		Residents: allResidents,
 		Order:     statusOrder,
 		Total:     totalCount,
 		Progress:  progressMap,

--- a/internal/commands/list/list_watch_test.go
+++ b/internal/commands/list/list_watch_test.go
@@ -3,10 +3,12 @@ package list
 import (
 	"strings"
 	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/commands/show"
 )
 
 func TestFormatAllHumanEmpty(t *testing.T) {
-	out := formatAllHuman(nil, nil, nil, 0, false)
+	out := formatAllHuman(nil, nil, nil, nil, 0, false)
 	if !strings.Contains(out, "No festivals found") {
 		t.Fatalf("expected empty-board message, got %q", out)
 	}
@@ -19,5 +21,61 @@ func TestFormatDungeonHumanEmpty(t *testing.T) {
 	out := formatDungeonHuman(nil, nil, nil, 0, false)
 	if !strings.Contains(out, "No festivals in dungeon") {
 		t.Fatalf("expected empty dungeon message, got %q", out)
+	}
+}
+
+// A campaign with no residents must render exactly what the pre-rail binary
+// rendered: no residents header, no separator, no count.
+func TestFormatStatusHuman_NoResidentsIsUnchanged(t *testing.T) {
+	withResidents := formatStatusHuman("active", nil, nil, nil, false)
+	if strings.Contains(strings.ToLower(withResidents), "resident") {
+		t.Errorf("resident-free output mentions residents: %q", withResidents)
+	}
+}
+
+func TestFormatStatusHuman_ResidentsAppendAfterFestivals(t *testing.T) {
+	residents := []*show.ResidentCard{
+		{Name: "alpha", Title: "Alpha", Type: "design"},
+		{Name: "beta", Title: "Beta", Type: "explore"},
+	}
+	out := formatStatusHuman("active", nil, residents, nil, false)
+
+	if !strings.Contains(out, "ACTIVE Residents (2)") {
+		t.Errorf("missing residents header: %q", out)
+	}
+	for _, want := range []string{"alpha", "beta", "[design]", "[explore]"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q: %q", want, out)
+		}
+	}
+	// Festivals first, residents after.
+	if fi, ri := strings.Index(out, "ACTIVE Festivals"), strings.Index(out, "ACTIVE Residents"); fi < 0 || ri < fi {
+		t.Errorf("residents block should follow the festival block: %q", out)
+	}
+}
+
+func TestFormatAllHuman_NoResidentsKeepsLegacyPath(t *testing.T) {
+	// With no residents the empty-board message must still appear, unchanged.
+	out := formatAllHuman(nil, nil, nil, nil, 0, false)
+	if !strings.Contains(out, "No festivals found") {
+		t.Errorf("expected the legacy empty message, got %q", out)
+	}
+	if strings.Contains(strings.ToLower(out), "resident") {
+		t.Errorf("resident-free output mentions residents: %q", out)
+	}
+}
+
+func TestFormatAllHuman_ResidentOnlyStageStillRenders(t *testing.T) {
+	residents := map[string][]*show.ResidentCard{
+		"active": {{Name: "solo", Title: "Solo", Type: "design"}},
+	}
+	// totalCount 0: no festivals at all, only a resident. It must not fall into
+	// the "No festivals found" branch, or the resident would be invisible.
+	out := formatAllHuman(nil, residents, []string{"active"}, nil, 0, false)
+	if strings.Contains(out, "No festivals found") {
+		t.Fatalf("a resident-only campaign must not report an empty board: %q", out)
+	}
+	if !strings.Contains(out, "solo") {
+		t.Errorf("resident missing from output: %q", out)
 	}
 }

--- a/internal/commands/show/format.go
+++ b/internal/commands/show/format.go
@@ -295,3 +295,83 @@ func renderPercentBar(progress float64) string {
 	opts.EmptyColor = ui.BorderColor
 	return ui.RenderProgressBar(opts)
 }
+
+// FormatResidentList renders the residents parked on a stage. It returns "" when
+// there are none, so a stage without residents stays byte-identical to the
+// pre-rail output: no header, no separator, no count.
+func FormatResidentList(status string, residents []*ResidentCard) string {
+	if len(residents) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	header := fmt.Sprintf("%s Residents (%d)", strings.ToUpper(status), len(residents))
+	sb.WriteString(ui.GetStatusStyle(status).Render(header))
+	sb.WriteString("\n")
+	sb.WriteString(ui.Dim(strings.Repeat("─", 40)))
+	sb.WriteString("\n")
+
+	width := 0
+	for _, r := range residents {
+		if len(r.Name) > width {
+			width = len(r.Name)
+		}
+	}
+	for _, r := range residents {
+		badge := ""
+		if r.Type != "" {
+			badge = ui.Dim(fmt.Sprintf("  [%s]", r.Type))
+		}
+		progress := ""
+		if p := r.Progress(); p != "" {
+			progress = ui.Dim("  " + p)
+		}
+		fmt.Fprintf(&sb, "  %-*s%s%s\n", width, r.Name, badge, progress)
+	}
+	return sb.String()
+}
+
+// FormatAllWithResidents renders every status with its festivals followed by its
+// residents. Only reached when at least one resident exists; a resident-free
+// campaign goes through FormatAllFestivals so its output is untouched.
+func FormatAllWithResidents(
+	allFestivals map[string][]*FestivalInfo,
+	allResidents map[string][]*ResidentCard,
+	statusOrder []string,
+	progressMap map[string]*progress.FestivalProgress,
+	withProgress bool,
+) string {
+	var sb strings.Builder
+
+	total := 0
+	for _, festivals := range allFestivals {
+		total += len(festivals)
+	}
+	residentTotal := 0
+	for _, residents := range allResidents {
+		residentTotal += len(residents)
+	}
+
+	sb.WriteString(ui.H1("All Festivals"))
+	sb.WriteString("\n")
+	fmt.Fprintf(&sb, "%s %s\n", ui.Label("Total"), ui.Value(fmt.Sprintf("%d", total)))
+	fmt.Fprintf(&sb, "%s %s\n", ui.Label("Residents"), ui.Value(fmt.Sprintf("%d", residentTotal)))
+	sb.WriteString(ui.Dim(strings.Repeat("─", 40)))
+	sb.WriteString("\n\n")
+
+	for _, status := range statusOrder {
+		festivals := allFestivals[status]
+		if withProgress {
+			sb.WriteString(FormatFestivalListWithProgress(status, festivals, progressMap))
+		} else {
+			sb.WriteString(FormatFestivalList(status, festivals))
+		}
+		if block := FormatResidentList(status, allResidents[status]); block != "" {
+			sb.WriteString("\n")
+			sb.WriteString(block)
+		}
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}

--- a/internal/commands/show/residents.go
+++ b/internal/commands/show/residents.go
@@ -1,0 +1,113 @@
+package show
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/Obedience-Corp/fest/internal/resident"
+	"github.com/Obedience-Corp/fest/internal/workspace"
+)
+
+// residentStages are the lifecycle folders a resident can occupy, mirroring
+// camp's v1 rail. Other statuses never yield residents.
+var residentStages = map[string]bool{"ready": true, "active": true}
+
+// ResidentCard is the lightweight view of a camp lifecycle resident. Residents
+// deliberately carry no phase, sequence, or task semantics: they are workitems
+// parked on a stage, not festivals.
+type ResidentCard struct {
+	Name  string
+	Title string
+	Type  string
+	Path  string
+	Run   *StandaloneWorkflowInfo
+}
+
+// residentCardJSON is the published shape for a resident card. Defined explicitly
+// rather than tagging ResidentCard so internal fields (the absolute Path, the whole
+// standalone runtime) cannot leak into the contract, and so every surface emits the
+// same keys.
+type residentCardJSON struct {
+	Name           string `json:"name"`
+	Title          string `json:"title"`
+	Type           string `json:"type"`
+	RunStatus      string `json:"run_status,omitempty"`
+	CompletedSteps int    `json:"completed_steps,omitempty"`
+	TotalSteps     int    `json:"total_steps,omitempty"`
+}
+
+// MarshalJSON keeps fest list and fest status list in agreement: both marshal the
+// same card type, so neither can drift into exposing internals.
+func (c *ResidentCard) MarshalJSON() ([]byte, error) {
+	out := residentCardJSON{Name: c.Name, Title: c.Title, Type: c.Type}
+	if c.Run != nil {
+		out.RunStatus = c.Run.RunStatus
+		out.CompletedSteps = c.Run.CompletedSteps
+		out.TotalSteps = c.Run.TotalSteps
+	}
+	return json.Marshal(out)
+}
+
+// Progress renders the resident's standalone run state, or "" when it has no
+// .workflow/ runtime.
+func (c *ResidentCard) Progress() string {
+	if c.Run == nil {
+		return ""
+	}
+	if c.Run.TotalSteps > 0 {
+		return strconv.Itoa(c.Run.CompletedSteps) + "/" + strconv.Itoa(c.Run.TotalSteps) + " steps"
+	}
+	return c.Run.RunStatus
+}
+
+// ListResidentsByStatus returns the residents parked on one lifecycle stage,
+// sorted by name. Only ready and active can hold residents; every other status
+// returns nil so callers need no special-casing.
+func ListResidentsByStatus(ctx context.Context, festivalsDir, status string) []*ResidentCard {
+	if !residentStages[status] {
+		return nil
+	}
+	stageDir := workspace.JoinStatus(festivalsDir, status)
+	entries, err := os.ReadDir(stageDir)
+	if err != nil {
+		return nil
+	}
+
+	var cards []*ResidentCard
+	for _, e := range entries {
+		if !e.IsDir() || strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		dir := filepath.Join(stageDir, e.Name())
+		marker, rerr := resident.Read(dir)
+		if rerr != nil || marker == nil {
+			continue
+		}
+		cards = append(cards, residentCard(ctx, dir, e.Name(), marker))
+	}
+	sort.Slice(cards, func(i, j int) bool { return cards[i].Name < cards[j].Name })
+	return cards
+}
+
+func residentCard(ctx context.Context, dir, name string, marker *resident.Marker) *ResidentCard {
+	card := &ResidentCard{
+		Name:  name,
+		Title: marker.Title,
+		Type:  marker.Type,
+		Path:  dir,
+	}
+	if card.Title == "" {
+		card.Title = name
+	}
+	// Run progress comes from fest's own standalone runtime, never from camp.
+	// A resident without a .workflow/ runtime simply has no progress to show.
+	if run, err := ResolveStandaloneWorkflow(ctx, dir); err == nil && run != nil {
+		card.Run = run
+	}
+	return card
+}

--- a/internal/commands/show/residents_test.go
+++ b/internal/commands/show/residents_test.go
@@ -1,0 +1,169 @@
+package show
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func stampResident(t *testing.T, dir, wfType, title string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "version: v1alpha8\nkind: workitem\nid: " + wfType + "-x-1\ntype: " + wfType + "\ntitle: " + title + "\n"
+	if err := os.WriteFile(filepath.Join(dir, ".workitem"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestListResidentsByStatus(t *testing.T) {
+	root := t.TempDir()
+	stampResident(t, filepath.Join(root, "active", "bravo"), "design", "Bravo")
+	stampResident(t, filepath.Join(root, "active", "alpha"), "explore", "Alpha")
+	stampResident(t, filepath.Join(root, "ready", "ready-one"), "design", "Ready One")
+	// Not residents: a festival, a plain dir, and a dot dir.
+	if err := os.MkdirAll(filepath.Join(root, "active", ".hidden"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stampResident(t, filepath.Join(root, "active", ".hidden"), "design", "Hidden")
+	if err := os.MkdirAll(filepath.Join(root, "active", "afest"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "active", "afest", "fest.yaml"), []byte("version: \"1.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// planning is not a rail stage.
+	stampResident(t, filepath.Join(root, "planning", "stray"), "design", "Stray")
+
+	t.Run("active is sorted and excludes non-residents", func(t *testing.T) {
+		got := ListResidentsByStatus(t.Context(), root, "active")
+		if len(got) != 2 {
+			t.Fatalf("got %d residents, want 2: %+v", len(got), got)
+		}
+		if got[0].Name != "alpha" || got[1].Name != "bravo" {
+			t.Errorf("not sorted by name: %s, %s", got[0].Name, got[1].Name)
+		}
+		if got[0].Type != "explore" {
+			t.Errorf("Type = %q, want explore", got[0].Type)
+		}
+	})
+
+	t.Run("ready", func(t *testing.T) {
+		got := ListResidentsByStatus(t.Context(), root, "ready")
+		if len(got) != 1 || got[0].Title != "Ready One" {
+			t.Fatalf("got %+v, want one Ready One", got)
+		}
+	})
+
+	t.Run("non-rail stages yield nothing", func(t *testing.T) {
+		for _, status := range []string{"planning", "ritual", "chains", "dungeon/completed"} {
+			if got := ListResidentsByStatus(t.Context(), root, status); got != nil {
+				t.Errorf("%s yielded %d residents, want none", status, len(got))
+			}
+		}
+	})
+
+	t.Run("missing stage dir is not an error", func(t *testing.T) {
+		if got := ListResidentsByStatus(t.Context(), t.TempDir(), "active"); got != nil {
+			t.Errorf("got %+v, want nil for an absent stage dir", got)
+		}
+	})
+}
+
+func TestResidentCard_TitleFallsBackToName(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "active", "untitled")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".workitem"),
+		[]byte("version: v1alpha8\nkind: workitem\nid: design-untitled-1\ntype: design\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := ListResidentsByStatus(t.Context(), root, "active")
+	if len(got) != 1 {
+		t.Fatalf("want 1 resident, got %d", len(got))
+	}
+	if got[0].Title != "untitled" {
+		t.Errorf("Title = %q, want the basename fallback", got[0].Title)
+	}
+}
+
+func TestResidentCard_Progress(t *testing.T) {
+	tests := []struct {
+		name string
+		run  *StandaloneWorkflowInfo
+		want string
+	}{
+		{"no runtime", nil, ""},
+		{"steps", &StandaloneWorkflowInfo{CompletedSteps: 1, TotalSteps: 3}, "1/3 steps"},
+		{"status only", &StandaloneWorkflowInfo{RunStatus: "blocked"}, "blocked"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &ResidentCard{Run: tc.run}
+			if got := c.Progress(); got != tc.want {
+				t.Errorf("Progress = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// Both fest list and fest status list marshal this type, so the published shape
+// must not include internal fields.
+func TestResidentCard_MarshalJSONShape(t *testing.T) {
+	c := &ResidentCard{
+		Name:  "runres",
+		Title: "Run Resident",
+		Type:  "explore",
+		Path:  "/absolute/should/not/leak",
+		Run:   &StandaloneWorkflowInfo{RunStatus: "active", CompletedSteps: 1, TotalSteps: 3, RuntimeDir: "/leaky"},
+	}
+	raw, err := json.Marshal(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	wantKeys := []string{"name", "title", "type", "run_status", "completed_steps", "total_steps"}
+	if len(got) != len(wantKeys) {
+		t.Errorf("keys = %v, want exactly %v", keysOf(got), wantKeys)
+	}
+	for _, k := range wantKeys {
+		if _, ok := got[k]; !ok {
+			t.Errorf("missing key %q in %s", k, raw)
+		}
+	}
+	for _, forbidden := range []string{"Path", "path", "Run", "RuntimeDir", "runtime_dir"} {
+		if _, ok := got[forbidden]; ok {
+			t.Errorf("internal field %q leaked into the contract: %s", forbidden, raw)
+		}
+	}
+
+	t.Run("no runtime omits run fields", func(t *testing.T) {
+		raw, err := json.Marshal(&ResidentCard{Name: "n", Title: "t", Type: "design"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(raw, &m); err != nil {
+			t.Fatal(err)
+		}
+		if len(m) != 3 {
+			t.Errorf("want only name/title/type, got %v", keysOf(m))
+		}
+	})
+}
+
+func keysOf(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/commands/status/handlers_listing.go
+++ b/internal/commands/status/handlers_listing.go
@@ -35,17 +35,26 @@ func runFestivalListing(ctx context.Context, festivalsRoot, filterStatus string,
 			return err
 		}
 
+		residents := show.ListResidentsByStatus(ctx, festivalsRoot, filterStatus)
+
 		if opts.json {
 			result := map[string]any{
 				"status":    filterStatus,
 				"count":     len(festivals),
 				"festivals": festivals,
 			}
+			// Additive: absent when the stage holds no residents.
+			if len(residents) > 0 {
+				result["residents"] = residents
+			}
 			if err := shared.EncodeJSON(os.Stdout, result); err != nil {
 				return errors.Wrap(err, "encoding JSON output")
 			}
 		} else {
 			fmt.Println(show.FormatFestivalList(filterStatus, festivals))
+			if block := show.FormatResidentList(filterStatus, residents); block != "" {
+				fmt.Println(block)
+			}
 		}
 	} else {
 		fmt.Println("Use 'fest list --all' to see all festivals grouped by status")

--- a/internal/navigation/fuzzy.go
+++ b/internal/navigation/fuzzy.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/Obedience-Corp/fest/internal/id"
+	"github.com/Obedience-Corp/fest/internal/resident"
 	"github.com/Obedience-Corp/fest/internal/workspace"
 )
 
@@ -122,7 +123,7 @@ func CollectNavigationTargets(festivalsDir string) []FuzzyTarget {
 			festivalName := entry.Name()
 			festivalPath := filepath.Join(statusPath, festivalName)
 
-			if !isNavigableFestivalDir(festivalName) {
+			if !isNavigableFestivalDir(festivalName) && !isNavigableResident(status, festivalPath) {
 				continue // Skip non-festival directories
 			}
 
@@ -165,7 +166,7 @@ func CollectFestivalsInStatus(festivalsDir, status string) []FuzzyTarget {
 		}
 		name := entry.Name()
 		path := filepath.Join(statusPath, name)
-		if !isNavigableFestivalDir(name) {
+		if !isNavigableFestivalDir(name) && !isNavigableResident(status, path) {
 			continue
 		}
 		targets = append(targets, FuzzyTarget{
@@ -180,6 +181,17 @@ func CollectFestivalsInStatus(festivalsDir, status string) []FuzzyTarget {
 func isNavigableFestivalDir(name string) bool {
 	_, err := id.ExtractLogicalIDFromDirName(name)
 	return err == nil
+}
+
+// isNavigableResident lets a lifecycle resident be a navigation target even though
+// its name carries no logical id. Only the working stages qualify: a resident in
+// festivals/.dungeon/ is terminal, and navigation parity there is out of scope for
+// v1, matching camp's rail.
+func isNavigableResident(status, dir string) bool {
+	if status != "ready" && status != "active" {
+		return false
+	}
+	return resident.IsResident(dir)
 }
 
 func statusNavigationPriority(status string) int {

--- a/internal/navigation/residents_test.go
+++ b/internal/navigation/residents_test.go
@@ -1,0 +1,132 @@
+package navigation
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func mkResident(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "version: v1alpha8\nkind: workitem\nid: design-x-1\ntype: design\ntitle: X\n"
+	if err := os.WriteFile(filepath.Join(dir, ".workitem"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mkFestival(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "fest.yaml"), []byte("version: \"1.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func targetNames(targets []FuzzyTarget) map[string]bool {
+	out := make(map[string]bool, len(targets))
+	for _, t := range targets {
+		out[t.Name] = true
+	}
+	return out
+}
+
+func TestCollectNavigationTargets_IncludesResidents(t *testing.T) {
+	root := t.TempDir()
+	mkFestival(t, filepath.Join(root, "active", "named-fest-NF0001"))
+	mkResident(t, filepath.Join(root, "active", "activeres"))
+	mkResident(t, filepath.Join(root, "ready", "readyres"))
+	// Out of scope for v1: a resident in the dungeon is terminal.
+	mkResident(t, filepath.Join(root, ".dungeon", "completed", "2026-07-29", "shelvedres"))
+	// A plain directory is still not navigable.
+	if err := os.MkdirAll(filepath.Join(root, "active", "plaindir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// planning is not a rail stage.
+	mkResident(t, filepath.Join(root, "planning", "planningres"))
+
+	names := targetNames(CollectNavigationTargets(root))
+
+	for _, want := range []string{"named-fest-NF0001", "activeres", "readyres"} {
+		if !names[want] {
+			t.Errorf("missing navigation target %q", want)
+		}
+	}
+	for _, unwanted := range []string{"shelvedres", "plaindir", "planningres"} {
+		if names[unwanted] {
+			t.Errorf("%q should not be a navigation target", unwanted)
+		}
+	}
+}
+
+// Festivals keep their place ahead of residents: residents are additional
+// targets, not replacements.
+func TestCollectNavigationTargets_FestivalsKeepPriority(t *testing.T) {
+	root := t.TempDir()
+	mkResident(t, filepath.Join(root, "active", "aaa-resident"))
+	mkFestival(t, filepath.Join(root, "active", "zzz-fest-ZF0001"))
+
+	targets := CollectNavigationTargets(root)
+	var festPriority, resPriority int
+	var seenFest, seenRes bool
+	for _, tg := range targets {
+		switch tg.Name {
+		case "zzz-fest-ZF0001":
+			festPriority, seenFest = tg.Priority, true
+		case "aaa-resident":
+			resPriority, seenRes = tg.Priority, true
+		}
+	}
+	if !seenFest || !seenRes {
+		t.Fatalf("expected both targets, fest=%v resident=%v", seenFest, seenRes)
+	}
+	if festPriority != resPriority {
+		t.Errorf("same stage should give the same priority: fest=%d resident=%d", festPriority, resPriority)
+	}
+}
+
+func TestCollectFestivalsInStatus_IncludesResidents(t *testing.T) {
+	root := t.TempDir()
+	mkFestival(t, filepath.Join(root, "active", "named-fest-NF0001"))
+	mkResident(t, filepath.Join(root, "active", "activeres"))
+
+	names := targetNames(CollectFestivalsInStatus(root, "active"))
+	if !names["named-fest-NF0001"] || !names["activeres"] {
+		t.Errorf("want both festival and resident, got %v", names)
+	}
+}
+
+func TestCollectFestivalsInStatus_DungeonExcludesResidents(t *testing.T) {
+	root := t.TempDir()
+	mkResident(t, filepath.Join(root, ".dungeon", "completed", "shelvedres"))
+
+	if names := targetNames(CollectFestivalsInStatus(root, "dungeon/completed")); names["shelvedres"] {
+		t.Error("a dungeon resident must not be a navigation target in v1")
+	}
+}
+
+// A festival-only campaign must produce the same targets as before residents
+// existed.
+func TestCollectNavigationTargets_NoResidentsUnchanged(t *testing.T) {
+	root := t.TempDir()
+	mkFestival(t, filepath.Join(root, "active", "one-fest-OF0001"))
+	mkFestival(t, filepath.Join(root, "ready", "two-fest-TF0002"))
+
+	names := targetNames(CollectNavigationTargets(root))
+	if !names["one-fest-OF0001"] || !names["two-fest-TF0002"] {
+		t.Errorf("festival targets missing: %v", names)
+	}
+	// Only the two festivals plus the status directories themselves.
+	for name := range names {
+		if name == "one-fest-OF0001" || name == "two-fest-TF0002" {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(root, name)); err != nil {
+			t.Errorf("unexpected target %q in a festival-only campaign", name)
+		}
+	}
+}


### PR DESCRIPTION
WF0001 phase 004, sequence 02. Residents become visible in `fest list`, `fest status list`, and `fest go`. Base `main` (fest #310 merged).

## Cards in list and status

`internal/commands/show/residents.go` — `ResidentCard`, `ListResidentsByStatus`, `Progress()`. Only `ready` and `active` yield residents; every other status returns nil, so callers need no special-casing.

`FormatResidentList` returns `""` for zero residents, which *is* the no-regression guarantee: no header, no separator, no count.

Run progress comes from `ResolveStandaloneWorkflow`, fest's own runtime reader. No camp dependency.

```
ACTIVE Residents (1)
────────────────────────────────────────
  plainres  [design]

READY Residents (1)
────────────────────────────────────────
  runres  [explore]  1/3 steps
```

The `1/3 steps` was produced by creating a real standalone workflow in the resident and advancing a step, not by hand-writing runtime state.

## `fest go`

Both navigation collectors gained a resident fallback for the working stages only — a resident in `festivals/.dungeon/` is terminal and out of v1 scope. `fest go` resolves through the same `CollectNavigationTargets` that feeds completion, so extending the collector fixed completion *and* `fest go <resident>` in one place.

Festival targets keep their priority: a festival and a resident on the same stage get the same value, so residents are additional targets rather than a reordering.

## A JSON contract leak, caught by running the command

`fest status list --json` marshalled `[]*ResidentCard` directly and emitted Go field names, the absolute path, and the entire standalone runtime:

```
"residents":[{"Name":"runres","Title":"Run Resident","Type":"explore",
              "Path":"/private/tmp/.../runres","Run":{"Mode":"standalone-tracked",...
```

while `fest list --json` used a hand-written mapper with clean keys. Two surfaces, two shapes, one leaking paths.

Fixed at the type: `ResidentCard.MarshalJSON` publishes an explicit shape and the duplicate mapper is gone, so both surfaces agree and a new field cannot leak by default. `TestResidentCard_MarshalJSONShape` asserts the exact key set and that `Path`, `Run`, and `RuntimeDir` are absent.

## Zero-resident: byte-identical, by diff

fest is in production, so this is a real diff of two binaries against the same festival-only fixture, not an assertion:

```
  fest list                            : IDENTICAL
  fest list all                        : IDENTICAL
  fest list active                     : IDENTICAL
  fest list --all                      : IDENTICAL
  fest status active                   : IDENTICAL
  fest status ready                    : IDENTICAL
  fest status list --status active     : IDENTICAL
  fest go completions                  : IDENTICAL
```

Goldens committed under the festival's `results/golden/`.

## What the "TUI board" actually is

The task asked to extend and pty-verify a TUI stage-column board. Driving both binaries in a pty established there isn't one, and corrected my own earlier note in the process:

- **`fest list --watch`** is the live-repainting surface this change affects. Verified with `pyte` + `pty.fork()`; residents render in the right stage sections with badges and `1/3 steps`, nothing clipped. Snapshot committed.
- **The bare `fest go` picker** is a real bubbletea TUI, but it **already** listed residents before this change — it uses `FestivalPickerItems` with `IncludeUnmarkedFestivalDirectories: true`. Confirmed by driving the pre-change binary in the same pty and getting a byte-identical screen. Unaffected, verified rather than assumed.
- **`charm_list.go`** is the `fest go list` shortcut/link selector, not a stage board.
- **`list_board.go`** is the text board builder shared by one-shot and `--watch`, so extending it covered both.

## Gate

`just test unit`: 2764 passed. `golangci-lint --new-from-merge-base origin/main`: 0 issues.
