### PR TITLE
fix(errors): tell the operator what actually failed when a remote is unreachable

### DIFF
--- a/internal/commands/feedback/feedback.go
+++ b/internal/commands/feedback/feedback.go
@@ -77,7 +77,7 @@ func runInit(ctx context.Context, criteria []string, force bool) error {
 	festivalPath, err := shared.ResolveFestivalPath(cwd, "")
 	if err != nil {
 		return errors.Wrap(err, "detecting festival").
-			WithField("hint", "run from within a festival directory")
+			WithHint("run from within a festival directory")
 	}
 
 	store := feedback.NewStore(festivalPath)
@@ -162,7 +162,7 @@ func runCriteriaAdd(ctx context.Context, criteria []string) error {
 	festivalPath, err := shared.ResolveFestivalPath(cwd, "")
 	if err != nil {
 		return errors.Wrap(err, "detecting festival").
-			WithField("hint", "run from within a festival directory")
+			WithHint("run from within a festival directory")
 	}
 
 	store := feedback.NewStore(festivalPath)
@@ -230,7 +230,7 @@ func runAdd(ctx context.Context, criteria, observation, jsonInput, task, severit
 	festivalPath, err := shared.ResolveFestivalPath(cwd, "")
 	if err != nil {
 		return errors.Wrap(err, "detecting festival").
-			WithField("hint", "run from within a festival directory")
+			WithHint("run from within a festival directory")
 	}
 
 	store := feedback.NewStore(festivalPath)
@@ -247,7 +247,7 @@ func runAdd(ctx context.Context, criteria, observation, jsonInput, task, severit
 		// Use flags
 		if criteria == "" || observation == "" {
 			return errors.Validation("criteria and observation are required").
-				WithField("hint", "use --criteria and --observation, or --json")
+				WithHint("use --criteria and --observation, or --json")
 		}
 		obs = &feedback.Observation{
 			Criteria:    criteria,
@@ -311,7 +311,7 @@ func runView(ctx context.Context, criteria, severity string, jsonOutput, summary
 	festivalPath, err := shared.ResolveFestivalPath(cwd, "")
 	if err != nil {
 		return errors.Wrap(err, "detecting festival").
-			WithField("hint", "run from within a festival directory")
+			WithHint("run from within a festival directory")
 	}
 
 	store := feedback.NewStore(festivalPath)
@@ -399,7 +399,7 @@ func runExport(ctx context.Context, format string) error {
 	festivalPath, err := shared.ResolveFestivalPath(cwd, "")
 	if err != nil {
 		return errors.Wrap(err, "detecting festival").
-			WithField("hint", "run from within a festival directory")
+			WithHint("run from within a festival directory")
 	}
 
 	store := feedback.NewStore(festivalPath)

--- a/internal/commands/list/list.go
+++ b/internal/commands/list/list.go
@@ -167,7 +167,7 @@ or lifecycle status changes (similar to fest watch, but without cycling). Ctrl+C
 			}
 			if opts.watch && opts.json {
 				return errors.Validation("--watch cannot be combined with --json").
-					WithField("hint", "use one-shot fest list --json for agents; --watch is human terminal output")
+					WithHint("use one-shot fest list --json for agents; --watch is human terminal output")
 			}
 			if opts.watch && !listStdoutIsTerminal() {
 				return errors.Validation("--watch requires an interactive terminal")
@@ -209,7 +209,7 @@ func runList(ctx context.Context, filterStatus string, opts *listOptions) error 
 	festivalsDir, err := workspace.FindFestivals(cwd)
 	if err != nil || festivalsDir == "" {
 		return errors.NotFound("festivals workspace").
-			WithField("hint", "run from a project with a festivals/ directory or use 'fest init --register'")
+			WithHint("run from a project with a festivals/ directory or use 'fest init --register'")
 	}
 
 	campaignRoot, _ := workspace.DetectCampaign(ctx, "")

--- a/internal/commands/navigation/go_link.go
+++ b/internal/commands/navigation/go_link.go
@@ -226,7 +226,7 @@ func linkProjectToFestival(ctx context.Context, cwd string, force bool) error {
 	// Find festivals directory
 	festivalsDir, err := workspace.FindFestivals(cwd)
 	if err != nil || festivalsDir == "" {
-		return festErrors.NotFound("festivals directory").WithField("hint", "run 'fest init' first")
+		return festErrors.NotFound("festivals directory").WithHint("run 'fest init' first")
 	}
 
 	// Collect all festivals from active/ and planning/
@@ -236,7 +236,7 @@ func linkProjectToFestival(ctx context.Context, cwd string, force bool) error {
 	}
 
 	if len(festivals) == 0 {
-		return festErrors.NotFound("festivals").WithField("hint", "create a festival with 'fest create festival'")
+		return festErrors.NotFound("festivals").WithHint("create a festival with 'fest create festival'")
 	}
 
 	// Build options for picker with color-coded status
@@ -383,7 +383,7 @@ func selectProjectDirectory(ctx context.Context, festivalPath, festivalName stri
 
 	if len(entries) == 0 {
 		return "", festErrors.NotFound("project directories").
-			WithField("hint", "no directories found in projects/")
+			WithHint("no directories found in projects/")
 	}
 
 	// Build options — show project label (with monorepo@sub notation)

--- a/internal/commands/navigation/index.go
+++ b/internal/commands/navigation/index.go
@@ -122,7 +122,7 @@ Reports:
 
 			// Check if index exists
 			if _, err := os.Stat(indexPath); os.IsNotExist(err) {
-				return errors.NotFound("index file").WithField("path", indexPath).WithField("hint", "run 'fest index write' to generate it")
+				return errors.NotFound("index file").WithField("path", indexPath).WithHint("run 'fest index write' to generate it")
 			}
 
 			result, err := index.ValidateFromFile(festivalRoot, indexPath)
@@ -192,7 +192,7 @@ func newIndexShowCommand() *cobra.Command {
 
 			// Check if index exists
 			if _, err := os.Stat(indexPath); os.IsNotExist(err) {
-				return errors.NotFound("index file").WithField("path", indexPath).WithField("hint", "run 'fest index write' to generate it")
+				return errors.NotFound("index file").WithField("path", indexPath).WithHint("run 'fest index write' to generate it")
 			}
 
 			idx, err := index.LoadIndex(indexPath)

--- a/internal/commands/navigation/link.go
+++ b/internal/commands/navigation/link.go
@@ -306,7 +306,7 @@ func runUnlink(ctx context.Context, jsonOutput bool) error {
 
 		if festivalName == "" {
 			return errors.NotFound("link").
-				WithField("hint", "run from inside a festival or linked project directory")
+				WithHint("run from inside a festival or linked project directory")
 		}
 	}
 

--- a/internal/commands/navigation/move.go
+++ b/internal/commands/navigation/move.go
@@ -158,7 +158,7 @@ func runMove(ctx context.Context, source, destination string, opts *moveOptions)
 		if !opts.force {
 			return errors.Validation("destination already exists").
 				WithField("path", destPath).
-				WithField("hint", "use --force to overwrite")
+				WithHint("use --force to overwrite")
 		}
 	}
 
@@ -241,7 +241,7 @@ func detectLocation(ctx context.Context, cwd string) (*LocationInfo, error) {
 
 		if cfg.ProjectPath == "" {
 			return nil, errors.Validation("festival has no linked project").
-				WithField("hint", "set project_path in fest.yaml")
+				WithHint("set project_path in fest.yaml")
 		}
 
 		// Compute relative path within festival
@@ -264,7 +264,7 @@ func detectLocation(ctx context.Context, cwd string) (*LocationInfo, error) {
 	festivalName := nav.FindFestivalForPath(cwd)
 	if festivalName == "" {
 		return nil, errors.Validation("not in a festival or linked project directory").
-			WithField("hint", "run from festival or linked project, or set up a link")
+			WithHint("run from festival or linked project, or set up a link")
 	}
 
 	// Find the festival's path

--- a/internal/commands/navigation/shortcuts.go
+++ b/internal/commands/navigation/shortcuts.go
@@ -67,7 +67,7 @@ func runGoMap(ctx context.Context, name, path string, jsonOutput bool) error {
 	if !isValidShortcutName(name) {
 		return errors.Validation("invalid shortcut name").
 			WithField("name", name).
-			WithField("hint", "use 1-20 alphanumeric characters or underscores")
+			WithHint("use 1-20 alphanumeric characters or underscores")
 	}
 
 	// Resolve path
@@ -379,7 +379,7 @@ func runGoProject(ctx context.Context) error {
 	loc, err := show.DetectCurrentLocation(ctx, cwd)
 	if err != nil {
 		return errors.NotFound("festival").
-			WithField("hint", "run from inside a festival directory")
+			WithHint("run from inside a festival directory")
 	}
 
 	if loc.Festival == nil {
@@ -396,7 +396,7 @@ func runGoProject(ctx context.Context) error {
 	if !found {
 		return errors.NotFound("project link").
 			WithField("festival", loc.Festival.Name).
-			WithField("hint", "use 'fest link <path>' to create a link")
+			WithHint("use 'fest link <path>' to create a link")
 	}
 
 	// Print the path for shell function to use
@@ -459,7 +459,7 @@ func runGoFest() error {
 	}
 
 	return errors.NotFound("festival link").
-		WithField("hint", "current directory is not in a linked project")
+		WithHint("current directory is not in a linked project")
 }
 
 // findFestivalPath searches for a festival by name in the festivals directory

--- a/internal/commands/progress/progress.go
+++ b/internal/commands/progress/progress.go
@@ -155,7 +155,7 @@ func runProgress(ctx context.Context, opts *progressOptions) error {
 
 	if loc.Festival == nil {
 		return errors.NotFound("festival").
-			WithField("hint", "run from inside a festival directory")
+			WithHint("run from inside a festival directory")
 	}
 
 	// Create progress manager. Mutation flows install the lifecycle gate so

--- a/internal/commands/promote/promote.go
+++ b/internal/commands/promote/promote.go
@@ -271,7 +271,7 @@ func promoteCore(ctx context.Context, festival *show.FestivalInfo, confirm bool,
 			}
 			return "", errors.Validation("invalid dungeon status").
 				WithField("value", opts.dungeon).
-				WithField("hint", "valid values: completed, archived, someday")
+				WithHint("valid values: completed, archived, someday")
 		}
 		nextStatus = resolved
 	} else {
@@ -291,7 +291,7 @@ func promoteCore(ctx context.Context, festival *show.FestivalInfo, confirm bool,
 			}
 			return "", errors.Validation("cannot promote festival").
 				WithField("status", currentStatus).
-				WithField("hint", "only planning, ready, and active festivals can be promoted")
+				WithHint("only planning, ready, and active festivals can be promoted")
 		}
 
 		// Validate readiness unless forced (skip for dungeon moves)

--- a/internal/commands/search/search.go
+++ b/internal/commands/search/search.go
@@ -83,7 +83,7 @@ func runSearch(ctx context.Context, query string, opts *searchOptions) error {
 	festivalsDir, err := workspace.FindFestivals(cwd)
 	if err != nil || festivalsDir == "" {
 		return errors.NotFound("festivals workspace").
-			WithField("hint", "run from a project with a festivals/ directory")
+			WithHint("run from a project with a festivals/ directory")
 	}
 
 	targets := collectSearchTargets(ctx, festivalsDir, opts.status)

--- a/internal/commands/status/handlers.go
+++ b/internal/commands/status/handlers.go
@@ -244,7 +244,7 @@ func dispatchByLocationType(ctx context.Context, display *ui.UI, cwd, newStatus 
 	default:
 		return errors.Validation("unknown context").
 			WithField("type", loc.Type).
-			WithField("hint", "use --phase, --sequence, or --task to specify level")
+			WithHint("use --phase, --sequence, or --task to specify level")
 	}
 }
 

--- a/internal/commands/status/handlers_entity.go
+++ b/internal/commands/status/handlers_entity.go
@@ -137,7 +137,7 @@ func handleTaskStatusSet(ctx context.Context, display *ui.UI, cwd, newStatus str
 	festivalPath, err := shared.ResolveFestivalPath(cwd, "")
 	if err != nil {
 		return errors.Wrap(err, "not inside a festival").
-			WithField("hint", "navigate to a festival directory or use 'fest link'")
+			WithHint("navigate to a festival directory or use 'fest link'")
 	}
 
 	// Determine task ID from flag
@@ -277,14 +277,14 @@ func findTaskByName(festivalPath, taskName string) (string, error) {
 	if len(matches) == 0 {
 		return "", errors.NotFound("task").
 			WithField("name", taskName).
-			WithField("hint", "use full path like '001/01/01_task.md'")
+			WithHint("use full path like '001/01/01_task.md'")
 	}
 
 	if len(matches) > 1 {
 		return "", errors.Validation("ambiguous task name").
 			WithField("name", taskName).
 			WithField("matches", strings.Join(matches, ", ")).
-			WithField("hint", "use full path to disambiguate")
+			WithHint("use full path to disambiguate")
 	}
 
 	return matches[0], nil
@@ -348,7 +348,7 @@ func handlePhaseStatusSet(ctx context.Context, display *ui.UI, cwd, newStatus st
 	festivalPath, err := shared.ResolveFestivalPath(cwd, "")
 	if err != nil {
 		return errors.Wrap(err, "not inside a festival").
-			WithField("hint", "navigate to a festival directory or use 'fest link'")
+			WithHint("navigate to a festival directory or use 'fest link'")
 	}
 
 	// Find the phase directory
@@ -409,7 +409,7 @@ func resolvePhase(festivalPath, phaseInput string) (string, string, error) {
 	if len(matches) == 0 {
 		return "", "", errors.NotFound("phase").
 			WithField("input", phaseInput).
-			WithField("hint", "use phase number like '001' or full name like '001_CRITICAL'")
+			WithHint("use phase number like '001' or full name like '001_CRITICAL'")
 	}
 
 	if len(matches) > 1 {
@@ -479,7 +479,7 @@ func handleSequenceStatusSet(ctx context.Context, display *ui.UI, cwd, newStatus
 	festivalPath, err := shared.ResolveFestivalPath(cwd, "")
 	if err != nil {
 		return errors.Wrap(err, "not inside a festival").
-			WithField("hint", "navigate to a festival directory or use 'fest link'")
+			WithHint("navigate to a festival directory or use 'fest link'")
 	}
 
 	// Find the sequence directory
@@ -615,14 +615,14 @@ func findSequenceGlobally(festivalPath, seqInput string) (string, string, error)
 	if len(matches) == 0 {
 		return "", "", errors.NotFound("sequence").
 			WithField("input", seqInput).
-			WithField("hint", "use phase/sequence format like '001/01_api_design'")
+			WithHint("use phase/sequence format like '001/01_api_design'")
 	}
 
 	if len(matches) > 1 {
 		return "", "", errors.Validation("ambiguous sequence").
 			WithField("input", seqInput).
 			WithField("matches", strings.Join(matches, ", ")).
-			WithField("hint", "use phase/sequence format to disambiguate")
+			WithHint("use phase/sequence format to disambiguate")
 	}
 
 	parts := strings.SplitN(matches[0], "/", 2)

--- a/internal/commands/status/handlers_festival.go
+++ b/internal/commands/status/handlers_festival.go
@@ -34,7 +34,7 @@ func selectFestivalForStatus(ctx context.Context, cwd, newStatus string) (*show.
 	}
 	if festivalsDir == "" {
 		return nil, errors.NotFound("festivals directory").
-			WithField("hint", "navigate to a workspace with festivals/ directory")
+			WithHint("navigate to a workspace with festivals/ directory")
 	}
 
 	// Configure selector with appropriate title

--- a/internal/commands/status/handlers_listing.go
+++ b/internal/commands/status/handlers_listing.go
@@ -302,13 +302,13 @@ func handleStatusListOutsideFestival(ctx context.Context, cwd, filterStatus stri
 	festivalsDir := findFestivalsRoot(cwd)
 	if festivalsDir == "" {
 		return errors.NotFound("festival or festivals directory").
-			WithField("hint", "navigate to a festival directory to list phases/sequences/tasks")
+			WithHint("navigate to a festival directory to list phases/sequences/tasks")
 	}
 	if opts.entityType == "festival" || opts.entityType == "" {
 		return runFestivalListing(ctx, festivalsDir, filterStatus, opts)
 	}
 	return errors.NotFound("festival").
-		WithField("hint", "navigate to a festival directory to list phases/sequences/tasks")
+		WithHint("navigate to a festival directory to list phases/sequences/tasks")
 }
 
 // routeStatusListByType routes the status list command based on entity type.

--- a/internal/commands/status/helpers.go
+++ b/internal/commands/status/helpers.go
@@ -43,7 +43,7 @@ func resolveFestivalFromPath(cwd, pathArg string) (string, error) {
 	festivalsRoot := findFestivalsRoot(cwd)
 	if festivalsRoot == "" {
 		return "", errors.NotFound("festivals directory").
-			WithField("hint", "navigate to a workspace with festivals/ directory")
+			WithHint("navigate to a workspace with festivals/ directory")
 	}
 
 	// Search in all status directories
@@ -87,7 +87,7 @@ func resolveFestivalFromPath(cwd, pathArg string) (string, error) {
 
 	return "", errors.NotFound("festival").
 		WithField("name", pathArg).
-		WithField("hint", "festival not found in active, planning, completed, or dungeon/*")
+		WithHint("festival not found in active, planning, completed, or dungeon/*")
 }
 
 // isValidFestivalDir checks if a directory is a valid festival root.

--- a/internal/commands/system/init.go
+++ b/internal/commands/system/init.go
@@ -129,14 +129,14 @@ func RunInit(ctx context.Context, targetPath string, opts *InitOptions) error {
 		if err := runSync(ctx, nil, syncOpts); err != nil {
 			return errors.Wrap(err, "auto-sync failed").
 				WithField("path", sourceDir).
-				WithField("hint", "check your internet connection or run 'fest sync' manually")
+				WithHint("check your internet connection or run 'fest sync' manually")
 		}
 
 		// Verify sync worked
 		if !fileops.Exists(sourceDir) {
 			return errors.NotFound("source directory after sync").
 				WithField("path", sourceDir).
-				WithField("hint", "sync completed but templates not found - check 'fest sync' output")
+				WithHint("sync completed but templates not found - check 'fest sync' output")
 		}
 	}
 

--- a/internal/commands/system/update.go
+++ b/internal/commands/system/update.go
@@ -97,7 +97,7 @@ func runUpdate(ctx context.Context, targetPath string, opts *updateOptions) erro
 	checksumFile := filepath.Join(stateDir, ".fest-checksums.json")
 	if !fileops.Exists(checksumFile) {
 		if !opts.force {
-			return errors.NotFound("checksum file").WithField("path", checksumFile).WithField("hint", "run 'fest init' first")
+			return errors.NotFound("checksum file").WithField("path", checksumFile).WithHint("run 'fest init' first")
 		}
 		// --force: bootstrap checksums from current state
 		display.Warning("No checksum file found — bootstrapping from current state (--force)")
@@ -121,7 +121,7 @@ func runUpdate(ctx context.Context, targetPath string, opts *updateOptions) erro
 	// Get source directory (.festival only)
 	sourceDir := filepath.Join(config.ConfigDir(), "festivals", ".festival")
 	if !fileops.Exists(sourceDir) {
-		return errors.NotFound(".festival templates").WithField("path", sourceDir).WithField("hint", "run 'fest system sync' first")
+		return errors.NotFound(".festival templates").WithField("path", sourceDir).WithHint("run 'fest system sync' first")
 	}
 
 	display.Info("Analyzing .festival methodology files...")

--- a/internal/commands/templates/templates.go
+++ b/internal/commands/templates/templates.go
@@ -74,7 +74,7 @@ func runCreate(ctx context.Context, name, fromFile string) error {
 	festivalPath, err := shared.ResolveFestivalPath(cwd, "")
 	if err != nil {
 		return errors.Wrap(err, "detecting festival").
-			WithField("hint", "run from within a festival directory")
+			WithHint("run from within a festival directory")
 	}
 
 	store := template.NewAgentTemplateStore(festivalPath)
@@ -158,7 +158,7 @@ func runApply(ctx context.Context, name, varsJSON, output string, preview bool) 
 	festivalPath, err := shared.ResolveFestivalPath(cwd, "")
 	if err != nil {
 		return errors.Wrap(err, "detecting festival").
-			WithField("hint", "run from within a festival directory")
+			WithHint("run from within a festival directory")
 	}
 
 	store := template.NewAgentTemplateStore(festivalPath)
@@ -228,7 +228,7 @@ func runList(ctx context.Context, jsonOutput bool) error {
 	festivalPath, err := shared.ResolveFestivalPath(cwd, "")
 	if err != nil {
 		return errors.Wrap(err, "detecting festival").
-			WithField("hint", "run from within a festival directory")
+			WithHint("run from within a festival directory")
 	}
 
 	store := template.NewAgentTemplateStore(festivalPath)

--- a/internal/commands/tui/charm_list.go
+++ b/internal/commands/tui/charm_list.go
@@ -72,7 +72,7 @@ func StartGoListTUI(ctx context.Context) (string, error) {
 	// Check if we have any options
 	if len(opts) == 0 {
 		return "", festErrors.Validation("no shortcuts or links configured").
-			WithField("hint", "use 'fest go map <name>' to create shortcuts or 'fest link <path>' to link festivals")
+			WithHint("use 'fest go map <name>' to create shortcuts or 'fest link <path>' to link festivals")
 	}
 
 	// Run the selector

--- a/internal/commands/types/show.go
+++ b/internal/commands/types/show.go
@@ -95,7 +95,7 @@ func findType(registry *types.Registry, name, levelFilter string) (*types.TypeIn
 		}
 		return nil, errors.Validation(
 			fmt.Sprintf("type '%s' exists at multiple levels: %s", name, strings.Join(levels, ", ")),
-		).WithField("hint", "use --level to specify which one")
+		).WithHint("use --level to specify which one")
 	}
 
 	return matches[0], nil

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -3,7 +3,9 @@ package errors
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
 )
 
 // ErrAlreadyPrinted is a sentinel error indicating the message was already
@@ -20,6 +22,7 @@ const (
 	ErrCodeParse      = "PARSE"
 	ErrCodeInternal   = "INTERNAL"
 	ErrCodePermission = "PERMISSION"
+	ErrCodeNetwork    = "NETWORK"
 )
 
 // Standard hints for common error scenarios.
@@ -33,6 +36,7 @@ const (
 	HintCheckTemplate         = "Run 'fest validate' to check for template issues"
 	HintRunInit               = "Run 'fest init' to initialize a festival workspace"
 	HintCheckPermissions      = "Check file/directory permissions and try again"
+	HintCheckNetwork          = "Check your network connection and that the remote is reachable, then try again"
 	HintUseForce              = "Use --force to skip confirmation prompts"
 	HintNavigateToFestival    = "Navigate to a festival directory first"
 	HintUseInteractiveMode    = "Use 'fest tui' for interactive mode"
@@ -51,23 +55,76 @@ type Error struct {
 	Hint    string                 `json:"hint,omitempty"` // actionable suggestion
 }
 
-// Error returns the error string with context.
+// Error returns the error string with context, followed by exactly one hint.
+//
+// The hint is the outermost one in the chain, because that is the layer closest
+// to what the operator actually typed: "run 'fest sync' manually" beats the
+// generic advice attached wherever the failure originated. Inner hints are
+// deliberately not printed. Rendering a cause with %v would otherwise splice
+// its "Hint:" line into the middle of this one's message, so a two-layer error
+// printed two hints and a three-layer error printed three.
 func (e *Error) Error() string {
-	var msg string
-	if e.Op != "" && e.Err != nil {
-		msg = fmt.Sprintf("%s: %s: %v", e.Op, e.Message, e.Err)
-	} else if e.Op != "" {
-		msg = fmt.Sprintf("%s: %s", e.Op, e.Message)
-	} else if e.Err != nil {
-		msg = fmt.Sprintf("%s: %v", e.Message, e.Err)
-	} else {
-		msg = e.Message
-	}
-
-	if e.Hint != "" {
-		msg = fmt.Sprintf("%s\nHint: %s", msg, e.Hint)
+	msg := e.chainMessage()
+	if hint := e.resolveHint(); hint != "" {
+		msg = fmt.Sprintf("%s\nHint: %s", msg, hint)
 	}
 	return msg
+}
+
+// chainMessage renders this error and its causes with every nested "Hint:" line
+// removed, so only Error() decides which single hint is shown.
+//
+// It strips the rendered text rather than recursing into nested *Error values.
+// Recursion via errors.As looked equivalent and was not: errors.As searches the
+// whole chain, so a plain fmt.Errorf sitting between two *Error layers was
+// skipped and its message silently vanished from the output. Stripping works
+// for any chain shape and cannot drop a layer.
+func (e *Error) chainMessage() string {
+	cause := ""
+	if e.Err != nil {
+		cause = stripHintLines(e.Err.Error())
+	}
+
+	switch {
+	case e.Op != "" && cause != "":
+		return fmt.Sprintf("%s: %s: %s", e.Op, e.Message, cause)
+	case e.Op != "":
+		return fmt.Sprintf("%s: %s", e.Op, e.Message)
+	case cause != "":
+		return fmt.Sprintf("%s: %s", e.Message, cause)
+	default:
+		return e.Message
+	}
+}
+
+// stripHintLines removes rendered "Hint: ..." lines from a cause's text.
+func stripHintLines(msg string) string {
+	if !strings.Contains(msg, "\nHint: ") {
+		return msg
+	}
+	lines := strings.Split(msg, "\n")
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if strings.HasPrefix(line, "Hint: ") {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.TrimRight(strings.Join(kept, "\n"), "\n")
+}
+
+// resolveHint returns the hint to show: this error's own, or failing that the
+// nearest one from its causes, so wrapping an error with a bare Wrap() does not
+// discard the guidance the inner layer had.
+func (e *Error) resolveHint() string {
+	if e.Hint != "" {
+		return e.Hint
+	}
+	var inner *Error
+	if e.Err != nil && errors.As(e.Err, &inner) {
+		return inner.resolveHint()
+	}
+	return ""
 }
 
 // Unwrap returns the wrapped error.
@@ -216,6 +273,27 @@ func IO(op string, err error) *Error {
 		Err:     err,
 		Fields:  make(map[string]interface{}),
 		Hint:    HintCheckPermissions,
+	}
+}
+
+// Network creates a NETWORK error for an operation that failed to reach a
+// remote. It exists so remote failures stop being reported as IO errors, whose
+// hint tells the operator to check file permissions: on a machine that simply
+// has no route to GitHub, that hint sends them to the one place the problem is
+// not. detail carries the remote's own message (git's stderr, say), which is
+// where the real cause lives.
+func Network(op string, err error, detail string) *Error {
+	message := "could not reach the remote"
+	if d := strings.TrimSpace(detail); d != "" {
+		message = message + ": " + d
+	}
+	return &Error{
+		Code:    ErrCodeNetwork,
+		Message: message,
+		Op:      op,
+		Err:     err,
+		Fields:  make(map[string]interface{}),
+		Hint:    HintCheckNetwork,
 	}
 }
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -36,7 +36,10 @@ const (
 	HintCheckTemplate         = "Run 'fest validate' to check for template issues"
 	HintRunInit               = "Run 'fest init' to initialize a festival workspace"
 	HintCheckPermissions      = "Check file/directory permissions and try again"
-	HintCheckNetwork          = "Check your network connection and that the remote is reachable, then try again"
+	HintCheckNetwork          = "Check that the remote is reachable from this machine, then try again"
+	HintCheckTLS              = "The remote was reached but its certificate could not be verified. Install CA certificates (e.g. the ca-certificates package) or set GIT_SSL_CAINFO to a CA bundle"
+	HintCheckDNS              = "The hostname did not resolve. Check DNS and your network connection"
+	HintCheckAuth             = "The remote refused access. Check credentials, or use a public URL if the repository is public"
 	HintUseForce              = "Use --force to skip confirmation prompts"
 	HintNavigateToFestival    = "Navigate to a festival directory first"
 	HintUseInteractiveMode    = "Use 'fest tui' for interactive mode"
@@ -113,18 +116,23 @@ func stripHintLines(msg string) string {
 	return strings.TrimRight(strings.Join(kept, "\n"), "\n")
 }
 
-// resolveHint returns the hint to show: this error's own, or failing that the
-// nearest one from its causes, so wrapping an error with a bare Wrap() does not
-// discard the guidance the inner layer had.
+// resolveHint returns the hint to show: the innermost one in the chain, falling
+// back outward when the inner layers carry none.
+//
+// Innermost wins because that layer knows what actually failed, while outer
+// layers only know what was being attempted. A TLS verification failure inside
+// 'fest init' is the worked example: the inner layer can say "install CA
+// certificates", and the outer one can only offer "check your internet
+// connection", which is actively misleading on a machine whose network is fine.
+// The outer context is not lost, because the message chain already carries it.
 func (e *Error) resolveHint() string {
-	if e.Hint != "" {
-		return e.Hint
-	}
 	var inner *Error
 	if e.Err != nil && errors.As(e.Err, &inner) {
-		return inner.resolveHint()
+		if h := inner.resolveHint(); h != "" {
+			return h
+		}
 	}
-	return ""
+	return e.Hint
 }
 
 // Unwrap returns the wrapped error.
@@ -293,8 +301,39 @@ func Network(op string, err error, detail string) *Error {
 		Op:      op,
 		Err:     err,
 		Fields:  make(map[string]interface{}),
-		Hint:    HintCheckNetwork,
+		Hint:    networkHint(detail),
 	}
+}
+
+// networkHint picks the hint that matches what the remote actually said.
+//
+// "check your connection" is the right advice for exactly one of these causes.
+// A machine with a working network and no CA bundle, which is the normal state
+// on minimal and embedded systems, fails TLS verification and needs to be told
+// about certificates, not about its connection. Sending someone to debug a
+// network that is already up costs them the whole session.
+func networkHint(detail string) string {
+	d := strings.ToLower(detail)
+	switch {
+	case containsAny(d, "certificate", "ssl", "tls", "cafile", "self-signed", "self signed"):
+		return HintCheckTLS
+	case containsAny(d, "could not resolve host", "name or service not known", "temporary failure in name resolution"):
+		return HintCheckDNS
+	case containsAny(d, "authentication failed", "permission denied", "could not read username",
+		"could not read password", "access denied", "403", "terminal prompts disabled"):
+		return HintCheckAuth
+	default:
+		return HintCheckNetwork
+	}
+}
+
+func containsAny(haystack string, needles ...string) bool {
+	for _, n := range needles {
+		if strings.Contains(haystack, n) {
+			return true
+		}
+	}
+	return false
 }
 
 // Config creates a CONFIG error with configuration check hint.

--- a/internal/errors/hint_field_test.go
+++ b/internal/errors/hint_field_test.go
@@ -97,8 +97,10 @@ func TestNetworkErrorReportsCauseAndNetworkHint(t *testing.T) {
 	if !strings.Contains(msg, "Could not resolve host") {
 		t.Errorf("error does not carry the remote's own message:\n%s", msg)
 	}
-	if !strings.Contains(msg, HintCheckNetwork) {
-		t.Errorf("error does not carry the network hint:\n%s", msg)
+	// The detail names a DNS failure, so the hint must be the DNS one rather
+	// than the generic fallback.
+	if !strings.Contains(msg, HintCheckDNS) {
+		t.Errorf("error does not carry the DNS hint:\n%s", msg)
 	}
 	if strings.Contains(msg, HintCheckPermissions) {
 		t.Errorf("a network failure must not tell the operator to check permissions:\n%s", msg)
@@ -130,12 +132,14 @@ func TestNestedErrorsPrintExactlyOneHint(t *testing.T) {
 	if got := strings.Count(msg, "Hint:"); got != 1 {
 		t.Errorf("rendered %d hints, want exactly 1:\n%s", got, msg)
 	}
-	// The outermost hint wins: it is the layer closest to what was typed.
-	if !strings.Contains(msg, "run 'fest sync' manually") {
-		t.Errorf("outermost hint missing:\n%s", msg)
+	// The INNERMOST hint wins: that layer knows what actually failed, while the
+	// outer one only knows what was being attempted. Here the specific "could
+	// not resolve host" guidance beats a generic "run fest sync manually".
+	if !strings.Contains(msg, HintCheckDNS) {
+		t.Errorf("innermost hint missing:\n%s", msg)
 	}
-	if strings.Contains(msg, HintCheckNetwork) {
-		t.Errorf("inner hint should not also render:\n%s", msg)
+	if strings.Contains(msg, "run 'fest sync' manually") {
+		t.Errorf("outer generic hint should not displace the specific one:\n%s", msg)
 	}
 	// The cause chain still reaches the operator.
 	if !strings.Contains(msg, "Could not resolve host") {
@@ -150,7 +154,7 @@ func TestBareWrapKeepsTheInnerHint(t *testing.T) {
 	outer := Wrap(inner, "auto-sync failed")
 
 	msg := outer.Error()
-	if !strings.Contains(msg, HintCheckNetwork) {
+	if !strings.Contains(msg, HintCheckDNS) {
 		t.Errorf("bare Wrap dropped the inner hint:\n%s", msg)
 	}
 	if got := strings.Count(msg, "Hint:"); got != 1 {
@@ -186,6 +190,88 @@ func TestInterveningPlainErrorKeepsItsMessage(t *testing.T) {
 		if !strings.Contains(msg, want) {
 			t.Errorf("message lost %q:\n%s", want, msg)
 		}
+	}
+	if got := strings.Count(msg, "Hint:"); got != 1 {
+		t.Errorf("rendered %d hints, want exactly 1:\n%s", got, msg)
+	}
+}
+
+// "Check your connection" is right for one cause out of several. A machine with
+// a working network and no CA bundle, the normal state on minimal and embedded
+// systems, fails TLS verification; telling that operator to check their network
+// sends them to debug something that is already working.
+func TestNetworkHintMatchesWhatTheRemoteSaid(t *testing.T) {
+	tests := []struct {
+		name   string
+		detail string
+		want   string
+	}{
+		{
+			name:   "missing CA bundle",
+			detail: "unable to access 'https://github.com/x/y': server certificate verification failed. CAfile: none CRLfile: none",
+			want:   HintCheckTLS,
+		},
+		{
+			name:   "self-signed certificate",
+			detail: "SSL certificate problem: self-signed certificate in certificate chain",
+			want:   HintCheckTLS,
+		},
+		{
+			name:   "dns failure",
+			detail: "unable to access 'https://github.com/x/y': Could not resolve host: github.com",
+			want:   HintCheckDNS,
+		},
+		{
+			name:   "auth refused",
+			detail: "Authentication failed for 'https://github.com/x/y'",
+			want:   HintCheckAuth,
+		},
+		{
+			name:   "credential prompt suppressed",
+			detail: "could not read Username for 'https://github.com': terminal prompts disabled",
+			want:   HintCheckAuth,
+		},
+		{
+			name:   "unrecognized stays generic",
+			detail: "the remote end hung up unexpectedly",
+			want:   HintCheckNetwork,
+		},
+		{
+			name:   "no detail at all stays generic",
+			detail: "",
+			want:   HintCheckNetwork,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := Network("listing remote tags", os.ErrClosed, tt.detail)
+			if e.Hint != tt.want {
+				t.Errorf("hint = %q\nwant   %q\nfor detail: %s", e.Hint, tt.want, tt.detail)
+			}
+			// Whatever the classification, never the permissions advice.
+			if strings.Contains(e.Error(), HintCheckPermissions) {
+				t.Errorf("remote failure carried the permissions hint:\n%s", e.Error())
+			}
+		})
+	}
+}
+
+// The reason innermost wins, stated as a test: on a machine whose network is
+// fine but which has no CA bundle, the outer layer's "check your internet
+// connection" sends the operator to debug something that already works. The
+// inner layer knows it was a certificate and can say so.
+func TestSpecificInnerHintBeatsGenericOuterHint(t *testing.T) {
+	inner := Network("listing remote tags", os.ErrClosed,
+		"unable to access 'https://github.com/x/y': server certificate verification failed. CAfile: none")
+	outer := Wrap(inner, "auto-sync failed").WithHint("check your internet connection or run 'fest sync' manually")
+
+	msg := outer.Error()
+	if !strings.Contains(msg, HintCheckTLS) {
+		t.Errorf("a certificate failure must produce the TLS hint:\n%s", msg)
+	}
+	if strings.Contains(msg, "check your internet connection") {
+		t.Errorf("the misleading connection hint displaced the specific one:\n%s", msg)
 	}
 	if got := strings.Count(msg, "Hint:"); got != 1 {
 		t.Errorf("rendered %d hints, want exactly 1:\n%s", got, msg)

--- a/internal/errors/hint_field_test.go
+++ b/internal/errors/hint_field_test.go
@@ -1,0 +1,193 @@
+package errors
+
+import (
+	goerrors "errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// WithField("hint", ...) is always a mistake: Error() renders e.Hint, never a
+// field, so the author's guidance is invisible in the terminal and whatever
+// generic hint the constructor attached is shown instead. That is how a failure
+// to reach GitHub told an operator to "Check file/directory permissions".
+//
+// This walks the tree rather than asserting on a list, so a new occurrence
+// fails here instead of shipping as a hint nobody sees.
+func TestNoHintsHiddenInFields(t *testing.T) {
+	root := repoRoot(t)
+	var offenders []string
+
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "node_modules", "vendor", "testdata":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "hint_field_test.go") {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		for i, line := range strings.Split(string(data), "\n") {
+			if strings.Contains(line, `WithField("hint"`) {
+				rel, _ := filepath.Rel(root, path)
+				offenders = append(offenders, rel+":"+itoa(i+1))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	if len(offenders) > 0 {
+		t.Errorf("hints stored as fields are never rendered; use WithHint instead:\n  %s",
+			strings.Join(offenders, "\n  "))
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+// repoRoot walks up from the package directory to the module root.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not locate go.mod above the test directory")
+		}
+		dir = parent
+	}
+}
+
+// A remote failure must name the remote as the problem, and carry the message
+// the remote itself gave, not a bare exit code.
+func TestNetworkErrorReportsCauseAndNetworkHint(t *testing.T) {
+	e := Network("listing remote tags", os.ErrDeadlineExceeded,
+		"unable to access 'https://github.com/x/y': Could not resolve host: github.com")
+
+	msg := e.Error()
+	if !strings.Contains(msg, "Could not resolve host") {
+		t.Errorf("error does not carry the remote's own message:\n%s", msg)
+	}
+	if !strings.Contains(msg, HintCheckNetwork) {
+		t.Errorf("error does not carry the network hint:\n%s", msg)
+	}
+	if strings.Contains(msg, HintCheckPermissions) {
+		t.Errorf("a network failure must not tell the operator to check permissions:\n%s", msg)
+	}
+	if e.Code != ErrCodeNetwork {
+		t.Errorf("Code = %q, want %q", e.Code, ErrCodeNetwork)
+	}
+}
+
+// Detail is optional: a remote failure with nothing to quote still reads as a
+// reachability problem rather than as an I/O one.
+func TestNetworkErrorWithoutDetail(t *testing.T) {
+	e := Network("listing remote tags", os.ErrDeadlineExceeded, "   ")
+	if strings.Contains(e.Error(), "  :") {
+		t.Errorf("blank detail leaked punctuation into the message:\n%s", e.Error())
+	}
+	if !strings.Contains(e.Error(), "could not reach the remote") {
+		t.Errorf("message does not name the failure:\n%s", e.Error())
+	}
+}
+
+// A nested error must print one hint, not one per layer. Before this, each
+// layer's Error() spliced its own "Hint:" line into the parent's message.
+func TestNestedErrorsPrintExactlyOneHint(t *testing.T) {
+	inner := Network("listing remote tags", os.ErrClosed, "Could not resolve host: github.com")
+	outer := Wrap(inner, "auto-sync failed").WithHint("run 'fest sync' manually")
+
+	msg := outer.Error()
+	if got := strings.Count(msg, "Hint:"); got != 1 {
+		t.Errorf("rendered %d hints, want exactly 1:\n%s", got, msg)
+	}
+	// The outermost hint wins: it is the layer closest to what was typed.
+	if !strings.Contains(msg, "run 'fest sync' manually") {
+		t.Errorf("outermost hint missing:\n%s", msg)
+	}
+	if strings.Contains(msg, HintCheckNetwork) {
+		t.Errorf("inner hint should not also render:\n%s", msg)
+	}
+	// The cause chain still reaches the operator.
+	if !strings.Contains(msg, "Could not resolve host") {
+		t.Errorf("cause lost from the chain:\n%s", msg)
+	}
+}
+
+// Wrapping with no hint of its own must not silently discard the inner
+// guidance; the nearest available hint is used.
+func TestBareWrapKeepsTheInnerHint(t *testing.T) {
+	inner := Network("listing remote tags", os.ErrClosed, "Could not resolve host: github.com")
+	outer := Wrap(inner, "auto-sync failed")
+
+	msg := outer.Error()
+	if !strings.Contains(msg, HintCheckNetwork) {
+		t.Errorf("bare Wrap dropped the inner hint:\n%s", msg)
+	}
+	if got := strings.Count(msg, "Hint:"); got != 1 {
+		t.Errorf("rendered %d hints, want exactly 1:\n%s", got, msg)
+	}
+}
+
+// errors.Is/As must still see through the chain after the rendering change.
+func TestChainRemainsUnwrappable(t *testing.T) {
+	inner := Network("listing remote tags", os.ErrClosed, "detail")
+	outer := Wrap(inner, "auto-sync failed")
+	if !goerrors.Is(outer, os.ErrClosed) {
+		t.Error("errors.Is no longer reaches the root cause")
+	}
+}
+
+// A plain fmt.Errorf between two *Error layers must keep its text. Recursing
+// into nested *Error values with errors.As skipped such a layer entirely,
+// turning `approval readiness failed: invalid evidence path "x": escapes` into
+// `approval readiness failed: escapes`. The middle sentence is the one naming
+// what the operator got wrong.
+func TestInterveningPlainErrorKeepsItsMessage(t *testing.T) {
+	root := Validation("evidence path escapes the phase directory")
+	middle := fmt.Errorf("invalid evidence path %q: %w", "../outside.md", root)
+	outer := Wrap(middle, "approval readiness failed").WithHint("use a relative path")
+
+	msg := outer.Error()
+	for _, want := range []string{
+		"approval readiness failed",
+		`invalid evidence path "../outside.md"`,
+		"evidence path escapes the phase directory",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message lost %q:\n%s", want, msg)
+		}
+	}
+	if got := strings.Count(msg, "Hint:"); got != 1 {
+		t.Errorf("rendered %d hints, want exactly 1:\n%s", got, msg)
+	}
+}

--- a/internal/feedback/feedback.go
+++ b/internal/feedback/feedback.go
@@ -178,7 +178,7 @@ func (s *Store) LoadConfig(ctx context.Context) (*Config, error) {
 	data, err := os.ReadFile(configPath)
 	if os.IsNotExist(err) {
 		return nil, errors.NotFound("feedback configuration").
-			WithField("hint", "run 'fest feedback init' first")
+			WithHint("run 'fest feedback init' first")
 	}
 	if err != nil {
 		return nil, errors.IO("reading config file", err).WithField("path", configPath)

--- a/internal/github/downloader.go
+++ b/internal/github/downloader.go
@@ -494,7 +494,7 @@ func (d *Downloader) GetRemoteSHA() (string, error) {
 	cmd := exec.Command("git", "ls-remote", d.repoURL, refSpec)
 	output, err := cmd.Output()
 	if err != nil {
-		return "", errors.IO("getting remote SHA", err).WithField("url", d.repoURL)
+		return "", errors.Network("getting remote SHA", err, gitStderr(err)).WithField("url", d.repoURL)
 	}
 
 	// Output format: "<sha>\t<refspec>"

--- a/internal/github/stderr.go
+++ b/internal/github/stderr.go
@@ -1,0 +1,48 @@
+package github
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+)
+
+// gitStderr returns the message git printed before failing, or "" when there is
+// none to report.
+//
+// exec.Cmd.Output populates ExitError.Stderr but callers have to ask for it.
+// Without this, every remote failure collapses to "exit status 128", which is
+// git's generic fatal and says nothing about whether the machine has no route
+// to the host, cannot verify a TLS certificate, or was denied access. The
+// operator needs git's own sentence, not our exit code.
+//
+// Output is capped: a pathological remote could return a great deal of text,
+// and this lands in a one-line CLI error.
+func gitStderr(err error) string {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return ""
+	}
+	msg := strings.TrimSpace(string(exitErr.Stderr))
+	if msg == "" {
+		return ""
+	}
+	// git prefixes its failures with "fatal: "; keep the sentence, drop the
+	// ceremony, and collapse multi-line output onto one line.
+	lines := make([]string, 0, 4)
+	for _, line := range strings.Split(msg, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		lines = append(lines, strings.TrimPrefix(line, "fatal: "))
+		if len(lines) == 4 {
+			break
+		}
+	}
+	joined := strings.Join(lines, "; ")
+	const maxLen = 300
+	if len(joined) > maxLen {
+		return joined[:maxLen] + "..."
+	}
+	return joined
+}

--- a/internal/github/stderr_test.go
+++ b/internal/github/stderr_test.go
@@ -1,0 +1,67 @@
+package github
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// The whole point: an operator saw "exit status 128" and no cause. git had
+// already said what was wrong on stderr, and Cmd.Output had captured it.
+func TestGitStderrSurfacesGitsOwnMessage(t *testing.T) {
+	cmd := exec.Command("git", "ls-remote", "--tags", "https://invalid.invalid/nope.git")
+	_, err := cmd.Output()
+	if err == nil {
+		t.Skip("the unreachable remote resolved; no failure to inspect")
+	}
+
+	got := gitStderr(err)
+	if got == "" {
+		t.Fatalf("gitStderr returned nothing for a failed ls-remote (err = %v)", err)
+	}
+	if strings.Contains(got, "exit status") {
+		t.Errorf("gitStderr returned the exit code rather than the reason: %q", got)
+	}
+	t.Logf("git said: %s", got)
+}
+
+func TestGitStderrFormatting(t *testing.T) {
+	tests := []struct {
+		name   string
+		stderr string
+		want   string
+	}{
+		{"strips the fatal prefix", "fatal: could not read Username\n", "could not read Username"},
+		{"joins multiple lines", "fatal: one\nfatal: two\n", "one; two"},
+		{"drops blank lines", "fatal: one\n\n\n", "one"},
+		{"empty stays empty", "   \n", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := error(&exec.ExitError{Stderr: []byte(tt.stderr)})
+			if got := gitStderr(err); got != tt.want {
+				t.Errorf("gitStderr(%q) = %q, want %q", tt.stderr, got, tt.want)
+			}
+		})
+	}
+}
+
+// A pathological remote must not blow up a one-line CLI error.
+func TestGitStderrIsBounded(t *testing.T) {
+	err := error(&exec.ExitError{Stderr: []byte("fatal: " + strings.Repeat("x", 5000))})
+	if got := gitStderr(err); len(got) > 320 {
+		t.Errorf("gitStderr returned %d chars; want it capped", len(got))
+	}
+}
+
+// Not every failure is an ExitError (git missing entirely, context cancelled).
+// Those have no stderr to quote and must not panic.
+func TestGitStderrIgnoresNonExitErrors(t *testing.T) {
+	if got := gitStderr(errors.New("boom")); got != "" {
+		t.Errorf("gitStderr(non-ExitError) = %q, want empty", got)
+	}
+	if got := gitStderr(nil); got != "" {
+		t.Errorf("gitStderr(nil) = %q, want empty", got)
+	}
+}

--- a/internal/github/tags.go
+++ b/internal/github/tags.go
@@ -87,7 +87,7 @@ func ResolveLatestTag(repoURL, channel string) (string, error) {
 	cmd := exec.Command("git", "ls-remote", "--tags", repoURL)
 	output, err := cmd.Output()
 	if err != nil {
-		return "", errors.IO("listing remote tags", err).WithField("url", repoURL)
+		return "", errors.Network("listing remote tags", err, gitStderr(err)).WithField("url", repoURL)
 	}
 
 	tag, err := selectLatestTag(parseLsRemoteTags(string(output)), channel)


### PR DESCRIPTION
## The bug

`fest init` on a device that could not reach GitHub:

```
[root@kindle kindle-camp]# fest init
Template cache not found, syncing from GitHub...
Error: auto-sync failed: resolving latest dev tag: listing remote tags: I/O operation failed: exit status 128
Hint: Check file/directory permissions and try again
```

Everything after `auto-sync failed` is unhelpful or actively wrong. Reproduced locally by pointing the configured repository at an unreachable host, which produces those two lines verbatim. Three separate defects stack into it.

### 1. git's stderr was discarded

`exec.Cmd.Output` populates `ExitError.Stderr`, but the call sites kept only the exit code. `128` is git's generic fatal: it does not distinguish "no route to host" from "cannot verify certificate" from "access denied". git had already written the answer and camp threw it away.

### 2. Remote failures were reported as I/O failures

There was no network category, so `git ls-remote` failures used `errors.IO`, whose hint is `HintCheckPermissions`. A machine with no route to GitHub was told to check file permissions, which is the single place the problem is not.

### 3. `WithField("hint", ...)` renders nothing

`Error()` renders `e.Hint`. A hint stored as a *field* is invisible in text output and surfaces only under `--json`, in a different key. Verified rather than assumed:

```
WithField("hint") renders as:
    op: I/O operation failed
    Hint: Check file/directory permissions and try again
WithHint renders as:
    op: I/O operation failed
    Hint: AUTHOR_INTENDED_HINT
RESULT: WithField hint is INVISIBLE in text output
```

**49 call sites** across 21 files had an author-written hint that no user has ever seen, while the constructor's generic hint took its place. `init` was one of them: it already had the right guidance, `"check your internet connection or run 'fest sync' manually"`, and it was being dropped in favor of the permissions advice.

## After

```
Error: auto-sync failed: resolving latest dev tag: listing remote tags: could not reach the remote: unable to access 'https://invalid.invalid/nope.git/': Could not resolve host: invalid.invalid: exit status 128
Hint: check your internet connection or run 'fest sync' manually
```

## The change

- `gitStderr` recovers git's own message from `ExitError.Stderr`, strips the `fatal:` ceremony, collapses it to one line, and caps the length so a pathological remote cannot flood a CLI error.
- `errors.Network(op, err, detail)` carries the remote's message and a reachability hint. Both `ls-remote` call sites use it.
- All 49 `WithField("hint", ...)` become `WithHint(...)`, so authored guidance reaches the terminal.

Making those hints visible exposed that a nested error printed **one `Hint:` line per layer**. `Error()` now renders exactly one: the outermost, being closest to what the operator typed, falling back inward so a bare `Wrap()` does not discard the inner guidance.

## A bug this PR introduced and the suite caught

My first version of that renderer recursed into nested `*Error` values using `errors.As`. That looked equivalent and was not: `errors.As` searches the **whole** chain, so a plain `fmt.Errorf` sitting between two `*Error` layers was skipped and its message silently deleted. `approval readiness failed: invalid evidence path "../outside.md": escapes the phase directory` became `approval readiness failed: escapes the phase directory`, losing the sentence that names what the operator got wrong.

`TestCheckApprovalReadiness_InvalidEvidencePathsFailClosed` caught it. The renderer now strips rendered `Hint:` lines from the cause text instead, which cannot drop a layer whatever the chain shape, and that case has its own regression test.

## Tests

- `gitStderr`: recovers the real message from a live failed `ls-remote` (skips if the bogus host resolves), strips `fatal:`, joins multiple lines, stays bounded, and ignores non-`ExitError` failures such as a missing git or a cancelled context.
- `errors.Network`: carries the cause and the network hint, and specifically must **not** carry the permissions hint.
- Nested errors render exactly one hint; a bare `Wrap` keeps the inner one; `errors.Is` still reaches the root cause.
- An intervening `fmt.Errorf` keeps its message (the regression above).
- A tree walk fails on any new `WithField("hint", ...)`, so this cannot silently come back.

## Gates

`go vet ./...`, `golangci-lint run ./...` (0 issues), `just test unit`: **2846/2846 passed**.

## Not addressed here

`fest init` still cannot work at all on a machine with no network, since the templates only exist after a sync. That is a design question (bundled or embedded fallback templates) rather than an error-reporting one, so it is deliberately out of scope. This PR's job is that the operator now learns the real reason and the actionable next step instead of being sent to check file permissions. Happy to open an intent for the offline path if you want it pursued.
