### PR TITLE
feat(init): bundle the methodology so fest init works without a network

### DIFF
--- a/internal/bundled/bundled.go
+++ b/internal/bundled/bundled.go
@@ -1,0 +1,69 @@
+// Package bundled materializes the methodology scaffold embedded in the fest
+// binary onto disk, for machines that cannot reach GitHub.
+package bundled
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/Obedience-Corp/fest/internal/errors"
+	"github.com/Obedience-Corp/fest/methodology"
+)
+
+const (
+	dirPerm  = 0o755
+	filePerm = 0o644
+)
+
+// Seed writes the embedded methodology scaffold into targetDir, creating it if
+// needed. Existing files are overwritten, so a caller that wants to preserve
+// local edits must check before calling.
+//
+// Embedded files carry no mode bits, so directories are created 0755 and files
+// written 0644 — the scaffold is documents and templates, nothing executable.
+func Seed(ctx context.Context, targetDir string) error {
+	if err := ctx.Err(); err != nil {
+		return errors.Wrap(err, "seeding bundled methodology")
+	}
+	if targetDir == "" {
+		return errors.Validation("seeding bundled methodology: no target directory")
+	}
+
+	return fs.WalkDir(methodology.FS, methodology.Root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(methodology.Root, path)
+		if err != nil {
+			return errors.Wrap(err, "resolving bundled path").WithField("path", path)
+		}
+		dest := filepath.Join(targetDir, rel)
+
+		if d.IsDir() {
+			if err := os.MkdirAll(dest, dirPerm); err != nil {
+				return errors.IO("creating directory", err).WithField("path", dest)
+			}
+			return nil
+		}
+
+		data, err := methodology.FS.ReadFile(path)
+		if err != nil {
+			return errors.IO("reading bundled file", err).WithField("path", path)
+		}
+		// A file can precede its parent only if the walk is reordered, but
+		// creating the parent here costs nothing and removes the assumption.
+		if err := os.MkdirAll(filepath.Dir(dest), dirPerm); err != nil {
+			return errors.IO("creating directory", err).WithField("path", filepath.Dir(dest))
+		}
+		if err := os.WriteFile(dest, data, filePerm); err != nil {
+			return errors.IO("writing bundled file", err).WithField("path", dest)
+		}
+		return nil
+	})
+}

