### PR TITLE
chore(lint): enable gofmt in golangci-lint so just lint all covers formatting [intent: add-gofmt-to-golangci-lint-20260731-144221]

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,5 @@
+version: "2"
+
+formatters:
+  enable:
+    - gofmt


### PR DESCRIPTION
## Summary

Intent: `add-gofmt-to-golangci-lint-20260731-144221` (`.campaign/intents/active/add-gofmt-to-golangci-lint-20260731-144221.md`)

"Add gofmt to golangci-lint so `just lint all` covers formatting."

Adds `.golangci.yml` at the repo root enabling the `gofmt` formatter. Previously no golangci-lint config file existed, so `just lint all` (`.justfiles/lint.just`) ran `golangci-lint run ./...` with only the tool's built-in default linter set (errcheck, govet, ineffassign, staticcheck, unused) and no formatting check. `gofmt -l .` and `just lint all` were run separately in CI-adjacent workflows; this closes that gap so a single gate command covers both.

## Config added

```yaml
version: "2"

formatters:
  enable:
    - gofmt
```

The installed `golangci-lint` binary is v2.12.2, which uses the v2 config schema. In v2, `gofmt` is a **formatter**, not a linter, so it must be declared under `formatters.enable`, not `linters.enable` (confirmed against the current golangci-lint docs at https://golangci-lint.run/docs/configuration/file and the v1->v2 migration guide, which explicitly moves `gofmt` from `linters.enable` to `formatters.enable`). `golangci-lint run` executes enabled formatters and reports diffs as issues without needing `--fix`.

### Confirmed additive, defaults unchanged

Captured `golangci-lint linters` output before and after adding the config file (full enabled + disabled linter listing) and diffed them: **byte-identical**. The default linter set (errcheck, govet, ineffassign, staticcheck, unused) is unchanged, and no other linter was enabled or disabled by this config. Adding the `formatters` section has no effect on the `linters` section.

## Proof the gate catches formatting errors

Added a scratch file `internal/bginit/zz_scratch_fmtcheck.go` with deliberately bad formatting:

```go
package bginit

func zzScratchFmtCheck() int {
	x :=    1
	y:=2
	return x+y
}
```

Before this change existed, `gofmt -l .` flagged it but `just lint all` would not have. With the new config:

```
$ gofmt -l .
internal/bginit/zz_scratch_fmtcheck.go

$ just lint all
golangci-lint run ./...
internal/bginit/zz_scratch_fmtcheck.go:4:1: File is not properly formatted (gofmt)
	x :=    1
^
internal/bginit/zz_scratch_fmtcheck.go:3:6: func zzScratchFmtCheck is unused (unused)
func zzScratchFmtCheck() int {
     ^
2 issues:
* gofmt: 1
* unused: 1
error: recipe `all` failed on line 11 with exit code 1
```

`just lint all` fails with a `gofmt` finding (the `unused` finding alongside it confirms the pre-existing default linters are still active too).

Removed the scratch file and reverted:

```
$ gofmt -l .
(no output)

$ just lint all
golangci-lint run ./...
0 issues.
```

## Gate results (full repo, this branch)

`just lint all`:

```
golangci-lint run ./...
0 issues.
```

`just test unit-raw`:

```
go test -short -timeout 30s ./...
ok  	github.com/Obedience-Corp/fest/cmd/fest	18.812s
...
ok  	github.com/Obedience-Corp/fest/internal/yamlutil	2.594s
ok  	github.com/Obedience-Corp/fest/tools/release-notes	3.880s
ok  	github.com/Obedience-Corp/fest/tools/release-notes/internal/notes	2.551s
```

All packages pass. Full unit test suite output (109 packages) is available on request; every package reports `ok` or `[no test files]`.

## Verified context before making the change

- No `.golangci.yml` or `.golangci.yaml` existed in the repo (confirmed in this worktree against `origin/main`, which includes today's merged PRs #318 and #319).
- `gofmt -l .` returned zero files before this change, so the repo was already fully gofmt-clean. This is a zero-risk config addition; it changes the gate, not the codebase.
- `.justfiles/lint.just` runs a bare `golangci-lint run ./...` with no `-c` flag, so a root-level `.golangci.yml` is picked up automatically with no recipe changes needed.

## Risks / follow-ups

None identified. The tree was already gofmt-clean, so this is purely a gate addition with no behavior change to existing code.
