### PR TITLE
fix(gates): give artifact_review gate steps default evidence

### DIFF
--- a/internal/commands/workflow/approval_hardening_test.go
+++ b/internal/commands/workflow/approval_hardening_test.go
@@ -502,3 +502,25 @@ func TestEvaluateApprovalJudge_PassesWorkDir(t *testing.T) {
 		t.Fatalf("WorkDir = %q, want /festival/root", gotDir)
 	}
 }
+
+// DefaultEvidencePaths now resolves phase artifacts for artifact_review gate
+// steps. That must not turn into a readiness requirement: defaults are hints
+// filtered to existing files, while an explicit **Evidence:** list is a promise
+// every file is present. If this test ever fails, every phase gate whose
+// artifacts are incomplete will hard-block before the judge runs.
+func TestCheckApprovalReadiness_GateStepDefaultsDoNotBlock(t *testing.T) {
+	step := wf.WorkflowStep{
+		Number:          3,
+		Name:            "QUALITY",
+		Checkpoint:      wf.CheckpointUserApproval,
+		CheckpointClass: wf.CheckpointClassArtifactReview,
+		// No EvidencePaths: the paths come from DefaultEvidencePaths.
+	}
+	// Inspector reports every conventional artifact as absent.
+	err := checkApprovalReadinessWithInspector("/phase", step, func(_, _ string) (bool, error) {
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("gate step with default evidence must not block readiness, got %v", err)
+	}
+}

--- a/internal/guidance/workflow/gate_templates_test.go
+++ b/internal/guidance/workflow/gate_templates_test.go
@@ -1,0 +1,52 @@
+package workflow
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The gate templates gained a "## Before you submit any step below" section.
+// StepHeaderRegexp matches "## Step", so it must not be picked up as a step:
+// a phantom step would renumber every real gate and desync workflow state.
+func TestShippedGateTemplatesParseToStepsOnly(t *testing.T) {
+	root := "../../../methodology/festivals/.festival/templates/phases"
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Skipf("templates not reachable: %v", err)
+	}
+	want := map[string]int{
+		"implementation": 4, "research": 3, "planning": 3,
+		"ingest": 3, "review": 3, "non_coding_action": 3,
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Join(root, e.Name(), "GATES.md"))
+		if err != nil {
+			continue
+		}
+		steps, err := NewParser().ParseContent(context.Background(), string(raw))
+		if err != nil {
+			t.Fatalf("%s: parse: %v", e.Name(), err)
+		}
+		if n, ok := want[e.Name()]; ok && len(steps) != n {
+			t.Errorf("%s: parsed %d steps, want %d: %v", e.Name(), len(steps), n, stepNames(steps))
+		}
+		for _, s := range steps {
+			if s.Name == "" || s.Name == "Before you submit any step below" {
+				t.Errorf("%s: prose parsed as a step: %q", e.Name(), s.Name)
+			}
+		}
+	}
+}
+
+func stepNames(steps []WorkflowStep) []string {
+	out := make([]string, 0, len(steps))
+	for _, s := range steps {
+		out = append(out, s.Name)
+	}
+	return out
+}

