### PR TITLE
feat(hooks): add task_start lifecycle verb with start-stage bindings

### DIFF
--- a/docs/concepts/hooks.md
+++ b/docs/concepts/hooks.md
@@ -141,7 +141,7 @@ Bindings only reference names. They never set `command`, `fail`, or `timeout`.
 
 | Verb | When |
 | --- | --- |
-| `task_start` | first transition into `in_progress` (`fest task in-progress`, `fest status set ... in_progress`) |
+| `task_start` | first transition into work (`fest task in-progress`, `fest status set ... in_progress`, or the first `--progress` above zero) |
 | `task_complete` | `fest task completed` |
 | `sequence_complete` | sequence completion |
 | `phase_complete` | phase completion |
@@ -150,11 +150,15 @@ Bindings only reference names. They never set `command`, `fail`, or `timeout`.
 Timings: **pre** (before the verb applies) and **post** (after the transition
 has already been applied).
 
-`task_start` fires only on the **first** start (no recorded start time yet):
-resuming a blocked task or re-marking an in-progress task never re-fires it. A
-`fail: closed` pre failure leaves the task unstarted. Numeric progress updates
-(`fest task update --progress N`) flip status without firing lifecycle hooks —
-the same rule terminal verbs already follow.
+`task_start` fires on the **first** transition into work, whichever surface
+causes it: `fest task in-progress`, `fest status set ... in_progress`, or the
+first `fest task update --progress N` above zero. Resuming a blocked task or
+re-marking an in-progress task never re-fires it; `fest task reset` clears the
+recorded start, so a reset task re-anchors on its next start. A `fail: closed`
+pre failure blocks the transition and leaves the task untouched. A `fail:
+closed` post failure keeps the task started and is recorded in the audit trail
+plus a stderr warning. Completion by progress (`--progress 100`) still bypasses
+`task_complete` hooks; only the terminal completion surfaces run those.
 
 Orchestration:
 

--- a/docs/concepts/hooks.md
+++ b/docs/concepts/hooks.md
@@ -1,8 +1,8 @@
 # Lifecycle Hooks
 
 fest hooks are **named commands** bound to festival lifecycle events (task
-complete, sequence complete, phase complete, gate approve). The approval judge
-is one hook among them, not a special case.
+start, task complete, sequence complete, phase complete, gate approve). The
+approval judge is one hook among them, not a special case.
 
 Related:
 
@@ -116,8 +116,16 @@ fest_type: task
 hooks:
   pre: [lint]
   post: [approval_judge, notify]
