### PR TITLE
docs(methodology): introduce lifecycle residents (WF0001 P5/S2)

### DIFF
--- a/methodology/festivals/.festival/FESTIVAL_SOFTWARE_PROJECT_MANAGEMENT.md
+++ b/methodology/festivals/.festival/FESTIVAL_SOFTWARE_PROJECT_MANAGEMENT.md
@@ -108,6 +108,29 @@ festivals/
 
 The lifecycle flow is: `planning/ → ready/ → active/ → dungeon/completed/`
 
+### Lifecycle Residents
+
+`ready/` and `active/` can also hold **residents**: workitem directories that a
+user has moved onto the lifecycle board without turning them into festivals. A
+resident is not a festival and never gains phases, sequences, or tasks. It keeps
+its original workflow type, so a design item parked in `active/` is still a design
+item that simply lives on the board.
+
+Fest treats residents as read-only information:
+
+- `fest list` and `fest status list` show them as cards in the stage column, with a
+  type badge and, when the directory carries a standalone `WORKFLOW.md` run, its
+  step progress.
+- `fest go <name>` navigates into one, and completion offers it alongside festivals.
+- `fest validate` reports a resident and exits cleanly rather than complaining that
+  it is a malformed festival.
+
+Fest never creates, moves, or deletes a resident. Promoting a workitem onto the
+board, advancing it between stages, completing it, and returning it to its original
+home are all camp operations (`camp workitem promote --target ready|active`,
+`camp workitem demote`). Fest reads the `.workitem` marker camp writes; it never
+writes it.
+
 ## Festival Types
 
 Festivals come in four types, each designed for different kinds of work:

--- a/methodology/festivals/.festival/README.md
+++ b/methodology/festivals/.festival/README.md
@@ -44,6 +44,19 @@ Run `fest --help` for the full command reference.
     └── orchestration/                         # Multi-agent orchestration patterns
 ```
 
+## Lifecycle Residents
+
+The `ready/` and `active/` directories can contain more than festivals. A workitem
+directory that a user has moved onto the lifecycle board appears there as a
+**resident**: still its original type, never gaining phases or sequences, and never
+mutated by fest.
+
+You will see residents as cards in `fest list` and `fest status list`, as targets in
+`fest go`, and as an informational note in `fest validate` rather than an error. All
+resident mechanics — putting one on the board, moving it between stages, completing
+it, or sending it home — belong to camp, not fest. See camp's `workitem promote` and
+`workitem demote` documentation for those.
+
 ## Templates
 
 Templates are used by `fest create` commands to scaffold festival structure. You don't need to read them — the CLI renders them with the correct variables when you create festivals, phases, sequences, and tasks.


### PR DESCRIPTION
WF0001 phase 005, sequence 02 (fest half). Documentation only. Base `main`.

The camp half is [camp#526](https://github.com/Obedience-Corp/camp/pull/527) — independent, either can merge first.

## Lifecycle residents in the methodology docs

`ready/` and `active/` can hold workitem directories a user moved onto the board without turning them into festivals. The methodology docs described those folders as festivals-only, so a reader had no way to learn what the extra cards in `fest list` are.

Two sections added to the **scaffold source** (`methodology/festivals/.festival/`), not this campaign's generated copy:

- `FESTIVAL_SOFTWARE_PROJECT_MANAGEMENT.md` gains `### Lifecycle Residents` immediately after the lifecycle-flow diagram, where the reader has just been told what `ready/` and `active/` hold.
- `README.md` gains `## Lifecycle Residents` before `## Templates`.

Both describe what a user *sees* — cards in `fest list`/`fest status list`, targets in `fest go`, an informational `fest validate` result — and state the ownership boundary plainly: every resident mechanic is a camp operation, and fest reads the `.workitem` marker it never writes. Mechanics are pointed at, not restated, since fest's methodology docs describe the user's view rather than camp's internals.

## Verified before documenting

Per the festival's anchors-are-claims rule, each described behavior was checked against merged source rather than assumed from the task text: resident recognition and `Classify` (fest #310), resident cards and `fest go` targets (fest #311), and camp's `promote --target ready|active` / `demote` (camp #521, #525).

## No docs regen commit

`just docs` ran clean (exit 0, "Combined reference written") and produced no diff: fest's generated CLI reference was already current, and the methodology docs are not cobra-generated. An empty commit would have been noise, so there isn't one.

## Gate

`just test unit`: 2751 passed.