--- a/internal/guidance/workflow/parser.go
+++ b/internal/guidance/workflow/parser.go
@@ -403,22 +403,52 @@ func DefaultEvidencePaths(step WorkflowStep) []string {
 	name := strings.ToUpper(step.Name)
 	switch {
 	case strings.Contains(name, "PHASE GOAL") || strings.Contains(name, "GOAL"):
-		return []string{
-			"PHASE_GOAL.md",
-			"output_specs/purpose.md",
-			"output_specs/requirements.md",
-			"output_specs/constraints.md",
-			"output_specs/context.md",
-			"output_specs/PRESENTATION.md",
-		}
+		return phaseArtifactEvidence()
 	case strings.Contains(name, "COMPLETE"):
 		return []string{
 			"output_specs/context.md",
 			"output_specs/requirements.md",
 			"output_specs/PRESENTATION.md",
 		}
+	case step.CheckpointClass == CheckpointClassArtifactReview:
+		// Every other phase-gate step lands here. Without this the switch fell
+		// through to nil, so a gate whose name happened not to contain GOAL or
+		// COMPLETE was handed only its own step definition and could do nothing
+		// but reject: it was asked whether the work met its goal while holding
+		// the question and none of the answer. Of the 19 gate steps fest ships,
+		// 10 were in that position, including QUALITY, SEQUENCE OUTCOMES and,
+		// most tellingly, EVIDENCE.
+		//
+		// Keying on the declared checkpoint class rather than on more step-name
+		// substrings means a phase type that adds a gate step gets evidence
+		// without anyone remembering to extend a list here. operator_attestation
+		// is deliberately excluded: checkAutoJudgeAllowed refuses to auto-judge
+		// it, so it never reaches a judge that would need evidence.
+		//
+		// These are defaults, not an **Evidence:** declaration, and the
+		// difference is load-bearing. Defaults skip the readiness gate
+		// (approval_readiness.go: the early return for non-presentation steps
+		// with no explicit EvidencePaths) and are filtered to files that exist
+		// and are non-empty before sending. Declaring these paths explicitly in
+		// the shipped templates would instead make every one of them mandatory
+		// and hard-block every phase whose artifacts are not all present.
+		return phaseArtifactEvidence()
 	default:
 		return nil
+	}
+}
+
+// phaseArtifactEvidence is the conventional set of phase-level artifacts a gate
+// judge reads. Paths that do not exist are dropped downstream, so listing the
+// full set costs nothing when a phase produced only some of them.
+func phaseArtifactEvidence() []string {
+	return []string{
+		"PHASE_GOAL.md",
+		"output_specs/purpose.md",
+		"output_specs/requirements.md",
+		"output_specs/constraints.md",
+		"output_specs/context.md",
+		"output_specs/PRESENTATION.md",
 	}
 }
 

--- a/internal/guidance/workflow/parser_test.go
+++ b/internal/guidance/workflow/parser_test.go
@@ -645,3 +645,60 @@ fest_parent: 001_PLAN
 		t.Errorf("Step 1 has %d actions, want 2", len(steps[0].Actions))
 	}
 }
+
+// Gate steps whose names contain neither GOAL nor COMPLETE used to fall through
+// to nil evidence, so the judge received only the step definition and could do
+// nothing but reject. These are the step names fest actually ships.
+func TestDefaultEvidencePaths_ArtifactReviewGateStepsGetPhaseArtifacts(t *testing.T) {
+	shipped := []string{
+		"SEQUENCE OUTCOMES", "QUALITY", "COVERAGE", "STRUCTURE",
+		"INCORPORATION", "ACTIONABILITY", "DOCUMENTATION", "FOLLOW-UP",
+		"EVIDENCE",
+	}
+	for _, name := range shipped {
+		t.Run(name, func(t *testing.T) {
+			got := DefaultEvidencePaths(WorkflowStep{
+				Name:            name,
+				CheckpointClass: CheckpointClassArtifactReview,
+			})
+			if len(got) == 0 {
+				t.Fatalf("gate step %q resolved to no evidence; the judge would see only its own step definition", name)
+			}
+			if got[0] != "PHASE_GOAL.md" {
+				t.Errorf("expected phase artifacts for %q, got %v", name, got)
+			}
+		})
+	}
+}
+
+// operator_attestation is a human gate; checkAutoJudgeAllowed refuses to
+// auto-judge it, so it must not start pulling evidence.
+func TestDefaultEvidencePaths_OperatorAttestationStaysEmpty(t *testing.T) {
+	got := DefaultEvidencePaths(WorkflowStep{
+		Name:            "APPROVAL",
+		CheckpointClass: CheckpointClassOperatorAttestation,
+	})
+	if len(got) != 0 {
+		t.Errorf("operator_attestation must not resolve evidence, got %v", got)
+	}
+}
+
+// An unclassed non-gate step keeps the previous nil behavior, so this change
+// stays scoped to phase gates.
+func TestDefaultEvidencePaths_UnclassedStepUnchanged(t *testing.T) {
+	if got := DefaultEvidencePaths(WorkflowStep{Name: "EXTRACT"}); len(got) != 0 {
+		t.Errorf("unclassed step should resolve no evidence, got %v", got)
+	}
+}
+
+// Explicit **Evidence:** still wins over any default.
+func TestDefaultEvidencePaths_ExplicitStillWinsForGateSteps(t *testing.T) {
+	got := DefaultEvidencePaths(WorkflowStep{
+		Name:            "QUALITY",
+		CheckpointClass: CheckpointClassArtifactReview,
+		EvidencePaths:   []string{"output_specs/QUALITY.md"},
+	})
+	if len(got) != 1 || got[0] != "output_specs/QUALITY.md" {
+		t.Errorf("explicit evidence must win, got %v", got)
+	}
+}

