### PR TITLE
fix(commit): flip file-list retry copy to fest commit --commit-large [intent: fest-flip-the-file-list-20260801-011034]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.6
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0
-	github.com/Obedience-Corp/camp v0.4.0-rc.2
+	github.com/Obedience-Corp/camp v0.4.0-rc.3
 	github.com/Obedience-Corp/obey-shared v0.4.6
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/Obedience-Corp/camp v0.4.0-rc.2 h1:+dydz5vsx1LOiSGDyFv29W+/ML2m/8BaM759D0uqvGI=
-github.com/Obedience-Corp/camp v0.4.0-rc.2/go.mod h1:Xko1DyzQ80Yf0lGCLu7ZiYWXTxdxXobRgUzERTMLeVE=
+github.com/Obedience-Corp/camp v0.4.0-rc.3 h1:XK73U0Vzt5G1qlnCp0Vehm4z8evCoNEsBG3PlJh9PNI=
+github.com/Obedience-Corp/camp v0.4.0-rc.3/go.mod h1:Xko1DyzQ80Yf0lGCLu7ZiYWXTxdxXobRgUzERTMLeVE=
 github.com/Obedience-Corp/obey-shared v0.4.6 h1:nvl2sM/5ri9LfmKpqXyt84T1z2TvNBiv4cpPkRVJyBk=
 github.com/Obedience-Corp/obey-shared v0.4.6/go.mod h1:VZ9rp2YklgdlipSr7aUlOHbmNjrRjif4qHybkLdn6ic=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=

--- a/internal/commands/commit/commit.go
+++ b/internal/commands/commit/commit.go
@@ -369,33 +369,38 @@ func stageAllChanges(ctx context.Context, repoPath string, report io.Writer) err
 	if err != nil {
 		var blocked *commitkit.GuardBlockedError
 		if stderrors.As(err, &blocked) {
-			return errors.New(guardRefusalMessage(blocked, "fest commit --commit-large"))
+			return errors.New(guardRefusalMessage(blocked))
 		}
 		return errors.Wrap(err, "staging changes")
 	}
-	reportStageOutcome(report, outcome, "fest commit --commit-large")
+	reportStageOutcome(report, outcome)
 	return nothingLeftAfterExclusions(ctx, repoPath, outcome)
 }
 
 // stageFiles stages the given paths through commitkit with outcome reporting
 // and fest-rendered GuardBlockedError text — the same contract as stageAllChanges,
 // for festival-scoped and campaign-root path lists.
+//
+// The options form carries --commit-large so fest's flag reaches the guard on
+// the same terms the stage-all branch gets. It does not reach a guard today:
+// camp only guards sweep forms, reading an explicit path list as the user's own
+// intent, so a synthesized list like this one is staged unchecked and the
+// refusal branch below cannot fire. The wiring and the retry it names are the
+// right ones the moment camp can guard a list fest built rather than the user.
 func stageFiles(ctx context.Context, repoPath string, report io.Writer, files ...string) error {
 	if err := ctx.Err(); err != nil {
 		return errors.Wrap(err, "context cancelled")
 	}
-	outcome, err := commitkit.StageFilesWithOutcome(ctx, repoPath, files...)
+	outcome, err := commitkit.StageFilesWithOptions(ctx, repoPath,
+		commitkit.StageOptions{CommitLarge: commitLarge}, files...)
 	if err != nil {
 		var blocked *commitkit.GuardBlockedError
 		if stderrors.As(err, &blocked) {
-			// commitkit exports no options form for file-list staging, so
-			// fest's flag cannot reach this branch; camp's own flag is the
-			// retry that works at a campaign root.
-			return errors.New(guardRefusalMessage(blocked, "camp commit --commit-large"))
+			return errors.New(guardRefusalMessage(blocked))
 		}
 		return errors.Wrap(err, "staging files")
 	}
-	reportStageOutcome(report, outcome, "camp commit --commit-large")
+	reportStageOutcome(report, outcome)
 	return nothingLeftAfterExclusions(ctx, repoPath, outcome)
 }
 
@@ -632,15 +637,16 @@ func commitCampaignRoot(ctx context.Context, campaignRoot string, paths []string
 		return "", nil
 	}
 
