### PR TITLE
fix(workflow,show): reject blocking checkpoints at standalone creation; teach fest list in show hint

### DIFF
--- a/internal/commands/festival/create_workflow_standalone.go
+++ b/internal/commands/festival/create_workflow_standalone.go
@@ -23,6 +23,22 @@ import (
 //
 // Festival-only flags (--position, --path, --festival) are rejected here so
 // users get an explicit error rather than confusing silent ignores.
+// rejectBlockingCheckpoints fails standalone creation for steps the
+// standalone runtime refuses to advance past, so `fest create workflow`
+// cannot mint a workflow that is unrunnable from birth (advance rejects a
+// blocking checkpoint at execution time with the same message).
+func rejectBlockingCheckpoints(input *WorkflowInput) error {
+	for i, step := range input.Steps {
+		if strings.TrimSpace(step.Checkpoint) == "approval_required" {
+			return errors.Validation("standalone workflows do not support blocking checkpoints").
+				WithField("step", i+1).
+				WithField("step_name", step.Name).
+				WithHint("use checkpoint \"verification\" or \"none\", or create the workflow inside a festival phase (--path) where 'fest workflow approve' is available")
+		}
+	}
+	return nil
+}
+
 func runStandaloneCreateWorkflow(ctx context.Context, opts *CreateWorkflowOptions, res *standalone.Result, cwd string) error {
 	if err := rejectFestivalOnlyFlags(opts); err != nil {
 		return emitWorkflowError(opts, err)
@@ -39,6 +55,9 @@ func runStandaloneCreateWorkflow(ctx context.Context, opts *CreateWorkflowOption
 		return emitWorkflowError(opts, err)
 	}
 	if err := validateWorkflowInput(input); err != nil {
+		return emitWorkflowError(opts, err)
+	}
+	if err := rejectBlockingCheckpoints(input); err != nil {
 		return emitWorkflowError(opts, err)
 	}
 

--- a/internal/commands/festival/create_workflow_standalone_test.go
+++ b/internal/commands/festival/create_workflow_standalone_test.go
@@ -135,3 +135,44 @@ func TestBuildStandaloneWorkflowInput_FromInlineSteps(t *testing.T) {
 		t.Errorf("Steps = %+v", got.Steps)
 	}
 }
+
+func TestRejectBlockingCheckpoints(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   *WorkflowInput
+		wantErr bool
+	}{
+		{
+			name: "approval_required step rejected",
+			input: &WorkflowInput{Title: "t", Steps: []WorkflowStepInput{
+				{Name: "PLAN", Goal: "g", Checkpoint: "none"},
+				{Name: "GATE", Goal: "g", Checkpoint: "approval_required"},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "non-blocking checkpoints allowed",
+			input: &WorkflowInput{Title: "t", Steps: []WorkflowStepInput{
+				{Name: "A", Goal: "g", Checkpoint: "verification"},
+				{Name: "B", Goal: "g", Checkpoint: "documentation"},
+				{Name: "C", Goal: "g", Checkpoint: "none"},
+				{Name: "D", Goal: "g"},
+			}},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := rejectBlockingCheckpoints(tt.input)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected rejection, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantErr && !strings.Contains(err.Error(), "blocking checkpoints") {
+				t.Fatalf("error should name blocking checkpoints: %v", err)
+			}
+		})
+	}
+}

--- a/internal/commands/show/show.go
+++ b/internal/commands/show/show.go
@@ -330,7 +330,7 @@ func showCycleExtraKeys() map[byte]ExtraKeyHandler {
 
 func notInFestivalError() error {
 	return errors.NotFound("festival").WithOp("show").
-		WithHint("navigate to a festival directory, use 'fest link' to link a project, pass --festival <selector>, or run from a terminal in a campaign workspace to cycle festivals")
+		WithHint("run 'fest list' to see festivals, then 'fest show <name>' or pass --festival <selector>; or navigate to a festival directory, use 'fest link' to link a project, or run from a terminal in a campaign workspace to cycle festivals")
 }
 
 func runShow(ctx context.Context, target string, opts *showOptions) error {

--- a/internal/commands/show/show_command_test.go
+++ b/internal/commands/show/show_command_test.go
@@ -367,3 +367,19 @@ func captureShowStdoutAllowError(t *testing.T, fn func() error) (string, error) 
 	}
 	return buf.String(), runErr
 }
+
+func TestNotInFestivalHint_LeadsWithDiscovery(t *testing.T) {
+	// The hint must teach selector discovery before selector usage: an agent
+	// outside a festival has no way to know a valid <selector> without
+	// `fest list` (intent fest-show-bare-invocation-outside-20260724).
+	err := notInFestivalError()
+	hint := err.Error()
+	listIdx := strings.Index(hint, "fest list")
+	selIdx := strings.Index(hint, "--festival <selector>")
+	if listIdx < 0 || selIdx < 0 {
+		t.Fatalf("hint must mention both fest list and --festival: %v", hint)
+	}
+	if listIdx > selIdx {
+		t.Fatalf("fest list should come before --festival in the hint: %v", hint)
+	}
+}


### PR DESCRIPTION
## What

Two agent-UX fixes from the 2026-08-05 intent triage, both verified still-broken at origin/main before fixing.

**1. `fest create workflow` no longer mints unrunnable standalone workflows.**
Standalone creation accepted `checkpoint: approval_required` and returned ok, but the standalone runtime refuses to advance past blocking checkpoints (`internal/commands/workflow/advance.go`), so the workflow was dead from birth and the agent only found out at execution time. Creation now rejects it up front with the same message plus an actionable hint (use `verification`/`none`, or target a festival phase with `--path` where `fest workflow approve` exists). Festival-phase creation is unchanged; blocking checkpoints remain valid there.

**2. Bare `fest show` outside a festival now teaches selector discovery.**
The non-TTY hint mentioned `--festival <selector>` but never said how to discover a selector. It now leads with `run 'fest list' to see festivals, then 'fest show <name>'` before the selector and navigation options.

## Verification

- New tests: table-driven `TestRejectBlockingCheckpoints` (rejection plus all non-blocking checkpoint values allowed), `TestNotInFestivalHint_LeadsWithDiscovery` (asserts discovery ordering, not just presence). Existing `TestRunShowCurrent_NonTerminalOutsideFestivalReturnsHint` still passes, so the explicit-selector teaching is preserved.
- Real binary check: creating with an `approval_required` step exits 1 with the hint and writes no `WORKFLOW.md`; bare `fest show` outside a festival prints the new hint.
- Full gate: `go test ./...` clean, `just lint all` 0 issues.

Intents: `fest-create-workflow-accepts-approvalrequired-20260725-215550` (option 1, creation-time validation, as the intent preferred), `fest-show-bare-invocation-outside-20260724-145457`.