--- a/methodology/festivals/.festival/templates/phases/implementation/GATES.md
+++ b/methodology/festivals/.festival/templates/phases/implementation/GATES.md
@@ -10,9 +10,11 @@ This gate verifies the implementation phase achieved its goal and produced worki
 
 ## Before you submit any step below
 
-The judge reads what this phase wrote down. It cannot browse your repositories,
-and on a provider without tool access it cannot open anything at all, so work
-that is real but only visible in a working directory does not reach it.
+Whether the judge can open your repositories depends on its provider:
+CLI-backed judges read the declared working directories themselves, while
+judges without tool access see only what this phase wrote down. Writing the
+essentials here keeps the gate independent of which judge you drew, and leaves
+the festival a durable record after the worktree is gone.
 
 Write the phase's evidence into `output_specs/` before submitting the first
 step. These are picked up automatically; you do not need to list them:

--- a/methodology/festivals/.festival/templates/phases/implementation/GATES.md
+++ b/methodology/festivals/.festival/templates/phases/implementation/GATES.md
@@ -8,6 +8,32 @@ fest_parent: [REPLACE: PHASE_ID]
 
 This gate verifies the implementation phase achieved its goal and produced working deliverables.
 
+## Before you submit any step below
+
+The judge reads what this phase wrote down. It cannot browse your repositories,
+and on a provider without tool access it cannot open anything at all, so work
+that is real but only visible in a working directory does not reach it.
+
+Write the phase's evidence into `output_specs/` before submitting the first
+step. These are picked up automatically; you do not need to list them:
+
+| File | What belongs in it |
+| --- | --- |
+| `output_specs/requirements.md` | each required outcome from PHASE_GOAL.md, with the raw command output that verifies it |
+| `output_specs/context.md` | where the work landed: commits, PRs, branches, build provenance |
+| `output_specs/constraints.md` | each quality standard, with its proof |
+| `output_specs/PRESENTATION.md` | the summary, and anything that needs a human decision |
+
+Paste real terminal output, not summaries of it. "All tests pass" is an
+assertion; the test run is evidence. A gate that rejects for missing evidence is
+usually correct, and the fix is to attach the artifact rather than to re-run the
+judge.
+
+Only add an `**Evidence:**` list to a step when you want to name files beyond
+these. Every path in such a list must exist and be non-empty or the step blocks
+before the judge runs, which is why the conventional files above are left
+implicit.
+
 ---
 
 ## Step 1: PHASE GOAL — Verify Goal Achievement

--- a/methodology/festivals/.festival/templates/phases/ingest/GATES.md
+++ b/methodology/festivals/.festival/templates/phases/ingest/GATES.md
@@ -8,6 +8,32 @@ fest_parent: [REPLACE: PHASE_ID]
 
 This gate verifies the ingest phase achieved its goal and produced approved structured output.
 