+  start: # task documents only; runs around task_start
+    pre: [anchor]
+    post: [announce]
 ---
 ```
+
+Bare `pre`/`post` bind around the step's **terminal** verb (`task_complete`,
+`sequence_complete`, `phase_complete`, `gate_approve`). The nested `start:`
+stage binds around **`task_start`** and is only honored on task documents;
+`fest validate` warns when it appears on a goal document.
 
 ### GATES.md body markers
 
@@ -133,6 +141,7 @@ Bindings only reference names. They never set `command`, `fail`, or `timeout`.
 
 | Verb | When |
 | --- | --- |
+| `task_start` | first transition into `in_progress` (`fest task in-progress`, `fest status set ... in_progress`) |
 | `task_complete` | `fest task completed` |
 | `sequence_complete` | sequence completion |
 | `phase_complete` | phase completion |
@@ -140,6 +149,12 @@ Bindings only reference names. They never set `command`, `fail`, or `timeout`.
 
 Timings: **pre** (before the verb applies) and **post** (after the transition
 has already been applied).
+
+`task_start` fires only on the **first** start (no recorded start time yet):
+resuming a blocked task or re-marking an in-progress task never re-fires it. A
+`fail: closed` pre failure leaves the task unstarted. Numeric progress updates
+(`fest task update --progress N`) flip status without firing lifecycle hooks —
+the same rule terminal verbs already follow.
 
 Orchestration:
 

--- a/docs/concepts/hooks.md
+++ b/docs/concepts/hooks.md
@@ -141,7 +141,7 @@ Bindings only reference names. They never set `command`, `fail`, or `timeout`.
 
 | Verb | When |
 | --- | --- |
-| `task_start` | first transition into work (`fest task in-progress`, `fest status set ... in_progress`, or the first `--progress` above zero) |
+| `task_start` | first transition into work (`fest task in-progress`, a direct completion, or the first `--progress` above zero) |
 | `task_complete` | `fest task completed` |
 | `sequence_complete` | sequence completion |
 | `phase_complete` | phase completion |
@@ -151,10 +151,12 @@ Timings: **pre** (before the verb applies) and **post** (after the transition
 has already been applied).
 
 `task_start` fires on the **first** transition into work, whichever surface
-causes it: `fest task in-progress`, `fest status set ... in_progress`, or the
-first `fest task update --progress N` above zero. Resuming a blocked task or
-re-marking an in-progress task never re-fires it; `fest task reset` clears the
-recorded start, so a reset task re-anchors on its next start. A `fail: closed`
+causes it: `fest task in-progress`, `fest status set ... in_progress`, a direct
+completion, or the first `fest task update --progress N` above zero. Reporting
+a blocker before work begins leaves the start hook armed. Resuming a task that
+was already started or re-marking it in progress never re-fires the hook;
+`fest task reset` clears the recorded start, so a reset task re-anchors on its
+next start. A `fail: closed`
 pre failure blocks the transition and leaves the task untouched. A `fail:
 closed` post failure keeps the task started and is recorded in the audit trail
 plus a stderr warning. Completion by progress (`--progress 100`) still bypasses

--- a/internal/frontmatter/hooks_test.go
+++ b/internal/frontmatter/hooks_test.go
@@ -85,3 +85,65 @@ body
 		t.Fatalf("user_key not preserved: %+v", fm.Extra)
 	}
 }
+
+func TestParse_StartHookBindings(t *testing.T) {
+	content := []byte(`---
+fest_type: task
+fest_id: t1
+fest_status: pending
+fest_created: 2026-07-19T00:00:00Z
+hooks:
+  pre: [lint-check]
+  start:
+    pre: [anchor]
+    post: [notify]
+---
+
+# Body
+`)
+	fm, _, err := Parse(content)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	pre, post := fm.Hooks.StartBindings()
+	if len(pre) != 1 || pre[0] != "anchor" {
+		t.Fatalf("start pre = %+v", pre)
+	}
+	if len(post) != 1 || post[0] != "notify" {
+		t.Fatalf("start post = %+v", post)
+	}
+	if len(fm.Hooks.Pre) != 1 || fm.Hooks.Pre[0] != "lint-check" {
+		t.Fatalf("completion pre must be untouched by start stage: %+v", fm.Hooks.Pre)
+	}
+}
+
+func TestParse_AbsentStartStageStaysAbsentOnInject(t *testing.T) {
+	content := []byte(`---
+fest_type: task
+fest_id: t1
+fest_status: pending
+fest_created: 2026-07-19T00:00:00Z
+hooks:
+  pre: [lint-check]
+---
+body
+`)
+	fm, body, err := Parse(content)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if pre, post := fm.Hooks.StartBindings(); pre != nil || post != nil {
+		t.Fatalf("absent start stage must be nil, got %+v %+v", pre, post)
+	}
+	fm.Status = StatusInProgress
+	out, err := Inject(body, fm)
+	if err != nil {
+		t.Fatalf("Inject: %v", err)
+	}
+	if strings.Contains(string(out), "start:") {
+		t.Fatalf("absent start stage materialized on inject:\n%s", out)
+	}
+	if !strings.Contains(string(out), "pre:") {
+		t.Fatalf("existing bindings lost on inject:\n%s", out)
+	}
+}

--- a/internal/frontmatter/schema.go
+++ b/internal/frontmatter/schema.go
@@ -232,7 +232,19 @@ type Frontmatter struct {
 
 // StepHooks binds already-declared hooks to a step's lifecycle by name.
 // Bindings never declare; they only reference names resolved from config.
+// Pre/Post bind around the step's terminal verb (task_complete,
+// sequence_complete, phase_complete, gate_approve). Start binds around the
+// task_start verb and is only honored on task documents.
 type StepHooks struct {
+	Pre   []string        `yaml:"pre,omitempty" json:"pre,omitempty"`
+	Post  []string        `yaml:"post,omitempty" json:"post,omitempty"`
+	Start *StepHooksStage `yaml:"start,omitempty" json:"start,omitempty"`
+}
+
+// StepHooksStage is a nested pre/post binding pair for a non-terminal verb.
+// A pointer field so an absent stage round-trips as absent through
+// parse -> mutate -> inject cycles instead of materializing as "start: {}".
+type StepHooksStage struct {
 	Pre  []string `yaml:"pre,omitempty" json:"pre,omitempty"`
 	Post []string `yaml:"post,omitempty" json:"post,omitempty"`
 }
@@ -240,6 +252,14 @@ type StepHooks struct {
 // HookBindings returns the step's pre/post hook name lists (may be empty).
 func (f Frontmatter) HookBindings() StepHooks {
 	return f.Hooks
+}
+
+// StartBindings returns the start-stage hook name lists, nil-safe.
+func (h StepHooks) StartBindings() (pre, post []string) {
+	if h.Start == nil {
+		return nil, nil
+	}
+	return h.Start.Pre, h.Start.Post
 }
 
 // Validate checks if the frontmatter is valid

--- a/internal/hooks/bind_test.go
+++ b/internal/hooks/bind_test.go
@@ -88,14 +88,14 @@ func TestPlanBindings_Empty(t *testing.T) {
 
 func TestV1Verbs_ClosedSet(t *testing.T) {
 	verbs := V1Verbs()
-	if len(verbs) != 4 {
-		t.Fatalf("want exactly 4 verbs, got %v", verbs)
+	if len(verbs) != 5 {
+		t.Fatalf("want exactly 5 verbs, got %v", verbs)
 	}
 	seen := map[Verb]bool{}
 	for _, v := range verbs {
 		seen[v] = true
 	}
-	for _, need := range []Verb{VerbTaskComplete, VerbSequenceComplete, VerbPhaseComplete, VerbGateApprove} {
+	for _, need := range []Verb{VerbTaskStart, VerbTaskComplete, VerbSequenceComplete, VerbPhaseComplete, VerbGateApprove} {
 		if !seen[need] {
 			t.Fatalf("missing verb %s", need)
 		}

--- a/internal/hooks/event.go
+++ b/internal/hooks/event.go
@@ -19,6 +19,7 @@ const (
 type Verb string
 
 const (
+	VerbTaskStart        Verb = "task_start"
 	VerbTaskComplete     Verb = "task_complete"
 	VerbSequenceComplete Verb = "sequence_complete"
 	VerbPhaseComplete    Verb = "phase_complete"
@@ -35,6 +36,7 @@ type Event struct {
 // V1Verbs is the closed set of lifecycle verbs supported in v1.
 func V1Verbs() []Verb {
 	return []Verb{
+		VerbTaskStart,
 		VerbTaskComplete,
 		VerbSequenceComplete,
 		VerbPhaseComplete,

--- a/internal/progress/events.go
+++ b/internal/progress/events.go
@@ -198,6 +198,12 @@ func materializeState(events []ProgressEvent) map[string]*TaskProgress {
 		case EventCompleted:
 			task.Status = StatusCompleted
 			ts := e.Timestamp
+			// A completion can be the task's first work signal (for example,
+			// UpdateProgress(100) or a direct MarkComplete). Mirror the live
+			// mutation so replay does not re-arm task_start hooks.
+			if task.StartedAt == nil {
+				task.StartedAt = &ts
+			}
 			task.CompletedAt = &ts
 			task.Progress = 100
 			task.TimeSpentMinutes = e.Minutes

--- a/internal/progress/events.go
+++ b/internal/progress/events.go
@@ -210,6 +210,13 @@ func materializeState(events []ProgressEvent) map[string]*TaskProgress {
 			if e.Percent > 0 && task.Status == StatusPending {
 				task.Status = StatusInProgress
 			}
+			// Mirror the live UpdateProgress mutation so the task_start
+			// first-start predicate (StartedAt == nil) is stable across
+			// process restarts.
+			if e.Percent > 0 && task.StartedAt == nil {
+				ts := e.Timestamp
+				task.StartedAt = &ts
+			}
 
 		case EventBlocked:
 			task.Status = StatusBlocked

--- a/internal/progress/events.go
+++ b/internal/progress/events.go
@@ -107,7 +107,7 @@ type ProgressEvent struct {
 	HookName     string `json:"hook_name,omitempty"`
 	HookLayer    string `json:"hook_layer,omitempty"`  // machine|festivals|festival
 	HookTiming   string `json:"hook_timing,omitempty"` // pre|post
-	HookVerb     string `json:"hook_verb,omitempty"`   // task_complete|sequence_complete|phase_complete|gate_approve
+	HookVerb     string `json:"hook_verb,omitempty"`   // task_start|task_complete|sequence_complete|phase_complete|gate_approve
 	HookOutcome  string `json:"hook_outcome,omitempty"`
 	HookSkip     string `json:"hook_skip,omitempty"`
 	HookExitCode int    `json:"hook_exit_code,omitempty"`

--- a/internal/progress/events_test.go
+++ b/internal/progress/events_test.go
@@ -111,6 +111,18 @@ func TestMaterializeState_TimeSpent(t *testing.T) {
 	}
 }
 
+func TestMaterializeState_CompletedEventSetsStartedAt(t *testing.T) {
+	ts := time.Date(2026, 8, 12, 10, 0, 0, 0, time.UTC)
+	tasks := materializeState([]ProgressEvent{
+		{Timestamp: ts, Event: EventCompleted, Task: "01_task.md"},
+	})
+
+	task := tasks["01_task.md"]
+	if task == nil || task.StartedAt == nil || !task.StartedAt.Equal(ts) {
+		t.Fatalf("completion replay must set StartedAt: %+v", task)
+	}
+}
+
 func TestGenerateEventsFromState(t *testing.T) {
 	now := time.Now().UTC()
 	earlier := now.Add(-1 * time.Hour)

--- a/internal/progress/hook_lifecycle.go
+++ b/internal/progress/hook_lifecycle.go
@@ -92,6 +92,18 @@ func StepHookBindingsFromFrontmatter(content []byte) (pre, post []string, humanG
 	return fm.Hooks.Pre, fm.Hooks.Post, strings.EqualFold(strings.TrimSpace(fm.Approval), "human-required")
 }
 
+// StartHookBindingsFromFrontmatter extracts the start-stage hook bindings
+// (hooks.start.pre / hooks.start.post) and human-gate flag from a task
+// document's frontmatter. Unparseable frontmatter yields no bindings.
+func StartHookBindingsFromFrontmatter(content []byte) (pre, post []string, humanGate bool) {
+	fm, _, err := frontmatter.Parse(content)
+	if err != nil || fm == nil {
+		return nil, nil, false
+	}
+	pre, post = fm.Hooks.StartBindings()
+	return pre, post, strings.EqualFold(strings.TrimSpace(fm.Approval), "human-required")
+}
+
 // BlockedHookError names the fail-closed hook that blocked a lifecycle verb.
 func BlockedHookError(verb hooks.Verb, runs []hooks.HookRun) error {
 	for _, run := range runs {

--- a/internal/progress/manager.go
+++ b/internal/progress/manager.go
@@ -2,6 +2,7 @@ package progress
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -86,11 +87,24 @@ func (m *Manager) UpdateProgress(ctx context.Context, taskID string, progress in
 		}
 	}
 
+	// The first progress above zero is the first start signal, so the
+	// task_start stage runs here too: without it a progress update would
+	// permanently disarm start anchors (StartedAt set, hooks never fired).
+	var stage *startHookStage
+	if task.StartedAt == nil && progress > 0 {
+		var err error
+		stage, err = m.beginTaskStartHooks(ctx, taskID)
+		if err != nil {
+			return err
+		}
+	}
+
 	now := time.Now().UTC()
 
-	// Start tracking time on first progress update
-	// Use current time - we only track actual work time, not time since file creation
-	if task.StartedAt == nil {
+	// Start tracking time on the first progress update above zero.
+	// Use current time - we only track actual work time, not time since
+	// file creation. A zero update records no work start.
+	if progress > 0 && task.StartedAt == nil {
 		task.StartedAt = &now
 	}
 
@@ -139,6 +153,9 @@ func (m *Manager) UpdateProgress(ctx context.Context, taskID string, progress in
 		return err
 	}
 	m.SyncFrontmatterStatus(taskID, task.Status)
+	if err := m.finishTaskStartHooks(ctx, stage); err != nil {
+		return err
+	}
 	if progress == 100 {
 		// Propagation is best-effort: a failure here should not block
 		// the progress update that already succeeded above.
@@ -224,30 +241,12 @@ func (m *Manager) MarkInProgress(ctx context.Context, taskID string) error {
 		}
 	}
 
-	firstStart := task.StartedAt == nil
-	var (
-		req     LifecycleHookRequest
-		planned []hooks.PlannedHook
-		runner  *hooks.Runner
-	)
-	if firstStart {
+	var stage *startHookStage
+	if task.StartedAt == nil {
 		var err error
-		req, planned, err = m.planTaskStartHooks(ctx, taskID)
+		stage, err = m.beginTaskStartHooks(ctx, taskID)
 		if err != nil {
 			return err
-		}
-		if len(planned) > 0 {
-			runner = newLifecycleHookRunner(m.store.FestivalPath())
-			preRuns, blocked, err := RunLifecycleStage(ctx, m.store, runner, req, planned, hooks.TimingPre)
-			if saveErr := m.store.SaveEvents(ctx); saveErr != nil && err == nil {
-				err = saveErr
-			}
-			if err != nil {
-				return errors.Wrap(err, "running task start pre hooks")
-			}
-			if blocked {
-				return BlockedHookError(hooks.VerbTaskStart, preRuns)
-			}
 		}
 	}
 
@@ -273,15 +272,59 @@ func (m *Manager) MarkInProgress(ctx context.Context, taskID string) error {
 		return err
 	}
 	m.SyncFrontmatterStatus(taskID, task.Status)
+	return m.finishTaskStartHooks(ctx, stage)
+}
 
-	if firstStart && len(planned) > 0 {
-		_, _, postErr := RunLifecycleStage(ctx, m.store, runner, req, planned, hooks.TimingPost)
-		if saveErr := m.store.SaveEvents(ctx); saveErr != nil && postErr == nil {
-			postErr = saveErr
-		}
-		if postErr != nil {
-			return errors.Wrap(postErr, "running task start post hooks")
-		}
+// startHookStage carries one first-start transition's planned task_start
+// bindings between the pre and post timings.
+type startHookStage struct {
+	req     LifecycleHookRequest
+	planned []hooks.PlannedHook
+	runner  *hooks.Runner
+}
+
+// beginTaskStartHooks plans the task's start-stage bindings and runs the pre
+// timing. A nil stage with nil error means nothing is bound. On a blocked pre
+// the caller must not apply the transition.
+func (m *Manager) beginTaskStartHooks(ctx context.Context, taskID string) (*startHookStage, error) {
+	req, planned, err := m.planTaskStartHooks(ctx, taskID)
+	if err != nil {
+		return nil, err
+	}
+	if len(planned) == 0 {
+		return nil, nil
+	}
+	stage := &startHookStage{req: req, planned: planned, runner: newLifecycleHookRunner(m.store.FestivalPath())}
+	preRuns, blocked, err := RunLifecycleStage(ctx, m.store, stage.runner, stage.req, stage.planned, hooks.TimingPre)
+	if saveErr := m.store.SaveEvents(ctx); saveErr != nil && err == nil {
+		err = saveErr
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "running task start pre hooks")
+	}
+	if blocked {
+		return nil, BlockedHookError(hooks.VerbTaskStart, preRuns)
+	}
+	return stage, nil
+}
+
+// finishTaskStartHooks runs the post timing after the start transition has
+// been applied. A fail-closed post failure keeps the task started; it is
+// recorded in the audit trail and warned to stderr, matching the completion
+// path's operator visibility.
+func (m *Manager) finishTaskStartHooks(ctx context.Context, stage *startHookStage) error {
+	if stage == nil {
+		return nil
+	}
+	_, postBlocked, postErr := RunLifecycleStage(ctx, m.store, stage.runner, stage.req, stage.planned, hooks.TimingPost)
+	if saveErr := m.store.SaveEvents(ctx); saveErr != nil && postErr == nil {
+		postErr = saveErr
+	}
+	if postErr != nil {
+		return errors.Wrap(postErr, "running task start post hooks")
+	}
+	if postBlocked {
+		fmt.Fprintln(os.Stderr, "Warning: a fail-closed task_start post hook failed; the task remains started (see wf_hook_run in the festival audit trail)")
 	}
 	return nil
 }

--- a/internal/progress/manager.go
+++ b/internal/progress/manager.go
@@ -204,7 +204,11 @@ func (m *Manager) MarkComplete(ctx context.Context, taskID string) error {
 	return nil
 }
 
-// MarkInProgress marks a task as in progress
+// MarkInProgress marks a task as in progress. On the first start (no
+// StartedAt yet) the task document's start-stage hook bindings run around
+// the transition (task_start verb): a blocked pre stage leaves the task
+// unstarted; the post stage runs after the status is applied. Re-entering
+// in_progress later never re-fires start hooks.
 func (m *Manager) MarkInProgress(ctx context.Context, taskID string) error {
 	if err := ctx.Err(); err != nil {
 		return errors.Wrap(err, "context cancelled")
@@ -217,6 +221,33 @@ func (m *Manager) MarkInProgress(ctx context.Context, taskID string) error {
 	if !exists {
 		task = &TaskProgress{
 			TaskID: taskID,
+		}
+	}
+
+	firstStart := task.StartedAt == nil
+	var (
+		req     LifecycleHookRequest
+		planned []hooks.PlannedHook
+		runner  *hooks.Runner
+	)
+	if firstStart {
+		var err error
+		req, planned, err = m.planTaskStartHooks(ctx, taskID)
+		if err != nil {
+			return err
+		}
+		if len(planned) > 0 {
+			runner = newLifecycleHookRunner(m.store.FestivalPath())
+			preRuns, blocked, err := RunLifecycleStage(ctx, m.store, runner, req, planned, hooks.TimingPre)
+			if saveErr := m.store.SaveEvents(ctx); saveErr != nil && err == nil {
+				err = saveErr
+			}
+			if err != nil {
+				return errors.Wrap(err, "running task start pre hooks")
+			}
+			if blocked {
+				return BlockedHookError(hooks.VerbTaskStart, preRuns)
+			}
 		}
 	}
 
@@ -242,7 +273,54 @@ func (m *Manager) MarkInProgress(ctx context.Context, taskID string) error {
 		return err
 	}
 	m.SyncFrontmatterStatus(taskID, task.Status)
+
+	if firstStart && len(planned) > 0 {
+		_, _, postErr := RunLifecycleStage(ctx, m.store, runner, req, planned, hooks.TimingPost)
+		if saveErr := m.store.SaveEvents(ctx); saveErr != nil && postErr == nil {
+			postErr = saveErr
+		}
+		if postErr != nil {
+			return errors.Wrap(postErr, "running task start post hooks")
+		}
+	}
 	return nil
+}
+
+// planTaskStartHooks reads the task document and plans its start-stage
+// bindings for the task_start verb. A missing task file yields no bindings:
+// progress can track tasks whose documents do not exist.
+func (m *Manager) planTaskStartHooks(ctx context.Context, taskID string) (LifecycleHookRequest, []hooks.PlannedHook, error) {
+	req := LifecycleHookRequest{
+		FestivalPath: m.store.FestivalPath(),
+		Phase:        taskPhaseCoordinate(taskID),
+		Task:         taskID,
+		Level:        hooks.LevelTask,
+		Verb:         hooks.VerbTaskStart,
+	}
+	taskPath := filepath.Join(m.store.FestivalPath(), taskID)
+	if !strings.HasSuffix(taskPath, ".md") {
+		taskPath += ".md"
+	}
+	content, err := os.ReadFile(taskPath)
+	if err != nil {
+		return req, nil, nil
+	}
+	req.Pre, req.Post, req.HumanGate = StartHookBindingsFromFrontmatter(content)
+	planned, err := PlanLifecycleHooks(ctx, req)
+	if err != nil {
+		return req, nil, errors.Wrap(err, "planning task start hooks")
+	}
+	return req, planned, nil
+}
+
+// taskPhaseCoordinate derives the audit-event phase coordinate from a
+// festival-relative task ID (its first path segment; empty for root-level ids).
+func taskPhaseCoordinate(taskID string) string {
+	parts := strings.Split(filepath.ToSlash(taskID), "/")
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[0]
 }
 
 // ReportBlocker reports a blocker for a task

--- a/internal/progress/manager.go
+++ b/internal/progress/manager.go
@@ -180,6 +180,15 @@ func (m *Manager) MarkComplete(ctx context.Context, taskID string) error {
 		}
 	}
 
+	var stage *startHookStage
+	if task.StartedAt == nil {
+		var err error
+		stage, err = m.beginTaskStartHooks(ctx, taskID)
+		if err != nil {
+			return err
+		}
+	}
+
 	now := time.Now().UTC()
 
 	// Set start time if not already set - use current time
@@ -210,6 +219,9 @@ func (m *Manager) MarkComplete(ctx context.Context, taskID string) error {
 		return err
 	}
 	m.SyncFrontmatterStatus(taskID, task.Status)
+	if err := m.finishTaskStartHooks(ctx, stage); err != nil {
+		return err
+	}
 	// Campaign ledger: high-intent task completion (D003/D006). Does not
 	// alter progress_events.jsonl content beyond the save already done.
 	m.emitLedger(ctx, ledgerkit.KindCompleted, taskID, "", map[string]any{
@@ -391,11 +403,6 @@ func (m *Manager) ReportBlocker(ctx context.Context, taskID, message string) err
 	task.Status = StatusBlocked
 	task.BlockerMessage = message
 	task.BlockedAt = &now
-
-	// Start tracking time if not already
-	if task.StartedAt == nil {
-		task.StartedAt = &now
-	}
 
 	// Queue blocked event
 	m.store.QueueEvent(&ProgressEvent{

--- a/internal/progress/manager_hooks_test.go
+++ b/internal/progress/manager_hooks_test.go
@@ -379,6 +379,115 @@ func TestUpdateProgress_FirstProgressFiresStartHooks(t *testing.T) {
 	}
 }
 
+func TestUpdateProgress_CompleteReplayDoesNotRefireStartHooks(t *testing.T) {
+	festDir := setupStartHookFestival(t, "hooks:\n  start:\n    pre: [start-anchor]\n")
+	var called []string
+	fakeLifecycleRunner(t, 0, &called)
+
+	mgr, err := NewManager(context.Background(), festDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := mgr.UpdateProgress(context.Background(), "001_PHASE/01_seq/01_task.md", 100); err != nil {
+		t.Fatalf("UpdateProgress(100): %v", err)
+	}
+	if len(called) != 1 {
+		t.Fatalf("start hook calls after completion = %v", called)
+	}
+
+	// A lone completed event must preserve the first-start predicate across
+	// reload, so a later mutation cannot re-run task_start.
+	mgr, err = NewManager(context.Background(), festDir)
+	if err != nil {
+		t.Fatalf("NewManager reload: %v", err)
+	}
+	task, exists := mgr.GetTaskProgress("001_PHASE/01_seq/01_task.md")
+	if !exists || task.StartedAt == nil {
+		t.Fatalf("completion replay lost StartedAt: exists=%v task=%+v", exists, task)
+	}
+	if err := mgr.MarkInProgress(context.Background(), "001_PHASE/01_seq/01_task.md"); err != nil {
+		t.Fatalf("MarkInProgress after reload: %v", err)
+	}
+	if len(called) != 1 {
+		t.Fatalf("start hook re-fired after completion replay: %v", called)
+	}
+}
+
+func TestReportBlockerBeforeStartKeepsStartHooksArmed(t *testing.T) {
+	festDir := setupStartHookFestival(t, "hooks:\n  start:\n    pre: [start-anchor]\n")
+	var called []string
+	fakeLifecycleRunner(t, 0, &called)
+
+	mgr, err := NewManager(context.Background(), festDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := mgr.ReportBlocker(context.Background(), "001_PHASE/01_seq/01_task.md", "waiting"); err != nil {
+		t.Fatalf("ReportBlocker: %v", err)
+	}
+	task, exists := mgr.GetTaskProgress("001_PHASE/01_seq/01_task.md")
+	if !exists || task.StartedAt != nil {
+		t.Fatalf("blocker-first must leave task_start armed: exists=%v task=%+v", exists, task)
+	}
+	if len(called) != 0 {
+		t.Fatalf("reporting a pre-start blocker ran start hooks: %v", called)
+	}
+
+	if err := mgr.ClearBlocker(context.Background(), "001_PHASE/01_seq/01_task.md"); err != nil {
+		t.Fatalf("ClearBlocker: %v", err)
+	}
+	if err := mgr.MarkInProgress(context.Background(), "001_PHASE/01_seq/01_task.md"); err != nil {
+		t.Fatalf("MarkInProgress: %v", err)
+	}
+	if len(called) != 1 {
+		t.Fatalf("start hook did not fire after blocker-first path: %v", called)
+	}
+}
+
+func TestMarkComplete_FirstWorkFiresStartHooks(t *testing.T) {
+	festDir := setupStartHookFestival(t, "hooks:\n  start:\n    pre: [start-anchor]\n    post: [start-notify]\n")
+	var called []string
+	fakeLifecycleRunner(t, 0, &called)
+
+	mgr, err := NewManager(context.Background(), festDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := mgr.MarkComplete(context.Background(), "001_PHASE/01_seq/01_task.md"); err != nil {
+		t.Fatalf("MarkComplete: %v", err)
+	}
+	if len(called) != 2 || called[0] != "test-start-anchor" || called[1] != "test-start-notify" {
+		t.Fatalf("hook exec calls = %v", called)
+	}
+	task, exists := mgr.GetTaskProgress("001_PHASE/01_seq/01_task.md")
+	if !exists || task.Status != StatusCompleted || task.StartedAt == nil {
+		t.Fatalf("task not completed after start hooks: exists=%v task=%+v", exists, task)
+	}
+}
+
+func TestMarkComplete_BlockedStartPreLeavesTaskUncompleted(t *testing.T) {
+	festDir := setupStartHookFestival(t, "hooks:\n  start:\n    pre: [start-anchor]\n")
+	var called []string
+	fakeLifecycleRunner(t, 1, &called)
+
+	mgr, err := NewManager(context.Background(), festDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	err = mgr.MarkComplete(context.Background(), "001_PHASE/01_seq/01_task.md")
+	if err == nil || !strings.Contains(err.Error(), "blocked by fail-closed hook") {
+		t.Fatalf("MarkComplete error = %v, want blocked start hook", err)
+	}
+	if task, exists := mgr.GetTaskProgress("001_PHASE/01_seq/01_task.md"); exists &&
+		(task.Status == StatusCompleted || task.Progress == 100 || task.StartedAt != nil) {
+		t.Fatalf("blocked start pre must leave the task uncompleted: %+v", task)
+	}
+	events := readEventsFile(t, festDir)
+	if strings.Contains(events, `"event":"completed"`) {
+		t.Fatalf("completion event must not be recorded on a blocked start:\n%s", events)
+	}
+}
+
 func TestUpdateProgress_BlockedStartPreLeavesTaskUntouched(t *testing.T) {
 	festDir := setupStartHookFestival(t, "hooks:\n  start:\n    pre: [start-anchor]\n")
 	var called []string

--- a/internal/progress/manager_hooks_test.go
+++ b/internal/progress/manager_hooks_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Obedience-Corp/fest/internal/hooks"
 )
@@ -343,5 +344,112 @@ func TestMarkInProgress_NoStartBindingsRunsNoHooks(t *testing.T) {
 	}
 	if len(called) != 0 {
 		t.Fatalf("completion-stage bindings must not run at start: %v", called)
+	}
+}
+
+func TestUpdateProgress_FirstProgressFiresStartHooks(t *testing.T) {
+	festDir := setupStartHookFestival(t, "hooks:\n  start:\n    pre: [start-anchor]\n    post: [start-notify]\n")
+	var called []string
+	fakeLifecycleRunner(t, 0, &called)
+
+	mgr, err := NewManager(context.Background(), festDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := mgr.UpdateProgress(context.Background(), "001_PHASE/01_seq/01_task.md", 10); err != nil {
+		t.Fatalf("UpdateProgress: %v", err)
+	}
+	if len(called) != 2 || called[0] != "test-start-anchor" || called[1] != "test-start-notify" {
+		t.Fatalf("hook exec calls = %v", called)
+	}
+	task, exists := mgr.GetTaskProgress("001_PHASE/01_seq/01_task.md")
+	if !exists || task.Status != StatusInProgress || task.StartedAt == nil {
+		t.Fatalf("task not started: exists=%v task=%+v", exists, task)
+	}
+
+	// Neither a later progress update nor an explicit in-progress re-fires.
+	if err := mgr.UpdateProgress(context.Background(), "001_PHASE/01_seq/01_task.md", 20); err != nil {
+		t.Fatalf("second UpdateProgress: %v", err)
+	}
+	if err := mgr.MarkInProgress(context.Background(), "001_PHASE/01_seq/01_task.md"); err != nil {
+		t.Fatalf("MarkInProgress: %v", err)
+	}
+	if len(called) != 2 {
+		t.Fatalf("start hooks re-fired after first progress: %v", called)
+	}
+}
+
+func TestUpdateProgress_BlockedStartPreLeavesTaskUntouched(t *testing.T) {
+	festDir := setupStartHookFestival(t, "hooks:\n  start:\n    pre: [start-anchor]\n")
+	var called []string
+	fakeLifecycleRunner(t, 1, &called)
+
+	mgr, err := NewManager(context.Background(), festDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	err = mgr.UpdateProgress(context.Background(), "001_PHASE/01_seq/01_task.md", 10)
+	if err == nil {
+		t.Fatal("blocked start pre hook must fail UpdateProgress")
+	}
+	if !strings.Contains(err.Error(), "blocked by fail-closed hook") {
+		t.Fatalf("error = %v", err)
+	}
+	if task, exists := mgr.GetTaskProgress("001_PHASE/01_seq/01_task.md"); exists &&
+		(task.Status == StatusInProgress || task.Progress != 0 || task.StartedAt != nil) {
+		t.Fatalf("blocked start pre must leave the task untouched: %+v", task)
+	}
+	events := readEventsFile(t, festDir)
+	if strings.Contains(events, `"event":"progress"`) {
+		t.Fatalf("progress event must not be recorded on a blocked start:\n%s", events)
+	}
+	if !strings.Contains(events, `"hook_verb":"task_start"`) || !strings.Contains(events, `"hook_blocked":true`) {
+		t.Fatalf("blocked task_start event missing:\n%s", events)
+	}
+}
+
+func TestUpdateProgress_ZeroProgressKeepsStartAnchorArmed(t *testing.T) {
+	festDir := setupStartHookFestival(t, "hooks:\n  start:\n    pre: [start-anchor]\n")
+	var called []string
+	fakeLifecycleRunner(t, 0, &called)
+
+	mgr, err := NewManager(context.Background(), festDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := mgr.UpdateProgress(context.Background(), "001_PHASE/01_seq/01_task.md", 0); err != nil {
+		t.Fatalf("UpdateProgress(0): %v", err)
+	}
+	if len(called) != 0 {
+		t.Fatalf("zero progress must not fire start hooks: %v", called)
+	}
+	if task, exists := mgr.GetTaskProgress("001_PHASE/01_seq/01_task.md"); exists && task.StartedAt != nil {
+		t.Fatalf("zero progress must not record a start: %+v", task)
+	}
+
+	// The anchor still fires when work actually begins.
+	if err := mgr.MarkInProgress(context.Background(), "001_PHASE/01_seq/01_task.md"); err != nil {
+		t.Fatalf("MarkInProgress: %v", err)
+	}
+	if len(called) != 1 {
+		t.Fatalf("start anchor lost after zero progress update: %v", called)
+	}
+}
+
+func TestMaterializeState_ProgressEventSetsStartedAt(t *testing.T) {
+	ts := time.Date(2026, 8, 12, 10, 0, 0, 0, time.UTC)
+	tasks := materializeState([]ProgressEvent{
+		{Timestamp: ts, Event: EventProgress, Task: "t1", Percent: 10},
+	})
+	task := tasks["t1"]
+	if task == nil || task.StartedAt == nil || !task.StartedAt.Equal(ts) {
+		t.Fatalf("progress replay must set StartedAt: %+v", task)
+	}
+	// Zero progress replay records no start, matching the live path.
+	tasks = materializeState([]ProgressEvent{
+		{Timestamp: ts, Event: EventProgress, Task: "t1", Percent: 0},
+	})
+	if task := tasks["t1"]; task == nil || task.StartedAt != nil {
+		t.Fatalf("zero progress replay must not set StartedAt: %+v", task)
 	}
 }

--- a/internal/progress/manager_hooks_test.go
+++ b/internal/progress/manager_hooks_test.go
@@ -156,3 +156,192 @@ func TestPropagateSequenceCompletion_PassingHooksCompleteGoalOnce(t *testing.T) 
 		t.Fatalf("pre/post sequence events missing:\n%s", events)
 	}
 }
+
+func setupStartHookFestival(t *testing.T, taskFrontmatter string) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	festYAML := `version: "1.0"
+name: start-hooks-test
+id: SHK-001
+metadata:
+  id: SHK-001
+hooks:
+  definitions:
+    start-anchor:
+      command: test-start-anchor
+    start-notify:
+      command: test-start-notify
+`
+	if err := os.WriteFile(filepath.Join(dir, "fest.yaml"), []byte(festYAML), 0o644); err != nil {
+		t.Fatalf("write fest.yaml: %v", err)
+	}
+	seqDir := filepath.Join(dir, "001_PHASE", "01_seq")
+	if err := os.MkdirAll(seqDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".fest"), 0o755); err != nil {
+		t.Fatalf("mkdir .fest: %v", err)
+	}
+	task := "---\nfest_type: task\nfest_id: 01_task\n" + taskFrontmatter + "---\n# Task body\n"
+	if err := os.WriteFile(filepath.Join(seqDir, "01_task.md"), []byte(task), 0o644); err != nil {
+		t.Fatalf("write task: %v", err)
+	}
+
+	t.Setenv("HOME", t.TempDir())
+	return dir
+}
+
+func fakeLifecycleRunnerPerCommand(t *testing.T, exits map[string]int, called *[]string) {
+	t.Helper()
+	orig := newLifecycleHookRunner
+	t.Cleanup(func() { newLifecycleHookRunner = orig })
+	newLifecycleHookRunner = func(workDir string) *hooks.Runner {
+		r := hooks.NewRunner(workDir)
+		r.Exec = func(ctx context.Context, command string, stdin []byte, dir string) hooks.CommandResult {
+			if called != nil {
+				*called = append(*called, command)
+			}
+			res := hooks.CommandResult{ExitCode: exits[command]}
+			if res.ExitCode != 0 {
+				res.Err = context.Canceled
+			}
+			return res
+		}
+		return r
+	}
+}
+
+func TestMarkInProgress_BlockedStartPreLeavesTaskUnstarted(t *testing.T) {
+	festDir := setupStartHookFestival(t, "hooks:\n  start:\n    pre: [start-anchor]\n")
+	var called []string
+	fakeLifecycleRunner(t, 1, &called)
+
+	mgr, err := NewManager(context.Background(), festDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	err = mgr.MarkInProgress(context.Background(), "001_PHASE/01_seq/01_task.md")
+	if err == nil {
+		t.Fatal("blocked start pre hook must fail MarkInProgress")
+	}
+	if !strings.Contains(err.Error(), "blocked by fail-closed hook") {
+		t.Fatalf("error = %v", err)
+	}
+	if task, exists := mgr.GetTaskProgress("001_PHASE/01_seq/01_task.md"); exists && task.Status == StatusInProgress {
+		t.Fatal("blocked start pre hook must leave the task unstarted")
+	}
+	if len(called) != 1 {
+		t.Fatalf("hook exec calls = %v", called)
+	}
+	events := readEventsFile(t, festDir)
+	if !strings.Contains(events, `"hook_verb":"task_start"`) || !strings.Contains(events, `"hook_blocked":true`) {
+		t.Fatalf("blocked task_start event missing:\n%s", events)
+	}
+	if strings.Contains(events, `"event":"started"`) {
+		t.Fatalf("started event must not be recorded on a blocked start:\n%s", events)
+	}
+}
+
+func TestMarkInProgress_StartHooksRunAroundTransition(t *testing.T) {
+	festDir := setupStartHookFestival(t, "hooks:\n  start:\n    pre: [start-anchor]\n    post: [start-notify]\n")
+	var called []string
+	fakeLifecycleRunner(t, 0, &called)
+
+	mgr, err := NewManager(context.Background(), festDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := mgr.MarkInProgress(context.Background(), "001_PHASE/01_seq/01_task.md"); err != nil {
+		t.Fatalf("MarkInProgress: %v", err)
+	}
+
+	task, exists := mgr.GetTaskProgress("001_PHASE/01_seq/01_task.md")
+	if !exists || task.Status != StatusInProgress {
+		t.Fatalf("task not in progress: exists=%v task=%+v", exists, task)
+	}
+	if len(called) != 2 || called[0] != "test-start-anchor" || called[1] != "test-start-notify" {
+		t.Fatalf("hook exec calls = %v", called)
+	}
+	events := readEventsFile(t, festDir)
+	if !strings.Contains(events, `"hook_verb":"task_start"`) ||
+		!strings.Contains(events, `"hook_timing":"pre"`) ||
+		!strings.Contains(events, `"hook_timing":"post"`) {
+		t.Fatalf("task_start pre/post events missing:\n%s", events)
+	}
+	if !strings.Contains(events, `"event":"started"`) {
+		t.Fatalf("started event missing:\n%s", events)
+	}
+
+	// Re-entering in_progress must not re-fire start hooks.
+	if err := mgr.MarkInProgress(context.Background(), "001_PHASE/01_seq/01_task.md"); err != nil {
+		t.Fatalf("second MarkInProgress: %v", err)
+	}
+	if len(called) != 2 {
+		t.Fatalf("start hooks re-fired on second start: %v", called)
+	}
+}
+
+func TestMarkInProgress_HumanGateSkipsStartHooks(t *testing.T) {
+	festDir := setupStartHookFestival(t, "approval: human-required\nhooks:\n  start:\n    pre: [start-anchor]\n")
+	var called []string
+	fakeLifecycleRunner(t, 0, &called)
+
+	mgr, err := NewManager(context.Background(), festDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := mgr.MarkInProgress(context.Background(), "001_PHASE/01_seq/01_task.md"); err != nil {
+		t.Fatalf("MarkInProgress: %v", err)
+	}
+	if len(called) != 0 {
+		t.Fatalf("human-gated step must not exec hooks: %v", called)
+	}
+	task, exists := mgr.GetTaskProgress("001_PHASE/01_seq/01_task.md")
+	if !exists || task.Status != StatusInProgress {
+		t.Fatalf("task not in progress: exists=%v task=%+v", exists, task)
+	}
+	events := readEventsFile(t, festDir)
+	if !strings.Contains(events, `"hook_skip":"human-gate"`) {
+		t.Fatalf("human-gate skip record missing:\n%s", events)
+	}
+}
+
+func TestMarkInProgress_FailedClosedStartPostKeepsTaskStarted(t *testing.T) {
+	festDir := setupStartHookFestival(t, "hooks:\n  start:\n    post: [start-notify]\n")
+	var called []string
+	fakeLifecycleRunnerPerCommand(t, map[string]int{"test-start-notify": 1}, &called)
+
+	mgr, err := NewManager(context.Background(), festDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := mgr.MarkInProgress(context.Background(), "001_PHASE/01_seq/01_task.md"); err != nil {
+		t.Fatalf("failed post hook must not fail MarkInProgress: %v", err)
+	}
+	task, exists := mgr.GetTaskProgress("001_PHASE/01_seq/01_task.md")
+	if !exists || task.Status != StatusInProgress {
+		t.Fatalf("task must stay started: exists=%v task=%+v", exists, task)
+	}
+	events := readEventsFile(t, festDir)
+	if !strings.Contains(events, `"hook_outcome":"fail"`) {
+		t.Fatalf("failed post hook audit record missing:\n%s", events)
+	}
+}
+
+func TestMarkInProgress_NoStartBindingsRunsNoHooks(t *testing.T) {
+	festDir := setupStartHookFestival(t, "hooks:\n  pre: [start-anchor]\n")
+	var called []string
+	fakeLifecycleRunner(t, 0, &called)
+
+	mgr, err := NewManager(context.Background(), festDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := mgr.MarkInProgress(context.Background(), "001_PHASE/01_seq/01_task.md"); err != nil {
+		t.Fatalf("MarkInProgress: %v", err)
+	}
+	if len(called) != 0 {
+		t.Fatalf("completion-stage bindings must not run at start: %v", called)
+	}
+}

--- a/internal/validator/hooks.go
+++ b/internal/validator/hooks.go
@@ -18,6 +18,10 @@ const CodeHooksUndeclaredBinding = "hooks_undeclared_binding"
 // CodeHooksConfigError warns when hook configuration cannot be loaded or resolved.
 const CodeHooksConfigError = "hooks_config_error"
 
+// CodeHooksStartBindingPlacement warns when hooks.start bindings appear on a
+// document where the task_start verb never fires.
+const CodeHooksStartBindingPlacement = "hooks_start_binding_placement"
+
 // IssuesForUndeclaredBindings builds non-blocking warnings for undeclared bound names.
 func IssuesForUndeclaredBindings(path string, planned []hooks.PlannedHook) []Issue {
 	var issues []Issue
@@ -109,16 +113,39 @@ func scanFrontmatterBindings(path, rel string, eff *hooks.Effective) []Issue {
 	if err != nil || fm == nil {
 		return nil
 	}
-	if len(fm.Hooks.Pre) == 0 && len(fm.Hooks.Post) == 0 {
+	startPre, startPost := fm.Hooks.StartBindings()
+	if len(fm.Hooks.Pre) == 0 && len(fm.Hooks.Post) == 0 &&
+		len(startPre) == 0 && len(startPost) == 0 {
 		return nil
 	}
 	level := hooks.LevelTask
+	goalDoc := false
 	switch filepath.Base(path) {
 	case "SEQUENCE_GOAL.md":
 		level = hooks.LevelSequence
+		goalDoc = true
 	case "PHASE_GOAL.md", "FESTIVAL_GOAL.md":
 		level = hooks.LevelPhase
+		goalDoc = true
 	}
-	planned := eff.PlanBindings(level, fm.Hooks.Pre, fm.Hooks.Post)
-	return IssuesForUndeclaredBindings(rel, planned)
+	var issues []Issue
+	if len(fm.Hooks.Pre) > 0 || len(fm.Hooks.Post) > 0 {
+		planned := eff.PlanBindings(level, fm.Hooks.Pre, fm.Hooks.Post)
+		issues = append(issues, IssuesForUndeclaredBindings(rel, planned)...)
+	}
+	if len(startPre) > 0 || len(startPost) > 0 {
+		if goalDoc {
+			issues = append(issues, Issue{
+				Level:   LevelWarning,
+				Code:    CodeHooksStartBindingPlacement,
+				Path:    rel,
+				Message: "hooks.start bindings only run on task documents (task_start never fires here)",
+				Fix:     "Move the start bindings to a task document or remove them",
+			})
+		} else {
+			planned := eff.PlanBindings(hooks.LevelTask, startPre, startPost)
+			issues = append(issues, IssuesForUndeclaredBindings(rel, planned)...)
+		}
+	}
+	return issues
 }

--- a/internal/validator/hooks_scan_test.go
+++ b/internal/validator/hooks_scan_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Obedience-Corp/fest/internal/config"
@@ -83,5 +84,70 @@ hooks:
 		if !found {
 			t.Fatalf("missing warning for %s in:\n%s", want, joined)
 		}
+	}
+}
+
+func TestScanUndeclaredBindings_StartStage(t *testing.T) {
+	festivalPath := t.TempDir()
+	seqDir := filepath.Join(festivalPath, "001_PHASE", "01_seq")
+	if err := os.MkdirAll(seqDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	task := `---
+fest_type: task
+fest_id: 01_task
+hooks:
+  start:
+    pre: [ghost-start, declared]
+---
+# Task
+`
+	if err := os.WriteFile(filepath.Join(seqDir, "01_task.md"), []byte(task), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	seqGoal := `---
+fest_type: sequence_goal
+fest_id: 01_seq
+hooks:
+  start:
+    pre: [declared]
+---
+# Goal
+`
+	if err := os.WriteFile(filepath.Join(seqDir, "SEQUENCE_GOAL.md"), []byte(seqGoal), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	eff, err := hooks.Resolve(nil, &config.HooksConfig{
+		Definitions: map[string]config.HookDefinition{"declared": {Command: "true"}},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	issues := ScanUndeclaredBindings(context.Background(), festivalPath, eff)
+	if len(issues) != 2 {
+		t.Fatalf("issues = %+v", issues)
+	}
+	var sawUndeclared, sawPlacement bool
+	for _, issue := range issues {
+		switch issue.Code {
+		case CodeHooksUndeclaredBinding:
+			if !strings.Contains(issue.Message, "ghost-start") {
+				t.Fatalf("undeclared warning names wrong hook: %+v", issue)
+			}
+			sawUndeclared = true
+		case CodeHooksStartBindingPlacement:
+			if filepath.Base(issue.Path) != "SEQUENCE_GOAL.md" {
+				t.Fatalf("placement warning on wrong doc: %+v", issue)
+			}
+			sawPlacement = true
+		default:
+			t.Fatalf("unexpected issue: %+v", issue)
+		}
+	}
+	if !sawUndeclared || !sawPlacement {
+		t.Fatalf("missing expected warnings: %+v", issues)
 	}
 }


### PR DESCRIPTION
## Summary

All v1 lifecycle verbs were completion verbs (task_complete, sequence_complete, phase_complete, gate_approve), so no hook could run before work begins. This adds `task_start` to the v1 set, bound on task documents via a nested start stage:

```yaml
hooks:
  pre: [lint]            # unchanged: binds around task_complete
  post: [approval_judge]
  start:                 # new: binds around task_start
    pre: [anchor]
    post: [announce]