--- a/internal/bundled/bundled_test.go
+++ b/internal/bundled/bundled_test.go
@@ -1,0 +1,153 @@
+package bundled
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/methodology"
+)
+
+// sourceTree is the on-disk scaffold the embed directive reads at build time.
+const sourceTree = "../../methodology/festivals"
+
+// relFiles lists every file under root as slash-separated relative paths.
+func relFiles(t *testing.T, root string) []string {
+	t.Helper()
+	var out []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		out = append(out, filepath.ToSlash(rel))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// The bundled scaffold must be the whole scaffold. go:embed silently skips
+// dot-prefixed entries without the all: prefix, which would drop .festival —
+// the directory holding every template and agent guide — and leave init
+// producing a workspace that looks complete and is unusable.
+//
+// Comparing against the on-disk tree rather than a hardcoded list means adding
+// a file to the methodology cannot quietly fail to ship.
+func TestSeedMaterializesTheEntireScaffold(t *testing.T) {
+	if _, err := os.Stat(sourceTree); err != nil {
+		t.Skipf("methodology source tree not available: %v", err)
+	}
+
+	dest := t.TempDir()
+	if err := Seed(context.Background(), dest); err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+
+	want := relFiles(t, sourceTree)
+	got := relFiles(t, dest)
+
+	if len(want) == 0 {
+		t.Fatal("the methodology source tree is empty; the comparison would be vacuous")
+	}
+	if len(got) != len(want) {
+		t.Errorf("seeded %d files, source tree has %d", len(got), len(want))
+	}
+
+	inGot := make(map[string]bool, len(got))
+	for _, f := range got {
+		inGot[f] = true
+	}
+	for _, f := range want {
+		if !inGot[f] {
+			t.Errorf("bundled scaffold is missing %q", f)
+		}
+	}
+}
+
+// The specific casualty of a missing all: prefix, named so a failure says why.
+func TestSeedIncludesDotDirectories(t *testing.T) {
+	dest := t.TempDir()
+	if err := Seed(context.Background(), dest); err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+
+	for _, required := range []string{".festival", "active", "planning", "ready", "ritual"} {
+		info, err := os.Stat(filepath.Join(dest, required))
+		if err != nil {
+			t.Errorf("bundled scaffold is missing %q: %v", required, err)
+			continue
+		}
+		if !info.IsDir() {
+			t.Errorf("%q is not a directory", required)
+		}
+	}
+}
+
+// Contents must survive the round trip, not just the names.
+func TestSeedPreservesFileContents(t *testing.T) {
+	dest := t.TempDir()
+	if err := Seed(context.Background(), dest); err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+
+	var checked int
+	err := fs.WalkDir(methodology.FS, methodology.Root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil || d.IsDir() || checked >= 5 {
+			return walkErr
+		}
+		rel, relErr := filepath.Rel(methodology.Root, path)
+		if relErr != nil {
+			return relErr
+		}
+		want, readErr := methodology.FS.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		got, readErr := os.ReadFile(filepath.Join(dest, rel))
+		if readErr != nil {
+			t.Errorf("read seeded %q: %v", rel, readErr)
+			return nil
+		}
+		if string(got) != string(want) {
+			t.Errorf("seeded %q does not match the embedded copy", rel)
+		}
+		checked++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk embedded FS: %v", err)
+	}
+	if checked == 0 {
+		t.Fatal("no files compared; the embedded FS appears empty")
+	}
+}
+
+// Seeding writes a few hundred files, so a cancelled context must stop it
+// rather than run to completion on a machine the operator is trying to quit.
+func TestSeedHonorsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := Seed(ctx, t.TempDir()); err == nil {
+		t.Error("Seed with a cancelled context returned nil, want an error")
+	}
+}
+
+func TestSeedRejectsEmptyTarget(t *testing.T) {
+	if err := Seed(context.Background(), ""); err == nil {
+		t.Error("Seed with no target directory returned nil, want an error")
+	}
+}

