### PR TITLE
fix: commit festival work in linked projects

### DIFF
--- a/docs/cli-reference/fest-reference.md
+++ b/docs/cli-reference/fest-reference.md
@@ -369,9 +369,9 @@ The fest commit command wraps git commit and automatically:
   1. Stages changes and prepends the festival reference to the commit message
   2. Creates a campaign root commit for festival-scoped files (task docs, progress, state)
 
-When a festival or sequence has a linked project, two commits are created even
-when this command is run from inside the festival:
-  - Project commit: stages all project changes
+When a festival or sequence has a linked project, up to two commits are created
+even when this command is run from inside the festival:
+  - Project commit: stages all project changes (skipped when the project is clean)
   - Campaign root commit: stages only festival directory, .campaign/fest/,
     festivals/.festival/.state/, and the submodule pointer
 

--- a/docs/cli-reference/fest-reference.md
+++ b/docs/cli-reference/fest-reference.md
@@ -369,13 +369,15 @@ The fest commit command wraps git commit and automatically:
   1. Stages changes and prepends the festival reference to the commit message
   2. Creates a campaign root commit for festival-scoped files (task docs, progress, state)
 
-When run from a linked project directory, two commits are created:
+When a festival or sequence has a linked project, two commits are created even
+when this command is run from inside the festival:
   - Project commit: stages all project changes
   - Campaign root commit: stages only festival directory, .campaign/fest/,
     festivals/.festival/.state/, and the submodule pointer
 
-When run from a festival directory, one commit is created at the campaign root
-with only festival-scoped files staged (not git add -A).
+The sequence's fest_working_dir is preferred over the festival navigation link
+and legacy fest.yaml project_path. A festival with no linked project creates one
+campaign-root commit containing only festival-scoped files (not git add -A).
 
 Use --no-root to skip the campaign root commit.
 
@@ -386,14 +388,14 @@ Reference format: [FE-{id}]
 Detection priority:
   1. Explicit --task flag value
   2. Task fest_ref from current directory (if inside festival task)
-  3. Festival ID from fest.yaml metadata
-  4. Explicit --festival flag (name or ID)
+  3. Explicit --festival flag (path, name, or ID)
+  4. Festival ID from fest.yaml metadata
 
 Examples:
 ```bash
   fest commit -m "Implement feature"
-  # In linked project → [FE-CS0001] Implement feature
-  # In festival task  → [FE-FEST-a3b2c1] Implement feature
+  # In linked project or sequence → [FE-CS0001] Implement feature
+  # In festival task              → [FE-FEST-a3b2c1] Implement feature
 
   fest commit --task FEST-b4c5d6 -m "Related work"
   # → [FE-FEST-b4c5d6] Related work
@@ -420,7 +422,7 @@ fest commit [flags]
 ```
       --auto-write        run configured commit message writer
       --commit-large      commit over-threshold files instead of keeping them out of git
-      --festival string   festival name or ID (overrides auto-detection)
+      --festival string   festival path, name, or ID (overrides auto-detection)
   -h, --help              help for commit
       --json              output result as JSON
   -m, --message string    commit message (required unless --auto-write)

--- a/docs/cli-reference/fest_commit.md
+++ b/docs/cli-reference/fest_commit.md
@@ -13,9 +13,9 @@ The fest commit command wraps git commit and automatically:
   1. Stages changes and prepends the festival reference to the commit message
   2. Creates a campaign root commit for festival-scoped files (task docs, progress, state)
 
-When a festival or sequence has a linked project, two commits are created even
-when this command is run from inside the festival:
-  - Project commit: stages all project changes
+When a festival or sequence has a linked project, up to two commits are created
+even when this command is run from inside the festival:
+  - Project commit: stages all project changes (skipped when the project is clean)
   - Campaign root commit: stages only festival directory, .campaign/fest/,
     festivals/.festival/.state/, and the submodule pointer
 

--- a/docs/cli-reference/fest_commit.md
+++ b/docs/cli-reference/fest_commit.md
@@ -13,13 +13,15 @@ The fest commit command wraps git commit and automatically:
   1. Stages changes and prepends the festival reference to the commit message
   2. Creates a campaign root commit for festival-scoped files (task docs, progress, state)
 
-When run from a linked project directory, two commits are created:
+When a festival or sequence has a linked project, two commits are created even
+when this command is run from inside the festival:
   - Project commit: stages all project changes
   - Campaign root commit: stages only festival directory, .campaign/fest/,
     festivals/.festival/.state/, and the submodule pointer
 
-When run from a festival directory, one commit is created at the campaign root
-with only festival-scoped files staged (not git add -A).
+The sequence's fest_working_dir is preferred over the festival navigation link
+and legacy fest.yaml project_path. A festival with no linked project creates one
+campaign-root commit containing only festival-scoped files (not git add -A).
 
 Use --no-root to skip the campaign root commit.
 
@@ -30,14 +32,14 @@ Reference format: [FE-{id}]
 Detection priority:
   1. Explicit --task flag value
   2. Task fest_ref from current directory (if inside festival task)
-  3. Festival ID from fest.yaml metadata
-  4. Explicit --festival flag (name or ID)
+  3. Explicit --festival flag (path, name, or ID)
+  4. Festival ID from fest.yaml metadata
 
 Examples:
 ```bash
   fest commit -m "Implement feature"
-  # In linked project → [FE-CS0001] Implement feature
-  # In festival task  → [FE-FEST-a3b2c1] Implement feature
+  # In linked project or sequence → [FE-CS0001] Implement feature
+  # In festival task              → [FE-FEST-a3b2c1] Implement feature
 
   fest commit --task FEST-b4c5d6 -m "Related work"
   # → [FE-FEST-b4c5d6] Related work
@@ -64,7 +66,7 @@ fest commit [flags]
 ```
       --auto-write        run configured commit message writer
       --commit-large      commit over-threshold files instead of keeping them out of git
