### PR TITLE
docs(cli): regenerate reference for fest tokens and gate against staleness

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -64,6 +64,8 @@ gate:
     go vet -tags=integration ./...
     echo "=== gate: lint ==="
     just lint all
+    echo "=== gate: docs ==="
+    just docs-check
     echo "=== gate: stable tests ==="
     just test all
     echo "=== gate: dev unit tests ==="
@@ -86,6 +88,23 @@ docs:
     set -euo pipefail
     just build quick
     ./{{bin_dir}}/{{binary_name}} gendocs --output docs/cli-reference --format markdown --single
+
+# Fail when the committed CLI reference no longer matches the code.
+# Generates into a temp dir rather than the working tree, so running the gate
+# never leaves modified files behind.
+docs-check:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just build quick
+    tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' EXIT
+    ./{{bin_dir}}/{{binary_name}} gendocs --output "$tmp" --format markdown --single
+    if ! diff -ru docs/cli-reference "$tmp" >/dev/null 2>&1; then
+        echo "FAIL: docs/cli-reference is stale. Run 'just docs' and commit the result." >&2
+        diff -ru docs/cli-reference "$tmp" | head -40 >&2
+        exit 1
+    fi
+    echo "docs/cli-reference is up to date"
 
 # Uninstall fest from $GOBIN
 uninstall:

--- a/docs/cli-reference/fest-reference.md
+++ b/docs/cli-reference/fest-reference.md
@@ -5503,6 +5503,53 @@ fest templates list [flags]
 ```
 ---
 
+## fest tokens
+
+Count planning-corpus tokens for a festival or the whole workspace
+
+### Synopsis
+
+Count tokens in festival planning documents using tcount.
+
+With no arguments, counts the festival containing the current directory.
+With --all, counts the entire festivals workspace (every status).
+With a path, counts that file or directory directly.
+
+Counting matches the tcount CLI: recursive, .gitignore-aware, and the
+reported number is tcount's primary method for the selected model.
+
+```
+fest tokens [path] [flags]
+```
+
+### Examples
+
+```
+  fest tokens                    # Current festival's planning corpus
+  fest tokens --all              # Entire festivals workspace
+  fest tokens 001_PLAN           # One phase directory
+  fest tokens --all --json       # Machine-readable totals
+```
+
+### Options
+
+```
+      --all            count the entire festivals workspace
+  -h, --help           help for tokens
+      --json           output in JSON format
+      --model string   model whose tokenizer to use (tcount default when empty)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
 ## fest types
 
 Discover types for fest create

--- a/docs/cli-reference/fest.md
+++ b/docs/cli-reference/fest.md
@@ -86,6 +86,7 @@ Run 'fest understand' to learn the methodology before executing tasks.
 * [fest system](fest_system.md)	 - Manage fest tool configuration and templates
 * [fest task](fest_task.md)	 - Manage task status (show, edit, complete, block, reset)
 * [fest templates](fest_templates.md)	 - Manage agent-created templates within a festival
+* [fest tokens](fest_tokens.md)	 - Count planning-corpus tokens for a festival or the whole workspace
 * [fest types](fest_types.md)	 - Discover types for fest create
 * [fest unbundle](fest_unbundle.md)	 - Unbundle a .festival archive into a directory
 * [fest understand](fest_understand.md)	 - Learn methodology FIRST - run before executing festival tasks

--- a/docs/cli-reference/fest_tokens.md
+++ b/docs/cli-reference/fest_tokens.md
@@ -1,0 +1,49 @@
+## fest tokens
+
+Count planning-corpus tokens for a festival or the whole workspace
+
+### Synopsis
+
+Count tokens in festival planning documents using tcount.
+
+With no arguments, counts the festival containing the current directory.
+With --all, counts the entire festivals workspace (every status).
+With a path, counts that file or directory directly.
+
+Counting matches the tcount CLI: recursive, .gitignore-aware, and the
+reported number is tcount's primary method for the selected model.
+
+```
+fest tokens [path] [flags]
+```
+
+### Examples
+
+```
+  fest tokens                    # Current festival's planning corpus
+  fest tokens --all              # Entire festivals workspace
+  fest tokens 001_PLAN           # One phase directory
+  fest tokens --all --json       # Machine-readable totals
+```
+
+### Options
+
+```
+      --all            count the entire festivals workspace
+  -h, --help           help for tokens
+      --json           output in JSON format
+      --model string   model whose tokenizer to use (tcount default when empty)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest](fest.md)	 - Festival Methodology CLI - goal-oriented project management for AI agents


### PR DESCRIPTION
## The drift

`fest tokens` shipped without a docs regen, so `docs/cli-reference` has been missing the command page and its index entry. Surfaced while regenerating docs for #331, and deliberately left out of that PR so its diff stayed reviewable.

The regen is **purely additive** (116 insertions, 0 deletions), so nothing stale was overwritten — this was a missing page, not a wrong one.

## Why this needs more than a regen

Regenerating fixes today's drift and nothing else. The same gap reopens the next time a command lands, and it is invisible until someone happens to run `just docs` for an unrelated reason — which is exactly how this one was found.

Added a `docs-check` recipe, wired into `just gate`:

```
=== gate: docs ===
docs/cli-reference is up to date
```

It generates into a **temp dir rather than the working tree**, so running the gate never leaves modified files behind — a check that dirties the tree it is checking would be its own problem.

## Verified in both directions

A guard that only ever passes is decoration, so I confirmed it fails on the case it exists for. With the docs reverted to their stale committed state:

```
error: recipe `docs-check` failed with exit code 1
```

and it prints the offending diff so the fix is obvious:

```
+  fest tokens                    # Current festival's planning corpus
+  fest tokens --all              # Entire festivals workspace
```

I also confirmed `gendocs` output is **deterministic** across runs before wiring it into a gate — a check that compares generated output is only safe if that output is stable, otherwise it fails spuriously and gets disabled.

## Gates

`just docs-check` passes. The change is generated docs plus a justfile recipe; no Go code is touched.
