### PR TITLE
fix(create): make festival dry-run a no-write preview

### DIFF
--- a/docs/cli-reference/fest-reference.md
+++ b/docs/cli-reference/fest-reference.md
@@ -962,7 +962,7 @@ fest create festival [flags]
 ```
       --agent                 Strict mode: process markers, auto-validate, rollback on blocking errors, JSON output
       --dest string           Destination under festivals/: planning or ritual (use 'fest promote' to advance to active) (default "planning")
-      --dry-run               Show template markers without creating file
+      --dry-run               Preview the festival file tree without writing anything
       --goal string           Festival goal
   -h, --help                  help for festival
       --json                  Emit JSON output

--- a/docs/cli-reference/fest_create_festival.md
+++ b/docs/cli-reference/fest_create_festival.md
@@ -11,7 +11,7 @@ fest create festival [flags]
 ```
       --agent                 Strict mode: process markers, auto-validate, rollback on blocking errors, JSON output
       --dest string           Destination under festivals/: planning or ritual (use 'fest promote' to advance to active) (default "planning")
-      --dry-run               Show template markers without creating file
+      --dry-run               Preview the festival file tree without writing anything
       --goal string           Festival goal
   -h, --help                  help for festival
       --json                  Emit JSON output

--- a/internal/commands/festival/create_festival.go
+++ b/internal/commands/festival/create_festival.go
@@ -49,7 +49,7 @@ type CreateFestivalOptions struct {
 	Seed        string // Inline seed/input-spec content for the ingest phase
 	SeedFile    string // File whose contents seed the ingest phase
 	SkipMarkers bool   // Skip marker processing
-	DryRun      bool   // Show markers without creating file
+	DryRun      bool   // Preview the scaffold tree without writing anything
 	JSONOutput  bool
 	Dest        string // "planning" (default) or "ritual" (for ritual-type festivals)
 	AgentMode   bool   // Strict mode for AI agents
@@ -94,6 +94,20 @@ type markerOccurrenceInfo struct {
 	MarkerType string `json:"marker_type"`
 	Content    string `json:"content"`
 }
+
+type festivalCoreTemplate struct {
+	Template string
+	Output   string
+}
+
+var festivalCoreTemplates = []festivalCoreTemplate{
+	{Template: "festival/OVERVIEW.md", Output: "FESTIVAL_OVERVIEW.md"},
+	{Template: "festival/GOAL.md", Output: "FESTIVAL_GOAL.md"},
+	{Template: "festival/RULES.md", Output: "FESTIVAL_RULES.md"},
+	{Template: "festival/TODO.md", Output: "TODO.md"},
+}
+
+var festivalGatePhaseTypes = []string{"planning", "implementation", "research", "review", "non_coding_action"}
 
 // createConfig holds all resolved configuration for festival creation.
 // It is populated by resolveCreateConfig() and passed to subsequent pipeline stages.
@@ -150,7 +164,7 @@ func NewCreateFestivalCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.Seed, "seed", "", "Inline seed content written to the ingest phase input_specs/ (requires a type with an ingest phase)")
 	cmd.Flags().StringVar(&opts.SeedFile, "seed-file", "", "File whose contents seed the ingest phase input_specs/ (mutually exclusive with --seed)")
 	cmd.Flags().BoolVar(&opts.SkipMarkers, "skip-markers", false, "Skip REPLACE marker processing")
-	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Show template markers without creating file")
+	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Preview the festival file tree without writing anything")
 	cmd.Flags().BoolVar(&opts.JSONOutput, "json", false, "Emit JSON output")
 	cmd.Flags().StringVar(&opts.Dest, "dest", "planning", "Destination under festivals/: planning or ritual (use 'fest promote' to advance to active)")
 	cmd.Flags().BoolVar(&opts.AgentMode, "agent", false, "Strict mode: process markers, auto-validate, rollback on blocking errors, JSON output")