+## Before you submit any step below
+
+The judge reads what this phase wrote down. It cannot browse your repositories,
+and on a provider without tool access it cannot open anything at all, so work
+that is real but only visible in a working directory does not reach it.
+
+Write the phase's evidence into `output_specs/` before submitting the first
+step. These are picked up automatically; you do not need to list them:
+
+| File | What belongs in it |
+| --- | --- |
+| `output_specs/requirements.md` | each required outcome from PHASE_GOAL.md, with the raw command output that verifies it |
+| `output_specs/context.md` | where the work landed: commits, PRs, branches, build provenance |
+| `output_specs/constraints.md` | each quality standard, with its proof |
+| `output_specs/PRESENTATION.md` | the summary, and anything that needs a human decision |
+
+Paste real terminal output, not summaries of it. "All tests pass" is an
+assertion; the test run is evidence. A gate that rejects for missing evidence is
+usually correct, and the fix is to attach the artifact rather than to re-run the
+judge.
+
+Only add an `**Evidence:**` list to a step when you want to name files beyond
+these. Every path in such a list must exist and be non-empty or the step blocks
+before the judge runs, which is why the conventional files above are left
+implicit.
+
 ---
 
 ## Step 1: PHASE GOAL — Verify Goal Achievement

--- a/methodology/festivals/.festival/templates/phases/ingest/GATES.md
+++ b/methodology/festivals/.festival/templates/phases/ingest/GATES.md
@@ -10,9 +10,11 @@ This gate verifies the ingest phase achieved its goal and produced approved stru
 
 ## Before you submit any step below
 
-The judge reads what this phase wrote down. It cannot browse your repositories,
-and on a provider without tool access it cannot open anything at all, so work
-that is real but only visible in a working directory does not reach it.
+Whether the judge can open your repositories depends on its provider:
+CLI-backed judges read the declared working directories themselves, while
+judges without tool access see only what this phase wrote down. Writing the
+essentials here keeps the gate independent of which judge you drew, and leaves
+the festival a durable record after the worktree is gone.
 
 Write the phase's evidence into `output_specs/` before submitting the first
 step. These are picked up automatically; you do not need to list them:

--- a/methodology/festivals/.festival/templates/phases/non_coding_action/GATES.md
+++ b/methodology/festivals/.festival/templates/phases/non_coding_action/GATES.md
@@ -8,6 +8,32 @@ fest_parent: [REPLACE: PHASE_ID]
 
 This gate verifies the non-coding action phase achieved its goal and produced documented results.
 
+## Before you submit any step below
+
+The judge reads what this phase wrote down. It cannot browse your repositories,
+and on a provider without tool access it cannot open anything at all, so work
+that is real but only visible in a working directory does not reach it.
+
+Write the phase's evidence into `output_specs/` before submitting the first
+step. These are picked up automatically; you do not need to list them:
+
+| File | What belongs in it |
+| --- | --- |
+| `output_specs/requirements.md` | each required outcome from PHASE_GOAL.md, with the raw command output that verifies it |
+| `output_specs/context.md` | where the work landed: commits, PRs, branches, build provenance |
+| `output_specs/constraints.md` | each quality standard, with its proof |
+| `output_specs/PRESENTATION.md` | the summary, and anything that needs a human decision |
+
+Paste real terminal output, not summaries of it. "All tests pass" is an
+assertion; the test run is evidence. A gate that rejects for missing evidence is
+usually correct, and the fix is to attach the artifact rather than to re-run the
+judge.
+
+Only add an `**Evidence:**` list to a step when you want to name files beyond
+these. Every path in such a list must exist and be non-empty or the step blocks
+before the judge runs, which is why the conventional files above are left
+implicit.
+
 ---
 
 ## Step 1: PHASE GOAL — Verify Goal Achievement