```

Bare `pre`/`post` keep their terminal-verb meaning, so existing documents are unaffected.

## Semantics

- Fires inside `Manager.MarkInProgress`, which covers both start surfaces (`fest task in-progress` and `fest status set ... in_progress`) and any future caller.
- First start only: a task with a recorded start time never re-fires it, so resuming a blocked task or re-marking in_progress is not a new start.
- A `fail: closed` pre failure blocks the verb and leaves the task unstarted (no status change, no started event).
- Post failures are audit-only via `wf_hook_run`, matching goal-completion post semantics; the task stays started.
- Human-required steps skip start hooks with `skipped: human-gate` audit records, same as other verbs.
- Numeric progress updates (`fest task update --progress N`) continue to bypass lifecycle hooks, the same rule the terminal verbs already follow.
- `fest validate` warns on undeclared start bindings and warns when `hooks.start` appears on a goal document, where task_start never fires.

## Motivation

Agent campaigns need a lifecycle injection point before work begins (anchor commands, context setup). The gap surfaced while designing commit-trailer anchoring in an agent-economy campaign workitem; the interim workaround there is an out-of-band anchor command, which this verb replaces.

## Testing

- `just test unit`: 2814 passed
- `just test integration`: 77 passed (containerized suite)
- `just lint all`: 0 issues

New coverage: blocked pre leaves task unstarted with no started event, pre+post run around the transition in binding order, no re-fire on second start, human-gate skips with audit records, failed closed post keeps the task started, completion-stage bindings never run at start, absent start stage stays absent through frontmatter inject round-trips, validator warnings for undeclared names and goal-document placement.