### PR TITLE
docs(watch): drop stale dispatchMu name from overlap test comment

### DIFF
--- a/internal/watch/watcher_test.go
+++ b/internal/watch/watcher_test.go
@@ -266,7 +266,7 @@ func TestWatcher_OnChangeNeverOverlaps(t *testing.T) {
 		time.Sleep(2 * time.Millisecond)
 	}
 
-	// cancelPendingTimer waits on dispatchMu for any in-flight onChange and
+	// cancelPendingTimer waits on the dispatcher for any in-flight onChange and
 	// neutralizes pending timers, so once it returns no callback runs or will
 	// run. That release/acquire also orders every onChange write to plainCounter
 	// before the reads below, keeping the canary honest under -race.


### PR DESCRIPTION
## Summary

Follow-up to review on merged #318.

- Update `TestWatcher_OnChangeNeverOverlaps` comment: cancel waits on the shared `dispatcher`, not the removed `dispatchMu` field.
- Matches wording already used in the shared-dispatcher tests added in #318.

## Test plan

- [x] Comment-only change (no behavior change)
- [ ] `go test ./internal/watch/ -count=1` (optional smoke)