--- a/methodology/festivals/.festival/templates/phases/non_coding_action/GATES.md
+++ b/methodology/festivals/.festival/templates/phases/non_coding_action/GATES.md
@@ -10,9 +10,11 @@ This gate verifies the non-coding action phase achieved its goal and produced do
 
 ## Before you submit any step below
 
-The judge reads what this phase wrote down. It cannot browse your repositories,
-and on a provider without tool access it cannot open anything at all, so work
-that is real but only visible in a working directory does not reach it.
+Whether the judge can open your repositories depends on its provider:
+CLI-backed judges read the declared working directories themselves, while
+judges without tool access see only what this phase wrote down. Writing the
+essentials here keeps the gate independent of which judge you drew, and leaves
+the festival a durable record after the worktree is gone.
 
 Write the phase's evidence into `output_specs/` before submitting the first
 step. These are picked up automatically; you do not need to list them:

--- a/methodology/festivals/.festival/templates/phases/planning/GATES.md
+++ b/methodology/festivals/.festival/templates/phases/planning/GATES.md
@@ -10,9 +10,11 @@ This gate verifies the planning phase achieved its goal and produced an approved
 
 ## Before you submit any step below
 
-The judge reads what this phase wrote down. It cannot browse your repositories,
-and on a provider without tool access it cannot open anything at all, so work
-that is real but only visible in a working directory does not reach it.
+Whether the judge can open your repositories depends on its provider:
+CLI-backed judges read the declared working directories themselves, while
+judges without tool access see only what this phase wrote down. Writing the
+essentials here keeps the gate independent of which judge you drew, and leaves
+the festival a durable record after the worktree is gone.
 
 Write the phase's evidence into `output_specs/` before submitting the first
 step. These are picked up automatically; you do not need to list them:

--- a/methodology/festivals/.festival/templates/phases/planning/GATES.md
+++ b/methodology/festivals/.festival/templates/phases/planning/GATES.md
@@ -8,6 +8,32 @@ fest_parent: [REPLACE: PHASE_ID]
 
 This gate verifies the planning phase achieved its goal and produced an approved, valid plan.
 
+## Before you submit any step below
+
+The judge reads what this phase wrote down. It cannot browse your repositories,
+and on a provider without tool access it cannot open anything at all, so work
+that is real but only visible in a working directory does not reach it.
+
+Write the phase's evidence into `output_specs/` before submitting the first
+step. These are picked up automatically; you do not need to list them:
+
+| File | What belongs in it |
+| --- | --- |
+| `output_specs/requirements.md` | each required outcome from PHASE_GOAL.md, with the raw command output that verifies it |
+| `output_specs/context.md` | where the work landed: commits, PRs, branches, build provenance |
+| `output_specs/constraints.md` | each quality standard, with its proof |
+| `output_specs/PRESENTATION.md` | the summary, and anything that needs a human decision |
+
+Paste real terminal output, not summaries of it. "All tests pass" is an
+assertion; the test run is evidence. A gate that rejects for missing evidence is
+usually correct, and the fix is to attach the artifact rather than to re-run the
+judge.
+
+Only add an `**Evidence:**` list to a step when you want to name files beyond
+these. Every path in such a list must exist and be non-empty or the step blocks
+before the judge runs, which is why the conventional files above are left
+implicit.
+
 ---
 
 ## Step 1: PHASE GOAL — Verify Goal Achievement

--- a/methodology/festivals/.festival/templates/phases/research/GATES.md
+++ b/methodology/festivals/.festival/templates/phases/research/GATES.md
@@ -10,9 +10,11 @@ This gate verifies the research phase achieved its goal and produced actionable 
 
 ## Before you submit any step below
 
-The judge reads what this phase wrote down. It cannot browse your repositories,
-and on a provider without tool access it cannot open anything at all, so work
-that is real but only visible in a working directory does not reach it.
+Whether the judge can open your repositories depends on its provider:
+CLI-backed judges read the declared working directories themselves, while
+judges without tool access see only what this phase wrote down. Writing the
+essentials here keeps the gate independent of which judge you drew, and leaves
+the festival a durable record after the worktree is gone.
 
 Write the phase's evidence into `output_specs/` before submitting the first
 step. These are picked up automatically; you do not need to list them:

--- a/methodology/festivals/.festival/templates/phases/research/GATES.md
+++ b/methodology/festivals/.festival/templates/phases/research/GATES.md
@@ -8,6 +8,32 @@ fest_parent: [REPLACE: PHASE_ID]
 
 This gate verifies the research phase achieved its goal and produced actionable findings.
 
+## Before you submit any step below
+
+The judge reads what this phase wrote down. It cannot browse your repositories,
+and on a provider without tool access it cannot open anything at all, so work
+that is real but only visible in a working directory does not reach it.
+
+Write the phase's evidence into `output_specs/` before submitting the first
+step. These are picked up automatically; you do not need to list them:
+
+| File | What belongs in it |
+| --- | --- |
+| `output_specs/requirements.md` | each required outcome from PHASE_GOAL.md, with the raw command output that verifies it |
+| `output_specs/context.md` | where the work landed: commits, PRs, branches, build provenance |
+| `output_specs/constraints.md` | each quality standard, with its proof |
+| `output_specs/PRESENTATION.md` | the summary, and anything that needs a human decision |
+
+Paste real terminal output, not summaries of it. "All tests pass" is an
+assertion; the test run is evidence. A gate that rejects for missing evidence is
+usually correct, and the fix is to attach the artifact rather than to re-run the
+judge.
+
+Only add an `**Evidence:**` list to a step when you want to name files beyond
+these. Every path in such a list must exist and be non-empty or the step blocks
+before the judge runs, which is why the conventional files above are left
+implicit.
+
 ---
 
 ## Step 1: PHASE GOAL — Verify Goal Achievement

--- a/methodology/festivals/.festival/templates/phases/review/GATES.md
+++ b/methodology/festivals/.festival/templates/phases/review/GATES.md
@@ -8,6 +8,32 @@ fest_parent: [REPLACE: PHASE_ID]
 
 This gate verifies the review phase achieved its goal and produced incorporated feedback.
 
+## Before you submit any step below
+
+The judge reads what this phase wrote down. It cannot browse your repositories,
+and on a provider without tool access it cannot open anything at all, so work
+that is real but only visible in a working directory does not reach it.
+
+Write the phase's evidence into `output_specs/` before submitting the first
+step. These are picked up automatically; you do not need to list them:
+
+| File | What belongs in it |
+| --- | --- |
+| `output_specs/requirements.md` | each required outcome from PHASE_GOAL.md, with the raw command output that verifies it |
+| `output_specs/context.md` | where the work landed: commits, PRs, branches, build provenance |
+| `output_specs/constraints.md` | each quality standard, with its proof |
+| `output_specs/PRESENTATION.md` | the summary, and anything that needs a human decision |
+
+Paste real terminal output, not summaries of it. "All tests pass" is an
+assertion; the test run is evidence. A gate that rejects for missing evidence is
+usually correct, and the fix is to attach the artifact rather than to re-run the
+judge.
+
+Only add an `**Evidence:**` list to a step when you want to name files beyond
+these. Every path in such a list must exist and be non-empty or the step blocks
+before the judge runs, which is why the conventional files above are left
+implicit.
+
 ---
 
 ## Step 1: PHASE GOAL — Verify Goal Achievement

--- a/methodology/festivals/.festival/templates/phases/review/GATES.md
+++ b/methodology/festivals/.festival/templates/phases/review/GATES.md
@@ -10,9 +10,11 @@ This gate verifies the review phase achieved its goal and produced incorporated 
 
 ## Before you submit any step below
 