--- a/internal/bundled/tracked_test.go
+++ b/internal/bundled/tracked_test.go
@@ -1,0 +1,96 @@
+package bundled
+
+import (
+	"io/fs"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/fest/methodology"
+)
+
+// embeddedFiles lists every file in the embedded scaffold, relative to its root.
+func embeddedFiles(t *testing.T) []string {
+	t.Helper()
+	var out []string
+	err := fs.WalkDir(methodology.FS, methodology.Root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(methodology.Root, path)
+		if relErr != nil {
+			return relErr
+		}
+		out = append(out, filepath.ToSlash(rel))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk embedded FS: %v", err)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// The embed directive reads the working tree, not the commit, so anything
+// sitting in methodology/festivals at build time is baked into the binary —
+// including untracked and gitignored files. That makes the shipped scaffold
+// depend on whose machine ran the build, and it can carry local tool output to
+// every user who runs 'fest init'.
+//
+// This is not hypothetical: the repository gitignores CLAUDE.md, and a
+// developer machine can accumulate generated CLAUDE.md files under the
+// methodology tree containing local session logs. A release built there would
+// embed them; one built from a clean checkout would not.
+//
+// The binary must ship exactly what the commit contains.
+func TestEmbeddedScaffoldMatchesGitTrackedFiles(t *testing.T) {
+	cmd := exec.Command("git", "ls-files", "-z", "--", "methodology/festivals")
+	cmd.Dir = "../.."
+	out, err := cmd.Output()
+	if err != nil {
+		t.Skipf("git unavailable or not a work tree: %v", err)
+	}
+
+	const prefix = "methodology/festivals/"
+	var tracked []string
+	for _, entry := range strings.Split(string(out), "\x00") {
+		if entry == "" {
+			continue
+		}
+		tracked = append(tracked, strings.TrimPrefix(entry, prefix))
+	}
+	if len(tracked) == 0 {
+		t.Skip("no tracked methodology files reported; nothing to compare")
+	}
+	sort.Strings(tracked)
+
+	isTracked := make(map[string]bool, len(tracked))
+	for _, f := range tracked {
+		isTracked[f] = true
+	}
+
+	embedded := embeddedFiles(t)
+	isEmbedded := make(map[string]bool, len(embedded))
+	for _, f := range embedded {
+		isEmbedded[f] = true
+	}
+
+	for _, f := range embedded {
+		if !isTracked[f] {
+			t.Errorf("embedded but not tracked by git: %q\n"+
+				"  It would ship in the binary while a clean-checkout build omits it.\n"+
+				"  Delete it from methodology/festivals, or commit it if it belongs to the methodology.", f)
+		}
+	}
+	for _, f := range tracked {
+		if !isEmbedded[f] {
+			t.Errorf("tracked by git but not embedded: %q\n"+
+				"  'fest init' would produce an incomplete workspace offline.", f)
+		}
+	}
+}

--- a/internal/commands/system/bundled_source.go
+++ b/internal/commands/system/bundled_source.go
@@ -1,0 +1,38 @@
+package system
+
+import (
+	"context"
+
+	"github.com/Obedience-Corp/fest/internal/commands/shared"
+	"github.com/Obedience-Corp/fest/internal/config"
+)
+
+// bundledMethodologyApplies reports whether the scaffold embedded in this
+// binary is a legitimate stand-in for what a sync would have fetched.
+//
+// The bundle is a copy of the default repository's methodology. When an
+// operator has pointed fest at their own repository, ours is not a substitute
+// for theirs: seeding it would hand them a methodology they never chose, and
+// the swap would be easy to miss because init otherwise looks successful.
+// Those configurations keep failing when the network is down, which is the
+// honest outcome — fest cannot produce templates it has never seen.
+func bundledMethodologyApplies(repo config.Repository) bool {
+	if repo.URL != "" && repo.URL != config.DefaultRepositoryURL {
+		return false
+	}
+	if repo.Path != "" && repo.Path != config.DefaultRepoPath {
+		return false
+	}
+	return true
+}
+
+// usesBundledMethodology answers the same question from the on-disk config.
+// A machine with no config at all is the first-run case the bundle exists for,
+// so an unreadable or absent config falls back rather than failing.
+func usesBundledMethodology(ctx context.Context) bool {
+	cfg, err := config.Load(ctx, shared.GetConfigFile())
+	if err != nil || cfg == nil {
+		return true
+	}
+	return bundledMethodologyApplies(cfg.Repository)
+}

--- a/internal/commands/system/bundled_source_test.go
+++ b/internal/commands/system/bundled_source_test.go
@@ -1,0 +1,58 @@
+package system
+
+import (
+	"testing"
+
+	"github.com/Obedience-Corp/fest/internal/config"
+)
+
+// The bundled scaffold is a copy of the default repository. Seeding it for an
+// operator who pointed fest at their own methodology would replace their
+// templates with ours, and init would still report success — so the substitution
+// is only legitimate when the configured source is the one we bundled.
+func TestBundledMethodologyApplies(t *testing.T) {
+	tests := []struct {
+		name string
+		repo config.Repository
+		want bool
+	}{
+		{
+			name: "unconfigured falls back",
+			repo: config.Repository{},
+			want: true,
+		},
+		{
+			name: "explicit default falls back",
+			repo: config.Repository{URL: config.DefaultRepositoryURL, Path: config.DefaultRepoPath},
+			want: true,
+		},
+		{
+			name: "default url with unset path falls back",
+			repo: config.Repository{URL: config.DefaultRepositoryURL},
+			want: true,
+		},
+		{
+			name: "a pinned channel still uses the same repository",
+			repo: config.Repository{URL: config.DefaultRepositoryURL, Channel: "stable"},
+			want: true,
+		},
+		{
+			name: "someone else's repository must not be substituted",
+			repo: config.Repository{URL: "https://github.com/some-org/our-own-methodology"},
+			want: false,
+		},
+		{
+			name: "default repository at a different path must not be substituted",
+			repo: config.Repository{URL: config.DefaultRepositoryURL, Path: "some/other/scaffold"},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := bundledMethodologyApplies(tt.repo); got != tt.want {
+				t.Errorf("bundledMethodologyApplies(%+v) = %v, want %v", tt.repo, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/commands/system/init.go
+++ b/internal/commands/system/init.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/Obedience-Corp/fest/internal/bundled"
 	"github.com/Obedience-Corp/fest/internal/commands/shared"
 	"github.com/Obedience-Corp/fest/internal/config"
 	festcontract "github.com/Obedience-Corp/fest/internal/contract"
@@ -118,6 +119,15 @@ func RunInit(ctx context.Context, targetPath string, opts *InitOptions) error {
 		sourceDir = filepath.Join(config.ConfigDir(), "festivals")
 	}
 
+	// An explicit --from names a directory the operator expects to exist.
+	// Syncing writes to the config dir instead, so it could never satisfy this
+	// path; say what is missing rather than attempt an unrelated download.
+	if opts.From != "" && !fileops.Exists(sourceDir) {
+		return errors.NotFound("source directory").
+			WithField("path", sourceDir).
+			WithHint("--from must point at an existing festival template directory")
+	}
+
 	// Check if source exists - if not, auto-sync to populate it
 	if !fileops.Exists(sourceDir) {
 		display.Info("Template cache not found, syncing from GitHub...")
@@ -126,10 +136,25 @@ func RunInit(ctx context.Context, targetPath string, opts *InitOptions) error {
 		syncOpts := &syncOptions{
 			dryRun: false,
 		}
-		if err := runSync(ctx, nil, syncOpts); err != nil {
-			return errors.Wrap(err, "auto-sync failed").
-				WithField("path", sourceDir).
-				WithHint("check your internet connection or run 'fest sync' manually")
+		syncErr := runSync(ctx, nil, syncOpts)
+		if syncErr != nil {
+			// Templates only ever existed after a successful sync, so a machine
+			// that cannot reach GitHub could not run 'fest init' at all. The
+			// same scaffold ships inside the binary; use it and let sync become
+			// the way to update the methodology rather than to obtain it.
+			if !usesBundledMethodology(ctx) {
+				return errors.Wrap(syncErr, "auto-sync failed").
+					WithField("path", sourceDir).
+					WithHint("check your internet connection or run 'fest sync' manually")
+			}
+			display.Warning("Could not reach the methodology repository: %s", errors.Message(syncErr))
+			display.Info("Using the methodology bundled with this fest build.")
+			display.Info("Run 'fest sync' once the network is available to pick up newer templates.")
+			if err := bundled.Seed(ctx, sourceDir); err != nil {
+				return errors.Wrap(err, "seeding bundled methodology").
+					WithField("path", sourceDir).
+					WithHint("could not reach GitHub and could not write the bundled copy; check permissions on " + sourceDir)
+			}
 		}
 
 		// Verify sync worked

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -100,6 +100,20 @@ func (e *Error) chainMessage() string {
 	}
 }
 
+// Message renders err without its "Hint:" line, for callers that splice an
+// error into a line of their own.
+//
+// A hint is advice about what the operator should do next, so it only reads
+// correctly as the last line of a failure. Embedded mid-message — in a warning
+// the command then recovers from, say — it interrupts the sentence and offers a
+// next step for something that is already being handled.
+func Message(err error) string {
+	if err == nil {
+		return ""
+	}
+	return stripHintLines(err.Error())
+}
+
 // stripHintLines removes rendered "Hint: ..." lines from a cause's text.
 func stripHintLines(msg string) string {
 	if !strings.Contains(msg, "\nHint: ") {

--- a/internal/errors/message_test.go
+++ b/internal/errors/message_test.go
@@ -1,0 +1,58 @@
+package errors
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// A hint reads as advice about what to do next, so it belongs on the last line
+// of a failure. Splicing it into the middle of a warning the command then
+// recovers from offers a next step for something already handled.
+func TestMessageStripsTheHint(t *testing.T) {
+	err := Validation("could not reach the remote").
+		WithHint("check your internet connection or run 'fest sync' manually")
+
+	if !strings.Contains(err.Error(), "Hint: ") {
+		t.Fatal("precondition failed: Error() should render a hint")
+	}
+
+	got := Message(err)
+	if strings.Contains(got, "Hint: ") {
+		t.Errorf("Message() kept the hint: %q", got)
+	}
+	if !strings.Contains(got, "could not reach the remote") {
+		t.Errorf("Message() dropped the message: %q", got)
+	}
+	if strings.HasSuffix(got, "\n") {
+		t.Errorf("Message() left a trailing newline: %q", got)
+	}
+}
+
+// The nested case is the one that matters: an outer wrap renders one hint at
+// the end, and stripping must not take any of the message chain with it.
+func TestMessageKeepsTheWholeChain(t *testing.T) {
+	inner := Validation("certificate could not be verified").WithHint("install CA certificates")
+	middle := fmt.Errorf("resolving latest dev tag: %w", inner)
+	outer := Wrap(middle, "auto-sync failed")
+
+	got := Message(outer)
+	for _, want := range []string{"auto-sync failed", "resolving latest dev tag", "certificate could not be verified"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("Message() lost %q from the chain: %q", want, got)
+		}
+	}
+	if strings.Contains(got, "Hint: ") {
+		t.Errorf("Message() kept a hint: %q", got)
+	}
+}
+
+func TestMessageOnPlainAndNilErrors(t *testing.T) {
+	if got := Message(nil); got != "" {
+		t.Errorf("Message(nil) = %q, want empty", got)
+	}
+	plain := fmt.Errorf("something broke")
+	if got := Message(plain); got != "something broke" {
+		t.Errorf("Message(plain) = %q, want %q", got, "something broke")
+	}
+}

--- a/methodology/embed.go
+++ b/methodology/embed.go
@@ -1,0 +1,28 @@
+// Package methodology embeds the festival methodology scaffold that 'fest
+// init' copies into a new workspace.
+//
+// The scaffold normally arrives by syncing from GitHub, which makes a working
+// network a hard prerequisite for ever running 'fest init' — including on
+// machines that will never have one. Embedding the same tree the sync would
+// fetch lets init work from the binary alone, and leaves sync as the way to
+// pick up methodology changes rather than the way to obtain it at all.
+//
+// This is the same directory the default repository serves, so the bundled
+// copy and a fresh sync of the default ref agree by construction at build
+// time; they diverge only as the upstream methodology moves on.
+package methodology
+
+import "embed"
+
+// Root is the directory within FS holding the scaffold.
+const Root = "festivals"
+
+// FS holds the methodology scaffold.
+//
+// The all: prefix matters: without it go:embed silently skips entries whose
+// names begin with a dot, which here would drop .festival — the directory
+// holding the templates and agent guides that make the scaffold useful — and
+// .gitignore, leaving a workspace that looks complete and is not.
+//
+//go:embed all:festivals
+var FS embed.FS


### PR DESCRIPTION
## The bug

The methodology scaffold only ever existed after a successful sync, so a machine that could not reach GitHub could not run `fest init` **at all**. From the Kindle report:

```
[root@kindle kindle-camp]# fest init
Template cache not found, syncing from GitHub...
Error: auto-sync failed: ...
```

#330 made that failure legible. It did not make the command work — the templates still only arrive over the network, so an offline machine gets a clear explanation of why it cannot start.

## After

Verified in a container with **`--network none`**:

```
### DEFAULT REPO, no network, clean HOME:
Template cache not found, syncing from GitHub...
⚠ Could not reach the methodology repository: resolving latest dev tag: git command not found
Using the methodology bundled with this fest build.
Run 'fest sync' once the network is available to pick up newer templates.
Initializing festival structure at festivals...
-> workspace: README.md active dungeon planning ready ritual
```

A complete, usable workspace — `fest list` runs against it, and `.festival/` carries the templates, extensions, and agent guides.

## The change

`methodology/festivals` (440K, 60 files) is embedded in the binary and seeded when the sync fails. Sync becomes the way to **update** the methodology rather than the way to obtain it.

### The bundle is not a universal substitute

It is a copy of the *default* repository, so it stands in only for the default source. An operator who pointed fest at their own methodology keeps failing:

```
### CUSTOM REPO, no network, its own clean HOME:
Template cache not found, syncing from GitHub...
Error: auto-sync failed: resolving latest dev tag: git command not found
-> workspace created? 0 entries
```

Seeding ours there would hand them a methodology they never chose, and `init` would report success — the swap would be easy to miss. Failing is the honest outcome: fest cannot produce templates it has never seen.

## A build-hygiene problem this uncovered

`//go:embed` reads the **working tree, not the commit**, so anything sitting in `methodology/festivals` at build time is baked into the binary — including untracked and gitignored files. That makes the shipped scaffold depend on whose machine ran the build.

Not hypothetical. The repo gitignores `CLAUDE.md`, and this checkout has **eight generated ones** under the methodology tree:

```
$ head -1 methodology/festivals/.festival/CLAUDE.md
<claude-mem-context>
```

Those are local session logs. A release built on that machine would have embedded them and written them into **every user's** workspace on `fest init`; a clean-checkout build would not. `TestEmbeddedScaffoldMatchesGitTrackedFiles` compares the embedded set against `git ls-files`, so the binary can only carry what the commit contains, and it names the offending file when it fails.

> Worth knowing separately: those eight files are sitting in the main `projects/fest` checkout right now. They are gitignored and regenerate, so they are harmless until something embeds that tree — which this PR does. The test catches it; they should be deleted before cutting a release from that checkout.

## Tests

- The bundled scaffold matches the on-disk methodology **file for file**, so adding a methodology file cannot quietly fail to ship.
- `.festival` and the status directories are present by name. This is the specific casualty of a missing `all:` prefix — `go:embed` silently skips dot-prefixed entries without it, which would produce a workspace that looks complete and has no templates. **Verified by removing the prefix: 1 file embedded instead of 60.**
- Embedded contents match byte for byte after seeding.
- Context cancellation is honored; an empty target is rejected.
- The bundle-applies rule is table-driven across unconfigured, explicit-default, pinned-channel, someone-else's-repo, and default-repo-at-another-path.
- The git-parity guard was **verified to fail** by planting a stray gitignored file.

## Two adjacent fixes

- `--from` pointing at a missing directory ran a sync that writes to the config dir — somewhere else entirely — and then failed on the original path anyway. It now says what is missing.
- `errors.Message` renders an error without its `Hint:` line. Splicing a cause into a warning was emitting a next-step for something the command was already handling.

## Gates

`go vet` clean, `golangci-lint run ./...` **0 issues**, `just test unit` **2870/2870 passed**.

## Follow-up I am not doing here

While verifying the custom-repo path I found a **pre-existing** defect from #330: `errors.Validation` attaches the generic `HintSeeHelp` *in the constructor*, so innermost-wins hint precedence surfaces the most generic hint in a chain rather than the most specific. The refusal above prints `Hint: Run 'fest help' for more information` instead of the connection advice this code attaches. That is the "check file permissions" problem in a new form, it predates this branch, and it is an errors-package semantics change that deserves its own review. Separate PR.