-      --festival string   festival name or ID (overrides auto-detection)
+      --festival string   festival path, name, or ID (overrides auto-detection)
   -h, --help              help for commit
       --json              output result as JSON
   -m, --message string    commit message (required unless --auto-write)

--- a/internal/commands/commit/commit.go
+++ b/internal/commands/commit/commit.go
@@ -16,7 +16,10 @@ import (
 	"github.com/Obedience-Corp/fest/internal/config"
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/frontmatter"
+	"github.com/Obedience-Corp/fest/internal/guidance/selection"
 	"github.com/Obedience-Corp/fest/internal/id"
+	"github.com/Obedience-Corp/fest/internal/navigation"
+	"github.com/Obedience-Corp/fest/internal/pathutil"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
 	"github.com/spf13/cobra"
@@ -60,13 +63,15 @@ The fest commit command wraps git commit and automatically:
   1. Stages changes and prepends the festival reference to the commit message
   2. Creates a campaign root commit for festival-scoped files (task docs, progress, state)
 
-When run from a linked project directory, two commits are created:
+When a festival or sequence has a linked project, two commits are created even
+when this command is run from inside the festival:
   - Project commit: stages all project changes
   - Campaign root commit: stages only festival directory, .campaign/fest/,
     festivals/.festival/.state/, and the submodule pointer
 
-When run from a festival directory, one commit is created at the campaign root
-with only festival-scoped files staged (not git add -A).
+The sequence's fest_working_dir is preferred over the festival navigation link
+and legacy fest.yaml project_path. A festival with no linked project creates one
+campaign-root commit containing only festival-scoped files (not git add -A).
 
 Use --no-root to skip the campaign root commit.
 
@@ -77,13 +82,13 @@ Reference format: [FE-{id}]
 Detection priority:
   1. Explicit --task flag value
   2. Task fest_ref from current directory (if inside festival task)
-  3. Festival ID from fest.yaml metadata
-  4. Explicit --festival flag (name or ID)
+  3. Explicit --festival flag (path, name, or ID)
+  4. Festival ID from fest.yaml metadata
 
 Examples:
   fest commit -m "Implement feature"
-  # In linked project → [FE-CS0001] Implement feature
-  # In festival task  → [FE-FEST-a3b2c1] Implement feature
+  # In linked project or sequence → [FE-CS0001] Implement feature
+  # In festival task              → [FE-FEST-a3b2c1] Implement feature
 
   fest commit --task FEST-b4c5d6 -m "Related work"
   # → [FE-FEST-b4c5d6] Related work
@@ -104,7 +109,7 @@ Examples:
 
 	cmd.Flags().StringVarP(&message, "message", "m", "", "commit message (required unless --auto-write)")
 	cmd.Flags().StringVar(&taskRef, "task", "", "task reference ID to use (e.g., FEST-a3b2c1)")
-	cmd.Flags().StringVar(&festivalFlag, "festival", "", "festival name or ID (overrides auto-detection)")
+	cmd.Flags().StringVar(&festivalFlag, "festival", "", "festival path, name, or ID (overrides auto-detection)")
 	cmd.Flags().BoolVar(&noTag, "no-tag", false, "don't prepend task reference")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "output result as JSON")
 	cmd.Flags().BoolVar(&autoStage, "stage", true, "auto-stage all changes before commit")