@@ -277,7 +291,6 @@ type createResult struct {
 	linkSkipReason    string
 	markersFilled     int
 	markersTotal      int
-	allMarkers        []map[string]any
 	validationResult  *ValidationSummary
 	registered        bool
 	seedPath          string
@@ -303,6 +316,10 @@ func RunCreateFestival(ctx context.Context, opts *CreateFestivalOptions) error {
 		return emitCreateFestivalError(opts, err)
 	}
 
+	if opts.DryRun {
+		return previewCreateFestival(ctx, cfg)
+	}
+
 	if err := scaffoldFestivalDirectory(ctx, cfg); err != nil {
 		return emitCreateFestivalError(opts, err)
 	}
@@ -324,13 +341,11 @@ func RunCreateFestival(ctx context.Context, opts *CreateFestivalOptions) error {
 	res.copiedGates = copiedGates
 
 	// Seed before the initial-size snapshot so seeded content is part of the
-	// creation baseline, not later counted as post-create growth. Skipped on
-	// dry-run. The seed file is registered in res.created after marker processing
-	// so user content is never marker-substituted.
-	if !opts.DryRun {
-		if err := writeSeedFile(cfg, res); err != nil {
-			return emitCreateFestivalCreatedError(ctx, cfg, res, err)
-		}
+	// creation baseline, not later counted as post-create growth. The seed file
+	// is registered in res.created after marker processing so user content is
+	// never marker-substituted.
+	if err := writeSeedFile(cfg, res); err != nil {
+		return emitCreateFestivalCreatedError(ctx, cfg, res, err)
 	}
 
 	recordInitialSize(ctx, cfg, res.festConfig)
@@ -341,14 +356,6 @@ func RunCreateFestival(ctx context.Context, opts *CreateFestivalOptions) error {
 
 	if res.seedPath != "" {
 		res.created = append(res.created, res.seedPath)
-	}
-
-	if opts.DryRun && res.markersTotal > 0 {
-		result := &MarkerResult{Markers: res.allMarkers, Total: res.markersTotal}
-		if err := PrintDryRunMarkers(result, opts.JSONOutput); err != nil {
-			return emitCreateFestivalCreatedError(ctx, cfg, res, err)
-		}
-		return nil
 	}
 
 	if err := validateIfConfigured(ctx, cfg, res); err != nil {
@@ -368,7 +375,7 @@ func RunCreateFestival(ctx context.Context, opts *CreateFestivalOptions) error {
 	writeContractEntries(cfg.campaignRoot)
 
 	// Campaign ledger: festival created (high-intent). Dry-run already returned.
-	if !opts.DryRun && cfg.destDir != "" {
+	if cfg.destDir != "" {
 		emit := campledger.NewFromFestival(ctx, cfg.destDir, campledger.WarnToStderr())
 		emit.Emit(ctx, ledgerkit.KindCreated, campledger.FestivalScope(cfg.destDir, ""),
 			campledger.WithPayload(map[string]any{
@@ -402,15 +409,8 @@ func renderFestivalTemplates(ctx context.Context, cfg *createConfig) ([]string, 
 	mgr := tpl.NewManager()
 	var created []string
 
-	core := []struct{ Template, Out string }{
-		{"festival/OVERVIEW.md", "FESTIVAL_OVERVIEW.md"},
-		{"festival/GOAL.md", "FESTIVAL_GOAL.md"},
-		{"festival/RULES.md", "FESTIVAL_RULES.md"},
-		{"festival/TODO.md", "TODO.md"},
-	}
-
-	for _, c := range core {
-		outPath, err := renderCoreFile(ctx, cfg, mgr, c.Template, c.Out)
+	for _, coreTemplate := range festivalCoreTemplates {
+		outPath, err := renderCoreFile(ctx, cfg, mgr, coreTemplate.Template, coreTemplate.Output)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -489,10 +489,8 @@ func renderOrCopyTemplate(mgr *tpl.Manager, t *tpl.Template, tmplCtx *tpl.Contex
 func copyGateTemplates(ctx context.Context, cfg *createConfig) ([]string, []string, error) {
 	gatesDir := filepath.Join(cfg.destDir, "gates")
 	srcPhasesDir := filepath.Join(cfg.tmplRoot, "phases")
-	phaseTypes := []string{"planning", "implementation", "research", "review", "non_coding_action"}
-
 	var copiedGates, created []string
-	for _, phaseType := range phaseTypes {
+	for _, phaseType := range festivalGatePhaseTypes {
 		srcGatesDir := filepath.Join(srcPhasesDir, phaseType, "gates")
 		if _, err := os.Stat(srcGatesDir); os.IsNotExist(err) {
 			continue
@@ -830,7 +828,7 @@ func processAllMarkers(ctx context.Context, cfg *createConfig, res *createResult
 			Markers:     cfg.opts.Markers,
 			MarkersFile: cfg.opts.MarkersFile,
 			SkipMarkers: cfg.skipMarkers,
-			DryRun:      cfg.opts.DryRun,
+			DryRun:      false,
 			JSONOutput:  cfg.opts.JSONOutput,
 		})
 		if err != nil {
@@ -839,7 +837,6 @@ func processAllMarkers(ctx context.Context, cfg *createConfig, res *createResult
 		if markerResult != nil {
 			res.markersFilled += markerResult.Filled
 			res.markersTotal += markerResult.Total
-			res.allMarkers = append(res.allMarkers, markerResult.Markers...)
 		}
 	}
 	return nil

--- a/internal/commands/festival/create_festival_preview.go
+++ b/internal/commands/festival/create_festival_preview.go
@@ -1,0 +1,300 @@
+package festival
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/internal/pathutil"
+	tpl "github.com/Obedience-Corp/fest/internal/template"
+	"github.com/Obedience-Corp/fest/internal/ui"
+)
+
+type festivalPreviewEntry struct {
+	path  string
+	isDir bool
+}
+
+type festivalPreview struct {
+	entries []festivalPreviewEntry
+}
+
+type createFestivalPreviewResult struct {
+	OK           bool              `json:"ok"`
+	Action       string            `json:"action"`
+	DryRun       bool              `json:"dry_run"`
+	Festival     map[string]string `json:"festival"`
+	TargetPath   string            `json:"target_path"`
+	PlannedPaths []string          `json:"planned_paths"`
+	Tree         string            `json:"tree"`
+}
+
+type festivalPreviewTreeNode struct {
+	name     string
+	isDir    bool
+	children []*festivalPreviewTreeNode
+	byName   map[string]*festivalPreviewTreeNode
+}
+
+func previewCreateFestival(ctx context.Context, cfg *createConfig) error {
+	preview, err := buildFestivalPreview(ctx, cfg)
+	if err != nil {
+		return emitCreateFestivalError(cfg.opts, err)
+	}
+
+	displayPath := func(path string) string {
+		return pathutil.DisplayPath(path, cfg.campaignRoot)
+	}
+	tree := renderFestivalPreviewTree(cfg.dirName, preview.entries)
+	plannedPaths := make([]string, 0, len(preview.entries))
+	for _, entry := range preview.entries {
+		path := displayPath(filepath.Join(cfg.destDir, entry.path))
+		if entry.isDir {
+			path += string(filepath.Separator)
+		}
+		plannedPaths = append(plannedPaths, path)
+	}
+
+	result := createFestivalPreviewResult{
+		OK:           true,
+		Action:       "create_festival_preview",
+		DryRun:       true,
+		Festival:     festivalMapForConfig(cfg),
+		TargetPath:   displayPath(cfg.destDir),
+		PlannedPaths: plannedPaths,
+		Tree:         tree,
+	}
+
+	if cfg.opts.JSONOutput {
+		encoder := json.NewEncoder(os.Stdout)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(result)
+	}
+
+	fmt.Println(ui.H2("Dry Run — No Files Created"))
+	fmt.Printf("Would create %s%c\n", result.TargetPath, filepath.Separator)
+	fmt.Println(tree)
+	return nil
+}
+
+func buildFestivalPreview(ctx context.Context, cfg *createConfig) (*festivalPreview, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, errors.Wrap(err, "context cancelled")
+	}
+
+	preview := &festivalPreview{}
+	addFile := func(path string) {
+		preview.entries = append(preview.entries, festivalPreviewEntry{path: filepath.Clean(path)})
+	}
+	addDir := func(path string) {
+		preview.entries = append(preview.entries, festivalPreviewEntry{path: filepath.Clean(path), isDir: true})
+	}
+
+	for _, coreTemplate := range festivalCoreTemplates {
+		if info, err := os.Stat(filepath.Join(cfg.tmplRoot, coreTemplate.Template)); err == nil && !info.IsDir() {
+			addFile(coreTemplate.Output)
+		}
+	}
+	addFile("fest.yaml")
+
+	if cfg.festivalType != nil {
+		for i, phaseSpec := range cfg.festivalType.GetAutoPhases() {
+			if err := ctx.Err(); err != nil {
+				return nil, errors.Wrap(err, "context cancelled")
+			}
+
+			phaseID := tpl.FormatPhaseID(i+1, phaseSpec.Name)
+			addDir(phaseID)
+			addFile(filepath.Join(phaseID, "PHASE_GOAL.md"))
+
+			phaseType := mapPhaseSpecType(phaseSpec.Type)
+			templateDir := filepath.Join(cfg.tmplRoot, "phases", phaseType)
+			entries, err := collectPhasePreviewEntries(ctx, templateDir)
+			if err != nil {
+				return nil, err
+			}
+			for _, entry := range entries {
+				entry.path = filepath.Join(phaseID, entry.path)
+				preview.entries = append(preview.entries, entry)
+			}
+		}
+	}
+
+	if cfg.seedRequested {
+		if ingestPhaseID, ok := ingestAutoPhaseID(cfg.festivalType); ok {
+			addDir(filepath.Join(ingestPhaseID, "input_specs"))
+			addFile(filepath.Join(ingestPhaseID, "input_specs", "seed.md"))
+		}
+	}
+
+	gateEntries, err := collectGatePreviewEntries(ctx, cfg.tmplRoot)
+	if err != nil {
+		return nil, err
+	}
+	preview.entries = append(preview.entries, gateEntries...)
+	preview.entries = deduplicateFestivalPreviewEntries(preview.entries)
+
+	return preview, nil
+}
+
+func collectPhasePreviewEntries(ctx context.Context, templateDir string) ([]festivalPreviewEntry, error) {
+	entries, err := os.ReadDir(templateDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, errors.IO("reading phase template directory", err).WithField("path", templateDir)
+	}
+
+	var planned []festivalPreviewEntry
+	for _, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			return nil, errors.Wrap(err, "context cancelled")
+		}
+		if entry.Name() == "GOAL.md" || entry.Name() == "gates" {
+			continue
+		}
+
+		path := filepath.Join(templateDir, entry.Name())
+		if entry.IsDir() {
+			walked, err := collectTemplateTree(ctx, path, entry.Name())
+			if err != nil {
+				return nil, err
+			}
+			planned = append(planned, walked...)
+			continue
+		}
+		planned = append(planned, festivalPreviewEntry{path: entry.Name()})
+	}
+	return planned, nil
+}
+
+func collectTemplateTree(ctx context.Context, root, relativeRoot string) ([]festivalPreviewEntry, error) {
+	planned := []festivalPreviewEntry{{path: relativeRoot, isDir: true}}
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if path == root {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		planned = append(planned, festivalPreviewEntry{
+			path:  filepath.Join(relativeRoot, rel),
+			isDir: entry.IsDir(),
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, errors.IO("reading phase template tree", err).WithField("path", root)
+	}
+	return planned, nil
+}
+
+func collectGatePreviewEntries(ctx context.Context, tmplRoot string) ([]festivalPreviewEntry, error) {
+	var planned []festivalPreviewEntry
+	for _, phaseType := range festivalGatePhaseTypes {
+		if err := ctx.Err(); err != nil {
+			return nil, errors.Wrap(err, "context cancelled")
+		}
+
+		sourceDir := filepath.Join(tmplRoot, "phases", phaseType, "gates")
+		entries, err := os.ReadDir(sourceDir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, errors.IO("reading gate template directory", err).WithField("path", sourceDir)
+		}
+
+		planned = append(planned,
+			festivalPreviewEntry{path: "gates", isDir: true},
+			festivalPreviewEntry{path: filepath.Join("gates", phaseType), isDir: true},
+		)
+		for _, entry := range entries {
+			if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".md") {
+				planned = append(planned, festivalPreviewEntry{path: filepath.Join("gates", phaseType, entry.Name())})
+			}
+		}
+	}
+	return planned, nil
+}
+
+func deduplicateFestivalPreviewEntries(entries []festivalPreviewEntry) []festivalPreviewEntry {
+	seen := make(map[string]int, len(entries))
+	result := make([]festivalPreviewEntry, 0, len(entries))
+	for _, entry := range entries {
+		key := filepath.Clean(entry.path)
+		if index, ok := seen[key]; ok {
+			result[index].isDir = result[index].isDir || entry.isDir
+			continue
+		}
+		seen[key] = len(result)
+		entry.path = key
+		result = append(result, entry)
+	}
+	return result
+}
+
+func renderFestivalPreviewTree(rootName string, entries []festivalPreviewEntry) string {
+	root := &festivalPreviewTreeNode{name: rootName, isDir: true, byName: make(map[string]*festivalPreviewTreeNode)}
+	for _, entry := range entries {
+		parts := strings.Split(filepath.ToSlash(entry.path), "/")
+		current := root
+		for i, part := range parts {
+			if part == "" || part == "." {
+				continue
+			}
+			child, ok := current.byName[part]
+			if !ok {
+				child = &festivalPreviewTreeNode{name: part, byName: make(map[string]*festivalPreviewTreeNode)}
+				current.byName[part] = child
+				current.children = append(current.children, child)
+			}
+			if i < len(parts)-1 || entry.isDir {
+				child.isDir = true
+			}
+			current = child
+		}
+	}
+
+	var output strings.Builder
+	output.WriteString(root.name)
+	output.WriteString("/\n")
+	renderFestivalPreviewChildren(&output, root, "")
+	return strings.TrimRight(output.String(), "\n")
+}
+
+func renderFestivalPreviewChildren(output *strings.Builder, node *festivalPreviewTreeNode, prefix string) {
+	sort.SliceStable(node.children, func(i, j int) bool {
+		return node.children[i].name < node.children[j].name
+	})
+	for i, child := range node.children {
+		last := i == len(node.children)-1
+		connector := "├── "
+		nextPrefix := prefix + "│   "
+		if last {
+			connector = "└── "
+			nextPrefix = prefix + "    "
+		}
+		output.WriteString(prefix)
+		output.WriteString(connector)
+		output.WriteString(child.name)
+		if child.isDir {
+			output.WriteString("/")
+		}
+		output.WriteString("\n")
+		renderFestivalPreviewChildren(output, child, nextPrefix)
+	}
+}

--- a/internal/commands/festival/create_festival_preview_test.go
+++ b/internal/commands/festival/create_festival_preview_test.go
@@ -1,0 +1,31 @@
+package festival
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderFestivalPreviewTree(t *testing.T) {
+	t.Parallel()
+
+	tree := renderFestivalPreviewTree("example-EX0001", []festivalPreviewEntry{
+		{path: "FESTIVAL_GOAL.md"},
+		{path: "001_INGEST", isDir: true},
+		{path: "001_INGEST/PHASE_GOAL.md"},
+		{path: "001_INGEST/input_specs", isDir: true},
+		{path: "001_INGEST/input_specs/seed.md"},
+	})
+
+	for _, expected := range []string{
+		"example-EX0001/",
+		"├── 001_INGEST/",
+		"│   ├── PHASE_GOAL.md",
+		"│   └── input_specs/",
+		"│       └── seed.md",
+		"└── FESTIVAL_GOAL.md",
+	} {
+		if !strings.Contains(tree, expected) {
+			t.Fatalf("preview tree missing %q:\n%s", expected, tree)
+		}
+	}
+}

--- a/tests/integration/create_festival_dry_run_test.go
+++ b/tests/integration/create_festival_dry_run_test.go
@@ -1,0 +1,151 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type createFestivalPreviewResult struct {
+	OK           bool              `json:"ok"`
+	Action       string            `json:"action"`
+	DryRun       bool              `json:"dry_run"`
+	Festival     map[string]string `json:"festival"`
+	TargetPath   string            `json:"target_path"`
+	PlannedPaths []string          `json:"planned_paths"`
+	Tree         string            `json:"tree"`
+}
+
+func TestCreateFestivalDryRunPreviewsTreeWithoutWorkspaceWrites(t *testing.T) {
+	tc := GetSharedContainer(t)
+	festivalsPath := setupWorkspace(t, tc, "/preview-campaign")
+	installPreviewTemplates(t, tc, festivalsPath)
+
+	before := snapshotFestivalWorkspace(t, tc, festivalsPath)
+	humanOutput, err := tc.RunFestInDir(
+		festivalsPath,
+		"create", "festival",
+		"--name", "preview-only",
+		"--type", "standard",
+		"--seed", "Starting context",
+		"--dry-run",
+		"--no-color",
+	)
+	require.NoError(t, err, "dry-run should succeed: %s", humanOutput)
+	require.Contains(t, humanOutput, "Dry Run — No Files Created")
+	require.Contains(t, humanOutput, "preview-only-PO0001/")
+	require.Contains(t, humanOutput, "├── 001_INGEST/")
+	require.Contains(t, humanOutput, "WORKFLOW.md")
+	require.Contains(t, humanOutput, "seed.md")
+	require.Contains(t, humanOutput, "002_PLAN/")
+	require.Contains(t, humanOutput, "FESTIVAL_GOAL.md")
+	require.Contains(t, humanOutput, "gates/")
+	require.Equal(t, before, snapshotFestivalWorkspace(t, tc, festivalsPath),
+		"human dry-run must leave every workspace path and file byte unchanged")
+
+	jsonOutput, err := tc.RunFestInDir(
+		festivalsPath,
+		"create", "festival",
+		"--name", "preview-only",
+		"--type", "standard",
+		"--seed", "Starting context",
+		"--dry-run",
+		"--agent",
+	)
+	require.NoError(t, err, "agent dry-run should succeed: %s", jsonOutput)
+
+	var preview createFestivalPreviewResult
+	require.NoError(t, json.Unmarshal([]byte(jsonOutput), &preview), "dry-run should emit JSON: %s", jsonOutput)
+	require.True(t, preview.OK)
+	require.True(t, preview.DryRun)
+	require.Equal(t, "create_festival_preview", preview.Action)
+	require.Equal(t, "PO0001", preview.Festival["id"])
+	require.NotEmpty(t, preview.TargetPath)
+	require.NotEmpty(t, preview.PlannedPaths)
+	require.Contains(t, preview.Tree, "001_INGEST/")
+	require.Contains(t, preview.Tree, "input_specs/")
+	require.Equal(t, before, snapshotFestivalWorkspace(t, tc, festivalsPath),
+		"agent dry-run must leave every workspace path and file byte unchanged")
+
+	createOutput, err := tc.RunFestInDir(
+		festivalsPath,
+		"create", "festival",
+		"--name", "preview-only",
+		"--type", "standard",
+		"--seed", "Starting context",
+		"--skip-markers",
+	)
+	require.NoError(t, err, "create after dry-run should succeed: %s", createOutput)
+	dirs, err := tc.ListDirectories(filepath.Join(festivalsPath, "planning"))
+	require.NoError(t, err)
+	require.Equal(t, []string{"preview-only-PO0001"}, dirs,
+		"real create should reuse the ID previewed by dry-run")
+}
+
+func TestCreateFestivalDryRunWithZeroMarkersDoesNotRegisterFestival(t *testing.T) {
+	tc := GetSharedContainer(t)
+	festivalsPath := setupWorkspace(t, tc, "/zero-marker-preview")
+	writeZeroMarkerFestivalTemplates(t, tc, festivalsPath)
+
+	before := snapshotFestivalWorkspace(t, tc, festivalsPath)
+	output, err := tc.RunFestInDir(
+		festivalsPath,
+		"create", "festival",
+		"--name", "marker-free",
+		"--dry-run",
+		"--json",
+	)
+	require.NoError(t, err, "zero-marker dry-run should succeed: %s", output)
+
+	var preview createFestivalPreviewResult
+	require.NoError(t, json.Unmarshal([]byte(output), &preview), "zero-marker dry-run should emit JSON: %s", output)
+	require.True(t, preview.OK, "zero-marker dry-run returned an error payload: %s", output)
+	require.Equal(t, "MF0001", preview.Festival["id"])
+	require.Contains(t, preview.Tree, "fest.yaml")
+	require.Equal(t, before, snapshotFestivalWorkspace(t, tc, festivalsPath),
+		"zero-marker dry-run must not create a directory or registry event")
+
+	planning, err := tc.ListDirectories(filepath.Join(festivalsPath, "planning"))
+	require.NoError(t, err)
+	require.Empty(t, planning)
+	eventsExist, err := tc.CheckFileExists(filepath.Join(festivalsPath, ".festival", ".state", "festival_events.jsonl"))
+	require.NoError(t, err)
+	require.False(t, eventsExist, "dry-run must not register the previewed festival")
+}
+
+func installPreviewTemplates(t *testing.T, tc *TestContainer, festivalsPath string) {
+	t.Helper()
+	_, err := tc.runCommand([]string{
+		"cp", "-R", "/root/.obey/fest/festivals/.festival/templates", festivalsPath + "/.festival/",
+	})
+	require.NoError(t, err, "copy methodology templates into test workspace")
+}
+
+func writeZeroMarkerFestivalTemplates(t *testing.T, tc *TestContainer, festivalsPath string) {
+	t.Helper()
+	templatesDir := filepath.Join(festivalsPath, ".festival", "templates", "festival")
+	_, err := tc.runCommand([]string{"mkdir", "-p", templatesDir})
+	require.NoError(t, err)
+	for _, name := range []string{"GOAL.md", "OVERVIEW.md", "RULES.md", "TODO.md"} {
+		require.NoError(t, writeFileInContainer(tc, filepath.Join(templatesDir, name), "# Complete template\n"))
+	}
+}
+
+func snapshotFestivalWorkspace(t *testing.T, tc *TestContainer, festivalsPath string) string {
+	t.Helper()
+	command := fmt.Sprintf(
+		"find %q -mindepth 1 -print | sort; find %q -type f -exec sha256sum {} \\; | sort",
+		festivalsPath,
+		festivalsPath,
+	)
+	snapshot, err := tc.runCommand([]string{"sh", "-c", command})
+	require.NoError(t, err)
+	return strings.TrimSpace(snapshot)
+}


### PR DESCRIPTION
## Summary

- make `fest create festival --dry-run` return before any scaffold writers run
- render the planned festival file tree for human output and structured preview JSON for agents
- share core and gate template definitions between preview and real creation

## Root cause

`--dry-run` entered the normal create pipeline, wrote the festival directory and templates, then returned early only when template markers were found. Marker-bearing previews left unregistered festival shells that consumed the apparent ID on the next create; marker-free previews could continue into registration.

## User impact

Dry runs now leave the workspace, registry, navigation state, ledger, and campaign contract untouched. A real create after a preview reuses the previewed festival ID.

## Validation

- `just test unit-raw`
- `go test -short -tags=dev ./...`
- `just lint all`
- `go vet -tags=integration ./...`
- `go vet -tags=dev ./...`
- `just build quick-stable`
- `just build quick-dev`
- `TESTCONTAINERS_RYUK_DISABLED=true go test -v -tags=integration -run 'TestCreateFestival(DryRun|AgentValidationFailure)' -timeout 5m ./tests/integration`

