### PR TITLE
fix(watch): route polling fallback through dispatch serialization [intent: fest-runpolling-fallback-bypasses-dispatchmu-20260717-145842]

### DIFF
--- a/internal/watch/watcher.go
+++ b/internal/watch/watcher.go
@@ -48,11 +48,54 @@ type Config struct {
 	OnError func(error)
 }
 
+// dispatcher owns a change callback and the state that keeps its invocations
+// serialized. Every scheduler in this package routes its callback through a
+// dispatcher rather than calling onChange directly, so the invariant holds
+// uniformly: the fsnotify debounce timers and the polling fallback both obey
+// it, and two schedulers sharing one dispatcher serialize against each other
+// instead of overlapping silently.
+type dispatcher struct {
+	onChange func()
+
+	// mu is held for the whole onChange call, so invocations never overlap even
+	// when a scheduler fires faster than a slow render completes. stopped is set
+	// under mu by stop: once that returns, no onChange is in flight and none can
+	// start, so nothing fires after the owner has torn the dispatcher down.
+	mu      sync.Mutex
+	stopped bool
+}
+
+func newDispatcher(onChange func()) *dispatcher {
+	return &dispatcher{onChange: onChange}
+}
+
+// dispatch runs onChange unless the dispatcher has been stopped, blocking until
+// any concurrent dispatch on the same dispatcher has finished.
+func (d *dispatcher) dispatch() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.stopped {
+		return
+	}
+	d.onChange()
+}
+
+// stop permanently disables dispatch. It waits for any in-flight onChange to
+// finish, so once stop returns no callback is running and none can start.
+func (d *dispatcher) stop() {
+	d.mu.Lock()
+	d.stopped = true
+	d.mu.Unlock()
+}
+
 // Watcher monitors files for changes and calls a callback when changes occur.
 type Watcher struct {
-	config   Config
-	onChange func()
-	watcher  *fsnotify.Watcher
+	config  Config
+	watcher *fsnotify.Watcher
+
+	// dispatcher serializes the change callback and gates it off at Close, so
+	// renders never overlap and none fires after Close or Watch return.
+	dispatcher *dispatcher
 
 	mu           sync.Mutex
 	timer        *time.Timer
@@ -66,14 +109,6 @@ type Watcher struct {
 	// live timer handle with nil, and fire a second time; the generation check
 	// makes that stale func a no-op so only the newest schedule ever fires.
 	gen uint64
-
-	// dispatchMu serializes onChange invocations so renders never overlap, even
-	// when MaxWait fires callbacks mid-storm faster than a slow render completes.
-	// stopped is set under dispatchMu by cancelPendingTimer: once that returns,
-	// no onChange is in flight and none can start, so nothing fires after Close
-	// or Watch return.
-	dispatchMu sync.Mutex
-	stopped    bool
 }
 
 // ErrNoWatchablePaths is returned when none of the specified paths can be watched.
@@ -83,6 +118,12 @@ var ErrNoWatchablePaths = os.ErrNotExist
 // The onChange callback is debounced according to config.Debounce.
 // Returns ErrNoWatchablePaths if none of the specified paths exist or can be watched.
 func New(cfg Config, onChange func()) (*Watcher, error) {
+	return newWatcher(cfg, newDispatcher(onChange))
+}
+
+// newWatcher builds a watcher around an existing dispatcher, so a caller that
+// may also run the polling fallback can hand both paths the same one.
+func newWatcher(cfg Config, d *dispatcher) (*Watcher, error) {
 	if cfg.Debounce == 0 {
 		cfg.Debounce = DefaultDebounce
 	}
@@ -93,10 +134,10 @@ func New(cfg Config, onChange func()) (*Watcher, error) {
 	}
 
 	w := &Watcher{
-		config:   cfg,
-		onChange: onChange,
-		watcher:  fsw,
-		watched:  make(map[string]struct{}),
+		config:     cfg,
+		watcher:    fsw,
+		dispatcher: d,
+		watched:    make(map[string]struct{}),
 	}
 
 	// Add all paths to the watcher.
@@ -254,9 +295,9 @@ func (w *Watcher) scheduleCallback() {
 // dispatch runs the onChange callback for a scheduled timer generation.
 // A timer whose generation was superseded (by a newer schedule or by a cancel)
 // is a no-op, so the newest schedule owns the callback and stale timers can
-// neither double-fire nor clobber the live timer handle. Invocations are
-// serialized through dispatchMu so onChange never overlaps itself, and the
-// stopped gate prevents any callback after cancelPendingTimer has returned.
+// neither double-fire nor clobber the live timer handle. The dispatcher then
+// serializes the callback, so onChange never overlaps itself and never runs
+// once cancelPendingTimer has stopped it.
 func (w *Watcher) dispatch(gen uint64) {
 	w.mu.Lock()
 	if w.gen != gen {
@@ -267,18 +308,13 @@ func (w *Watcher) dispatch(gen uint64) {
 	w.timer = nil
 	w.mu.Unlock()
 
-	w.dispatchMu.Lock()
-	defer w.dispatchMu.Unlock()
-	if w.stopped {
-		return
-	}
-	w.onChange()
+	w.dispatcher.dispatch()
 }
 
 // cancelPendingTimer cancels any pending debounced callback and permanently
 // disables further dispatch. Bumping gen neutralizes any timer whose Stop()
-// lost the race, and setting stopped under dispatchMu (which waits for any
-// in-flight onChange to finish) guarantees no callback fires after this returns.
+// lost the race, and stopping the dispatcher (which waits for any in-flight
+// onChange to finish) guarantees no callback fires after this returns.
 func (w *Watcher) cancelPendingTimer() {
 	w.mu.Lock()
 	if w.timer != nil {
@@ -289,9 +325,7 @@ func (w *Watcher) cancelPendingTimer() {
 	w.gen++
 	w.mu.Unlock()
 
-	w.dispatchMu.Lock()
-	w.stopped = true
-	w.dispatchMu.Unlock()
+	w.dispatcher.stop()
 }
 
 // Close releases all resources associated with the watcher.
@@ -302,12 +336,17 @@ func (w *Watcher) Close() error {
 
 // WatchWithFallback attempts file watching, falling back to polling if it fails.
 // This is a convenience function that combines New, Watch, and polling fallback.
+// Only one of the two paths ever runs, but both are handed the same dispatcher,
+// so onChange obeys the same serialization and stop invariants either way.
 func WatchWithFallback(ctx context.Context, cfg Config, onChange func()) error {
-	w, err := New(cfg, onChange)
+	d := newDispatcher(onChange)
+
+	w, err := newWatcher(cfg, d)
 	if err != nil {
 		// Fallback to polling if configured
 		if cfg.FallbackPoll > 0 {
-			return runPolling(ctx, cfg.FallbackPoll, onChange)
+			defer d.stop()
+			return runPolling(ctx, cfg.FallbackPoll, d)
 		}
 		return err
 	}
@@ -316,8 +355,13 @@ func WatchWithFallback(ctx context.Context, cfg Config, onChange func()) error {
 	return w.Watch(ctx)
 }
 
-// runPolling runs a simple polling loop as fallback.
-func runPolling(ctx context.Context, interval time.Duration, onChange func()) error {
+// runPolling runs a simple polling loop as fallback, firing every tick through
+// d rather than calling the callback directly. That puts the fallback under the
+// same invariant as the fsnotify path: the callback never overlaps itself, never
+// overlaps a Watcher sharing the dispatcher, and stops once d is stopped.
+// Stopping d belongs to whoever owns it; runPolling dispatches inline on its own
+// goroutine, so no callback is in flight when it returns.
+func runPolling(ctx context.Context, interval time.Duration, d *dispatcher) error {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
@@ -326,7 +370,7 @@ func runPolling(ctx context.Context, interval time.Duration, onChange func()) er
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			onChange()
+			d.dispatch()
 		}
 	}
 }

--- a/internal/watch/watcher_test.go
+++ b/internal/watch/watcher_test.go
@@ -203,9 +203,9 @@ func TestWatcher_MaxWaitFiresDuringSustainedChanges(t *testing.T) {
 
 	w := &Watcher{
 		config: cfg,
-		onChange: func() {
+		dispatcher: newDispatcher(func() {
 			callCount.Add(1)
-		},
+		}),
 	}
 	defer w.cancelPendingTimer()
 
@@ -242,7 +242,7 @@ func TestWatcher_OnChangeNeverOverlaps(t *testing.T) {
 	}
 
 	w := &Watcher{config: cfg}
-	w.onChange = func() {
+	w.dispatcher = newDispatcher(func() {
 		n := inFlight.Add(1)
 		for {
 			m := maxInFlight.Load()
@@ -255,7 +255,7 @@ func TestWatcher_OnChangeNeverOverlaps(t *testing.T) {
 		// this callback is still running, exercising the serialization path.
 		time.Sleep(15 * time.Millisecond)
 		inFlight.Add(-1)
-	}
+	})
 
 	// Sustained events reset the trailing debounce forever; MaxWait keeps firing
 	// callbacks mid-storm, so without serialization these would overlap.
@@ -286,8 +286,8 @@ func TestWatcher_DispatchIgnoresStaleGeneration(t *testing.T) {
 	// Debounce is long enough that no AfterFunc timer fires on its own; the test
 	// drives dispatch directly to exercise the generation guard deterministically.
 	w := &Watcher{
-		config:   Config{Debounce: time.Hour},
-		onChange: func() { calls.Add(1) },
+		config:     Config{Debounce: time.Hour},
+		dispatcher: newDispatcher(func() { calls.Add(1) }),
 	}
 
 	w.scheduleCallback() // gen == 1
@@ -389,9 +389,9 @@ func TestRunPolling(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
 	defer cancel()
 
-	err := runPolling(ctx, 50*time.Millisecond, func() {
+	err := runPolling(ctx, 50*time.Millisecond, newDispatcher(func() {
 		callCount.Add(1)
-	})
+	}))
 
 	if err != nil {
 		t.Errorf("runPolling() error = %v", err)
@@ -400,5 +400,204 @@ func TestRunPolling(t *testing.T) {
 	// Should have been called 2-3 times (at 50ms and 100ms, maybe 150ms)
 	if count := callCount.Load(); count < 2 {
 		t.Errorf("expected at least 2 polling callbacks, got %d", count)
+	}
+}
+
+func TestRunPolling_ReturnsOnContextCancel(t *testing.T) {
+	var callCount atomic.Int32
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runPolling(ctx, 10*time.Millisecond, newDispatcher(func() {
+			callCount.Add(1)
+		}))
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("runPolling() returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("runPolling() did not return after context cancellation")
+	}
+
+	// runPolling dispatches inline on its own goroutine, so its return means no
+	// callback is in flight and the ticker is stopped: the count must be frozen.
+	settled := callCount.Load()
+	time.Sleep(50 * time.Millisecond)
+	if got := callCount.Load(); got != settled {
+		t.Errorf("polling fired %d more callbacks after returning, want 0", got-settled)
+	}
+}
+
+func TestRunPolling_StoppedDispatcherSilencesTicks(t *testing.T) {
+	var callCount atomic.Int32
+
+	d := newDispatcher(func() { callCount.Add(1) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runPolling(ctx, 10*time.Millisecond, d)
+	}()
+
+	time.Sleep(60 * time.Millisecond)
+	d.stop()
+	stoppedAt := callCount.Load()
+	if stoppedAt == 0 {
+		t.Fatal("expected polling callbacks before stop, got none")
+	}
+
+	// Ticks keep arriving, but a stopped dispatcher must swallow every one, the
+	// same gate Close relies on for the fsnotify path.
+	time.Sleep(60 * time.Millisecond)
+	if got := callCount.Load(); got != stoppedAt {
+		t.Errorf("polling fired %d callbacks after the dispatcher stopped, want 0", got-stoppedAt)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("runPolling() did not return after context cancellation")
+	}
+}
+
+func TestRunPolling_SharedDispatcherNeverOverlapsWatcher(t *testing.T) {
+	var inFlight atomic.Int32
+	var maxInFlight atomic.Int32
+	// plainCounter is deliberately unsynchronized: if a polling tick and a
+	// watcher debounce timer ever run the callback concurrently, the
+	// read-modify-write races and -race fails the test.
+	var plainCounter int
+
+	d := newDispatcher(func() {
+		n := inFlight.Add(1)
+		for {
+			m := maxInFlight.Load()
+			if n <= m || maxInFlight.CompareAndSwap(m, n) {
+				break
+			}
+		}
+		plainCounter++
+		// Run slower than either scheduler's cadence so the other one fires while
+		// this callback is still in the critical section.
+		time.Sleep(15 * time.Millisecond)
+		inFlight.Add(-1)
+	})
+
+	// The watcher and the polling fallback share one dispatcher, which is the
+	// arrangement WatchWithFallback hands out and the case the old free-function
+	// runPolling could not serialize.
+	w := &Watcher{
+		config:     Config{Debounce: 5 * time.Millisecond, MaxWait: 10 * time.Millisecond},
+		dispatcher: d,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	polling := make(chan error, 1)
+	go func() {
+		polling <- runPolling(ctx, 2*time.Millisecond, d)
+	}()
+
+	storm := 400 * time.Millisecond
+	deadline := time.Now().Add(storm)
+	for time.Now().Before(deadline) {
+		w.scheduleCallback()
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	cancel()
+	select {
+	case err := <-polling:
+		if err != nil {
+			t.Fatalf("runPolling() returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("runPolling() did not return after context cancellation")
+	}
+
+	// cancelPendingTimer waits on the dispatcher for any in-flight callback and
+	// neutralizes pending timers, so once it returns nothing runs or will run.
+	// That release/acquire also orders every callback write to plainCounter
+	// before the reads below, keeping the canary honest under -race.
+	w.cancelPendingTimer()
+
+	if got := maxInFlight.Load(); got > 1 {
+		t.Fatalf("callback overlapped: max concurrent invocations = %d, want <= 1", got)
+	}
+	if plainCounter == 0 {
+		t.Fatal("expected at least one callback during the storm, got none")
+	}
+}
+
+func TestDispatcher(t *testing.T) {
+	tests := []struct {
+		name      string
+		run       func(d *dispatcher)
+		wantCalls int32
+	}{
+		{
+			name:      "dispatch runs the callback",
+			run:       func(d *dispatcher) { d.dispatch() },
+			wantCalls: 1,
+		},
+		{
+			name: "repeated dispatch runs the callback each time",
+			run: func(d *dispatcher) {
+				d.dispatch()
+				d.dispatch()
+			},
+			wantCalls: 2,
+		},
+		{
+			name: "dispatch after stop is inert",
+			run: func(d *dispatcher) {
+				d.stop()
+				d.dispatch()
+			},
+			wantCalls: 0,
+		},
+		{
+			name: "stop is idempotent",
+			run: func(d *dispatcher) {
+				d.stop()
+				d.stop()
+				d.dispatch()
+			},
+			wantCalls: 0,
+		},
+		{
+			name: "stop mid-sequence silences only later dispatches",
+			run: func(d *dispatcher) {
+				d.dispatch()
+				d.stop()
+				d.dispatch()
+			},
+			wantCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls atomic.Int32
+			d := newDispatcher(func() { calls.Add(1) })
+
+			tt.run(d)
+
+			if got := calls.Load(); got != tt.wantCalls {
+				t.Errorf("callback invocations = %d, want %d", got, tt.wantCalls)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Intent

- **ID:** `fest-runpolling-fallback-bypasses-dispatchmu-20260717-145842`
- **Title:** fest: runPolling fallback bypasses dispatchMu serialization (latent, not live)
- **File:** `.campaign/intents/active/fest-runpolling-fallback-bypasses-dispatchmu-20260717-145842.md`

Residual from `fest-serialize-watch-onchange-dispatch-20260712-001747`, which shipped as PR #260.

## This is latent hardening, not a live bug

Nothing is broken in `fest` today. `WatchWithFallback` runs the polling fallback only when `New` fails, so exactly one of the two paths is ever live in a single call, and a lone polling loop dispatches inline on its own ticker goroutine and therefore cannot overlap itself. Every other consumer of the package (`internal/commands/list`, `internal/commands/show`, `internal/commands/progress`, `internal/tui/explore`) uses `watch.New` directly and never reaches the polling path at all.

The problem is that the invariant PR #260 established did not cover the fallback. Before this change, `runPolling` was a free function that called `onChange()` directly with no access to `dispatchMu` or the `stopped` flag, both of which lived as private fields on `Watcher`. So the guarantee "onChange never overlaps itself and never fires after stop" was a property of one code path rather than a property of the package. If a future change ran both paths together, or added a second scheduler sharing a callback, the overlap would return with no test or type to catch it.

I verified the intent is still accurate on this branch before changing anything: `internal/watch/watcher.go:329` (pre-change numbering) called `onChange()` straight from the ticker loop.

## Design

Extract the serialization state into a small unexported `dispatcher` type that owns three things together: the callback, the mutex held across the whole call, and the `stopped` gate.

- `Watcher` now holds a `*dispatcher` instead of the `onChange`, `dispatchMu`, and `stopped` fields. `Watcher.dispatch(gen)` keeps its generation guard unchanged and then calls `d.dispatch()`; `cancelPendingTimer` calls `d.stop()`.
- `runPolling` takes a `*dispatcher` and fires each tick through `d.dispatch()`.
- `WatchWithFallback` builds one dispatcher up front and hands it to whichever path runs, via a new unexported `newWatcher(cfg, d)` that `New` also delegates to.

The reason for binding the callback to the dispatcher rather than passing a `func()` per call is that it makes the pairing unforgeable: you cannot route two different callbacks through one gate, or one callback through two gates, by accident. And because `WatchWithFallback` shares a single dispatcher across both paths, the fix is not just cosmetic uniformity: if the two paths ever do run concurrently, they now serialize against each other rather than overlapping silently, which is precisely the failure mode the intent named.

Ownership of `stop` stays with whoever created the dispatcher. `runPolling` does not stop it, because a dispatcher it shares with a live `Watcher` is not its to tear down. `WatchWithFallback` stops it in the fallback branch; `Watcher.Close` already stops it in the other. This keeps `runPolling` composable while preserving the "nothing fires after return" property, since it dispatches inline and so has no callback in flight when it returns.

Behavior is otherwise identical: debounce and MaxWait semantics, close semantics, and fallback-only-when-New-fails are untouched. **No public API change.** `New`, `Config`, `Watcher`, `AddPath`, `AddTree`, `Watch`, `Close`, and `WatchWithFallback` all keep their existing signatures, so the five call sites outside the package are unaffected.

## Tests

Three new polling tests plus a table-driven unit test for the dispatcher:

- `TestRunPolling_SharedDispatcherNeverOverlapsWatcher` runs a polling loop and a `Watcher` debounce storm against one shared dispatcher with a callback slower than either scheduler's cadence, asserting max concurrent invocations stays at 1. It also increments a deliberately unsynchronized counter so `-race` fails if the two ever overlap.
- `TestRunPolling_ReturnsOnContextCancel` asserts `runPolling` returns nil on cancellation and that the callback count is frozen afterward.
- `TestRunPolling_StoppedDispatcherSilencesTicks` asserts ticks arriving after `stop` are swallowed, which is the gate `Close` relies on.
- `TestDispatcher` covers dispatch, repeated dispatch, dispatch-after-stop, stop idempotence, and mid-sequence stop.

I confirmed the new tests actually catch the old behavior rather than passing vacuously. Temporarily reverting the polling loop to call the callback directly produced both a hard failure and a genuine data race between a polling tick and a watcher debounce timer:

```
--- FAIL: TestRunPolling_StoppedDispatcherSilencesTicks (0.12s)
    watcher_test.go:463: polling fired 6 callbacks after the dispatcher stopped, want 0
WARNING: DATA RACE
Read at 0x00c000188800 by goroutine 14:
  ...watch.(*dispatcher).dispatch()
  ...watch.(*Watcher).dispatch()
Previous write at 0x00c000188800 by goroutine 12:
  ...watch.runPolling()
```

Existing tests were updated only for the new construction shape (`dispatcher: newDispatcher(fn)` in place of the `onChange` field); none of their assertions changed.

## Gates

| Gate | Result |
| --- | --- |
| `go build ./...` | clean |
| `just lint vet` (`go vet ./...`) | clean |
| `just lint all` (`golangci-lint run ./...`) | 0 issues |
| `just test unit-raw` | all packages ok, no failures |
| `go test -race -count=3 ./internal/watch/...` | ok, 11.969s |
| `go test -race` on the four consumer packages | ok |

One note on the lint run: the first `just lint all` reported a stale `staticcheck` finding in `../gate-evidence-defaults/internal/guidance/workflow/navigator_format_judge_test.go`, a file in a sibling worktree that no longer exists (that work merged as PR #317, which is this branch's base). It was golangci-lint cache pollution, not a finding against this change. After `golangci-lint cache clean` the run reports 0 issues. Worth knowing if other worktree branches hit the same phantom failure.

## Tradeoffs and residual risk

- The dispatcher is one shared mutex, so a slow callback on a shared dispatcher backpressures the other scheduler. That is the intended semantics (it is the same backpressure PR #260 introduced for the fsnotify path) but it means a pathologically slow render will now also delay polling ticks if both ever share a dispatcher. Ticks are dropped rather than queued, which matches the existing coalescing behavior.
- `Watcher.dispatcher` is a pointer and is never nil-checked. `New` and `newWatcher` always set it, but a hand-rolled `&Watcher{}` literal that skips it will panic on first dispatch. I chose not to add a defensive nil guard because a missing dispatcher is a programming error, not a runtime condition, and the package's existing style documents invariants rather than defending against internal misuse. Three in-package tests construct `Watcher` literals directly and were updated accordingly.
- The concurrency tests are timing-based, consistent with the rest of the package. They passed `-count=3` under `-race`, but they are sleep-driven and so carry the usual small flake risk on a heavily loaded machine.