-	outcome, err := commitkit.StageFilesWithOutcome(ctx, campaignRoot, paths...)
+	outcome, err := commitkit.StageFilesWithOptions(ctx, campaignRoot,
+		commitkit.StageOptions{CommitLarge: commitLarge}, paths...)
 	if err != nil {
 		var blocked *commitkit.GuardBlockedError
 		if stderrors.As(err, &blocked) {
-			return "", errors.New(guardRefusalMessage(blocked, "camp commit --commit-large"))
+			return "", errors.New(guardRefusalMessage(blocked))
 		}
 		return "", errors.Wrap(err, "staging festival files at campaign root")
 	}
-	reportStageOutcome(report, outcome, "camp commit --commit-large")
+	reportStageOutcome(report, outcome)
 
 	hasChanges, err := commitkit.HasStagedChanges(ctx, campaignRoot)
 	if err != nil {

--- a/internal/commands/commit/guard.go
+++ b/internal/commands/commit/guard.go
@@ -12,17 +12,20 @@ import (
 // Fest renders the staging guard's decisions in its own voice from camp's
 // typed data; no camp error text is parsed or echoed. The facts and the ways
 // out are the same ones camp names, and every printed remedy must be runnable
-// on the branch that printed it: the retry command is supplied per call site,
-// because fest's --commit-large reaches only the stage-all branches
-// (commitkit exports no options form for file-list staging), while a
-// campaign-root refusal can always retry through camp's own flag.
+// on the branch that printed it. Every stage fest performs now passes its own
+// --commit-large through commitkit's options forms, so one retry command is
+// right everywhere: fest's own flag, on the command the user already ran.
+
+// commitLargeRetry is the commit-it-anyway command named by every refusal and
+// exclusion fest prints. Naming camp here instead would hand the user a second
+// binary to rerun for a decision fest's own flag already overrides.
+const commitLargeRetry = "fest commit --commit-large"
 
 // guardRefusalMessage is the result.Error text for a staging refusal: what was
 // refused, that nothing was staged, and every way out. A refusal is the one
 // moment the guard spends the user's attention, so the message has to pay for
-// it rather than saying a bare "staging refused". retryCmd is the
-// commit-it-anyway command that actually works where the refusal happened.
-func guardRefusalMessage(blocked *commitkit.GuardBlockedError, retryCmd string) string {
+// it rather than saying a bare "staging refused".
+func guardRefusalMessage(blocked *commitkit.GuardBlockedError) string {
 	var b strings.Builder
 	switch blocked.Kind {
 	case commitkit.Bulk:
@@ -40,7 +43,7 @@ func guardRefusalMessage(blocked *commitkit.GuardBlockedError, retryCmd string) 
 			files, formatBytes(total), worst.CommonPrefix)
 		fmt.Fprintf(&b, "  gitignore it        echo '%s/' >> .gitignore\n", worst.CommonPrefix)
 		fmt.Fprintf(&b, "  keep and sync it    camp artifacts add %s\n", worst.CommonPrefix)
-		fmt.Fprintf(&b, "  commit it anyway    %s -m \"...\"\n", retryCmd)
+		fmt.Fprintf(&b, "  commit it anyway    %s -m \"...\"\n", commitLargeRetry)
 		fmt.Fprintf(&b, "  turn the guard off  camp settings set local.commit.guards.bulk off")
 	default:
 		fmt.Fprintf(&b, "%s over the %s limit would be committed; nothing was staged\n",
@@ -52,7 +55,7 @@ func guardRefusalMessage(blocked *commitkit.GuardBlockedError, retryCmd string) 
 			fmt.Fprintf(&b, "  keep and sync it    camp artifacts add %s\n",
 				filepath.ToSlash(filepath.Dir(v.Path)))
 		}
-		fmt.Fprintf(&b, "  commit it anyway    %s -m \"...\"\n", retryCmd)
+		fmt.Fprintf(&b, "  commit it anyway    %s -m \"...\"\n", commitLargeRetry)
 		fmt.Fprintf(&b, "  handle it for me    camp settings set local.commit.guards.large_files auto")
 	}
 	return b.String()
@@ -63,10 +66,7 @@ func guardRefusalMessage(blocked *commitkit.GuardBlockedError, retryCmd string) 
 // file, a flagged tracked file, or a guard that could not run are each one
 // line here rather than a silent diff surprise. Written to stderr by callers
 // so a machine-read stdout stays pure.
-// retryCmd is the commit-it-anyway command that actually works on the branch
-// that staged (camp commit refuses outside a campaign, so the standalone
-// branches must name fest's own flag).
-func reportStageOutcome(w io.Writer, outcome *commitkit.StageOutcome, retryCmd string) {
+func reportStageOutcome(w io.Writer, outcome *commitkit.StageOutcome) {
 	if outcome == nil {
 		return
 	}
@@ -75,7 +75,7 @@ func reportStageOutcome(w io.Writer, outcome *commitkit.StageOutcome, retryCmd s
 	}
 	for _, v := range outcome.Excluded {
 		_, _ = fmt.Fprintf(w, "Kept out of git: %s (%s, over the %s limit); commit it anyway with '%s' or 'camp settings set local.commit.guards.large_files auto'\n",
-			v.Path, formatBytes(v.Size), formatBytes(outcome.Limits.MaxFileSize), retryCmd)
+			v.Path, formatBytes(v.Size), formatBytes(outcome.Limits.MaxFileSize), commitLargeRetry)
 	}
 	for _, v := range outcome.Reported {
 		_, _ = fmt.Fprintf(w, "Tracked file grew past %s: %s (%s); committed as usual\n",

--- a/internal/commands/commit/guard_test.go
+++ b/internal/commands/commit/guard_test.go
@@ -1,98 +1,169 @@
 package commit
 
 import (
+	stderrors "errors"
 	"strings"
 	"testing"
 
 	"github.com/Obedience-Corp/camp/pkg/commitkit"
 )
 
+// errGuardUnavailable stands in for whatever camp reports when the guard cannot
+// read its thresholds; fest only has to pass it through.
+var errGuardUnavailable = stderrors.New("no settings file")
+
 // The refusal message is fest's one chance to explain a blocked commit, so
 // these tests pin the contract: every refusal names what was found, that
-// nothing was staged, and working ways out (including camp commit
-// commit-it-anyway retry that works where the refusal happened). All
-// assertions run against
-// typed data rendered by fest; none depend on camp's error strings.
+// nothing was staged, and working ways out. The commit-it-anyway retry is
+// fest's own flag on every branch, because every stage fest performs carries
+// --commit-large into the guard decision. All assertions run against typed
+// data rendered by fest; none depend on camp's error strings.
 
-func TestGuardRefusalMessageBulkNamesEveryWayOut(t *testing.T) {
-	blocked := &commitkit.GuardBlockedError{
-		Kind: commitkit.Bulk,
-		Violations: []commitkit.GuardViolation{
-			{Kind: commitkit.Bulk, CommonPrefix: "node_modules", Count: 1204, TotalBytes: 220 << 20},
+func TestGuardRefusalMessageNamesEveryWayOut(t *testing.T) {
+	tests := []struct {
+		name    string
+		blocked *commitkit.GuardBlockedError
+		want    []string
+		notWant []string
+	}{
+		{
+			name: "bulk",
+			blocked: &commitkit.GuardBlockedError{
+				Kind: commitkit.Bulk,
+				Violations: []commitkit.GuardViolation{
+					{Kind: commitkit.Bulk, CommonPrefix: "node_modules", Count: 1204, TotalBytes: 220 << 20},
+				},
+			},
+			want: []string{
+				"1204 untracked files",
+				"node_modules/",
+				"nothing was staged",
+				"echo 'node_modules/' >> .gitignore",
+				"camp artifacts add node_modules",
+				"fest commit --commit-large",
+				"camp settings set local.commit.guards.bulk off",
+			},
+			notWant: []string{"camp commit --commit-large"},
+		},
+		{
+			name: "over threshold",
+			blocked: &commitkit.GuardBlockedError{
+				Kind: commitkit.OverThreshold,
+				Violations: []commitkit.GuardViolation{
+					{Kind: commitkit.OverThreshold, Path: "media/clip.bin", Size: 900 << 20},
+				},
+				Limits: commitkit.GuardLimits{MaxFileSize: 100 << 20},
+			},
+			want: []string{
+				"1 file over the 100.0 MB limit",
+				"media/clip.bin",
+				"nothing was staged",
+				"camp artifacts add media",
+				"fest commit --commit-large",
+				"camp settings set local.commit.guards.large_files auto",
+			},
+			notWant: []string{"camp commit --commit-large"},
+		},
+		{
+			name: "over threshold with several files",
+			blocked: &commitkit.GuardBlockedError{
+				Kind: commitkit.OverThreshold,
+				Violations: []commitkit.GuardViolation{
+					{Kind: commitkit.OverThreshold, Path: "media/clip.bin", Size: 900 << 20},
+					{Kind: commitkit.OverThreshold, Path: "data/dump.sql", Size: 300 << 20},
+				},
+				Limits: commitkit.GuardLimits{MaxFileSize: 100 << 20},
+			},
+			want: []string{
+				"2 files over the 100.0 MB limit",
+				"media/clip.bin",
+				"data/dump.sql",
+				"camp artifacts add media",
+				"camp artifacts add data",
+				"fest commit --commit-large",
+			},
+			notWant: []string{"camp commit --commit-large"},
 		},
 	}
 
-	msg := guardRefusalMessage(blocked, "fest commit --commit-large")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := guardRefusalMessage(tt.blocked)
 
-	for _, want := range []string{
-		"1204 untracked files",
-		"node_modules/",
-		"nothing was staged",
-		"echo 'node_modules/' >> .gitignore",
-		"camp artifacts add node_modules",
-		"fest commit --commit-large",
-		"camp settings set local.commit.guards.bulk off",
-	} {
-		if !strings.Contains(msg, want) {
-			t.Errorf("bulk refusal missing %q in:\n%s", want, msg)
-		}
+			for _, want := range tt.want {
+				if !strings.Contains(msg, want) {
+					t.Errorf("refusal missing %q in:\n%s", want, msg)
+				}
+			}
+			for _, notWant := range tt.notWant {
+				if strings.Contains(msg, notWant) {
+					t.Errorf("refusal must not send the user to another binary; found %q in:\n%s", notWant, msg)
+				}
+			}
+		})
 	}
 }
 
-func TestGuardRefusalMessageLargeFilesNamesEveryWayOut(t *testing.T) {
-	blocked := &commitkit.GuardBlockedError{
-		Kind: commitkit.OverThreshold,
-		Violations: []commitkit.GuardViolation{
-			{Kind: commitkit.OverThreshold, Path: "media/clip.bin", Size: 900 << 20},
+func TestReportStageOutcome(t *testing.T) {
+	tests := []struct {
+		name    string
+		outcome *commitkit.StageOutcome
+		want    []string
+		silent  bool
+	}{
+		{
+			name:    "nil outcome says nothing",
+			outcome: nil,
+			silent:  true,
 		},
-		Limits: commitkit.GuardLimits{MaxFileSize: 100 << 20},
+		{
+			name:    "uneventful stage says nothing",
+			outcome: &commitkit.StageOutcome{},
+			silent:  true,
+		},
+		{
+			name: "exclusion carries fest's own retry",
+			outcome: &commitkit.StageOutcome{
+				Excluded: []commitkit.GuardViolation{
+					{Kind: commitkit.OverThreshold, Path: "render.bin", Size: 512 << 20},
+				},
+				Reported: []commitkit.GuardViolation{
+					{Kind: commitkit.TrackedGrowth, Path: "fixtures/golden.json", Size: 150 << 20},
+				},
+				Limits: commitkit.GuardLimits{MaxFileSize: 100 << 20},
+			},
+			want: []string{
+				"Kept out of git: render.bin",
+				"fest commit --commit-large",
+				"Tracked file grew past 100.0 MB: fixtures/golden.json",
+			},
+		},
+		{
+			name: "a guard that could not run is said out loud",
+			outcome: &commitkit.StageOutcome{
+				Unavailable: errGuardUnavailable,
+			},
+			want: []string{"Staged without the size and bulk guard", "no settings file"},
+		},
 	}
 
-	msg := guardRefusalMessage(blocked, "camp commit --commit-large")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var b strings.Builder
+			reportStageOutcome(&b, tt.outcome)
 
-	for _, want := range []string{
-		"1 file over the 100.0 MB limit",
-		"media/clip.bin",
-		"nothing was staged",
-		"camp artifacts add media",
-		"camp commit --commit-large",
-		"camp settings set local.commit.guards.large_files auto",
-	} {
-		if !strings.Contains(msg, want) {
-			t.Errorf("large-file refusal missing %q in:\n%s", want, msg)
-		}
-	}
-}
-
-func TestReportStageOutcomeSaysWhatTheGuardDid(t *testing.T) {
-	var b strings.Builder
-	reportStageOutcome(&b, &commitkit.StageOutcome{
-		Excluded: []commitkit.GuardViolation{
-			{Kind: commitkit.OverThreshold, Path: "render.bin", Size: 512 << 20},
-		},
-		Reported: []commitkit.GuardViolation{
-			{Kind: commitkit.TrackedGrowth, Path: "fixtures/golden.json", Size: 150 << 20},
-		},
-		Limits: commitkit.GuardLimits{MaxFileSize: 100 << 20},
-	}, "fest commit --commit-large")
-
-	out := b.String()
-	for _, want := range []string{
-		"Kept out of git: render.bin",
-		"fest commit --commit-large",
-		"Tracked file grew past 100.0 MB: fixtures/golden.json",
-	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("outcome report missing %q in:\n%s", want, out)
-		}
-	}
-}
-
-func TestReportStageOutcomeIsSilentWhenThereIsNothingToSay(t *testing.T) {
-	var b strings.Builder
-	reportStageOutcome(&b, nil, "fest commit --commit-large")
-	reportStageOutcome(&b, &commitkit.StageOutcome{}, "fest commit --commit-large")
-	if b.Len() != 0 {
-		t.Errorf("an uneventful stage must print nothing, got:\n%s", b.String())
+			out := b.String()
+			if tt.silent {
+				if out != "" {
+					t.Errorf("expected no output, got:\n%s", out)
+				}
+				return
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(out, want) {
+					t.Errorf("outcome report missing %q in:\n%s", want, out)
+				}
+			}
+		})
 	}
 }

--- a/tests/integration/commit_guard_test.go
+++ b/tests/integration/commit_guard_test.go
@@ -94,6 +94,51 @@ func TestCommitGuard_LargeFileKeptOutInStandaloneWorkspace(t *testing.T) {
 		"--commit-large must force the over-threshold file into the commit")
 }
 
+// The campaign-root branch stages a synthesized path list (the festival
+// directory, .campaign/fest, festivals/.festival/.state) rather than sweeping
+// the worktree, and camp's guard deliberately skips explicit path lists:
+// naming a path is read as the user's own intent, so only sweep forms are
+// checked (camp internal/git/stageguard.go, isStageEverything). The list fest
+// builds is not something the user named, so nothing on this branch is
+// guarded today: an over-threshold file inside a festival directory reaches
+// git with no exclusion and no report.
+//
+// This test pins that as the observed truth rather than as the desired one.
+// Closing the gap needs a camp-side way to guard a synthesized list; when that
+// lands, this test should fail and be rewritten as the exclusion assertion its
+// two neighbours already make.
+func TestCommitGuard_CampaignRootFileListIsNotGuarded(t *testing.T) {
+	tc := GetSharedContainer(t)
+	ensureGuardGit(t, tc)
+
+	dir := "/guard-root"
+	// .campaign is what makes this a campaign workspace rather than a bare
+	// repo, which is what routes the commit down the file-list branch.
+	_, err := tc.Exec("sh", "-c",
+		"mkdir -p "+dir+"/festivals/.festival "+dir+"/.campaign && cd "+dir+" && git init -q")
+	require.NoError(t, err)
+	require.NoError(t, tc.WriteFile(dir+"/festivals/active/guard-festival/fest.yaml", guardFestYAML))
+
+	festDir := dir + "/festivals/active/guard-festival"
+	_, err = tc.Exec("sh", "-c",
+		"truncate -s 512M "+festDir+"/render-output.bin && echo notes > "+festDir+"/notes.md")
+	require.NoError(t, err)
+
+	out, err := tc.RunFestInDir(festDir, "commit", "--no-tag", "-m", "campaign root festival commit")
+	require.NoError(t, err, "the campaign root commit must succeed: %s", out)
+
+	assert.NotContains(t, out, "Kept out of git",
+		"the guard does not run on an explicit path list, so nothing is reported as excluded")
+
+	committed, err := tc.Exec("git", "-C", dir, "ls-tree", "-r", "--name-only", "HEAD")
+	require.NoError(t, err)
+	assert.Contains(t, committed, "festivals/active/guard-festival/notes.md",
+		"the ordinary festival file must be committed")
+	assert.Contains(t, committed, "festivals/active/guard-festival/render-output.bin",
+		"the over-threshold file reaches git unguarded on the file-list branch; "+
+			"if this now fails, camp guards synthesized lists and this test should assert exclusion instead")
+}
+
 func TestCommitGuard_LargeFileKeptOutInLinkedSubmodule(t *testing.T) {
 	tc := GetSharedContainer(t)
 	ensureGuardGit(t, tc)


### PR DESCRIPTION
## Intent

- **ID**: `fest-flip-the-file-list-20260801-011034`
- **Title**: fest: flip the file-list retry copy from `camp commit --commit-large` to `fest commit --commit-large`
- **File**: `.campaign/intents/inbox/fest-flip-the-file-list-20260801-011034.md`

The intent is **not stale**: the export exists and fest was not using it. But the premise behind it turns out to be incomplete, and that is the most important thing in this PR. Read the "What this does not fix" section before merging.

## The dependency bump

`github.com/Obedience-Corp/camp` v0.4.0-rc.2 to **v0.4.0-rc.3**.

v0.4.0-rc.3 is the newest camp tag and the first one carrying `commitkit.StageFilesWithOptions` (camp PR #530). There is no stable v0.4.0 yet, so the rc is the only release with the export. The bump pulls in nothing else: camp's own `go.mod` hash is byte-identical between rc.2 and rc.3 (`h1:Xko1DyzQ80Yf0lGCLu7ZiYWXTxdxXobRgUzERTMLeVE=`), so `go mod tidy` produced no transitive changes. The full diff outside the two staging call sites is the version line and its two `go.sum` lines.

## What changed

**Call sites flipped** (both stage through a file list that `fest commit` itself builds, and both are re-reachable by rerunning `fest commit --commit-large`):

| Location | Before | After |
| --- | --- | --- |
| `internal/commands/commit/commit.go` `stageFiles` | `StageFilesWithOutcome`, copy named `camp commit --commit-large` | `StageFilesWithOptions` with `StageOptions{CommitLarge: commitLarge}`, copy names `fest commit --commit-large` |
| `internal/commands/commit/commit.go` `commitCampaignRoot` | same | same |

`stageAllChanges` already used the options form and already named fest's flag; it is unchanged apart from the signature change below.

**Call sites deliberately left**: none. The brief anticipated a site where the user genuinely must rerun camp rather than fest. Tracing all three staging call sites, no such site exists: every one of them is staging that `fest commit` performs during a run the user started with `fest commit`, so fest's own flag is the correct retry everywhere.

**Consequent simplification**: because all three call sites now pass the same string, the per-call-site `retryCmd` parameter on `guardRefusalMessage` and `reportStageOutcome` no longer carries information. It collapses into a `commitLargeRetry` constant in `guard.go`. This also removes the comment in `guard.go` explaining the split, which was the CA0004 artifact the intent set out to close.

**Removed a now-false comment** in `stageFiles`: "commitkit exports no options form for file-list staging". That is no longer true as of rc.3.

## What this does not fix, and why you should not read this PR as closing a user-visible gap

The flipped copy is currently **unreachable**. Camp's guard does not run at all on an explicit path list.

`camp internal/git/stageguard.go`, `runStageGuard` returns immediately when the call names paths:

```go
if !isStageEverything(files) {
    return nil, nil, nil
}
```

That check runs *before* the `opts.CommitLarge` check, and the rationale is deliberate and documented in camp:

> The distinction is the design's: an explicit `git add path/to/media.mp4` is an intent, and camp honors it. Only the sweep forms are guarded, because only they can pick up something the user never mentioned.

So for any real path list, `StageFilesWithOptions` and `StageFilesWithOutcome` behave identically: no guard, no `GuardBlockedError`, nil outcome, nothing reported. I verified this rather than inferring it, by calling both forms directly against a fixture repo with a 512 MB sparse file:

```
=== filelist ===   (StageFilesWithOptions, CommitLarge:false, explicit path)
  err=<nil>
  outcome=<nil>
  staged="fest-dir/notes.md\nfest-dir/render.bin\n"

=== sweep ===      (StageAllWithOptions, CommitLarge:false)
  err=<nil>
  outcome=&{Excluded:[{Kind:over_threshold Path:fest-dir/render.bin Size:536870912}] ...}
  staged="fest-dir/notes.md\n"
```

The 512 MB file **was staged** on the file-list path.

**The real gap this uncovered**: fest's campaign-root festival commit is unguarded. The path list fest passes is synthesized by `festivalScopedPaths` (the festival directory, `.campaign/fest`, `festivals/.festival/.state`), not named by the user. Camp's "an explicit path is user intent" premise does not hold for a list fest built on the user's behalf, so an over-threshold file dropped inside a festival directory goes into the campaign root commit with no exclusion, no report, and no way for the user to find out.

Closing that needs a camp-side change (a way to ask for the guard on a synthesized list, since fest cannot switch to a sweep at the campaign root without staging everything there, which is exactly what festival-scoped staging exists to avoid). That is out of scope here and wants its own intent against camp.

I pinned the current behavior in a new integration test, `TestCommitGuard_CampaignRootFileListIsNotGuarded`, written to assert the observed truth and to **fail loudly** if camp starts guarding synthesized lists, with a comment saying to rewrite it as an exclusion assertion at that point.

## Tests

- Rewrote `internal/commands/commit/guard_test.go` as table-driven, error cases first, matching the surrounding style. Added a multi-file over-threshold case and a guard-unavailable case that were not covered before. Every case now also asserts `camp commit --commit-large` is **absent**, so a regression back to the old copy fails rather than passing silently.
- Added `TestCommitGuard_CampaignRootFileListIsNotGuarded` to `tests/integration/commit_guard_test.go`, exercising the campaign-root file-list branch through the container harness. That branch had no integration coverage at all before; the two existing guard tests both cover sweep branches.

## Gate results

```
just fmt          gofmt -w .
just lint vet     go vet ./...                          (clean)
just lint all     golangci-lint run ./...               0 issues.
just test unit-raw                                      all packages ok
                  internal/commands/commit  ok  0.863s
integration (containerized, full suite)
                  tests/integration            ok  204.591s
                  tests/integration/lifecycle  ok   16.772s
```

Guard tests specifically:

```
--- PASS: TestCommitGuard_LargeFileKeptOutInStandaloneWorkspace (4.47s)
--- PASS: TestCommitGuard_CampaignRootFileListIsNotGuarded (2.86s)
--- PASS: TestCommitGuard_LargeFileKeptOutInLinkedSubmodule (1.12s)
```

## Tradeoffs and residual risk

1. **This ships inert copy.** The flipped strings cannot be printed today. It is still worth landing: the old comment was factually false after rc.3, the old copy pointed at the wrong binary if it ever became reachable, and the parameter it justified was dead flexibility. But it does not change anything a user sees, and the PR title should not be read as fixing a reported symptom.
2. **Depending on an rc.** fest now requires camp v0.4.0-rc.3 rather than a stable tag. If v0.4.0 stable lands before this merges, retag the dependency to it.
3. **The new integration test asserts current behavior that is arguably a bug.** That is intentional and commented, but it does mean a reviewer could mistake it for endorsement. It is there to make the gap visible and to break when the gap closes.
4. Test cost: one more 512 MB sparse file in the shared container. Sparse via `truncate`, and the guard measures `lstat` size, so it costs no real disk or time.