@@ -148,14 +153,19 @@ func runCommit(cmd *cobra.Command, args []string) error {
 	// Resolve workspace for campaign integration (nil-safe: ok if absent).
 	ws, _ := scope.WorkspaceFrom(ctx)
 
-	// Determine if we're in a project submodule vs campaign root.
-	var inSubmodule bool
-	var submoduleRelPath string
-	if ws != nil && ws.Type == scope.WorkspaceTypeCampaign {
-		inSubmodule, submoduleRelPath = isInSubmodule(ws.Root)
-	}
-
 	festivalPath, hasFestival := scope.FestivalFrom(ctx)
+	if festivalFlag != "" {
+		var resolveErr error
+		festivalPath, resolveErr = resolveFestivalFlagPath(ctx, ws, festivalFlag)
+		if resolveErr != nil {
+			result.Success = false
+			result.Error = resolveErr.Error()
+			return outputResult(result)
+		}
+		hasFestival = true
+		ctx = scope.WithFestival(ctx, festivalPath)
+		cmd.SetContext(ctx)
+	}
 
 	// Check if we're in a git repository
 	inRepo, err := isGitRepo(ctx)
@@ -177,6 +187,22 @@ func runCommit(cmd *cobra.Command, args []string) error {
 		return outputResult(result)
 	}
 
+	// A sequence's working directory and a festival's project link are explicit
+	// commit targets. Resolve them while the caller is still in the festival so
+	// the command can preserve festival context without requiring a manual cd.
+	projectCommit := false
+	var submoduleRelPath string
+	if ws != nil && ws.Type == scope.WorkspaceTypeCampaign {
+		primaryRepoPath, projectCommit, submoduleRelPath, err = resolveCommitTarget(
+			ctx, ws.Root, primaryRepoPath, festivalPath, hasFestival,
+		)
+		if err != nil {
+			result.Success = false
+			result.Error = err.Error()
+			return outputResult(result)
+		}
+	}
+
 	// Guard outcomes and refusals go to the command's stderr so --json stdout
 	// stays a pure document.
 	report := cmd.ErrOrStderr()
@@ -184,8 +210,8 @@ func runCommit(cmd *cobra.Command, args []string) error {
 	// Auto-stage changes if enabled (default: true).
 	// When at campaign root (not in submodule), stage only festival-scoped paths.
 	if autoStage {
-		if inSubmodule {
-			// In submodule: stage all changes in the project repo
+		if projectCommit {
+			// In a project: stage all changes in the project repo.
 			if err := stageAllChanges(ctx, primaryRepoPath, report); err != nil {
 				result.Success = false
 				result.Error = err.Error()
@@ -280,10 +306,10 @@ func runCommit(cmd *cobra.Command, args []string) error {
 	result.Success = true
 	result.TaskRef = ref
 
-	// Campaign root commit: stage festival-scoped files and commit separately.
-	// Only when we're in a submodule (the campaign root commit is a second commit).
-	// When at the campaign root, the primary commit above already handled festival files.
-	if !noRoot && inSubmodule && ws != nil && ws.Type == scope.WorkspaceTypeCampaign && hasFestival {
+	// Campaign root commit: after a project commit, stage festival-scoped files
+	// and any tracked submodule pointer separately. Without a project target,
+	// the primary campaign-root commit above already handled festival files.
+	if !noRoot && projectCommit && ws != nil && ws.Type == scope.WorkspaceTypeCampaign && hasFestival {
 		rootHash, rootErr := commitFestivalAtRoot(ctx, ws, festivalPath, submoduleRelPath, result.CampaignTag, ref, rawMsg, report)
 		if rootErr != nil {
 			_, _ = fmt.Fprintf(report, "%s %s\n", ui.Warning("campaign root commit skipped:"), rootErr.Error())
@@ -339,15 +365,131 @@ func isGitRepo(ctx context.Context) (bool, error) {
 }
 
 func currentGitRoot(ctx context.Context) (string, error) {
+	return gitRootAt(ctx, "")
+}
+
+func gitRootAt(ctx context.Context, dir string) (string, error) {
 	if err := ctx.Err(); err != nil {
 		return "", errors.Wrap(err, "context cancelled")
 	}
-	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--show-toplevel")
+	args := []string{"rev-parse", "--show-toplevel"}
+	if dir != "" {
+		args = append([]string{"-C", dir}, args...)
+	}
+	cmd := exec.CommandContext(ctx, "git", args...)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", errors.Wrap(err, "finding git root")
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// resolveCommitTarget selects the repository that owns implementation changes.
+// A caller already inside a project stays there. A caller inside a festival is
+// redirected using the nearest sequence's fest_working_dir, then the festival
+// navigation link, then the legacy fest.yaml project_path fallback.
+func resolveCommitTarget(
+	ctx context.Context,
+	campaignRoot string,
+	currentRepo string,
+	festivalPath string,
+	hasFestival bool,
+) (repoPath string, project bool, submoduleRelPath string, err error) {
+	if filepath.Clean(currentRepo) != filepath.Clean(campaignRoot) {
+		return currentRepo, true, gitlinkRelPath(ctx, campaignRoot, currentRepo), nil
+	}
+	if !hasFestival || festivalPath == "" {
+		return currentRepo, false, "", nil
+	}
+
+	target, declared, err := festivalProjectTarget(campaignRoot, festivalPath)
+	if err != nil {
+		return "", false, "", err
+	}
+	if !declared {
+		return currentRepo, false, "", nil
+	}
+
+	info, statErr := os.Stat(target)
+	if statErr != nil {
+		return "", false, "", errors.Wrap(statErr, "finding linked project").WithField("path", target)
+	}
+	if !info.IsDir() {
+		return "", false, "", errors.Validation("linked project is not a directory").WithField("path", target)
+	}
+
+	targetRepo, rootErr := gitRootAt(ctx, target)
+	if rootErr != nil {
+		return "", false, "", errors.Wrap(rootErr, "resolving linked project repository").WithField("path", target)
+	}
+	if filepath.Clean(targetRepo) == filepath.Clean(campaignRoot) {
+		return currentRepo, false, "", nil
+	}
+
+	return targetRepo, true, gitlinkRelPath(ctx, campaignRoot, targetRepo), nil
+}
+
+// festivalProjectTarget returns the explicit implementation directory for the
+// caller's current sequence or festival. The bool distinguishes "not linked"
+// from an invalid declared link, which must fail loudly rather than committing
+// the wrong repository.
+func festivalProjectTarget(campaignRoot, festivalPath string) (string, bool, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", false, errors.Wrap(err, "getting working directory")
+	}
+
+	if rel, relErr := filepath.Rel(festivalPath, cwd); relErr == nil && rel != "." && !pathEscapesRoot(rel) {
+		parts := strings.Split(rel, string(os.PathSeparator))
+		if len(parts) >= 2 {
+			sequencePath := filepath.Join(festivalPath, parts[0], parts[1])
+			if workingDir := selection.ExtractWorkingDir(sequencePath); workingDir != "" {
+				_, absolute, resolveErr := pathutil.ResolveProjectPathValue(workingDir, campaignRoot)
+				if resolveErr != nil {
+					return "", true, errors.Wrap(resolveErr, "resolving fest_working_dir")
+				}
+				return absolute, true, nil
+			}
+		}
+	}
+
+	if nav, navErr := navigation.LoadNavigation(); navErr == nil {
+		if linked := nav.GetLinkedProject(filepath.Base(festivalPath)); linked != "" {
+			return linked, true, nil
+		}
+	}
+
+	cfg, cfgErr := config.LoadFestivalConfig(festivalPath, campaignRoot)
+	if cfgErr != nil {
+		return "", false, errors.Wrap(cfgErr, "loading festival config")
+	}
+	if cfg.ProjectPath == "" {
+		return "", false, nil
+	}
+	_, absolute, resolveErr := pathutil.ResolveProjectPathValue(cfg.ProjectPath, campaignRoot)
+	if resolveErr != nil {
+		return "", true, errors.Wrap(resolveErr, "resolving project_path")
+	}
+	return absolute, true, nil
+}
+
+func pathEscapesRoot(rel string) bool {
+	return rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator))
+}
+
+// gitlinkRelPath returns the campaign-relative path only when the target is a
+// tracked submodule. Worktrees and external repositories still receive the
+// project commit, but are not offered to the campaign-root staging path list.
+func gitlinkRelPath(ctx context.Context, campaignRoot, repoPath string) string {
+	rel, err := filepath.Rel(campaignRoot, repoPath)
+	if err != nil || pathEscapesRoot(rel) || rel == "." {
+		return ""
+	}
+	out, err := exec.CommandContext(ctx, "git", "-C", campaignRoot, "ls-files", "--stage", "--", rel).Output()
+	if err != nil || !strings.HasPrefix(strings.TrimSpace(string(out)), "160000 ") {
+		return ""
+	}
+	return rel
 }
 
 // stageAllChanges stages everything in the repository at repoPath through
@@ -454,6 +596,43 @@ func detectFestivalIDFromFlag(ctx context.Context, flag string) (string, error) 
 	if !ok || ws == nil {
 		return "", errors.NotFound("workspace")
 	}
+	festivalPath, err := resolveFestivalFlagPath(ctx, ws, flag)
+	if err != nil {
+		return "", err
+	}
+	return loadFestivalID(festivalPath, ws.Root)
+}
+
+// resolveFestivalFlagPath resolves every form accepted by --festival. Paths
+// are validated directly; names and IDs are searched across lifecycle status
+// directories. Keeping this resolution at command entry lets the same context
+// drive tag detection, project targeting, and the campaign-root commit.
+func resolveFestivalFlagPath(ctx context.Context, ws *scope.WorkspaceInfo, flag string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", errors.Wrap(err, "context cancelled")
+	}
+	if ws == nil {
+		return "", errors.NotFound("workspace")
+	}
+
+	if filepath.IsAbs(flag) {
+		return validateFestivalFlagPath(flag, ws.Root)
+	}
+
+	// A relative path can be relative to the caller or the campaign root. Only
+	// treat it as a path when it exists or contains an explicit path separator;
+	// a bare value remains eligible for the name/ID search below.
+	cwd, cwdErr := os.Getwd()
+	if cwdErr == nil {
+		for _, candidate := range []string{filepath.Join(cwd, flag), filepath.Join(ws.Root, flag)} {
+			if info, statErr := os.Stat(candidate); statErr == nil && info.IsDir() {
+				return validateFestivalFlagPath(candidate, ws.Root)
+			}
+		}
+	}
+	if strings.ContainsRune(flag, os.PathSeparator) {
+		return "", errors.NotFound(fmt.Sprintf("festival path %q", flag))
+	}
 
 	// Search status directories for a matching festival.
 	for _, status := range id.StatusDirectories {
@@ -470,22 +649,40 @@ func detectFestivalIDFromFlag(ctx context.Context, flag string) (string, error) 
 
 			// Match by directory name (e.g., "obey-alignment-OA0001")
 			if entry.Name() == flag {
-				return loadFestivalID(festivalPath, ws.Root)
+				return festivalPath, nil
 			}
 
 			// Match by ID suffix (e.g., directory ends with "-OA0001")
 			if strings.HasSuffix(entry.Name(), "-"+flag) {
-				return loadFestivalID(festivalPath, ws.Root)
+				return festivalPath, nil
 			}
 
 			// Match by loading config and comparing metadata.id
 			if fid, err := loadFestivalID(festivalPath, ws.Root); err == nil && fid == flag {
-				return fid, nil
+				return festivalPath, nil
 			}
 		}
 	}
 
 	return "", errors.NotFound(fmt.Sprintf("festival matching flag %q", flag))
+}
+
+func validateFestivalFlagPath(path, campaignRoot string) (string, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", errors.Wrap(err, "resolving festival path")
+	}
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return "", errors.Wrap(err, "finding festival path").WithField("path", absPath)
+	}
+	if !info.IsDir() {
+		return "", errors.Validation("festival path is not a directory").WithField("path", absPath)
+	}
+	if _, err := loadFestivalID(absPath, campaignRoot); err != nil {
+		return "", errors.Wrap(err, "validating festival path").WithField("path", absPath)
+	}
+	return absPath, nil
 }
 
 // loadFestivalID loads fest.yaml from the given festival directory and returns
@@ -543,16 +740,6 @@ func commitWithCampaignSupport(ctx context.Context, ws *scope.WorkspaceInfo, rep
 	result.Message = commitMessage
 
 	return nil
-}
-
-// isInSubmodule returns true and the submodule-relative path if the current
-// working directory is inside a git submodule of the campaign root.
-func isInSubmodule(campaignRoot string) (bool, string) {
-	relPath, err := resolveProjectRelPath(campaignRoot)
-	if err != nil {
-		return false, ""
-	}
-	return true, relPath
 }
 
 // festivalScopedPaths returns the campaign-root-relative paths that should be
@@ -690,38 +877,6 @@ func commitFestivalAtRoot(ctx context.Context, ws *scope.WorkspaceInfo, festival
 	}
 
 	return commitCampaignRoot(ctx, ws.Root, paths, rootMsg, report)
-}
-
-// resolveProjectRelPath returns the current git repository's path relative to
-// campaignRoot. Used to identify which submodule pointer to update.
-func resolveProjectRelPath(campaignRoot string) (string, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", errors.Wrap(err, "getting working directory")
-	}
-
-	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
-	cmd.Dir = cwd
-	out, err := cmd.Output()
-	if err != nil {
-		return "", errors.Wrap(err, "finding git root")
-	}
-	gitRoot := strings.TrimSpace(string(out))
-
-	if gitRoot == campaignRoot {
-		return "", errors.New("current directory is the campaign root, not a submodule")
-	}
-
-	relPath, err := filepath.Rel(campaignRoot, gitRoot)
-	if err != nil {
-		return "", errors.Wrap(err, "computing relative project path")
-	}
-
-	if strings.HasPrefix(relPath, "..") {
-		return "", errors.New("project is outside the campaign root")
-	}
-
-	return relPath, nil
 }
 
 func detectCurrentTaskRef(ctx context.Context) (string, error) {

--- a/internal/commands/commit/commit.go
+++ b/internal/commands/commit/commit.go
@@ -63,9 +63,9 @@ The fest commit command wraps git commit and automatically:
   1. Stages changes and prepends the festival reference to the commit message
   2. Creates a campaign root commit for festival-scoped files (task docs, progress, state)
 
-When a festival or sequence has a linked project, two commits are created even
-when this command is run from inside the festival:
-  - Project commit: stages all project changes
+When a festival or sequence has a linked project, up to two commits are created
+even when this command is run from inside the festival:
+  - Project commit: stages all project changes (skipped when the project is clean)
   - Campaign root commit: stages only festival directory, .campaign/fest/,
     festivals/.festival/.state/, and the submodule pointer
 
@@ -296,28 +296,59 @@ func runCommit(cmd *cobra.Command, args []string) error {
 		festMessage = fmt.Sprintf("[%s] %s", ref, rawMsg)
 	}
 
-	// Execute commit with campaign tag support.
-	if err := commitWithCampaignSupport(ctx, ws, primaryRepoPath, ref, rawMsg, festMessage, result); err != nil {
-		result.Success = false
-		result.Error = err.Error()
-		return outputResult(result)
+	// A clean linked project is valid when the festival itself changed (for
+	// example, close-out evidence). Skip only that project commit and continue
+	// to the scoped campaign-root commit below. All other modes retain the
+	// ordinary no-changes error from commitWithCampaignSupport.
+	primaryCommitted := true
+	if projectCommit {
+		hasProjectChanges, hasErr := commitkit.HasStagedChanges(ctx, primaryRepoPath)
+		if hasErr != nil {
+			result.Error = errors.Wrap(hasErr, "checking staged project changes").Error()
+			return outputResult(result)
+		}
+		primaryCommitted = hasProjectChanges
 	}
 
-	result.Success = true
+	if primaryCommitted {
+		if err := commitWithCampaignSupport(ctx, ws, primaryRepoPath, ref, rawMsg, festMessage, result); err != nil {
+			result.Error = err.Error()
+			return outputResult(result)
+		}
+	} else {
+		result.Message, result.CampaignTag = campaignCommitMessage(ctx, ws, ref, rawMsg, festMessage)
+	}
+
 	result.TaskRef = ref
 
 	// Campaign root commit: after a project commit, stage festival-scoped files
 	// and any tracked submodule pointer separately. Without a project target,
 	// the primary campaign-root commit above already handled festival files.
+	if noRoot && projectCommit && !primaryCommitted {
+		result.Error = "no changes to commit"
+		return outputResult(result)
+	}
 	if !noRoot && projectCommit && ws != nil && ws.Type == scope.WorkspaceTypeCampaign && hasFestival {
 		rootHash, rootErr := commitFestivalAtRoot(ctx, ws, festivalPath, submoduleRelPath, result.CampaignTag, ref, rawMsg, report)
 		if rootErr != nil {
+			if !primaryCommitted {
+				result.Error = rootErr.Error()
+				return outputResult(result)
+			}
 			_, _ = fmt.Fprintf(report, "%s %s\n", ui.Warning("campaign root commit skipped:"), rootErr.Error())
 		} else if rootHash != "" {
 			result.CampaignHash = rootHash
+			if !primaryCommitted {
+				result.Hash = rootHash
+				result.Message = festivalRootCommitMessage(result.CampaignTag, ref, rawMsg)
+			}
+		} else if !primaryCommitted {
+			result.Error = "no changes to commit"
+			return outputResult(result)
 		}
 	}
 
+	result.Success = true
 	return outputResult(result)
 }
 
@@ -703,25 +734,8 @@ func loadFestivalID(festivalPath, campaignRoot string) (string, error) {
 // festival refs into a single name-style tag: [{campaign-name}:{cid}-FE-{fid}].
 // Campaign detection or sync failures degrade gracefully — the commit still proceeds.
 func commitWithCampaignSupport(ctx context.Context, ws *scope.WorkspaceInfo, repoPath, festRef, rawMsg, festMessage string, result *CommitResult) error {
-	commitMessage := festMessage
-
-	if ws != nil && ws.Type == scope.WorkspaceTypeCampaign {
-		cid, err := commitkit.DetectCampaign(ctx)
-		if err == nil && cid != "" {
-			name, _ := commitkit.DetectCampaignName(ctx)
-			if festRef != "" {
-				// festRef is "FE-<id>"; pass the bare id (the formatter re-adds FE-).
-				festID := strings.TrimPrefix(festRef, commitRefPrefix+"-")
-				tag := commitkit.FormatContextTagsFullNamed(name, cid, "", festID, "")
-				commitMessage = tag + " " + rawMsg
-				result.CampaignTag = tag
-			} else {
-				tag := commitkit.FormatContextTagsFullNamed(name, cid, "", "", "")
-				commitMessage = tag + " " + festMessage
-				result.CampaignTag = tag
-			}
-		}
-	}
+	commitMessage, campaignTag := campaignCommitMessage(ctx, ws, festRef, rawMsg, festMessage)
+	result.CampaignTag = campaignTag
 
 	// commitkit.Commit captures git's output internally, which is the --json
 	// contract: nothing but the encoded document may reach stdout. The same
@@ -740,6 +754,34 @@ func commitWithCampaignSupport(ctx context.Context, ws *scope.WorkspaceInfo, rep
 	result.Message = commitMessage
 
 	return nil
+}
+
+// campaignCommitMessage builds the shared campaign/festival tag without
+// requiring a project commit. Festival-only commits use the same tag for the
+// campaign-root commit even when the linked project has nothing staged.
+func campaignCommitMessage(ctx context.Context, ws *scope.WorkspaceInfo, festRef, rawMsg, festMessage string) (string, string) {
+	commitMessage := festMessage
+	var campaignTag string
+
+	if ws != nil && ws.Type == scope.WorkspaceTypeCampaign {
+		cid, err := commitkit.DetectCampaign(ctx)
+		if err == nil && cid != "" {
+			name, _ := commitkit.DetectCampaignName(ctx)
+			if festRef != "" {
+				// festRef is "FE-<id>"; pass the bare id (the formatter re-adds FE-).
+				festID := strings.TrimPrefix(festRef, commitRefPrefix+"-")
+				tag := commitkit.FormatContextTagsFullNamed(name, cid, "", festID, "")
+				commitMessage = tag + " " + rawMsg
+				campaignTag = tag
+			} else {
+				tag := commitkit.FormatContextTagsFullNamed(name, cid, "", "", "")
+				commitMessage = tag + " " + festMessage
+				campaignTag = tag
+			}
+		}
+	}
+
+	return commitMessage, campaignTag
 }
 
 // festivalScopedPaths returns the campaign-root-relative paths that should be
@@ -866,17 +908,18 @@ func commitFestivalAtRoot(ctx context.Context, ws *scope.WorkspaceInfo, festival
 		return "", err
 	}
 
-	// Build the campaign root commit message with "fest:" prefix.
+	return commitCampaignRoot(ctx, ws.Root, paths, festivalRootCommitMessage(campaignTag, festRef, rawMsg), report)
+}
+
+func festivalRootCommitMessage(campaignTag, festRef, rawMsg string) string {
 	rootMsg := "fest: " + rawMsg
-
-	// Apply the same campaign tag used for the project commit.
 	if campaignTag != "" {
-		rootMsg = campaignTag + " " + rootMsg
-	} else if festRef != "" {
-		rootMsg = fmt.Sprintf("[%s] %s", festRef, rootMsg)
+		return campaignTag + " " + rootMsg
 	}
-
-	return commitCampaignRoot(ctx, ws.Root, paths, rootMsg, report)
+	if festRef != "" {
+		return fmt.Sprintf("[%s] %s", festRef, rootMsg)
+	}
+	return rootMsg
 }
 
 func detectCurrentTaskRef(ctx context.Context) (string, error) {

--- a/internal/commands/commit/commit.go
+++ b/internal/commands/commit/commit.go
@@ -347,6 +347,10 @@ func runCommit(cmd *cobra.Command, args []string) error {
 			return outputResult(result)
 		}
 	}
+	if !primaryCommitted && result.Hash == "" {
+		result.Error = "no changes to commit"
+		return outputResult(result)
+	}
 
 	result.Success = true
 	return outputResult(result)

--- a/internal/commands/commit/commit_test.go
+++ b/internal/commands/commit/commit_test.go
@@ -5,7 +5,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/scope"
 )
 
 func TestFormatCommitRef(t *testing.T) {
@@ -72,6 +75,55 @@ func TestNewCommitCommand_CampaignTaggingIndependentOfSync(t *testing.T) {
 	}
 	if syncFlag.DefValue != "false" {
 		t.Errorf("--sync-submodule-ref default = %q, want %q", syncFlag.DefValue, "false")
+	}
+}
+
+func TestRunCommit_CleanProjectWithoutFestivalReturnsNoChanges(t *testing.T) {
+	campaign := t.TempDir()
+	project := filepath.Join(campaign, "projects", "app")
+	if err := os.MkdirAll(filepath.Join(campaign, ".campaign"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, repo := range []string{campaign, project} {
+		cmd := exec.Command("git", "init", "-q", repo)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git init %s: %v\n%s", repo, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(project, "app.txt"), []byte("initial\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"-C", project, "add", "app.txt"},
+		{"-C", project, "-c", "user.name=Fest Test", "-c", "user.email=fest@example.com", "commit", "-q", "-m", "initial"},
+	} {
+		cmd := exec.Command("git", args...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	t.Chdir(project)
+	cmd := NewCommitCommand()
+	cmd.SetContext(scope.WithWorkspace(context.Background(), &scope.WorkspaceInfo{
+		Root: campaign,
+		Type: scope.WorkspaceTypeCampaign,
+	}))
+	message = "chore: no changes"
+	autoStage = true
+	autoWrite = false
+	noRoot = false
+	noTag = true
+	jsonOut = false
+	festivalFlag = ""
+	taskRef = ""
+
+	err := runCommit(cmd, nil)
+	if err == nil || !strings.Contains(err.Error(), "no changes to commit") {
+		t.Fatalf("runCommit error = %v, want no changes to commit", err)
 	}
 }
 

--- a/tests/integration/commit_linked_project_test.go
+++ b/tests/integration/commit_linked_project_test.go
@@ -182,3 +182,64 @@ metadata:
 	assert.Contains(t, rootLog, "FE-FC0001")
 	assert.Contains(t, rootLog, "fest: fix: preserve explicit festival path")
 }
+
+// A linked project is the implementation target, not a requirement that every
+// festival commit contain project changes. Close-out and evidence commits often
+// change only festival files; a clean project must not prevent those files from
+// reaching the campaign-root commit.
+func TestCommitFromLinkedFestivalAllowsFestivalOnlyChanges(t *testing.T) {
+	tc := GetSharedContainer(t)
+	ensureGuardGit(t, tc)
+
+	const (
+		campaign = "/commit-festival-only-campaign"
+		festival = campaign + "/festivals/active/festival-only-FO0001"
+		project  = campaign + "/projects/app"
+	)
+
+	_, err := tc.Exec("sh", "-c", strings.Join([]string{
+		"mkdir -p /commit-festival-only-src && cd /commit-festival-only-src && git init -q",
+		"echo initial > app.txt && git add -A && git commit -q -m initial",
+		"mkdir -p " + campaign + "/festivals/.festival " + campaign + "/.campaign",
+		"cd " + campaign + " && git init -q",
+		"git submodule add -q /commit-festival-only-src projects/app",
+		"git add -A && git commit -q -m 'campaign baseline'",
+	}, " && "))
+	require.NoError(t, err)
+
+	require.NoError(t, tc.WriteFile(festival+"/fest.yaml", `version: "1.0"
+metadata:
+  id: FO0001
+  name: festival-only
+`))
+	out, err := tc.RunFestInDir(festival, "link", project)
+	require.NoError(t, err, "festival link must be created: %s", out)
+	require.NoError(t, tc.WriteFile(festival+"/EVIDENCE.md", "festival-only evidence\n"))
+
+	projectBefore, err := tc.Exec("git", "-C", project, "rev-parse", "HEAD")
+	require.NoError(t, err)
+	out, err = tc.Exec("sh", "-c", "cd "+festival+" && /fest commit -m 'docs: festival-only evidence'")
+	require.NoError(t, err, "a clean linked project must not block festival-only work: %s", out)
+
+	projectAfter, err := tc.Exec("git", "-C", project, "rev-parse", "HEAD")
+	require.NoError(t, err)
+	assert.Equal(t, projectBefore, projectAfter, "a clean project must remain unchanged")
+
+	rootLog, err := tc.Exec("git", "-C", campaign, "log", "-1", "--format=%s")
+	require.NoError(t, err)
+	assert.Contains(t, rootLog, "FE-FO0001")
+	assert.Contains(t, rootLog, "fest: docs: festival-only evidence")
+
+	rootFiles, err := tc.Exec("git", "-C", campaign, "show", "--name-only", "--format=", "HEAD")
+	require.NoError(t, err)
+	assert.Contains(t, rootFiles, "festivals/active/festival-only-FO0001/EVIDENCE.md")
+
+	rootBefore, err := tc.Exec("git", "-C", campaign, "rev-parse", "HEAD")
+	require.NoError(t, err)
+	out, err = tc.Exec("sh", "-c", "cd "+festival+" && /fest commit -m 'docs: nothing left'")
+	require.Error(t, err, "no changes in either repository must still fail")
+	assert.Contains(t, out, "no changes to commit")
+	rootAfter, err := tc.Exec("git", "-C", campaign, "rev-parse", "HEAD")
+	require.NoError(t, err)
+	assert.Equal(t, rootBefore, rootAfter, "a no-op must not create a commit")
+}

--- a/tests/integration/commit_linked_project_test.go
+++ b/tests/integration/commit_linked_project_test.go
@@ -1,0 +1,184 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A sequence's fest_working_dir is the explicit repository target for its
+// implementation work. Running the commit gate from that sequence must commit
+// the linked project first, then commit festival state and the updated
+// submodule pointer at the campaign root. Requiring the caller to cd into the
+// project loses the sequence context that selected the target in the first
+// place and makes the gate's plain `fest commit` instruction incomplete.
+func TestCommitFromSequenceTargetsWorkingDirectory(t *testing.T) {
+	tc := GetSharedContainer(t)
+	ensureGuardGit(t, tc)
+
+	const (
+		campaign = "/commit-linked-campaign"
+		festival = campaign + "/festivals/active/linked-commit-LC0001"
+		sequence = festival + "/001_IMPLEMENT/01_change_app"
+		project  = campaign + "/projects/app"
+	)
+
+	_, err := tc.Exec("sh", "-c", strings.Join([]string{
+		"mkdir -p /commit-linked-src && cd /commit-linked-src && git init -q",
+		"echo initial > app.txt && git add -A && git commit -q -m initial",
+		"mkdir -p " + campaign + "/festivals/.festival " + campaign + "/.campaign",
+		"cd " + campaign + " && git init -q",
+		"git submodule add -q /commit-linked-src projects/app",
+		"git add -A && git commit -q -m 'campaign baseline'",
+	}, " && "))
+	require.NoError(t, err)
+
+	require.NoError(t, tc.WriteFile(festival+"/fest.yaml", `version: "1.0"
+metadata:
+  id: LC0001
+  name: linked-commit
+`))
+	require.NoError(t, tc.WriteFile(sequence+"/SEQUENCE_GOAL.md", `---
+fest_type: sequence
+fest_id: 01_change_app
+fest_name: change app
+fest_parent: 001_IMPLEMENT
+fest_order: 1
+fest_status: in_progress
+fest_working_dir: projects/app
+---
+
+# Sequence Goal
+`))
+	require.NoError(t, tc.WriteFile(sequence+"/01_change.md", `---
+fest_type: task
+fest_id: 01_change.md
+fest_name: change
+fest_parent: 01_change_app
+fest_order: 1
+fest_status: in_progress
+---
+
+# Change app
+`))
+	require.NoError(t, tc.WriteFile(project+"/app.txt", "changed by festival\n"))
+
+	out, err := tc.Exec("sh", "-c", "cd "+sequence+" && /fest commit -m 'fix: change linked app'")
+	require.NoError(t, err, "plain fest commit from the sequence must target fest_working_dir: %s", out)
+
+	projectLog, err := tc.Exec("git", "-C", project, "log", "-1", "--format=%s")
+	require.NoError(t, err)
+	assert.Contains(t, projectLog, "FE-LC0001", "project commit must carry the festival reference")
+	assert.Contains(t, projectLog, "fix: change linked app")
+
+	projectFile, err := tc.Exec("git", "-C", project, "show", "HEAD:app.txt")
+	require.NoError(t, err)
+	assert.Contains(t, projectFile, "changed by festival", "the project change must be committed in the project")
+
+	rootLog, err := tc.Exec("git", "-C", campaign, "log", "-1", "--format=%s")
+	require.NoError(t, err)
+	assert.Contains(t, rootLog, "FE-LC0001", "campaign commit must carry the same festival reference")
+	assert.Contains(t, rootLog, "fest: fix: change linked app")
+
+	rootFiles, err := tc.Exec("git", "-C", campaign, "show", "--name-only", "--format=", "HEAD")
+	require.NoError(t, err)
+	assert.Contains(t, rootFiles, "festivals/active/linked-commit-LC0001")
+	assert.Contains(t, rootFiles, "projects/app", "campaign commit must advance the project pointer")
+}
+
+// A festival-level navigation link provides the same target when the caller is
+// at the festival root, where there is no sequence fest_working_dir to prefer.
+func TestCommitFromFestivalTargetsNavigationLink(t *testing.T) {
+	tc := GetSharedContainer(t)
+	ensureGuardGit(t, tc)
+
+	const (
+		campaign = "/commit-navigation-campaign"
+		festival = campaign + "/festivals/active/navigation-commit-NC0001"
+		project  = campaign + "/projects/app"
+	)
+
+	_, err := tc.Exec("sh", "-c", strings.Join([]string{
+		"mkdir -p /commit-navigation-src && cd /commit-navigation-src && git init -q",
+		"echo initial > app.txt && git add -A && git commit -q -m initial",
+		"mkdir -p " + campaign + "/festivals/.festival " + campaign + "/.campaign",
+		"cd " + campaign + " && git init -q",
+		"git submodule add -q /commit-navigation-src projects/app",
+		"git add -A && git commit -q -m 'campaign baseline'",
+	}, " && "))
+	require.NoError(t, err)
+
+	require.NoError(t, tc.WriteFile(festival+"/fest.yaml", `version: "1.0"
+metadata:
+  id: NC0001
+  name: navigation-commit
+`))
+	out, err := tc.RunFestInDir(festival, "link", project)
+	require.NoError(t, err, "festival link must be created: %s", out)
+	require.NoError(t, tc.WriteFile(project+"/app.txt", "changed through navigation link\n"))
+
+	out, err = tc.Exec("sh", "-c", "cd "+festival+" && /fest commit -m 'fix: honor navigation link'")
+	require.NoError(t, err, "plain fest commit from the festival must target its navigation link: %s", out)
+
+	projectLog, err := tc.Exec("git", "-C", project, "log", "-1", "--format=%s")
+	require.NoError(t, err)
+	assert.Contains(t, projectLog, "FE-NC0001")
+	assert.Contains(t, projectLog, "fix: honor navigation link")
+
+	rootLog, err := tc.Exec("git", "-C", campaign, "log", "-1", "--format=%s")
+	require.NoError(t, err)
+	assert.Contains(t, rootLog, "FE-NC0001")
+	assert.Contains(t, rootLog, "fest: fix: honor navigation link")
+}
+
+// --festival accepts a path as scope input. Previously the command deferred
+// scope resolution because the flag was present, but tag detection only
+// searched festival names and IDs. An absolute path therefore committed the
+// project with a campaign-only tag and skipped the campaign-root commit.
+func TestCommitFromProjectResolvesAbsoluteFestivalPath(t *testing.T) {
+	tc := GetSharedContainer(t)
+	ensureGuardGit(t, tc)
+
+	const (
+		campaign = "/commit-flag-campaign"
+		festival = campaign + "/festivals/active/flag-commit-FC0001"
+		project  = campaign + "/projects/app"
+	)
+
+	_, err := tc.Exec("sh", "-c", strings.Join([]string{
+		"mkdir -p /commit-flag-src && cd /commit-flag-src && git init -q",
+		"echo initial > app.txt && git add -A && git commit -q -m initial",
+		"mkdir -p " + campaign + "/festivals/.festival " + campaign + "/.campaign",
+		"cd " + campaign + " && git init -q",
+		"git submodule add -q /commit-flag-src projects/app",
+		"git add -A && git commit -q -m 'campaign baseline'",
+	}, " && "))
+	require.NoError(t, err)
+
+	require.NoError(t, tc.WriteFile(festival+"/fest.yaml", `version: "1.0"
+metadata:
+  id: FC0001
+  name: flag-commit
+`))
+	require.NoError(t, tc.WriteFile(festival+"/NOTES.md", "festival evidence\n"))
+	require.NoError(t, tc.WriteFile(project+"/app.txt", "staged project change\n"))
+	_, err = tc.Exec("git", "-C", project, "add", "app.txt")
+	require.NoError(t, err)
+
+	out, err := tc.Exec("sh", "-c", "cd "+project+" && /fest commit --stage=false --festival "+festival+" -m 'fix: preserve explicit festival path'")
+	require.NoError(t, err, "absolute --festival path must resolve full festival context: %s", out)
+
+	projectLog, err := tc.Exec("git", "-C", project, "log", "-1", "--format=%s")
+	require.NoError(t, err)
+	assert.Contains(t, projectLog, "FE-FC0001", "path-based commit must not degrade to a campaign-only tag")
+
+	rootLog, err := tc.Exec("git", "-C", campaign, "log", "-1", "--format=%s")
+	require.NoError(t, err)
+	assert.Contains(t, rootLog, "FE-FC0001")
+	assert.Contains(t, rootLog, "fest: fix: preserve explicit festival path")
+}


### PR DESCRIPTION
## Summary

- route plain `fest commit` from a sequence through `fest_working_dir`, then fall back to the festival navigation link and legacy `project_path`
- create the project commit first and the scoped campaign-root commit second with the same FE reference
- skip the project commit when the linked repository is clean, allowing festival-only evidence and close-out commits to proceed at the campaign root
- retain `no changes to commit` when neither the linked project nor festival scope changed
- resolve `--festival` paths, names, and IDs before commit routing so absolute paths no longer degrade to campaign-only tags
- document the behavior and add container regressions for all entry paths

## Root cause

`fest commit` selected its primary repository solely from the caller's current Git root. Running it from a festival therefore committed only campaign files, while changing into the linked project discarded sequence-level targeting context. Separately, `--festival /absolute/path` deferred scope resolution but the tag resolver only searched festival names and IDs, silently dropping the FE reference and skipping the root follow-up commit.

After project routing was added, a clean linked repository exposed a second edge case: the project-side `no changes` result stopped execution before festival-only files could be committed at the campaign root. The command now treats a clean linked project as a skipped optional commit while preserving a real no-op error when both scopes are clean.

## Validation

- `go test ./...`
- `go vet ./...`
- `just lint all`
- focused container regressions for sequence, navigation-link, absolute-path, festival-only, and true no-op workflows
- complete container suite: `FULL_INTEGRATION_PASS`
- `just install stable` into an isolated `GOBIN`; installed macOS binary reported commit `246a5c4`
- installed Linux binary at `/usr/local/bin/fest`; festival-only linked-project smoke test produced `[FE-DO0001] fest: docs: installed festival-only evidence`, left the project commit unchanged, and left both repositories clean
