### PR TITLE
fix(hooks): run task_complete bindings on every completion surface

### DIFF
--- a/docs/concepts/hooks.md
+++ b/docs/concepts/hooks.md
@@ -142,7 +142,7 @@ Bindings only reference names. They never set `command`, `fail`, or `timeout`.
 | Verb | When |
 | --- | --- |
 | `task_start` | first transition into work (`fest task in-progress`, a direct completion, or the first `--progress` above zero) |
-| `task_complete` | `fest task completed` |
+| `task_complete` | any transition into completed (`fest task completed`, `fest status set ... completed`, a programmatic 100% progress update) |
 | `sequence_complete` | sequence completion |
 | `phase_complete` | phase completion |
 | `gate_approve` | GATES.md blocking approval checkpoint |
@@ -159,8 +159,16 @@ was already started or re-marking it in progress never re-fires the hook;
 next start. A `fail: closed`
 pre failure blocks the transition and leaves the task untouched. A `fail:
 closed` post failure keeps the task started and is recorded in the audit trail
-plus a stderr warning. Completion by progress (`--progress 100`) still bypasses
-`task_complete` hooks; only the terminal completion surfaces run those.
+plus a stderr warning.
+
+`task_complete` fires on **every** completion surface, not just `fest task
+completed`: `fest status set ... completed` and programmatic 100% progress
+updates run the same bindings. Completion hooks fire on the transition into
+completed; repeating a 100% progress update on an already-completed task never
+re-fires them, while explicitly re-completing via `fest task completed` does
+(matching its historical behavior). When an unstarted task is completed
+directly, the pre order is `task_complete` pre, then `task_start` pre; after
+the transition, `task_start` post runs before `task_complete` post.
 
 Orchestration:
 

--- a/internal/commands/status/task_status_hooks_test.go
+++ b/internal/commands/status/task_status_hooks_test.go
@@ -1,0 +1,107 @@
+package status
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/ui"
+)
+
+// setupTaskHookFixture builds an active festival whose task binds one
+// completion hook named "checker" running checkerCommand (a real command:
+// true to pass, false to fail closed).
+func setupTaskHookFixture(t *testing.T, checkerCommand string) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	festYAML := `version: "1.0"
+name: task-status-hooks-test
+id: TSH-001
+metadata:
+  id: TSH-001
+  status_history:
+    - status: active
+      timestamp: 2026-02-10T00:00:00Z
+hooks:
+  definitions:
+    checker:
+      command: ` + checkerCommand + `
+`
+	if err := os.WriteFile(filepath.Join(dir, "fest.yaml"), []byte(festYAML), 0o644); err != nil {
+		t.Fatalf("write fest.yaml: %v", err)
+	}
+
+	seqDir := filepath.Join(dir, "001_PHASE", "01_seq")
+	if err := os.MkdirAll(seqDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	task := "---\nfest_type: task\nfest_id: 01_task\nhooks:\n  pre: [checker]\n---\n# Task body\n"
+	taskRel := filepath.Join("001_PHASE", "01_seq", "01_task.md")
+	if err := os.WriteFile(filepath.Join(dir, taskRel), []byte(task), 0o644); err != nil {
+		t.Fatalf("write task: %v", err)
+	}
+
+	// Machine-layer isolation: never read the developer's real ~/.obey/fest.
+	t.Setenv("HOME", t.TempDir())
+	return dir, taskRel
+}
+
+// TestTaskStatusSetCompletedRunsCompletionHooks is the regression test for
+// the bypass this change closes: 'fest status set <task> completed' used to
+// mark a task completed without ever consulting its completion hook bindings,
+// because those hooks lived only in the 'fest task completed' command layer.
+func TestTaskStatusSetCompletedRunsCompletionHooks(t *testing.T) {
+	t.Run("fail_closed_hook_blocks_completion", func(t *testing.T) {
+		festDir, taskRel := setupTaskHookFixture(t, "false")
+
+		err := handleTaskStatusSet(context.Background(), &ui.UI{}, festDir,
+			"completed", &statusOptions{task: taskRel, noCommit: true})
+		if err == nil {
+			t.Fatal("fail-closed completion hook must block status set completed")
+		}
+		if !strings.Contains(err.Error(), "blocked by fail-closed hook") {
+			t.Fatalf("err = %v", err)
+		}
+
+		events := readTaskHookEvents(t, festDir)
+		if !strings.Contains(events, `"hook_verb":"task_complete"`) || !strings.Contains(events, `"hook_blocked":true`) {
+			t.Fatalf("blocked task_complete event missing:\n%s", events)
+		}
+		if strings.Contains(events, `"event":"completed"`) {
+			t.Fatalf("completed event must not be recorded on a blocked completion:\n%s", events)
+		}
+	})
+
+	t.Run("passing_hook_completes_with_audit_trail", func(t *testing.T) {
+		festDir, taskRel := setupTaskHookFixture(t, "true")
+
+		err := handleTaskStatusSet(context.Background(), &ui.UI{}, festDir,
+			"completed", &statusOptions{task: taskRel, noCommit: true})
+		if err != nil {
+			t.Fatalf("handleTaskStatusSet: %v", err)
+		}
+
+		events := readTaskHookEvents(t, festDir)
+		if !strings.Contains(events, `"hook_verb":"task_complete"`) || !strings.Contains(events, `"hook_outcome":"pass"`) {
+			t.Fatalf("task_complete pass event missing:\n%s", events)
+		}
+		if !strings.Contains(events, `"event":"completed"`) {
+			t.Fatalf("completed event missing:\n%s", events)
+		}
+	})
+}
+
+func readTaskHookEvents(t *testing.T, festDir string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(festDir, ".fest", "progress_events.jsonl"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		t.Fatalf("read events: %v", err)
+	}
+	return string(data)
+}

--- a/internal/commands/task/completed.go
+++ b/internal/commands/task/completed.go
@@ -3,32 +3,17 @@ package task
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
 	"github.com/Obedience-Corp/fest/internal/errors"
 	"github.com/Obedience-Corp/fest/internal/gates"
-	"github.com/Obedience-Corp/fest/internal/hooks"
 	"github.com/Obedience-Corp/fest/internal/lifecycle"
 	"github.com/Obedience-Corp/fest/internal/progress"
 	"github.com/Obedience-Corp/fest/internal/scope"
 	"github.com/Obedience-Corp/fest/internal/ui"
 	"github.com/spf13/cobra"
 )