-The judge reads what this phase wrote down. It cannot browse your repositories,
-and on a provider without tool access it cannot open anything at all, so work
-that is real but only visible in a working directory does not reach it.
+Whether the judge can open your repositories depends on its provider:
+CLI-backed judges read the declared working directories themselves, while
+judges without tool access see only what this phase wrote down. Writing the
+essentials here keeps the gate independent of which judge you drew, and leaves
+the festival a durable record after the worktree is gone.
 
 Write the phase's evidence into `output_specs/` before submitting the first
 step. These are picked up automatically; you do not need to list them:


### PR DESCRIPTION
Closes the recurring "the phase gate judge rejects for structural reasons" problem. Intent: `fest-phase-gate-templates-give-20260727-123326` (open since 2026-07-27, hit again in CA0004 phase 001, OI0007, and JE0001).

## The bug

`DefaultEvidencePaths` only recognizes presentation steps, names containing `GOAL`, and names containing `COMPLETE`. Everything else returns `nil`.

Probing the real resolver with every gate step name fest ships:

```
PHASE GOAL           ok   PHASE_GOAL.md
COMPLETENESS         ok   output_specs/context.md
APPROVAL             NIL  <- judge gets GATES.md only
COVERAGE             NIL
DOCUMENTATION        NIL
EVIDENCE             NIL
SEQUENCE OUTCOMES    NIL
ACTIONABILITY        NIL
FOLLOW-UP            NIL
INCORPORATION        NIL
QUALITY              NIL
STRUCTURE            NIL
```

10 of 19 shipped gate steps resolve to nothing. `GATES.md` is the *step definition*, so those judges are asked "did each sequence achieve its stated goal?" while holding a document containing only that question. They can do nothing but reject, and the rejection text is accurate: "the step declared no deliverables."

The `EVIDENCE` step resolving to no evidence is the clearest symptom.

This got sharper after the judge capability gate landed: a judge on a chat provider gets no tools, so it cannot compensate by reading `working_dirs`. Whatever is not inlined does not exist to it.

## The fix, and the one it is deliberately not

Resolve from the declared `CheckpointClass` rather than adding more step-name substrings, so a phase type that adds a gate step gets evidence without anyone extending a list. `operator_attestation` stays excluded, since `checkAutoJudgeAllowed` already refuses to auto-judge it.

**These are defaults, not an `**Evidence:**` declaration, and that distinction is the whole design.** My first instinct was to add `**Evidence:**` blocks to the templates. That would have broken every festival:

```go
// approval_readiness.go
if !wf.IsPresentationStep(step) && len(step.EvidencePaths) == 0 {
    return nil   // readiness skipped
}
```

Declaring evidence makes a step explicit, and explicit evidence requires **every** listed file to exist and be non-empty (`TestCheckApprovalReadiness_ExplicitEvidenceRequiresEveryFile`). Scaffolded phases have none of them, so every gate would hard-block on readiness before the judge ran, which is strictly worse than the current rejection. Defaults skip readiness and are filtered to existing files, so listing a file that does not exist costs nothing.

`TestCheckApprovalReadiness_GateStepDefaultsDoNotBlock` pins that behavior.

## Second half of the gap

Implementation phases scaffold no `output_specs/` at all, unlike ingest, so there was nothing for the resolver to find even once fixed. All six `GATES.md` templates now carry a short section saying what to write and where, as prose rather than as a declaration, for the reason above. It also tells the reader why the conventional files are left implicit, so the next person does not add the `**Evidence:**` block I almost did.

## Risk introduced, and how it is covered

The new prose adds a `##` heading to a file the step parser reads. A heading mistaken for a step would renumber every real gate and desync workflow state. `TestShippedGateTemplatesParseToStepsOnly` parses all six shipped templates and asserts the exact step counts (4/3/3/3/3/3) and that no prose becomes a step.

## Verification

`just gate` passes: stable and dev command surfaces plus the containerized integration suite. `gofmt` clean.

New tests: 4 resolver cases (shipped gate names, attestation stays empty, unclassed steps unchanged, explicit still wins), 1 readiness non-blocking case, 1 template parse case.