### PR TITLE
fix(commit): stage only festival paths git can match

### DIFF
--- a/internal/commands/commit/commit.go
+++ b/internal/commands/commit/commit.go
@@ -200,9 +200,10 @@ func runCommit(cmd *cobra.Command, args []string) error {
 				result.Error = err.Error()
 				return outputResult(result)
 			}
-			// An empty list means git cannot match any festival-scoped path;
-			// commitkit reads no files as "stage everything", the opposite of
-			// scoped staging.
+			// An empty list means git can match no festival-scoped path, so
+			// there is nothing to stage. Passing it on would fail the commit
+			// with commitkit's ErrNoFilesSpecified over paths that hold no
+			// user data; the commit proceeds on whatever is already staged.
 			if len(paths) > 0 {
 				if stageErr := stageFiles(ctx, ws.Root, report, paths...); stageErr != nil {
 					result.Success = false
@@ -625,8 +626,8 @@ func commitCampaignRoot(ctx context.Context, campaignRoot string, paths []string
 	}
 
 	// No matchable festival-scoped path is the same silent skip as no changes:
-	// there is nothing for the root commit to carry, and an empty list would
-	// otherwise reach commitkit as "stage everything".
+	// there is nothing for the root commit to carry, and commitkit would
+	// reject the empty list with ErrNoFilesSpecified rather than stage it.
 	if len(paths) == 0 {
 		return "", nil
 	}

--- a/internal/commands/commit/commit.go
+++ b/internal/commands/commit/commit.go
@@ -200,10 +200,15 @@ func runCommit(cmd *cobra.Command, args []string) error {
 				result.Error = err.Error()
 				return outputResult(result)
 			}
-			if stageErr := stageFiles(ctx, ws.Root, report, paths...); stageErr != nil {
-				result.Success = false
-				result.Error = stageErr.Error()
-				return outputResult(result)
+			// An empty list means git cannot match any festival-scoped path;
+			// commitkit reads no files as "stage everything", the opposite of
+			// scoped staging.
+			if len(paths) > 0 {
+				if stageErr := stageFiles(ctx, ws.Root, report, paths...); stageErr != nil {
+					result.Success = false
+					result.Error = stageErr.Error()
+					return outputResult(result)
+				}
 			}
 		} else {
 			// Fallback: stage all (non-campaign workspace)
@@ -550,6 +555,11 @@ func isInSubmodule(campaignRoot string) (bool, string) {
 //   - .campaign/fest/ (navigation state)
 //   - festivals/.festival/.state/ (global festival event log)
 //   - The submodule pointer path (if submoduleRelPath is non-empty)
+//
+// Only paths git can match are returned. The two fest-owned state directories
+// appear the first time fest navigates in a campaign, so a campaign fresh from
+// `camp init` has neither, and a single unmatched pathspec fails the whole
+// `git add` — which made the first `fest commit` in a new campaign impossible.
 func festivalScopedPaths(ctx context.Context, campaignRoot, festivalPath, submoduleRelPath string) ([]string, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, errors.Wrap(err, "context cancelled")
@@ -560,17 +570,48 @@ func festivalScopedPaths(ctx context.Context, campaignRoot, festivalPath, submod
 		return nil, errors.Wrap(err, "computing festival relative path")
 	}
 
-	paths := []string{
+	candidates := []string{
 		festivalRel,
 		filepath.Join(".campaign", "fest"),
 		filepath.Join("festivals", ".festival", ".state"),
 	}
 
 	if submoduleRelPath != "" {
-		paths = append(paths, submoduleRelPath)
+		candidates = append(candidates, submoduleRelPath)
 	}
 
-	return paths, nil
+	return matchablePaths(ctx, campaignRoot, candidates), nil
+}
+
+// matchablePaths keeps the pathspecs `git add` can resolve in the repository at
+// repoRoot, preserving the given order. A path present in the working tree
+// qualifies; a path that is gone but still tracked qualifies too, because
+// staging it is what records the deletion. Anything else is dropped: git
+// refuses the entire `git add` over one unmatched pathspec, so an absent
+// path would take the paths that do exist down with it.
+func matchablePaths(ctx context.Context, repoRoot string, candidates []string) []string {
+	matchable := make([]string, 0, len(candidates))
+	for _, path := range candidates {
+		if _, err := os.Lstat(filepath.Join(repoRoot, path)); err == nil {
+			matchable = append(matchable, path)
+			continue
+		}
+		if trackedInGit(ctx, repoRoot, path) {
+			matchable = append(matchable, path)
+		}
+	}
+	return matchable
+}
+
+// trackedInGit reports whether the index of the repository at repoRoot holds
+// any entry under path. A tracked path missing from the working tree is the
+// deletion case, which must still reach `git add`.
+func trackedInGit(ctx context.Context, repoRoot, path string) bool {
+	out, err := exec.CommandContext(ctx, "git", "-C", repoRoot, "ls-files", "--", path).Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) != ""
 }
 
 // commitCampaignRoot stages festival-scoped paths at the campaign root and
@@ -581,6 +622,13 @@ func festivalScopedPaths(ctx context.Context, campaignRoot, festivalPath, submod
 func commitCampaignRoot(ctx context.Context, campaignRoot string, paths []string, commitMessage string, report io.Writer) (string, error) {
 	if err := ctx.Err(); err != nil {
 		return "", errors.Wrap(err, "context cancelled")
+	}
+
+	// No matchable festival-scoped path is the same silent skip as no changes:
+	// there is nothing for the root commit to carry, and an empty list would
+	// otherwise reach commitkit as "stage everything".
+	if len(paths) == 0 {
+		return "", nil
 	}
 
 	outcome, err := commitkit.StageFilesWithOutcome(ctx, campaignRoot, paths...)

--- a/internal/commands/commit/commit_test.go
+++ b/internal/commands/commit/commit_test.go
@@ -2,6 +2,8 @@ package commit
 
 import (
 	"context"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 )
@@ -73,10 +75,33 @@ func TestNewCommitCommand_CampaignTaggingIndependentOfSync(t *testing.T) {
 	}
 }
 
+// makeDirs creates each campaign-root-relative directory under root.
+func makeDirs(t *testing.T, root string, rel ...string) {
+	t.Helper()
+	for _, r := range rel {
+		if err := os.MkdirAll(filepath.Join(root, r), 0o755); err != nil {
+			t.Fatalf("creating %s: %v", r, err)
+		}
+	}
+}
+
+// livedInCampaign is a campaign fest has already navigated in: the festival,
+// both fest-owned state directories, and a project submodule all on disk.
+func livedInCampaign(t *testing.T) (root, festival string) {
+	t.Helper()
+	root = t.TempDir()
+	makeDirs(t, root,
+		filepath.Join("festivals", "active", "my-fest-FA0001"),
+		filepath.Join(".campaign", "fest"),
+		filepath.Join("festivals", ".festival", ".state"),
+		filepath.Join("projects", "fest"),
+	)
+	return root, filepath.Join(root, "festivals", "active", "my-fest-FA0001")
+}
+
 func TestFestivalScopedPaths_WithSubmodule(t *testing.T) {
-	root := "/campaign"
-	festival := filepath.Join(root, "festivals", "active", "my-fest-FA0001")
-	submodule := "projects/fest"
+	root, festival := livedInCampaign(t)
+	submodule := filepath.Join("projects", "fest")
 
 	paths, err := festivalScopedPaths(context.Background(), root, festival, submodule)
 	if err != nil {
@@ -87,7 +112,7 @@ func TestFestivalScopedPaths_WithSubmodule(t *testing.T) {
 		filepath.Join("festivals", "active", "my-fest-FA0001"),
 		filepath.Join(".campaign", "fest"),
 		filepath.Join("festivals", ".festival", ".state"),
-		"projects/fest",
+		filepath.Join("projects", "fest"),
 	}
 
 	if len(paths) != len(want) {
@@ -102,8 +127,7 @@ func TestFestivalScopedPaths_WithSubmodule(t *testing.T) {
 }
 
 func TestFestivalScopedPaths_NoSubmodule(t *testing.T) {
-	root := "/campaign"
-	festival := filepath.Join(root, "festivals", "active", "my-fest-FA0001")
+	root, festival := livedInCampaign(t)
 
 	paths, err := festivalScopedPaths(context.Background(), root, festival, "")
 	if err != nil {
@@ -116,14 +140,19 @@ func TestFestivalScopedPaths_NoSubmodule(t *testing.T) {
 
 	// Should not contain any submodule path
 	for _, p := range paths {
-		if p == "projects/fest" || p == "" {
+		if p == filepath.Join("projects", "fest") || p == "" {
 			t.Errorf("unexpected path in result: %q", p)
 		}
 	}
 }
 
 func TestFestivalScopedPaths_ExpectedContents(t *testing.T) {
-	root := "/home/user/campaign"
+	root := t.TempDir()
+	makeDirs(t, root,
+		filepath.Join("festivals", "ready", "deploy-v2-DP0003"),
+		filepath.Join(".campaign", "fest"),
+		filepath.Join("festivals", ".festival", ".state"),
+	)
 	festival := filepath.Join(root, "festivals", "ready", "deploy-v2-DP0003")
 
 	paths, err := festivalScopedPaths(context.Background(), root, festival, "")
@@ -147,6 +176,106 @@ func TestFestivalScopedPaths_ExpectedContents(t *testing.T) {
 		if !pathSet[e] {
 			t.Errorf("missing expected path %q in %v", e, paths)
 		}
+	}
+}
+
+// A campaign fresh from `camp init` has neither fest-owned state directory.
+// Listing them anyway aborts the whole `git add`, so the first fest commit in
+// a new campaign never happened.
+func TestFestivalScopedPaths_FreshCampaignOmitsAbsentStatePaths(t *testing.T) {
+	root := t.TempDir()
+	makeDirs(t, root, filepath.Join("festivals", "active", "my-fest-FA0001"))
+	festival := filepath.Join(root, "festivals", "active", "my-fest-FA0001")
+
+	paths, err := festivalScopedPaths(context.Background(), root, festival, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []string{filepath.Join("festivals", "active", "my-fest-FA0001")}
+	if len(paths) != len(want) || paths[0] != want[0] {
+		t.Fatalf("got %v, want %v", paths, want)
+	}
+}
+
+// Only the absent paths are dropped: a campaign missing just one of the two
+// state directories still stages the other.
+func TestFestivalScopedPaths_PartialStatePaths(t *testing.T) {
+	root := t.TempDir()
+	makeDirs(t, root,
+		filepath.Join("festivals", "active", "my-fest-FA0001"),
+		filepath.Join(".campaign", "fest"),
+	)
+	festival := filepath.Join(root, "festivals", "active", "my-fest-FA0001")
+
+	paths, err := festivalScopedPaths(context.Background(), root, festival, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []string{
+		filepath.Join("festivals", "active", "my-fest-FA0001"),
+		filepath.Join(".campaign", "fest"),
+	}
+	if len(paths) != len(want) {
+		t.Fatalf("got %d paths, want %d: %v", len(paths), len(want), paths)
+	}
+	for i, got := range paths {
+		if got != want[i] {
+			t.Errorf("paths[%d] = %q, want %q", i, got, want[i])
+		}
+	}
+}
+
+// Absence from the working tree is not absence from git: a tracked path the
+// user deleted must still be staged, because staging it is what records the
+// deletion.
+func TestFestivalScopedPaths_KeepsTrackedButDeletedPath(t *testing.T) {
+	root, festival := livedInCampaign(t)
+	navFile := filepath.Join(root, ".campaign", "fest", "navigation.json")
+	if err := os.WriteFile(navFile, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{{"init"}, {"add", "--", ".campaign/fest"}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = root
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+	if err := os.RemoveAll(filepath.Join(root, ".campaign", "fest")); err != nil {
+		t.Fatal(err)
+	}
+
+	paths, err := festivalScopedPaths(context.Background(), root, festival, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found := false
+	for _, p := range paths {
+		if p == filepath.Join(".campaign", "fest") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("tracked-but-deleted %q must stay staged so the deletion is recorded, got %v",
+			filepath.Join(".campaign", "fest"), paths)
+	}
+}
+
+func TestMatchablePaths_ContextCancelled(t *testing.T) {
+	root := t.TempDir()
+	makeDirs(t, root, "present")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// A path on disk needs no git call, so it survives cancellation; an absent
+	// one cannot be confirmed tracked and is dropped rather than guessed at.
+	paths := matchablePaths(ctx, root, []string{"present", "absent"})
+	if len(paths) != 1 || paths[0] != "present" {
+		t.Fatalf("got %v, want [present]", paths)
 	}
 }
 

--- a/tests/integration/commit_drain_test.go
+++ b/tests/integration/commit_drain_test.go
@@ -110,14 +110,6 @@ func TestCommitDrain_QueuedBookkeepingLandsBeforeTheFestivalCommit(t *testing.T)
 	camp := "/guard-drain"
 	require.NoError(t, tc.WriteFile(camp+"/festivals/active/guard-festival/fest.yaml", guardFestYAML))
 	require.NoError(t, tc.WriteFile(camp+"/festivals/active/guard-festival/NOTES.md", "# Progress\n"))
-	// Any campaign fest has navigated has these; a bare camp init does not,
-	// and fest's scoped staging lists them unconditionally (intent filed:
-	// fest-commit-fails-in-a-fresh-campaign). The fixture mirrors the lived-in
-	// shape rather than the bug.
-	_, err = tc.Exec("sh", "-c",
-		"mkdir -p "+camp+"/.campaign/fest "+camp+"/festivals/.festival/.state"+
-			" && touch "+camp+"/.campaign/fest/.gitkeep "+camp+"/festivals/.festival/.state/.gitkeep")
-	require.NoError(t, err)
 
 	// A baseline commit first: camp init leaves the branch unborn, and a
 	// deferred job cannot execute against no HEAD (intent filed:

--- a/tests/integration/commit_fresh_campaign_test.go
+++ b/tests/integration/commit_fresh_campaign_test.go
@@ -56,9 +56,9 @@ func TestCommitFreshCampaign_FirstCommitSucceedsWithoutFestStateDirs(t *testing.
 	require.NoError(t, tc.WriteFile(camp+"/festivals/active/fresh-festival/NOTES.md", "# First run\n"))
 
 	// An unrelated dirty file at the campaign root: scoped staging must still
-	// be scoped after the fix. Dropping every path would leave commitkit an
-	// empty file list, which it reads as "stage the whole tree" — the failure
-	// mode a fix for this bug can easily introduce.
+	// be scoped after the fix. A filter that dropped too much and then fell
+	// back to staging the whole tree would sweep this file in, which is the
+	// failure mode a fix for this bug can easily introduce.
 	require.NoError(t, tc.WriteFile(camp+"/unrelated.txt", "not part of the festival\n"))
 
 	// Invoked through a shell, not RunFestInDir, so the quoted message survives

--- a/tests/integration/commit_fresh_campaign_test.go
+++ b/tests/integration/commit_fresh_campaign_test.go
@@ -1,0 +1,92 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A campaign fest has never navigated in has neither .campaign/fest nor
+// festivals/.festival/.state. fest's scoped staging listed both regardless,
+// and git refuses an entire `git add` over one pathspec it cannot match, so
+// the very first `fest commit` in a new campaign died on
+// "pathspec '.campaign/fest' did not match any files". That is the shipped
+// bundle's first-run path: the failure met new users before anything else did.
+//
+// The campaign here is built by the released camp binary fest links against,
+// so the fixture is the first run a real user gets, not an approximation of it.
+func TestCommitFreshCampaign_FirstCommitSucceedsWithoutFestStateDirs(t *testing.T) {
+	tc := GetSharedContainer(t)
+	ensureGuardGit(t, tc)
+	ensureCampInContainer(t, tc)
+
+	out, err := tc.Exec("sh", "-c",
+		"export HOME=/root && cd / && camp init fresh-campaign -d 'fresh campaign fixture' -m 'prove the first commit'")
+	require.NoError(t, err, "camp init should succeed: %s", out)
+	camp := "/fresh-campaign"
+
+	// The whole test rests on camp init really leaving both fest-owned state
+	// directories unborn, so assert that rather than assume it.
+	for _, absent := range []string{camp + "/.campaign/fest", camp + "/festivals/.festival/.state"} {
+		exists, existErr := tc.CheckDirExists(absent)
+		require.NoError(t, existErr)
+		require.False(t, exists,
+			"a campaign fest has never navigated in must not have %s; the fixture is not a fresh campaign", absent)
+	}
+
+	// A baseline commit first: camp init leaves the branch unborn, and a
+	// deferred bookkeeping job cannot execute against no HEAD (intent filed:
+	// deferred-bookkeeping-commits-fail-on-an-unborn-branch). That camp-side
+	// bug is separate from this one; the festival arrives after the baseline
+	// so the fest commit has work of its own to do.
+	out, err = tc.Exec("sh", "-c",
+		"export HOME=/root && cd "+camp+" && camp commit -m 'campaign baseline'")
+	require.NoError(t, err, "baseline camp commit should succeed: %s", out)
+
+	// festivals/.festival marks the directory as fest's; the festival itself
+	// lives under a status directory, as fest lays them out. Neither creates
+	// the .state directory, which is what fest navigation would add later.
+	_, err = tc.Exec("mkdir", "-p", camp+"/festivals/.festival")
+	require.NoError(t, err)
+	require.NoError(t, tc.WriteFile(camp+"/festivals/active/fresh-festival/fest.yaml", guardFestYAML))
+	require.NoError(t, tc.WriteFile(camp+"/festivals/active/fresh-festival/NOTES.md", "# First run\n"))
+
+	// An unrelated dirty file at the campaign root: scoped staging must still
+	// be scoped after the fix. Dropping every path would leave commitkit an
+	// empty file list, which it reads as "stage the whole tree" — the failure
+	// mode a fix for this bug can easily introduce.
+	require.NoError(t, tc.WriteFile(camp+"/unrelated.txt", "not part of the festival\n"))
+
+	// Invoked through a shell, not RunFestInDir, so the quoted message survives
+	// as one argument and the commit subject can be asserted.
+	out, err = tc.Exec("sh", "-c",
+		"export HOME=/root && cd "+camp+"/festivals/active/fresh-festival"+
+			" && /fest commit --no-tag -m 'first festival commit'")
+	require.NoError(t, err, "the first fest commit in a fresh campaign must succeed: %s", out)
+	assert.NotContains(t, out, "did not match any files",
+		"the unmatched-pathspec failure must be gone, not merely tolerated: %s", out)
+
+	// Not a vacuous success: the festival content is in the commit.
+	committed, err := tc.Exec("git", "-C", camp, "log", "-1", "--name-only", "--pretty=format:%s")
+	require.NoError(t, err)
+	assert.Contains(t, committed, "first festival commit", "the festival commit must be HEAD")
+	assert.Contains(t, committed, "festivals/active/fresh-festival/NOTES.md",
+		"the festival files must be in the commit: %s", committed)
+	assert.NotContains(t, committed, "unrelated.txt",
+		"staging must stay scoped to festival paths: %s", committed)
+
+	status, err := tc.Exec("git", "-C", camp, "status", "--porcelain")
+	require.NoError(t, err)
+	assert.Contains(t, status, "?? unrelated.txt",
+		"the unrelated file must be left untracked, not swept in: %s", status)
+
+	// The commit is real: HEAD carries it and the tree holds the festival.
+	tree, err := tc.Exec("git", "-C", camp, "ls-tree", "-r", "--name-only", "HEAD")
+	require.NoError(t, err)
+	assert.Contains(t, tree, "festivals/active/fresh-festival/fest.yaml",
+		"the festival must be in history after the first commit")
+}


### PR DESCRIPTION
## The bug

The first `fest commit` in a brand-new campaign fails:

```
Error: staging files: git add failed: fatal: pathspec '.campaign/fest' did not match any files
```

`festivalScopedPaths` listed `.campaign/fest` and `festivals/.festival/.state` unconditionally when
staging festival-scoped paths at a campaign root. Neither directory exists until fest first navigates
in the campaign, and git refuses an entire `git add` over one pathspec it cannot match, so the
unmatched path took the festival directory down with it and nothing was committed.

This is the shipped bundle's first-run path. A user who runs `camp init`, creates a festival, and
commits hits the failure before anything else. Found by CA0004's `commit_drain` integration test,
which had been working around it with a `mkdir -p` in the fixture.

## The fix

`festivalScopedPaths` now returns only pathspecs git can resolve. A candidate qualifies if it is
present in the working tree, or absent but still tracked. The second case matters: `git add` on a
tracked path that was deleted succeeds and records the deletion, so filtering on working-tree
existence alone would have silently dropped deletions of these paths from festival commits. Existence
is checked with `os.Lstat` first, and `git ls-files` runs only for candidates that are missing from
disk, so a lived-in campaign where everything exists makes no extra git calls at all.

Nothing is created on demand. A commit command should not have filesystem side effects, and the
absent directories carry no user data to lose.

Both call sites now skip staging when the filtered list is empty: nothing git can match means nothing
to stage, and passing the empty list on would fail the commit with commitkit's `ErrNoFilesSpecified`
over paths that hold no user data. In practice the list is never empty (the festival directory always
exists), so this is a guard against a future caller, not a live path.

Behavior for existing campaigns is unchanged: when the paths exist, the same list reaches staging in
the same order.

## Tests

New `tests/integration/commit_fresh_campaign_test.go` builds a campaign with the released `camp`
binary fest links against, asserts that `camp init` really leaves both fest-owned state directories
unborn, and proves the first `fest commit` succeeds and carries the festival files. It also leaves an
unrelated dirty file at the campaign root and asserts it stays untracked, which pins the
stage-everything failure mode a fix for this bug can easily introduce.

`tests/integration/commit_drain_test.go` loses its `mkdir -p .campaign/fest festivals/.festival/.state`
workaround, so the drain test now exercises the fix too. Its baseline `camp commit` stays: that is a
separate camp-side unborn-branch bug being fixed independently.

Unit tests in `internal/commands/commit` now build real fixtures under `t.TempDir` instead of
asserting over string paths that never existed, and cover the fresh campaign, a partially populated
campaign, the tracked-but-deleted path, and a cancelled context.

### Verification

Both integration tests were run against a binary built from `origin/main` to confirm they fail with
the exact reported error, then against this branch:

| Command | Result |
| --- | --- |
| `go build ./...` | pass |
| `go vet ./...` | pass |
| `go test ./...` | pass (102 packages) |
| `golangci-lint run ./...` (`just lint all`) | 0 issues |
| `golangci-lint run --build-tags integration ./tests/integration/...` | 29 pre-existing issues, none in touched files |
| `go test -tags integration ./tests/integration/ -run TestCommit -v` | 5/5 pass |
| `go test -tags integration ./tests/integration/` (full suite) | pass, 184s |
| Both commit tests against a pre-fix binary | fail with `pathspec '.campaign/fest' did not match any files` |

## Tradeoffs and caveats

- `trackedInGit` adds a `git ls-files` call per missing candidate. That is at most two calls, only in
  campaigns where the directories are absent, and zero in the healthy case.
- If `ls-files` fails for any reason, the path is dropped rather than guessed at. A cancelled context
  reaches this path, which is why the unit test pins that behavior.
- The linked-submodule root commit goes through the same helper and is covered by the unit tests, but
  the new container test exercises the campaign-root branch only. The submodule branch already fails
  soft there (a skipped root commit warning rather than a failed commit), so the first-run path was
  the one worth pinning in a container.
- `internal/commands/status` solves the same problem a different way (stage each path, tolerate the
  ones that no longer exist). This change does not touch it; the batched staging call here needs the
  filter up front to keep guard outcome reporting intact.
