### PR TITLE
fix(errors): let a specific hint outrank a generic one from any depth

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -56,16 +56,21 @@ type Error struct {
 	Err     error                  `json:"-"`
 	Fields  map[string]interface{} `json:"fields,omitempty"`
 	Hint    string                 `json:"hint,omitempty"` // actionable suggestion
+
+	// hintFromClass marks a Hint that a constructor attached from the error
+	// class alone, with no knowledge of what actually failed. Those lose to any
+	// hint chosen for the specific failure, wherever it sits in the chain.
+	// Unexported so it cannot be set from outside: WithHint is how a caller
+	// says "this one is mine".
+	hintFromClass bool
 }
 
 // Error returns the error string with context, followed by exactly one hint.
 //
-// The hint is the outermost one in the chain, because that is the layer closest
-// to what the operator actually typed: "run 'fest sync' manually" beats the
-// generic advice attached wherever the failure originated. Inner hints are
-// deliberately not printed. Rendering a cause with %v would otherwise splice
-// its "Hint:" line into the middle of this one's message, so a two-layer error
-// printed two hints and a three-layer error printed three.
+// Which hint that is, is resolveHint's decision; see it for the precedence and
+// why. Inner hints are deliberately not printed: rendering a cause with %v
+// would splice its "Hint:" line into the middle of this one's message, so a
+// two-layer error printed two hints and a three-layer error printed three.
 func (e *Error) Error() string {
 	msg := e.chainMessage()
 	if hint := e.resolveHint(); hint != "" {
@@ -116,8 +121,9 @@ func stripHintLines(msg string) string {
 	return strings.TrimRight(strings.Join(kept, "\n"), "\n")
 }
 
-// resolveHint returns the hint to show: the innermost one in the chain, falling
-// back outward when the inner layers carry none.
+// resolveHint returns the hint to show: the innermost hint that says something
+// about this particular failure, falling back to a class-level hint only when
+// no layer offers better, and outward when a layer carries none.
 //
 // Innermost wins because that layer knows what actually failed, while outer
 // layers only know what was being attempted. A TLS verification failure inside
@@ -125,10 +131,44 @@ func stripHintLines(msg string) string {
 // certificates", and the outer one can only offer "check your internet
 // connection", which is actively misleading on a machine whose network is fine.
 // The outer context is not lost, because the message chain already carries it.
+//
+// Specific beats inner, though, or innermost-wins inverts its own purpose.
+// Several constructors attach a catch-all hint from the error class alone —
+// Validation hands out "Run 'fest help'" to every caller — so a chain whose
+// innermost layer happens to be a Validation would surface that over an outer
+// hint written for the actual operation. Real case: a sync failure reported
+// "Run 'fest help' for more information" instead of the connection advice the
+// call site attached, which is the same "check file permissions" dead end that
+// visible hints were meant to remove.
 func (e *Error) resolveHint() string {
+	if h := e.specificHint(); h != "" {
+		return h
+	}
+	return e.fallbackHint()
+}
+
+// specificHint returns the innermost hint that was chosen for this failure
+// rather than for its class: an explicit WithHint, or one a constructor derived
+// from the failure itself.
+func (e *Error) specificHint() string {
 	var inner *Error
 	if e.Err != nil && errors.As(e.Err, &inner) {
-		if h := inner.resolveHint(); h != "" {
+		if h := inner.specificHint(); h != "" {
+			return h
+		}
+	}
+	if e.hintFromClass {
+		return ""
+	}
+	return e.Hint
+}
+
+// fallbackHint returns the innermost class-level hint, used only when nothing
+// in the chain offers something more specific.
+func (e *Error) fallbackHint() string {
+	var inner *Error
+	if e.Err != nil && errors.As(e.Err, &inner) {
+		if h := inner.fallbackHint(); h != "" {
 			return h
 		}
 	}
@@ -227,14 +267,19 @@ func (e *Error) WithFields(fields map[string]interface{}) *Error {
 }
 
 // WithHint adds an actionable suggestion to the error.
+// A hint set here is about this call site, so it outranks the catch-all a
+// constructor may have attached from the error class — including one further in
+// the chain.
 func (e *Error) WithHint(hint string) *Error {
 	e.Hint = hint
+	e.hintFromClass = false
 	return e
 }
 
 // WithHintf adds a formatted actionable suggestion to the error.
 func (e *Error) WithHintf(format string, args ...interface{}) *Error {
 	e.Hint = fmt.Sprintf(format, args...)
+	e.hintFromClass = false
 	return e
 }
 
@@ -265,22 +310,24 @@ func hintForResource(resource string) string {
 // Validation creates a VALIDATION error with a helpful hint.
 func Validation(message string) *Error {
 	return &Error{
-		Code:    ErrCodeValidation,
-		Message: message,
-		Fields:  make(map[string]interface{}),
-		Hint:    HintSeeHelp,
+		Code:          ErrCodeValidation,
+		Message:       message,
+		Fields:        make(map[string]interface{}),
+		Hint:          HintSeeHelp,
+		hintFromClass: true,
 	}
 }
 
 // IO creates an IO error with permission check hint.
 func IO(op string, err error) *Error {
 	return &Error{
-		Code:    ErrCodeIO,
-		Message: "I/O operation failed",
-		Op:      op,
-		Err:     err,
-		Fields:  make(map[string]interface{}),
-		Hint:    HintCheckPermissions,
+		Code:          ErrCodeIO,
+		Message:       "I/O operation failed",
+		Op:            op,
+		Err:           err,
+		Fields:        make(map[string]interface{}),
+		Hint:          HintCheckPermissions,
+		hintFromClass: true,
 	}
 }
 
@@ -339,31 +386,34 @@ func containsAny(haystack string, needles ...string) bool {
 // Config creates a CONFIG error with configuration check hint.
 func Config(message string) *Error {
 	return &Error{
-		Code:    ErrCodeConfig,
-		Message: message,
-		Fields:  make(map[string]interface{}),
-		Hint:    HintCheckConfig,
+		Code:          ErrCodeConfig,
+		Message:       message,
+		Fields:        make(map[string]interface{}),
+		Hint:          HintCheckConfig,
+		hintFromClass: true,
 	}
 }
 
 // Template creates a TEMPLATE error with template check hint.
 func Template(message string) *Error {
 	return &Error{
-		Code:    ErrCodeTemplate,
-		Message: message,
-		Fields:  make(map[string]interface{}),
-		Hint:    HintCheckTemplate,
+		Code:          ErrCodeTemplate,
+		Message:       message,
+		Fields:        make(map[string]interface{}),
+		Hint:          HintCheckTemplate,
+		hintFromClass: true,
 	}
 }
 
 // Parse creates a PARSE error with configuration check hint.
 func Parse(message string, err error) *Error {
 	return &Error{
-		Code:    ErrCodeParse,
-		Message: message,
-		Err:     err,
-		Fields:  make(map[string]interface{}),
-		Hint:    HintCheckConfig,
+		Code:          ErrCodeParse,
+		Message:       message,
+		Err:           err,
+		Fields:        make(map[string]interface{}),
+		Hint:          HintCheckConfig,
+		hintFromClass: true,
 	}
 }
 

--- a/internal/errors/hint_precedence_test.go
+++ b/internal/errors/hint_precedence_test.go
@@ -1,0 +1,112 @@
+package errors
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func hintOf(t *testing.T, err error) string {
+	t.Helper()
+	rendered := err.Error()
+	_, hint, found := strings.Cut(rendered, "\nHint: ")
+	if !found {
+		return ""
+	}
+	if strings.Contains(hint, "\nHint: ") {
+		t.Errorf("rendered more than one hint:\n%s", rendered)
+	}
+	return hint
+}
+
+// The defect. Validation attaches "Run 'fest help'" from the error class alone,
+// with no knowledge of what failed. Under plain innermost-wins that catch-all
+// displaced the hint the call site wrote for the actual operation, which is the
+// same dead end as being told to check file permissions on a network failure.
+//
+// Observed for real: 'fest init' against an unreachable remote printed
+// "Run 'fest help' for more information" instead of its connection advice.
+func TestSpecificHintBeatsAnInnerClassHint(t *testing.T) {
+	inner := Validation("git command not found")
+	middle := fmt.Errorf("resolving latest dev tag: %w", inner)
+	outer := Wrap(middle, "auto-sync failed").
+		WithHint("check your internet connection or run 'fest sync' manually")
+
+	if got, want := hintOf(t, outer), "check your internet connection or run 'fest sync' manually"; got != want {
+		t.Errorf("hint = %q, want %q", got, want)
+	}
+	if strings.Contains(outer.Error(), HintSeeHelp) {
+		t.Errorf("the class-level hint still surfaced:\n%s", outer.Error())
+	}
+}
+
+// The rule this must not break. A hint a constructor derived from the actual
+// failure is specific, so innermost still wins over an outer call-site hint:
+// the TLS case from the visible-hints work, where the inner layer knows it is a
+// certificate problem and the outer one can only guess at the network.
+func TestDerivedInnerHintStillBeatsAnOuterHint(t *testing.T) {
+	inner := Network("listing remote tags",
+		fmt.Errorf("exit status 128"),
+		"server certificate verification failed. CAfile: none")
+	outer := Wrap(inner, "auto-sync failed").
+		WithHint("check your internet connection or run 'fest sync' manually")
+
+	if got := hintOf(t, outer); got != HintCheckTLS {
+		t.Errorf("hint = %q, want the TLS hint %q", got, HintCheckTLS)
+	}
+}
+
+// With nothing better anywhere, a class-level hint is still better than none,
+// and the innermost one is the most relevant of them.
+func TestClassHintsAreUsedWhenNothingIsMoreSpecific(t *testing.T) {
+	inner := IO("writing file", fmt.Errorf("permission denied"))
+	outer := Wrap(inner, "saving progress")
+
+	if got := hintOf(t, outer); got != HintCheckPermissions {
+		t.Errorf("hint = %q, want %q", got, HintCheckPermissions)
+	}
+}
+
+// WithHint on the same error that carried a class hint replaces it outright.
+func TestWithHintOverridesTheClassHintOnItsOwnError(t *testing.T) {
+	err := Validation("bad --status value").
+		WithHint("valid values are: active, ready, planning")
+
+	if got, want := hintOf(t, err), "valid values are: active, ready, planning"; got != want {
+		t.Errorf("hint = %q, want %q", got, want)
+	}
+}
+
+// An outer class hint must not beat an inner specific one either; specificity
+// is what decides, and depth only breaks ties within the same kind.
+func TestInnerSpecificHintBeatsAnOuterClassHint(t *testing.T) {
+	inner := New("evidence path escapes the phase directory").
+		WithHint("list only paths inside the phase directory")
+	outer := Config("loading gates").WithField("k", "v")
+	outer.Err = inner
+
+	if got, want := hintOf(t, outer), "list only paths inside the phase directory"; got != want {
+		t.Errorf("hint = %q, want %q", got, want)
+	}
+}
+
+// A chain with no hints anywhere renders none, rather than an empty "Hint:".
+func TestNoHintAnywhereRendersNoHintLine(t *testing.T) {
+	err := Wrap(fmt.Errorf("underlying"), "outer")
+	if strings.Contains(err.Error(), "Hint:") {
+		t.Errorf("rendered a hint line for a chain with no hints:\n%s", err.Error())
+	}
+}
+
+// The message chain must survive whichever hint wins.
+func TestPrecedenceDoesNotDisturbTheMessageChain(t *testing.T) {
+	inner := Validation("git command not found")
+	middle := fmt.Errorf("resolving latest dev tag: %w", inner)
+	outer := Wrap(middle, "auto-sync failed").WithHint("check your internet connection")
+
+	for _, want := range []string{"auto-sync failed", "resolving latest dev tag", "git command not found"} {
+		if !strings.Contains(outer.Error(), want) {
+			t.Errorf("message chain lost %q:\n%s", want, outer.Error())
+		}
+	}
+}


### PR DESCRIPTION
## The bug

Innermost-wins hint precedence inverted its own purpose.

Several constructors attach a catch-all hint from the **error class alone**, with no knowledge of what actually failed:

```go
func Validation(message string) *Error {
	return &Error{..., Hint: HintSeeHelp}   // "Run 'fest help' for more information"
}
```

So a chain whose innermost layer happened to be a `Validation` surfaced that generic advice over the hint the call site wrote for the real operation. Innermost-wins was meant to prefer the layer that *knows what failed*; in practice it preferred whichever layer was deepest, and the deepest layer is often the one with the least specific advice.

Real case, `fest init` against an unreachable remote:

```
before: Hint: Run 'fest help' for more information
after:  Hint: check your internet connection or run 'fest sync' manually
```

The call site attached the second one. The first is what users saw. That is the same dead end as being told to check file permissions when a remote is unreachable — the exact failure that making hints visible was supposed to remove.

## The fix

Precedence is now **specificity first, depth second**.

A hint is *specific* when it says something about this failure:
- a caller set it with `WithHint` / `WithHintf`, or
- a constructor derived it from the failure itself — `Network` classifies git's stderr, `NotFound` reads the resource.

A hint is *class-level* when a constructor attached it from the error code alone (`Validation`, `IO`, `Config`, `Template`, `Parse`). Those are marked at construction and used only when no layer in the chain offers something better — still innermost-first among themselves, so nothing regresses for chains that only have class hints.

The marker is an unexported field, so it cannot be set from outside the package: `WithHint` is how a caller says "this one is mine", and it clears the flag even on an error that started with a class hint.

### This deliberately preserves the TLS case

The rule that motivated innermost-wins still holds, and has its own test:

```go
inner := Network("listing remote tags", err, "server certificate verification failed. CAfile: none")
outer := Wrap(inner, "auto-sync failed").WithHint("check your internet connection ...")
// → the CA-certificate hint, not the network one
```

Both hints are specific there, so depth breaks the tie and the inner one wins — the inner layer knows it is a certificate problem, the outer can only guess at the network.

## Verified by breaking it

The tests were confirmed to fail against the unfixed code, reproducing the exact symptom:

```
--- FAIL: TestSpecificHintBeatsAnInnerClassHint
    hint = "Run 'fest help' for more information",
      want "check your internet connection or run 'fest sync' manually"
    the class-level hint still surfaced:
      auto-sync failed: resolving latest dev tag: git command not found
      Hint: Run 'fest help' for more information
```

And end to end, offline in a container:

```
Error: auto-sync failed: resolving latest dev tag: git command not found
Hint: check your internet connection or run 'fest sync' manually
```

## Tests

Specific-beats-inner-class (the defect), derived-inner-still-beats-outer (the TLS rule), class hints used when nothing is better, `WithHint` overriding a class hint on its own error, inner-specific over outer-class, no hint anywhere rendering no `Hint:` line, and the message chain surviving whichever hint wins.

## Also

Corrects the `Error()` doc comment, which still described the **outermost-wins** rule that innermost-wins had already replaced — it had been stale since that change, and directly contradicted the code beneath it.

## Gates

`go vet` clean, `golangci-lint run ./...` **0 issues**, `just test unit` **2867/2867 passed**. Notably no existing test depended on the old ordering, which is some evidence the previous behavior was never deliberate.