-
-// newTaskHookRunner is an injectable seam so tests can fake hook execution.
-var newTaskHookRunner = hooks.NewRunner
-
-// blockedHookName returns the first fail-closed hook that blocked the verb.
-func blockedHookName(runs []hooks.HookRun) string {
-	for _, run := range runs {
-		if run.Blocked {
-			return run.Name
-		}
-	}
-	return ""
-}
 
 var (
 	completedJSON bool
@@ -141,60 +126,28 @@ func runCompleted(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	hookReq := progress.LifecycleHookRequest{
-		FestivalPath: festivalPath,
-		Phase:        filepath.Base(phasePath),
-		Task:         taskID,
-		Level:        hooks.LevelTask,
-		Verb:         hooks.VerbTaskComplete,
-	}
-	if content, readErr := os.ReadFile(taskFilePath); readErr == nil {
-		hookReq.Pre, hookReq.Post, hookReq.HumanGate = progress.StepHookBindingsFromFrontmatter(content)
-	}
-	planned, err := progress.PlanLifecycleHooks(ctx, hookReq)
-	if err != nil {
-		return err
-	}
-	runner := newTaskHookRunner(festivalPath)
-	preRuns, preBlocked, preErr := progress.RunLifecycleStage(ctx, mgr.Store(), runner, hookReq, planned, hooks.TimingPre)
-	if saveErr := mgr.Store().SaveEvents(ctx); saveErr != nil && preErr == nil {
-		preErr = saveErr
-	}
-	if preErr != nil {
-		return errors.Wrap(preErr, "running pre-completion hooks")
-	}
-	if preBlocked {
-		blockErr := progress.BlockedHookError(hooks.VerbTaskComplete, preRuns)
-		if completedJSON {
-			result := map[string]any{
-				"success":     false,
-				"task":        taskID,
-				"blocked":     true,
-				"failed_hook": blockedHookName(preRuns),
-				"message":     "Task completion blocked by fail-closed hook",
-			}
-			if encErr := shared.EncodeJSON(os.Stdout, result); encErr != nil {
-				return errors.Wrap(encErr, "encoding JSON output")
-			}
-		} else {
-			fmt.Println()
-			fmt.Println(ui.Error("Task completion BLOCKED by fail-closed hook: " + blockedHookName(preRuns)))
-		}
-		return blockErr
-	}
-
+	// Completion hooks (task_complete pre/post) run inside MarkComplete so
+	// every completion surface shares them; this command only renders a
+	// blocked-hook outcome.
 	if err := mgr.MarkComplete(ctx, taskID); err != nil {
+		if hookName, blocked := progress.BlockedHookName(err); blocked {
+			if completedJSON {
+				result := map[string]any{
+					"success":     false,
+					"task":        taskID,
+					"blocked":     true,
+					"failed_hook": hookName,
+					"message":     "Task completion blocked by fail-closed hook",
+				}
+				if encErr := shared.EncodeJSON(os.Stdout, result); encErr != nil {
+					return errors.Wrap(encErr, "encoding JSON output")
+				}
+			} else {
+				fmt.Println()
+				fmt.Println(ui.Error("Task completion BLOCKED by fail-closed hook: " + hookName))
+			}
+		}
 		return err
-	}
-
-	_, postBlocked, postErr := progress.RunLifecycleStage(ctx, mgr.Store(), runner, hookReq, planned, hooks.TimingPost)
-	if saveErr := mgr.Store().SaveEvents(ctx); saveErr != nil && postErr == nil {
-		postErr = saveErr
-	}
-	if postErr != nil {
-		fmt.Fprintf(os.Stderr, "Warning: post-completion hooks: %v\n", postErr)
-	} else if postBlocked {
-		fmt.Fprintln(os.Stderr, "Warning: a fail-closed post hook failed; the task remains completed (see wf_hook_run in the festival audit trail)")
 	}
 
 	if completedJSON {

--- a/internal/commands/task/completed.go
+++ b/internal/commands/task/completed.go
@@ -127,25 +127,29 @@ func runCompleted(cmd *cobra.Command, args []string) error {
 	}
 
 	// Completion hooks (task_complete pre/post) run inside MarkComplete so
-	// every completion surface shares them; this command only renders a
-	// blocked-hook outcome.
+	// every completion surface shares them; this command only renders the
+	// outcome. In JSON mode every failure emits a structured document, not
+	// just the blocked-pre path: a post-stage failure leaves the task
+	// completed, so agents need machine-readable output to tell the two apart.
 	if err := mgr.MarkComplete(ctx, taskID); err != nil {
-		if hookName, blocked := progress.BlockedHookName(err); blocked {
-			if completedJSON {
-				result := map[string]any{
-					"success":     false,
-					"task":        taskID,
-					"blocked":     true,
-					"failed_hook": hookName,
-					"message":     "Task completion blocked by fail-closed hook",
-				}
-				if encErr := shared.EncodeJSON(os.Stdout, result); encErr != nil {
-					return errors.Wrap(encErr, "encoding JSON output")
-				}
-			} else {
-				fmt.Println()
-				fmt.Println(ui.Error("Task completion BLOCKED by fail-closed hook: " + hookName))
+		hookName, blocked := progress.BlockedHookName(err)
+		if completedJSON {
+			result := map[string]any{
+				"success": false,
+				"task":    taskID,
+				"blocked": blocked,
+				"message": err.Error(),
 			}
+			if blocked {
+				result["failed_hook"] = hookName
+				result["message"] = "Task completion blocked by fail-closed hook"
+			}
+			if encErr := shared.EncodeJSON(os.Stdout, result); encErr != nil {
+				return errors.Wrap(encErr, "encoding JSON output")
+			}
+		} else if blocked {
+			fmt.Println()
+			fmt.Println(ui.Error("Task completion BLOCKED by fail-closed hook: " + hookName))
 		}
 		return err
 	}

--- a/internal/commands/task/completed_hooks_test.go
+++ b/internal/commands/task/completed_hooks_test.go
@@ -1,16 +1,17 @@
 package task
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/Obedience-Corp/fest/internal/hooks"
 )
 
-func setupHookedFestival(t *testing.T, taskFrontmatterExtra string) (string, string) {
+// setupHookedFestival builds an active festival whose fest.yaml declares one
+// hook definition named "checker" running checkerCommand. Completion hooks now
+// execute inside progress.Manager, so these tests drive the real runner with
+// real commands (true/false) instead of faking an exec seam.
+func setupHookedFestival(t *testing.T, taskFrontmatterExtra, checkerCommand string) (string, string) {
 	t.Helper()
 	festDir, taskRel := setupActiveFestival(t)
 
@@ -25,7 +26,7 @@ metadata:
 hooks:
   definitions:
     checker:
-      command: test-checker
+      command: ` + checkerCommand + `
 `
 	if err := os.WriteFile(filepath.Join(festDir, "fest.yaml"), []byte(festYAML), 0o644); err != nil {
 		t.Fatalf("write fest.yaml: %v", err)
@@ -41,26 +42,6 @@ hooks:
 	return festDir, taskRel
 }
 
-func fakeTaskRunner(t *testing.T, exitCode int, called *[]string) {
-	t.Helper()
-	orig := newTaskHookRunner
-	t.Cleanup(func() { newTaskHookRunner = orig })
-	newTaskHookRunner = func(workDir string) *hooks.Runner {
-		r := hooks.NewRunner(workDir)
-		r.Exec = func(ctx context.Context, command string, stdin []byte, dir string) hooks.CommandResult {
-			if called != nil {
-				*called = append(*called, command)
-			}
-			res := hooks.CommandResult{ExitCode: exitCode}
-			if exitCode != 0 {
-				res.Err = context.Canceled // any non-nil error stands in for exec failure
-			}
-			return res
-		}
-		return r
-	}
-}
-
 func readHookEvents(t *testing.T, festDir string) string {
 	t.Helper()
 	data, err := os.ReadFile(filepath.Join(festDir, ".fest", "progress_events.jsonl"))
@@ -74,9 +55,7 @@ func readHookEvents(t *testing.T, festDir string) string {
 }
 
 func TestRunCompleted_PreHookBlockedRefusesCompletion(t *testing.T) {
-	festDir, taskRel := setupHookedFestival(t, "hooks:\n  pre: [checker]\n")
-	var called []string
-	fakeTaskRunner(t, 1, &called)
+	festDir, taskRel := setupHookedFestival(t, "hooks:\n  pre: [checker]\n", "false")
 	resetTaskFlags()
 	completedYes = true
 
@@ -89,9 +68,6 @@ func TestRunCompleted_PreHookBlockedRefusesCompletion(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "blocked by fail-closed hook") {
 		t.Fatalf("err = %v", err)
-	}
-	if len(called) != 1 {
-		t.Fatalf("hook exec calls = %v", called)
 	}
 
 	taskID := canonicalTaskID(t, festDir, taskRel)
@@ -109,9 +85,7 @@ func TestRunCompleted_PreHookBlockedRefusesCompletion(t *testing.T) {
 }
 
 func TestRunCompleted_UndeclaredBindingSkipsAndCompletes(t *testing.T) {
-	festDir, taskRel := setupHookedFestival(t, "hooks:\n  pre: [ghost]\n")
-	var called []string
-	fakeTaskRunner(t, 0, &called)
+	festDir, taskRel := setupHookedFestival(t, "hooks:\n  pre: [ghost]\n", "false")
 	resetTaskFlags()
 	completedYes = true
 
@@ -122,8 +96,11 @@ func TestRunCompleted_UndeclaredBindingSkipsAndCompletes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("undeclared binding must skip, not fail: %v", err)
 	}
-	if len(called) != 0 {
-		t.Fatalf("undeclared hook must never exec: %v", called)
+
+	taskID := canonicalTaskID(t, festDir, taskRel)
+	task, ok := taskStatus(t, festDir, taskID)
+	if !ok || task.Status != "completed" {
+		t.Fatalf("task not completed: %+v", task)
 	}
 
 	events := readHookEvents(t, festDir)
@@ -133,9 +110,8 @@ func TestRunCompleted_UndeclaredBindingSkipsAndCompletes(t *testing.T) {
 }
 
 func TestRunCompleted_HumanGateSkipsAutomationHooks(t *testing.T) {
-	festDir, taskRel := setupHookedFestival(t, "hooks:\n  pre: [checker]\napproval: human-required\n")
-	var called []string
-	fakeTaskRunner(t, 1, &called) // would block if it ever ran
+	// checker would block if it ever ran; the human gate must skip it.
+	festDir, taskRel := setupHookedFestival(t, "hooks:\n  pre: [checker]\napproval: human-required\n", "false")
 	resetTaskFlags()
 	completedYes = true
 
@@ -146,8 +122,11 @@ func TestRunCompleted_HumanGateSkipsAutomationHooks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("human-gate step must skip automation hooks: %v", err)
 	}
-	if len(called) != 0 {
-		t.Fatalf("automation hooks must never exec on a human gate: %v", called)
+
+	taskID := canonicalTaskID(t, festDir, taskRel)
+	task, ok := taskStatus(t, festDir, taskID)
+	if !ok || task.Status != "completed" {
+		t.Fatalf("task not completed: %+v", task)
 	}
 
 	events := readHookEvents(t, festDir)
@@ -157,9 +136,7 @@ func TestRunCompleted_HumanGateSkipsAutomationHooks(t *testing.T) {
 }
 
 func TestRunCompleted_PostHookRunsAfterCompletion(t *testing.T) {
-	festDir, taskRel := setupHookedFestival(t, "hooks:\n  post: [checker]\n")
-	var called []string
-	fakeTaskRunner(t, 0, &called)
+	festDir, taskRel := setupHookedFestival(t, "hooks:\n  post: [checker]\n", "true")
 	resetTaskFlags()
 	completedYes = true
 
@@ -169,9 +146,6 @@ func TestRunCompleted_PostHookRunsAfterCompletion(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("runCompleted: %v", err)
-	}
-	if len(called) != 1 {
-		t.Fatalf("post hook exec calls = %v", called)
 	}
 
 	taskID := canonicalTaskID(t, festDir, taskRel)

--- a/internal/progress/hook_lifecycle.go
+++ b/internal/progress/hook_lifecycle.go
@@ -2,6 +2,7 @@ package progress
 
 import (
 	"context"
+	stderrors "errors"
 	"strings"
 
 	"github.com/Obedience-Corp/fest/internal/errors"
@@ -104,13 +105,16 @@ func StartHookBindingsFromFrontmatter(content []byte) (pre, post []string, human
 	return pre, post, strings.EqualFold(strings.TrimSpace(fm.Approval), "human-required")
 }
 
+// blockedHookMessage identifies a BlockedHookError in an error chain.
+const blockedHookMessage = "blocked by fail-closed hook"
+
 // BlockedHookError names the fail-closed hook that blocked a lifecycle verb.
 func BlockedHookError(verb hooks.Verb, runs []hooks.HookRun) error {
 	for _, run := range runs {
 		if !run.Blocked {
 			continue
 		}
-		e := errors.Validation("blocked by fail-closed hook").
+		e := errors.Validation(blockedHookMessage).
 			WithField("hook", run.Name).
 			WithField("verb", string(verb)).
 			WithField("outcome", string(run.Outcome)).
@@ -120,5 +124,20 @@ func BlockedHookError(verb hooks.Verb, runs []hooks.HookRun) error {
 		}
 		return e
 	}
-	return errors.Validation("blocked by fail-closed hook").WithField("verb", string(verb))
+	return errors.Validation(blockedHookMessage).WithField("verb", string(verb))
+}
+
+// BlockedHookName reports whether err (or anything in its chain) is a
+// BlockedHookError, returning the offending hook's name when recorded so
+// command surfaces can render it without re-running hook logic.
+func BlockedHookName(err error) (string, bool) {
+	for cur := err; cur != nil; cur = stderrors.Unwrap(cur) {
+		e, ok := cur.(*errors.Error)
+		if !ok || e.Message != blockedHookMessage {
+			continue
+		}
+		name, _ := e.Fields["hook"].(string)
+		return name, true
+	}
+	return "", false
 }

--- a/internal/progress/manager.go
+++ b/internal/progress/manager.go
@@ -167,18 +167,21 @@ func (m *Manager) UpdateProgress(ctx context.Context, taskID string, progress in
 		return err
 	}
 	m.SyncFrontmatterStatus(taskID, task.Status)
-	if err := m.finishTaskHooks(ctx, startStage, "started"); err != nil {
-		return err
-	}
-	if err := m.finishTaskHooks(ctx, completeStage, "completed"); err != nil {
-		return err
+	// The transition is applied; every remaining side effect must still be
+	// attempted when a post stage fails. A start post failure must not skip
+	// the task_complete post stage, and neither may skip parent propagation:
+	// otherwise a completed task leaves its sequence goal permanently stalled.
+	// The first post error is returned after all side effects have run.
+	postErr := m.finishTaskHooks(ctx, startStage, "started")
+	if err := m.finishTaskHooks(ctx, completeStage, "completed"); postErr == nil {
+		postErr = err
 	}
 	if progress == 100 {
 		// Propagation is best-effort: a failure here should not block
 		// the progress update that already succeeded above.
 		_ = m.PropagateCompletion(ctx, taskID)
 	}
-	return nil
+	return postErr
 }
 
 // MarkComplete marks a task as complete
@@ -247,11 +250,16 @@ func (m *Manager) MarkComplete(ctx context.Context, taskID string) error {
 		return err
 	}
 	m.SyncFrontmatterStatus(taskID, task.Status)
-	if err := m.finishTaskHooks(ctx, startStage, "started"); err != nil {
-		return err
-	}
-	if err := m.finishTaskHooks(ctx, completeStage, "completed"); err != nil {
-		return err
+	// The completion is applied; every remaining side effect must still be
+	// attempted when a post stage fails. A start post failure must not skip
+	// the task_complete post stage, and neither may skip the ledger emit or
+	// parent propagation: otherwise a completed task leaves its sequence goal
+	// permanently stalled. The first post error is returned after all side
+	// effects have run, preserving the historical contract that ledger and
+	// propagation always follow a successful completion mutation.
+	postErr := m.finishTaskHooks(ctx, startStage, "started")
+	if err := m.finishTaskHooks(ctx, completeStage, "completed"); postErr == nil {
+		postErr = err
 	}
 	// Campaign ledger: high-intent task completion (D003/D006). Does not
 	// alter progress_events.jsonl content beyond the save already done.
@@ -261,7 +269,7 @@ func (m *Manager) MarkComplete(ctx context.Context, taskID string) error {
 	// Propagation is best-effort: a failure here should not block
 	// the task completion that already succeeded above.
 	_ = m.PropagateCompletion(ctx, taskID)
-	return nil
+	return postErr
 }
 
 // MarkInProgress marks a task as in progress. On the first start (no

--- a/internal/progress/manager.go
+++ b/internal/progress/manager.go
@@ -87,13 +87,27 @@ func (m *Manager) UpdateProgress(ctx context.Context, taskID string, progress in
 		}
 	}
 
+	// A 100% update is a completion transition, so the task_complete verb
+	// runs here too: without it UpdateProgress(100) would complete a task
+	// with its completion bindings silently skipped. Hooks fire only on an
+	// actual transition into completed; replaying 100 on an already-completed
+	// task never re-fires them.
+	var completeStage *taskHookStage
+	if progress == 100 && task.Status != StatusCompleted {
+		var err error
+		completeStage, err = m.beginTaskHooks(ctx, taskID, hooks.VerbTaskComplete)
+		if err != nil {
+			return err
+		}
+	}
+
 	// The first progress above zero is the first start signal, so the
 	// task_start stage runs here too: without it a progress update would
 	// permanently disarm start anchors (StartedAt set, hooks never fired).
-	var stage *startHookStage
+	var startStage *taskHookStage
 	if task.StartedAt == nil && progress > 0 {
 		var err error
-		stage, err = m.beginTaskStartHooks(ctx, taskID)
+		startStage, err = m.beginTaskHooks(ctx, taskID, hooks.VerbTaskStart)
 		if err != nil {
 			return err
 		}
@@ -153,7 +167,10 @@ func (m *Manager) UpdateProgress(ctx context.Context, taskID string, progress in
 		return err
 	}
 	m.SyncFrontmatterStatus(taskID, task.Status)
-	if err := m.finishTaskStartHooks(ctx, stage); err != nil {
+	if err := m.finishTaskHooks(ctx, startStage, "started"); err != nil {
+		return err
+	}
+	if err := m.finishTaskHooks(ctx, completeStage, "completed"); err != nil {
 		return err
 	}
 	if progress == 100 {
@@ -180,10 +197,21 @@ func (m *Manager) MarkComplete(ctx context.Context, taskID string) error {
 		}
 	}
 
-	var stage *startHookStage
+	// Completion bindings run around the transition here so every completion
+	// surface shares them (task completed command, status set, progress 100).
+	// Pre ordering preserves the historical 'fest task completed' flow:
+	// task_complete pre, then first-start task_start pre, mutation,
+	// task_start post, task_complete post. An explicit re-completion of an
+	// already-completed task re-fires its bindings, matching the historical
+	// command behavior.
+	completeStage, err := m.beginTaskHooks(ctx, taskID, hooks.VerbTaskComplete)
+	if err != nil {
+		return err
+	}
+
+	var startStage *taskHookStage
 	if task.StartedAt == nil {
-		var err error
-		stage, err = m.beginTaskStartHooks(ctx, taskID)
+		startStage, err = m.beginTaskHooks(ctx, taskID, hooks.VerbTaskStart)
 		if err != nil {
 			return err
 		}
@@ -219,7 +247,10 @@ func (m *Manager) MarkComplete(ctx context.Context, taskID string) error {
 		return err
 	}
 	m.SyncFrontmatterStatus(taskID, task.Status)
-	if err := m.finishTaskStartHooks(ctx, stage); err != nil {
+	if err := m.finishTaskHooks(ctx, startStage, "started"); err != nil {
+		return err
+	}
+	if err := m.finishTaskHooks(ctx, completeStage, "completed"); err != nil {
 		return err
 	}
 	// Campaign ledger: high-intent task completion (D003/D006). Does not
@@ -253,10 +284,10 @@ func (m *Manager) MarkInProgress(ctx context.Context, taskID string) error {
 		}
 	}
 
-	var stage *startHookStage
+	var stage *taskHookStage
 	if task.StartedAt == nil {
 		var err error
-		stage, err = m.beginTaskStartHooks(ctx, taskID)
+		stage, err = m.beginTaskHooks(ctx, taskID, hooks.VerbTaskStart)
 		if err != nil {
 			return err
 		}
@@ -284,47 +315,74 @@ func (m *Manager) MarkInProgress(ctx context.Context, taskID string) error {
 		return err
 	}
 	m.SyncFrontmatterStatus(taskID, task.Status)
-	return m.finishTaskStartHooks(ctx, stage)
+	return m.finishTaskHooks(ctx, stage, "started")
 }
 
-// startHookStage carries one first-start transition's planned task_start
-// bindings between the pre and post timings.
-type startHookStage struct {
+// taskHookStage carries one task transition's planned lifecycle bindings
+// between the pre and post timings.
+type taskHookStage struct {
 	req     LifecycleHookRequest
 	planned []hooks.PlannedHook
 	runner  *hooks.Runner
+	label   string // human wording for error text, e.g. "task start"
 }
 
-// beginTaskStartHooks plans the task's start-stage bindings and runs the pre
-// timing. A nil stage with nil error means nothing is bound. On a blocked pre
-// the caller must not apply the transition.
-func (m *Manager) beginTaskStartHooks(ctx context.Context, taskID string) (*startHookStage, error) {
-	req, planned, err := m.planTaskStartHooks(ctx, taskID)
+// beginTaskHooks plans the task document's bindings for verb and runs the
+// pre timing. task_start plans the nested start-stage bindings; task_complete
+// plans the bare pre/post bindings. A nil stage with nil error means nothing
+// is bound. On a blocked pre the caller must not apply the transition. A
+// missing task file yields no bindings: progress can track tasks whose
+// documents do not exist.
+func (m *Manager) beginTaskHooks(ctx context.Context, taskID string, verb hooks.Verb) (*taskHookStage, error) {
+	req := LifecycleHookRequest{
+		FestivalPath: m.store.FestivalPath(),
+		Phase:        taskPhaseCoordinate(taskID),
+		Task:         taskID,
+		Level:        hooks.LevelTask,
+		Verb:         verb,
+	}
+	label := "task start"
+	if verb == hooks.VerbTaskComplete {
+		label = "task completion"
+	}
+	taskPath := filepath.Join(m.store.FestivalPath(), taskID)
+	if !strings.HasSuffix(taskPath, ".md") {
+		taskPath += ".md"
+	}
+	content, err := os.ReadFile(taskPath)
 	if err != nil {
-		return nil, err
+		return nil, nil
+	}
+	if verb == hooks.VerbTaskStart {
+		req.Pre, req.Post, req.HumanGate = StartHookBindingsFromFrontmatter(content)
+	} else {
+		req.Pre, req.Post, req.HumanGate = StepHookBindingsFromFrontmatter(content)
+	}
+	planned, err := PlanLifecycleHooks(ctx, req)
+	if err != nil {
+		return nil, errors.Wrap(err, "planning "+label+" hooks")
 	}
 	if len(planned) == 0 {
 		return nil, nil
 	}
-	stage := &startHookStage{req: req, planned: planned, runner: newLifecycleHookRunner(m.store.FestivalPath())}
+	stage := &taskHookStage{req: req, planned: planned, runner: newLifecycleHookRunner(m.store.FestivalPath()), label: label}
 	preRuns, blocked, err := RunLifecycleStage(ctx, m.store, stage.runner, stage.req, stage.planned, hooks.TimingPre)
 	if saveErr := m.store.SaveEvents(ctx); saveErr != nil && err == nil {
 		err = saveErr
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, "running task start pre hooks")
+		return nil, errors.Wrap(err, "running "+label+" pre hooks")
 	}
 	if blocked {
-		return nil, BlockedHookError(hooks.VerbTaskStart, preRuns)
+		return nil, BlockedHookError(verb, preRuns)
 	}
 	return stage, nil
 }
 
-// finishTaskStartHooks runs the post timing after the start transition has
-// been applied. A fail-closed post failure keeps the task started; it is
-// recorded in the audit trail and warned to stderr, matching the completion
-// path's operator visibility.
-func (m *Manager) finishTaskStartHooks(ctx context.Context, stage *startHookStage) error {
+// finishTaskHooks runs the post timing after the transition has been applied.
+// A fail-closed post failure keeps the transition applied (appliedState names
+// it in the warning); it is recorded in the audit trail and warned to stderr.
+func (m *Manager) finishTaskHooks(ctx context.Context, stage *taskHookStage, appliedState string) error {
 	if stage == nil {
 		return nil
 	}
@@ -333,39 +391,12 @@ func (m *Manager) finishTaskStartHooks(ctx context.Context, stage *startHookStag
 		postErr = saveErr
 	}
 	if postErr != nil {
-		return errors.Wrap(postErr, "running task start post hooks")
+		return errors.Wrap(postErr, "running "+stage.label+" post hooks")
 	}
 	if postBlocked {
-		fmt.Fprintln(os.Stderr, "Warning: a fail-closed task_start post hook failed; the task remains started (see wf_hook_run in the festival audit trail)")
+		fmt.Fprintf(os.Stderr, "Warning: a fail-closed %s post hook failed; the task remains %s (see wf_hook_run in the festival audit trail)\n", string(stage.req.Verb), appliedState)
 	}
 	return nil
-}
-
-// planTaskStartHooks reads the task document and plans its start-stage
-// bindings for the task_start verb. A missing task file yields no bindings:
-// progress can track tasks whose documents do not exist.
-func (m *Manager) planTaskStartHooks(ctx context.Context, taskID string) (LifecycleHookRequest, []hooks.PlannedHook, error) {
-	req := LifecycleHookRequest{
-		FestivalPath: m.store.FestivalPath(),
-		Phase:        taskPhaseCoordinate(taskID),
-		Task:         taskID,
-		Level:        hooks.LevelTask,
-		Verb:         hooks.VerbTaskStart,
-	}
-	taskPath := filepath.Join(m.store.FestivalPath(), taskID)
-	if !strings.HasSuffix(taskPath, ".md") {
-		taskPath += ".md"
-	}
-	content, err := os.ReadFile(taskPath)
-	if err != nil {
-		return req, nil, nil
-	}
-	req.Pre, req.Post, req.HumanGate = StartHookBindingsFromFrontmatter(content)
-	planned, err := PlanLifecycleHooks(ctx, req)
-	if err != nil {
-		return req, nil, errors.Wrap(err, "planning task start hooks")
-	}
-	return req, planned, nil
 }
 
 // taskPhaseCoordinate derives the audit-event phase coordinate from a

--- a/internal/progress/manager_hooks_test.go
+++ b/internal/progress/manager_hooks_test.go
@@ -173,6 +173,10 @@ hooks:
       command: test-start-anchor
     start-notify:
       command: test-start-notify
+    complete-check:
+      command: test-complete-check
+    complete-announce:
+      command: test-complete-announce
 `
 	if err := os.WriteFile(filepath.Join(dir, "fest.yaml"), []byte(festYAML), 0o644); err != nil {
 		t.Fatalf("write fest.yaml: %v", err)
@@ -560,5 +564,203 @@ func TestMaterializeState_ProgressEventSetsStartedAt(t *testing.T) {
 	})
 	if task := tasks["t1"]; task == nil || task.StartedAt != nil {
 		t.Fatalf("zero progress replay must not set StartedAt: %+v", task)
+	}
+}
+
+func TestMarkComplete_CompletionHooksRunAroundTransition(t *testing.T) {
+	festDir := setupStartHookFestival(t, "hooks:\n  pre: [complete-check]\n  post: [complete-announce]\n")
+	var called []string
+	fakeLifecycleRunner(t, 0, &called)
+
+	mgr, err := NewManager(context.Background(), festDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := mgr.MarkComplete(context.Background(), "001_PHASE/01_seq/01_task.md"); err != nil {
+		t.Fatalf("MarkComplete: %v", err)
+	}
+
+	task, exists := mgr.GetTaskProgress("001_PHASE/01_seq/01_task.md")
+	if !exists || task.Status != StatusCompleted {
+		t.Fatalf("task not completed: exists=%v task=%+v", exists, task)
+	}
+	if len(called) != 2 || called[0] != "test-complete-check" || called[1] != "test-complete-announce" {
+		t.Fatalf("hook exec calls = %v", called)
+	}
+	events := readEventsFile(t, festDir)
+	if !strings.Contains(events, `"hook_verb":"task_complete"`) ||
+		!strings.Contains(events, `"hook_timing":"pre"`) ||
+		!strings.Contains(events, `"hook_timing":"post"`) {
+		t.Fatalf("task_complete pre/post events missing:\n%s", events)
+	}
+	if !strings.Contains(events, `"event":"completed"`) {
+		t.Fatalf("completed event missing:\n%s", events)
+	}
+}
+
+func TestMarkComplete_BlockedCompletePreLeavesTaskIncomplete(t *testing.T) {
+	festDir := setupStartHookFestival(t, "hooks:\n  pre: [complete-check]\n")
+	var called []string
+	fakeLifecycleRunner(t, 1, &called)
+
+	mgr, err := NewManager(context.Background(), festDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	err = mgr.MarkComplete(context.Background(), "001_PHASE/01_seq/01_task.md")
+	if err == nil {
+		t.Fatal("blocked completion pre hook must fail MarkComplete")
+	}
+	if !strings.Contains(err.Error(), "blocked by fail-closed hook") {
+		t.Fatalf("error = %v", err)
+	}
+	if task, exists := mgr.GetTaskProgress("001_PHASE/01_seq/01_task.md"); exists && task.Status == StatusCompleted {
+		t.Fatal("blocked completion pre hook must leave the task incomplete")
+	}
+	if len(called) != 1 {
+		t.Fatalf("hook exec calls = %v", called)
+	}
+	events := readEventsFile(t, festDir)
+	if !strings.Contains(events, `"hook_verb":"task_complete"`) || !strings.Contains(events, `"hook_blocked":true`) {
+		t.Fatalf("blocked task_complete event missing:\n%s", events)
+	}
+	if strings.Contains(events, `"event":"completed"`) {
+		t.Fatalf("completed event must not be recorded on a blocked completion:\n%s", events)
+	}
+}
+
+func TestMarkComplete_StartAndCompletionHookOrder(t *testing.T) {
+	festDir := setupStartHookFestival(t,
+		"hooks:\n  pre: [complete-check]\n  post: [complete-announce]\n  start:\n    pre: [start-anchor]\n    post: [start-notify]\n")
+	var called []string
+	fakeLifecycleRunner(t, 0, &called)
+
+	mgr, err := NewManager(context.Background(), festDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := mgr.MarkComplete(context.Background(), "001_PHASE/01_seq/01_task.md"); err != nil {
+		t.Fatalf("MarkComplete: %v", err)
+	}
+
+	// Historical 'fest task completed' order: complete pre, start pre,
+	// transition, start post, complete post.
+	want := []string{"test-complete-check", "test-start-anchor", "test-start-notify", "test-complete-announce"}
+	if len(called) != len(want) {
+		t.Fatalf("hook exec calls = %v", called)
+	}
+	for i := range want {
+		if called[i] != want[i] {
+			t.Fatalf("hook order = %v, want %v", called, want)
+		}
+	}
+}
+
+func TestMarkComplete_FailClosedCompletePostKeepsTaskCompleted(t *testing.T) {
+	festDir := setupStartHookFestival(t, "hooks:\n  post: [complete-announce]\n")
+	var called []string
+	fakeLifecycleRunnerPerCommand(t, map[string]int{"test-complete-announce": 1}, &called)
+
+	mgr, err := NewManager(context.Background(), festDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := mgr.MarkComplete(context.Background(), "001_PHASE/01_seq/01_task.md"); err != nil {
+		t.Fatalf("failed post hook must not fail MarkComplete: %v", err)
+	}
+	task, exists := mgr.GetTaskProgress("001_PHASE/01_seq/01_task.md")
+	if !exists || task.Status != StatusCompleted {
+		t.Fatalf("task must stay completed: exists=%v task=%+v", exists, task)
+	}
+	events := readEventsFile(t, festDir)
+	if !strings.Contains(events, `"hook_outcome":"fail"`) {
+		t.Fatalf("failed post hook audit record missing:\n%s", events)
+	}
+}
+
+func TestUpdateProgress_HundredFiresCompletionHooks(t *testing.T) {
+	festDir := setupStartHookFestival(t, "hooks:\n  pre: [complete-check]\n  post: [complete-announce]\n")
+	var called []string
+	fakeLifecycleRunner(t, 0, &called)
+
+	mgr, err := NewManager(context.Background(), festDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := mgr.UpdateProgress(context.Background(), "001_PHASE/01_seq/01_task.md", 100); err != nil {
+		t.Fatalf("UpdateProgress(100): %v", err)
+	}
+
+	task, exists := mgr.GetTaskProgress("001_PHASE/01_seq/01_task.md")
+	if !exists || task.Status != StatusCompleted {
+		t.Fatalf("task not completed: exists=%v task=%+v", exists, task)
+	}
+	if len(called) != 2 || called[0] != "test-complete-check" || called[1] != "test-complete-announce" {
+		t.Fatalf("hook exec calls = %v", called)
+	}
+	events := readEventsFile(t, festDir)
+	if !strings.Contains(events, `"hook_verb":"task_complete"`) {
+		t.Fatalf("task_complete events missing:\n%s", events)
+	}
+}
+
+func TestUpdateProgress_HundredBlockedPreLeavesTaskUntouchedByCompletion(t *testing.T) {
+	festDir := setupStartHookFestival(t, "hooks:\n  pre: [complete-check]\n")
+	var called []string
+	fakeLifecycleRunner(t, 1, &called)
+
+	mgr, err := NewManager(context.Background(), festDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	err = mgr.UpdateProgress(context.Background(), "001_PHASE/01_seq/01_task.md", 100)
+	if err == nil {
+		t.Fatal("blocked completion pre hook must fail UpdateProgress(100)")
+	}
+	if task, exists := mgr.GetTaskProgress("001_PHASE/01_seq/01_task.md"); exists && task.Status == StatusCompleted {
+		t.Fatal("blocked completion pre hook must leave the task incomplete")
+	}
+	events := readEventsFile(t, festDir)
+	if strings.Contains(events, `"event":"completed"`) {
+		t.Fatalf("completed event must not be recorded on a blocked completion:\n%s", events)
+	}
+}
+
+func TestUpdateProgress_RepeatHundredDoesNotRefireCompletionHooks(t *testing.T) {
+	festDir := setupStartHookFestival(t, "hooks:\n  pre: [complete-check]\n  post: [complete-announce]\n")
+	var called []string
+	fakeLifecycleRunner(t, 0, &called)
+
+	mgr, err := NewManager(context.Background(), festDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := mgr.UpdateProgress(context.Background(), "001_PHASE/01_seq/01_task.md", 100); err != nil {
+		t.Fatalf("first UpdateProgress(100): %v", err)
+	}
+	fired := len(called)
+
+	if err := mgr.UpdateProgress(context.Background(), "001_PHASE/01_seq/01_task.md", 100); err != nil {
+		t.Fatalf("second UpdateProgress(100): %v", err)
+	}
+	if len(called) != fired {
+		t.Fatalf("completion hooks re-fired on already-completed task: %v", called)
+	}
+}
+
+func TestUpdateProgress_MidProgressRunsNoCompletionHooks(t *testing.T) {
+	festDir := setupStartHookFestival(t, "hooks:\n  pre: [complete-check]\n  post: [complete-announce]\n")
+	var called []string
+	fakeLifecycleRunner(t, 0, &called)
+
+	mgr, err := NewManager(context.Background(), festDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := mgr.UpdateProgress(context.Background(), "001_PHASE/01_seq/01_task.md", 50); err != nil {
+		t.Fatalf("UpdateProgress(50): %v", err)
+	}
+	if len(called) != 0 {
+		t.Fatalf("completion bindings must not run mid-progress: %v", called)
 	}
 }

--- a/internal/progress/manager_hooks_test.go
+++ b/internal/progress/manager_hooks_test.go
@@ -764,3 +764,133 @@ func TestUpdateProgress_MidProgressRunsNoCompletionHooks(t *testing.T) {
 		t.Fatalf("completion bindings must not run mid-progress: %v", called)
 	}
 }
+
+// fakeLifecycleRunnerFunc routes each hook exec through fn, so tests can
+// give individual commands side effects (like sabotaging the events dir).
+func fakeLifecycleRunnerFunc(t *testing.T, fn func(command string) hooks.CommandResult, called *[]string) {
+	t.Helper()
+	orig := newLifecycleHookRunner
+	t.Cleanup(func() { newLifecycleHookRunner = orig })
+	newLifecycleHookRunner = func(workDir string) *hooks.Runner {
+		r := hooks.NewRunner(workDir)
+		r.Exec = func(ctx context.Context, command string, stdin []byte, dir string) hooks.CommandResult {
+			if called != nil {
+				*called = append(*called, command)
+			}
+			return fn(command)
+		}
+		return r
+	}
+}
+
+// breakEventsDir makes the store's SaveEvents fail with a real I/O error by
+// replacing the .fest directory with a plain file; restoreEventsDir undoes it.
+func breakEventsDir(t *testing.T, festDir string) {
+	t.Helper()
+	fest := filepath.Join(festDir, ".fest")
+	if err := os.Rename(fest, fest+"-hidden"); err != nil {
+		t.Fatalf("hide .fest: %v", err)
+	}
+	if err := os.WriteFile(fest, []byte("not a dir"), 0o644); err != nil {
+		t.Fatalf("shadow .fest: %v", err)
+	}
+}
+
+func restoreEventsDir(t *testing.T, festDir string) {
+	t.Helper()
+	fest := filepath.Join(festDir, ".fest")
+	if err := os.Remove(fest); err != nil {
+		t.Fatalf("remove shadow: %v", err)
+	}
+	if err := os.Rename(fest+"-hidden", fest); err != nil {
+		t.Fatalf("restore .fest: %v", err)
+	}
+}
+
+func TestMarkComplete_PostInfraFailureStillRunsRemainingSideEffects(t *testing.T) {
+	festDir := setupStartHookFestival(t, "hooks:\n  post: [complete-announce]\n  start:\n    post: [start-notify]\n")
+	seqDir := filepath.Join(festDir, "001_PHASE", "01_seq")
+	seqGoal := "---\nfest_type: sequence_goal\nfest_id: 01_seq\n---\n# Sequence Goal\n"
+	if err := os.WriteFile(filepath.Join(seqDir, "SEQUENCE_GOAL.md"), []byte(seqGoal), 0o644); err != nil {
+		t.Fatalf("write sequence goal: %v", err)
+	}
+
+	// The start post hook breaks the events dir so its stage hits a real
+	// SaveEvents infrastructure error; the complete post hook repairs it,
+	// proving the later stage still ran and letting propagation proceed.
+	var called []string
+	fakeLifecycleRunnerFunc(t, func(command string) hooks.CommandResult {
+		switch command {
+		case "test-start-notify":
+			breakEventsDir(t, festDir)
+		case "test-complete-announce":
+			restoreEventsDir(t, festDir)
+		}
+		return hooks.CommandResult{}
+	}, &called)
+
+	mgr, err := NewManager(context.Background(), festDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	err = mgr.MarkComplete(context.Background(), "001_PHASE/01_seq/01_task.md")
+	if err == nil {
+		t.Fatal("start post infra failure must surface as an error")
+	}
+	if !strings.Contains(err.Error(), "task start post hooks") {
+		t.Fatalf("error = %v", err)
+	}
+
+	// The task completed before the failing post stage.
+	task, exists := mgr.GetTaskProgress("001_PHASE/01_seq/01_task.md")
+	if !exists || task.Status != StatusCompleted {
+		t.Fatalf("task must stay completed: exists=%v task=%+v", exists, task)
+	}
+	// The task_complete post stage still ran after the start post failure.
+	if len(called) != 2 || called[0] != "test-start-notify" || called[1] != "test-complete-announce" {
+		t.Fatalf("hook exec calls = %v", called)
+	}
+	// Parent propagation still ran: the sequence goal completed.
+	if got := seqGoalStatus(t, festDir); got != "completed" {
+		t.Fatalf("sequence goal status = %q, want completed (propagation skipped)", got)
+	}
+}
+
+func TestUpdateProgress_HundredPostInfraFailureStillPropagates(t *testing.T) {
+	festDir := setupStartHookFestival(t, "hooks:\n  post: [complete-announce]\n  start:\n    post: [start-notify]\n")
+	seqDir := filepath.Join(festDir, "001_PHASE", "01_seq")
+	seqGoal := "---\nfest_type: sequence_goal\nfest_id: 01_seq\n---\n# Sequence Goal\n"
+	if err := os.WriteFile(filepath.Join(seqDir, "SEQUENCE_GOAL.md"), []byte(seqGoal), 0o644); err != nil {
+		t.Fatalf("write sequence goal: %v", err)
+	}
+
+	var called []string
+	fakeLifecycleRunnerFunc(t, func(command string) hooks.CommandResult {
+		switch command {
+		case "test-start-notify":
+			breakEventsDir(t, festDir)
+		case "test-complete-announce":
+			restoreEventsDir(t, festDir)
+		}
+		return hooks.CommandResult{}
+	}, &called)
+
+	mgr, err := NewManager(context.Background(), festDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	err = mgr.UpdateProgress(context.Background(), "001_PHASE/01_seq/01_task.md", 100)
+	if err == nil {
+		t.Fatal("start post infra failure must surface as an error")
+	}
+	task, exists := mgr.GetTaskProgress("001_PHASE/01_seq/01_task.md")
+	if !exists || task.Status != StatusCompleted {
+		t.Fatalf("task must stay completed: exists=%v task=%+v", exists, task)
+	}
+	if len(called) != 2 || called[1] != "test-complete-announce" {
+		t.Fatalf("hook exec calls = %v", called)
+	}
+	if got := seqGoalStatus(t, festDir); got != "completed" {
+		t.Fatalf("sequence goal status = %q, want completed (propagation skipped)", got)
+	}
+}


### PR DESCRIPTION
## Summary

Completion hooks previously lived only in the `fest task completed` command layer, so `fest status set <task> completed` and programmatic `UpdateProgress(100)` completed tasks without ever consulting their bindings. This was flagged as residual risk 3 in the hostile review of #326, which wired `task_start` at the manager layer and left completion behind.

This change moves `task_complete` planning and execution into `progress.Manager`, mirroring the #326 `task_start` pattern:

- `Manager.MarkComplete` always runs the task document's bare `pre`/`post` bindings around the transition.
- `Manager.UpdateProgress` runs them when a 100% update actually transitions the task into completed.
- `fest task completed` now delegates to the manager and only renders the blocked-hook outcome. Its `--json` contract is unchanged (`success`/`task`/`blocked`/`failed_hook`/`message`).
- The start and completion stages share one implementation (`beginTaskHooks`/`finishTaskHooks`), replacing the start-only helpers.

## Semantics

- Pre ordering preserves the historical `fest task completed` flow exactly: `task_complete` pre, then first-start `task_start` pre, transition, `task_start` post, `task_complete` post.
- A blocked `task_complete` pre leaves the task untouched; no completed event is recorded.
- A fail-closed post failure keeps the task completed, recorded in the audit trail plus a stderr warning.
- Replaying `UpdateProgress(100)` on an already-completed task never re-fires completion hooks. Explicitly re-completing via `fest task completed` still re-fires them, matching its historical behavior.
- Behavior change: infrastructure errors from post hooks (runner failure, event save) now fail the command with the task already completed, matching `MarkInProgress` semantics. Previously `fest task completed` only warned on stderr and exited 0.

## Surfaces covered

- `fest task completed`: unchanged UX, hooks now run inside the manager.
- `fest status set <task> completed`: bypass closed; regression test drives the real handler with a real fail-closed hook.
- Programmatic `UpdateProgress(100)`: both CLI update paths already reject 100%, so this is defense in depth for library callers.

Quality gates remain command-layer and are out of scope here; `fest status set completed` still does not evaluate them. That asymmetry predates this change and is worth its own decision.

## Testing

- Full unit suite: 2833 tests pass. `go vet` and `golangci-lint` clean.
- New manager tests: hook order around the transition, blocked pre leaves task incomplete, fail-closed post keeps task completed, 100% transition fires, replay guard, mid-progress fires nothing.
- New status handler regression test for the closed bypass (blocked and passing variants).
- Command-layer hook tests now drive the real runner with real commands (`true`/`false`) since the command exec seam was removed with the code it faked.
- Containerized integration gate (`just gate`) run before opening this PR.
